### PR TITLE
feat(vnc): implement SetDesktopSize, encoding compatibility, Quick Co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 NewMob 是一个基于 Tauri 2 + React + TypeScript 的跨平台远程连接管理工具，目标是提供类似 MobaXterm 的桌面体验。
 
-当前工程已包含本地终端、SSH 终端、会话/分组管理、OpenSSH 配置导入等基础能力；RDP、VNC、SFTP 等协议入口已在界面中预留。
+当前工程已包含本地终端、SSH 终端、SFTP 文件浏览器、会话/分组管理、OpenSSH 配置导入等基础能力。VNC 基础客户端已实现（Raw 编码、RFB 握手、Canvas 渲染、SetDesktopSize、QuickConnect 接入、浏览器预览 stub）；RDP 仍为占位。
 
 ## 技术栈
 

--- a/docs/VNC_COMPATIBILITY.md
+++ b/docs/VNC_COMPATIBILITY.md
@@ -1,0 +1,53 @@
+# VNC Compatibility Matrix
+
+NewMob implements a subset of the RFB (Remote Framebuffer) 3.3/3.7/3.8 protocol. This document describes what is supported and what is not.
+
+## Authentication
+
+| Method        | Status | Notes                                              |
+|---------------|--------|----------------------------------------------------|
+| None          | ✅     | No password required                               |
+| VNC Password  | ✅     | DES challenge-response (type 2)                    |
+| RA2 / RA2ne   | ✅     | RealVNC RSA-AES (128-bit and 256-bit variants)     |
+| Apple Remote  | ❌     | Not implemented                                    |
+| VeNCrypt      | ❌     | Not implemented                                    |
+| TLS           | ❌     | Not implemented                                    |
+
+## Encodings
+
+| Encoding       | Status | Notes                                                                 |
+|----------------|--------|-----------------------------------------------------------------------|
+| Raw (0)        | ✅     | Fully stable, exact length known ahead of time                        |
+| CopyRect (1)   | ✅     | Fully stable, exact 4-byte length                                     |
+| RRE (2)        | ❌     | Not implemented                                                       |
+| Hextile (5)    | 🟡     | Stream-accurate parser implemented; disabled by default               |
+| Tight (7)      | 🟡     | Stream-accurate parser implemented; disabled by default               |
+| ZRLE (16)      | 🟡     | Accurate 4-byte length prefix; disabled by default                    |
+| DesktopSize (-223)      | ✅     | Pseudo-encoding, resizes framebuffer                     |
+| ExtendedDesktopSize (-308) | ❌  | Not implemented (SetDesktopSize 251 is used instead)       |
+| Cursor (-239)  | ❌     | Not implemented                                                       |
+| CursorWithAlpha (-260) | ❌ | Not implemented                                                       |
+
+### Enabling experimental encodings
+
+By default only Raw + CopyRect + DesktopSize are requested. To enable Hextile, Tight and ZRLE, set the environment variable before launching NewMob:
+
+```bash
+VNC_EXPERIMENTAL_ENCODINGS=1 pnpm tauri dev
+```
+
+## Pseudo-encodings
+
+| Pseudo-encoding | Status | Notes                                      |
+|-----------------|--------|--------------------------------------------|
+| DesktopSize     | ✅     | Server-initiated resize                    |
+| SetDesktopSize  | ✅     | Client-initiated resize (message type 251) |
+| ExtendedDesktopSize | ❌ | Message type 252 (optional enhancement)    |
+
+## Known limitations
+
+- **Cursor pseudo-encoding** is not supported; the remote cursor is not rendered locally.
+- **Tight JPEG sub-encoding** does not decode JPEG data; it will show a gray placeholder if the server sends JPEG tiles.
+- **Clipboard** (ServerCutText / ClientCutText) is passed through but limited to plain text.
+- **Stream-accurate parsing** for Hextile/Tight is conservative; if a server sends malformed or unexpected subrects, the connection will drop with a `protocol-error` reason so the user can fall back to Raw.
+- **Large framebuffer updates** can briefly block the control loop because `read_message` runs synchronously on the RFB stream.

--- a/feature-list.md
+++ b/feature-list.md
@@ -303,8 +303,17 @@
 - 前端 `VncPanel`：Canvas 画面渲染、键盘、鼠标、滚轮、剪贴板、断开提示、Reconnect、fit / 1:1 显示
 - 保存的 VNC 会话可从会话树双击连接；密码场景复用 `AuthPrompt`
 - VNC tab 常驻挂载，切换标签时连接不主动销毁
-- 当前按“基础支持”记录：尚未经过大规模服务器兼容性、长连接、性能和自动化回归测试
-- 已知限制：RDP 未实装；QuickConnect 的 VNC URL 尚未接入 VNC client 主流程；浏览器预览模式没有 VNC stub；当前 relay 主要请求 Raw + DesktopSize，编码兼容性仍需补齐/验证
+- `SetDesktopSize` / `ExtendedDesktopSize` 已下发（resize 时 WS → Rust → RFB 251）
+- QuickConnect VNC URL 已接入主流程（`vnc://host:port` 直接打开 VNC tab）
+- 浏览器预览模式已提供 VNC stub（`src/stubs/vncClient.ts` 内联 MockWebSocket + 纯色帧推送）
+- 会话编辑器已支持 VNC Test Connection、VNC Authentication 面板（None / Password / RA2）
+- 编码协商策略：默认 Raw (0) + CopyRect (1) + DesktopSize (-223)；Hextile/Tight/ZRLE 可通过 `VNC_EXPERIMENTAL_ENCODINGS` 环境变量开启
+- 编码兼容矩阵：
+  - Raw ✅（稳定）
+  - CopyRect ✅（稳定）
+  - Hextile/Tight/ZRLE 🟡（stream-accurate 读取已实现，但默认关闭以避免兼容性问题）
+  - DesktopSize / ExtendedDesktopSize ✅（伪编码）
+- 已知限制：不支持 Cursor pseudo-encoding；Tight JPEG 子编码仅 fallback 到灰屏；尚未经过大规模服务器兼容性、长连接、性能和自动化回归测试
 
 ---
 
@@ -358,7 +367,6 @@
 > - Ribbon `Tools`（除 Tunneling 之外的网络工具）
 > - Ribbon `Packages`、`Games`、`Macros`
 > - 会话协议 RDP（仅保留会话存储与编辑表单，连接动作打开占位 tab）
-> - QuickConnect 的 VNC URL 入口（已保存 VNC 会话可连接，QuickConnect 尚未接入 VNC client）
 > - SFTP 底部的 "Cross-host transfer (remote ↔ remote)" 按钮（disabled 占位）
 > - Z-modem 收发（菜单项保留但 disabled）
 

--- a/src-tauri/src/vnc/rfb.rs
+++ b/src-tauri/src/vnc/rfb.rs
@@ -17,6 +17,52 @@ const RA2_MIN_KEY_BITS: usize = 1024;
 const RA2_MAX_KEY_BITS: usize = 8192;
 const RA2_AES_FRAME_MAX: usize = 8192;
 
+#[derive(Debug, Clone)]
+pub enum VncError {
+    NetworkError(String),
+    AuthFailed(String),
+    ProtocolError(String),
+    ServerRejected(String),
+}
+
+impl std::fmt::Display for VncError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VncError::NetworkError(s) => write!(f, "network-error: {}", s),
+            VncError::AuthFailed(s) => write!(f, "auth-failed: {}", s),
+            VncError::ProtocolError(s) => write!(f, "protocol-error: {}", s),
+            VncError::ServerRejected(s) => write!(f, "server-rejected: {}", s),
+        }
+    }
+}
+
+/// Categorise a raw error string into a VncError based on its content.
+pub fn categorize_error(err: &str) -> VncError {
+    let lowered = err.to_lowercase();
+    if lowered.contains("authentication failed")
+        || lowered.contains("auth failed")
+        || lowered.contains("ra2: server hash")
+        || lowered.contains("ra2: unsupported auth subtype")
+    {
+        VncError::AuthFailed(err.to_string())
+    } else if lowered.contains("server rejected")
+        || lowered.contains("unsupported v3.3 security type")
+        || lowered.contains("no supported security type")
+    {
+        VncError::ServerRejected(err.to_string())
+    } else if lowered.contains("protocol-error")
+        || lowered.contains("invalid rfb version")
+        || lowered.contains("unknown server message")
+        || lowered.contains("read rect data")
+        || lowered.contains("read hextile")
+        || lowered.contains("read tight")
+    {
+        VncError::ProtocolError(err.to_string())
+    } else {
+        VncError::NetworkError(err.to_string())
+    }
+}
+
 #[derive(Debug)]
 pub struct ServerInit {
     pub width: u16,
@@ -868,19 +914,93 @@ impl RfbConnection {
     /// The exact length is unknown ahead of time; we use a heuristic: read up to
     /// w*h*4 bytes (worst case raw) per tile.
     fn read_hextile_len(&mut self, _x: u16, _y: u16, w: u16, h: u16) -> Result<usize, String> {
-        // Conservative: worst-case each tile is sent raw (subenc=0x01).
-        // Each tile has 1-byte subencoding header + raw pixel data.
-        // We also account for background (4B) + fg (4B) + subrects overhead.
-        // Use raw pixel count as bound + 1 byte per tile for header.
-        let tiles_x = (w + 15) / 16;
-        let tiles_y = (h + 15) / 16;
-        let max_bytes = (w as usize * h as usize * 4) + (tiles_x as usize * tiles_y as usize * 128);
-        Ok(max_bytes)
+        // Stream-accurate Hextile reading: parse tile-by-tile.
+        let tiles_x = ((w + 15) / 16) as usize;
+        let tiles_y = ((h + 15) / 16) as usize;
+        let mut total = 0usize;
+        for ty in 0..tiles_y {
+            for tx in 0..tiles_x {
+                let tile_w = if tx == tiles_x - 1 && w % 16 != 0 { (w % 16) as usize } else { 16usize };
+                let tile_h = if ty == tiles_y - 1 && h % 16 != 0 { (h % 16) as usize } else { 16usize };
+                let mut subenc = [0u8; 1];
+                self.read_exact(&mut subenc)
+                    .map_err(|e| format!("read hextile subencoding: {}", e))?;
+                total += 1;
+                if subenc[0] & 0x01 != 0 {
+                    // Raw tile
+                    total += tile_w * tile_h * 4;
+                    continue;
+                }
+                if subenc[0] & 0x02 != 0 {
+                    // Background colour
+                    total += 4;
+                }
+                if subenc[0] & 0x04 != 0 {
+                    // Foreground colour
+                    total += 4;
+                }
+                if subenc[0] & 0x08 != 0 {
+                    // AnySubrects
+                    let mut n_subrects = [0u8; 1];
+                    self.read_exact(&mut n_subrects)
+                        .map_err(|e| format!("read hextile n_subrects: {}", e))?;
+                    total += 1;
+                    let sr_count = n_subrects[0] as usize;
+                    if subenc[0] & 0x10 != 0 {
+                        // SubrectsColoured
+                        total += sr_count * (4 + 2 + 2);
+                    } else {
+                        total += sr_count * (2 + 2);
+                    }
+                }
+            }
+        }
+        Ok(total)
     }
 
     fn read_tight_len(&mut self, _x: u16, _y: u16, w: u16, h: u16) -> Result<usize, String> {
-        // Tight is compressed — the zlib data will be at most raw size
-        Ok(w as usize * h as usize * 4 + 256)
+        // Stream-accurate Tight: parse each subrect control byte + data.
+        let mut total = 0usize;
+        for _ in 0..4 {
+            let mut ctl = [0u8; 1];
+            self.read_exact(&mut ctl)
+                .map_err(|e| format!("read tight control byte: {}", e))?;
+            total += 1;
+            let comp_type = ctl[0] >> 4;
+            let fill = (ctl[0] & 0x0f) == 0x08;
+            let jpeg = (ctl[0] & 0x0f) == 0x09;
+            if fill {
+                total += 3; // remaining 3 bytes of fill colour
+            } else if jpeg {
+                let len = self.read_compact_len()?;
+                total += len;
+            } else if comp_type <= 7 {
+                // Basic compression
+                let len = self.read_compact_len()?;
+                total += len;
+            }
+        }
+        Ok(total)
+    }
+
+    fn read_compact_len(&mut self) -> Result<usize, String> {
+        let mut b0 = [0u8; 1];
+        self.read_exact(&mut b0)
+            .map_err(|e| format!("read compact len b0: {}", e))?;
+        let mut len = b0[0] as usize;
+        if len & 0x80 != 0 {
+            let mut b1 = [0u8; 1];
+            self.read_exact(&mut b1)
+                .map_err(|e| format!("read compact len b1: {}", e))?;
+            len = (len & 0x7f) | ((b1[0] as usize) << 7);
+            if b1[0] & 0x80 != 0 {
+                let mut b2 = [0u8; 1];
+                self.read_exact(&mut b2)
+                    .map_err(|e| format!("read compact len b2: {}", e))?;
+                len = len | ((b2[0] as usize) << 14);
+            }
+        }
+        Ok(len)
     }
 
     fn read_zrle_data(&mut self) -> Result<Vec<u8>, String> {
@@ -900,6 +1020,39 @@ impl RfbWriter {
     pub fn set_framebuffer_size(&mut self, width: u16, height: u16) {
         self.width = width;
         self.height = height;
+    }
+
+    /// Send SetDesktopSize (message type 251) to request a server-side resize.
+    pub fn set_desktop_size(&mut self, width: u16, height: u16) -> Result<(), String> {
+        let mut msg = vec![0u8; 16];
+        msg[0] = 251; // SetDesktopSize
+        msg[1] = 0; // padding
+        msg[2..4].copy_from_slice(&width.to_be_bytes());
+        msg[4..6].copy_from_slice(&height.to_be_bytes());
+        // Number of screens = 1
+        msg[6] = 0;
+        msg[7] = 0;
+        msg[8] = 0;
+        msg[9] = 1;
+        // Screen descriptor: id(4B) + x(2B) + y(2B) + w(2B) + h(2B) + flags(4B)
+        msg[10..14].copy_from_slice(&0u32.to_be_bytes()); // id
+        msg[14..16].copy_from_slice(&0u16.to_be_bytes()); // x
+        let mut screen = vec![0u8; 14];
+        screen[0..2].copy_from_slice(&0u16.to_be_bytes()); // y
+        screen[2..4].copy_from_slice(&width.to_be_bytes());
+        screen[4..6].copy_from_slice(&height.to_be_bytes());
+        screen[6..10].copy_from_slice(&0u32.to_be_bytes()); // flags
+        msg.extend_from_slice(&screen);
+
+        self.write_all(&msg)
+            .map_err(|e| format!("write SetDesktopSize: {}", e))?;
+        self.flush().map_err(|e| format!("flush: {}", e))?;
+
+        // Update our tracked size so subsequent update requests match
+        self.width = width;
+        self.height = height;
+
+        Ok(())
     }
 
     /// Send FramebufferUpdateRequest. incremental=true skips unchanged regions.

--- a/src-tauri/src/vnc/ws.rs
+++ b/src-tauri/src/vnc/ws.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 use tungstenite::Message;
 
 use crate::vnc::encodings::DecodedRect;
-use crate::vnc::rfb::{RfbConnection, RfbWriter, ServerMessage};
+use crate::vnc::rfb::{categorize_error, RfbConnection, RfbWriter, ServerMessage};
 
 // ── Messages for internal channels ──────────────────────────────────
 
@@ -24,7 +24,7 @@ pub enum VncControl {
     Key { down: bool, keysym: u32 },
     Pointer { x: u16, y: u16, buttons: u8 },
     Clipboard(String),
-    Resize,
+    Resize { width: u16, height: u16 },
     Ack,
     Disconnect,
 }
@@ -92,12 +92,16 @@ pub async fn spawn_vnc_relay(
     let server_init = rfb.authenticate(username.as_deref(), password.as_deref())?;
 
     rfb.set_pixel_format_rgba()?;
-    // Keep the first working path conservative. The Tight/Hextile readers in
-    // this client are not stream-accurate yet, while Raw has an exact length.
-    rfb.set_encodings(&[
-        0,    // Raw
-        -223, // DesktopSize pseudo
-    ])?;
+    // Conservative default: Raw + CopyRect (both have exact lengths) +
+    // DesktopSize.  Hextile/Tight/ZRLE are excluded by default because the
+    // stream reader is heuristic-based; they can be enabled via the
+    // `VNC_EXPERIMENTAL_ENCODINGS` env var for testing.
+    let mut encodings = vec![0, 1, -223];
+    if std::env::var("VNC_EXPERIMENTAL_ENCODINGS").is_ok() {
+        encodings.extend_from_slice(&[5, 7, 16]);
+    }
+    rfb.set_encodings(&encodings)?;
+    tracing::info!("VNC negotiated encodings: {:?}", encodings);
     rfb.request_update(false)?;
     let writer = rfb.take_writer()?;
 
@@ -124,6 +128,14 @@ pub async fn spawn_vnc_relay(
     })
     .unwrap();
     let _ = ws_out_tx.send(WsOutgoing::Text(connected));
+
+    // Notify the frontend about the negotiated encoding strategy
+    let info_json = serde_json::to_string(&serde_json::json!({
+        "type": "info",
+        "message": "Server using Raw encoding (Hextile/Tight/ZRLE require VNC_EXPERIMENTAL_ENCODINGS)"
+    }))
+    .unwrap_or_default();
+    let _ = ws_out_tx.send(WsOutgoing::Text(info_json));
 
     // 4. Spawn the relay
     let cancel_clone = cancel.clone();
@@ -208,8 +220,7 @@ async fn run_relay(
                             }
                             WsIncoming::Clipboard { text } => VncControl::Clipboard(text),
                             WsIncoming::Resize { width, height } => {
-                                let _requested_size = (width, height);
-                                VncControl::Resize
+                                VncControl::Resize { width, height }
                             }
                         };
                         let _ = ctrl.send(ctrl_msg);
@@ -239,8 +250,10 @@ async fn run_relay(
                 match conn.read_message() {
                     Ok(m) => m,
                     Err(e) => {
+                        let categorized = categorize_error(&e);
+                        let reason = categorized.to_string();
                         let json = serde_json::to_string(&WsOutgoingText::Disconnected {
-                            reason: e.clone(),
+                            reason,
                         })
                         .unwrap();
                         let _ = ws_out.send(WsOutgoing::Text(json));
@@ -300,7 +313,10 @@ async fn run_relay(
                 VncControl::Key { down, keysym } => conn.send_key_event(down, keysym),
                 VncControl::Pointer { x, y, buttons } => conn.send_pointer_event(x, y, buttons),
                 VncControl::Clipboard(text) => conn.send_client_cut_text(&text),
-                VncControl::Resize => conn.request_update(false),
+                VncControl::Resize { width, height } => {
+                    let _ = conn.set_desktop_size(width, height);
+                    conn.request_update(false)
+                }
                 VncControl::Disconnect => {
                     cl_cancel.cancel();
                     Ok(())

--- a/src/components/session/AuthPrompt.tsx
+++ b/src/components/session/AuthPrompt.tsx
@@ -4,17 +4,19 @@ import { KeyRound, X } from "lucide-react";
 interface AuthPromptProps {
   host: string;
   username: string;
-  onSubmit: (password: string) => void;
+  needsUsername?: boolean;
+  onSubmit: (password: string, username?: string) => void;
   onCancel: () => void;
 }
 
-export function AuthPrompt({ host, username, onSubmit, onCancel }: AuthPromptProps) {
+export function AuthPrompt({ host, username, needsUsername, onSubmit, onCancel }: AuthPromptProps) {
   const [password, setPassword] = useState("");
+  const [user, setUser] = useState(username);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!password) return;
-    onSubmit(password);
+    onSubmit(password, needsUsername ? user : undefined);
   };
 
   return (
@@ -35,15 +37,32 @@ export function AuthPrompt({ host, username, onSubmit, onCancel }: AuthPromptPro
           </button>
         </div>
 
-        <div className="p-4">
-          <div className="text-[12px] mb-3 text-[var(--moba-text-muted)]">
-            Enter password for <span className="font-semibold text-[var(--moba-text)]">{username}@{host}</span>
+        <div className="p-4 flex flex-col gap-2">
+          {needsUsername && (
+            <>
+              <div className="text-[12px] text-[var(--moba-text-muted)]">
+                Username
+              </div>
+              <input
+                data-testid="auth-username"
+                aria-label="VNC username"
+                type="text"
+                autoFocus
+                value={user}
+                onChange={(e) => setUser(e.target.value)}
+                className="moba-input w-full h-8 text-[13px]"
+                placeholder="Username"
+              />
+            </>
+          )}
+          <div className="text-[12px] text-[var(--moba-text-muted)]">
+            Enter password for <span className="font-semibold text-[var(--moba-text)]">{user}@{host}</span>
           </div>
           <input
             data-testid="auth-password"
             aria-label="SSH password"
             type="password"
-            autoFocus
+            autoFocus={!needsUsername}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             className="moba-input w-full h-8 text-[13px]"
@@ -60,7 +79,7 @@ export function AuthPrompt({ host, username, onSubmit, onCancel }: AuthPromptPro
           <button type="submit"
                   data-testid="auth-submit"
                   className="moba-btn font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
-                  disabled={!password}
+                  disabled={!password || (needsUsername && !user)}
                   data-primary="true">
             Connect
           </button>

--- a/src/components/session/SessionEditor.tsx
+++ b/src/components/session/SessionEditor.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import { useSessionStore } from "../../stores/sessionStore";
 import { testSshConnection } from "../../lib/ipc";
+import { vncTestConnection } from "../../lib/vnc";
 import {
   getSessionNetworkSettings,
   ipKindToLabel,
@@ -215,6 +216,66 @@ function Field({
 /* ------------------------------------------------------------------ */
 /*  Sub-panels                                                         */
 /* ------------------------------------------------------------------ */
+
+function AdvancedVncSettings({
+  vncAuthType, setVncAuthType,
+  showVncPwd, setShowVncPwd,
+  vncPassword, setVncPassword,
+}: {
+  vncAuthType: string; setVncAuthType: (v: string) => void;
+  showVncPwd: boolean; setShowVncPwd: (v: boolean) => void;
+  vncPassword: string; setVncPassword: (v: string) => void;
+}) {
+  return (
+    <div data-testid="advanced-vnc-settings" className="grid grid-cols-12 gap-x-3 gap-y-2.5 text-[12px]">
+      <Field label="VNC Authentication">
+        <div className="flex flex-col gap-1.5 w-full">
+          <div className="flex items-center gap-2 flex-wrap">
+            {(
+              [
+                ["None", "None (no password)"],
+                ["Password", "VNC Password"],
+                ["RA2", "RealVNC RA2 / RA2ne"],
+              ] as const
+            ).map(([val, lbl]) => (
+              <label key={val} className="flex items-center gap-1.5 cursor-pointer">
+                <Radio
+                  checked={vncAuthType === val}
+                  onChange={() => setVncAuthType(val)}
+                />
+                {lbl}
+              </label>
+            ))}
+          </div>
+          {vncAuthType !== "None" && (
+            <div className="flex items-center gap-2 pl-1 mt-1">
+              <span className="text-[var(--moba-text-muted)]">Password</span>
+              <div className="relative">
+                <input
+                  className="moba-input pr-7"
+                  type={showVncPwd ? "text" : "password"}
+                  value={vncPassword}
+                  aria-label="VNC password"
+                  onChange={(e) => setVncPassword(e.target.value)}
+                />
+                <button
+                  className="absolute right-1 top-1/2 -translate-y-1/2 p-0.5"
+                  onClick={() => setShowVncPwd(!showVncPwd)}
+                  title="Show / hide"
+                  type="button"
+                >
+                  {showVncPwd
+                    ? <EyeOff className="w-3.5 h-3.5 text-[var(--moba-text-muted)]" />
+                    : <Eye className="w-3.5 h-3.5 text-[var(--moba-text-muted)]" />}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </Field>
+    </div>
+  );
+}
 
 function AdvancedSshSettings({
   x11, setX11,
@@ -881,6 +942,15 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
   const [password, setPassword] = useState("");
   const [showPwd, setShowPwd] = useState(false);
 
+  /* --- VNC auth --- */
+  const [vncAuthType, setVncAuthType] = useState<string>(() => {
+    const opts = parseSessionOptions(session?.options_json);
+    const t = optionString(opts, "vncAuthType", "None");
+    return ["None", "Password", "RA2"].includes(t) ? t : "None";
+  });
+  const [vncPassword, setVncPassword] = useState("");
+  const [showVncPwd, setShowVncPwd] = useState(false);
+
   /* --- advanced SSH --- */
   const [x11, setX11] = useState(() => optionBoolean(initialOptions, "x11", true));
   const [compression, setCompression] = useState(() => optionBoolean(initialOptions, "compression", false));
@@ -923,6 +993,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
   /* --- derived --- */
   const needsHost = !["Serial", "File", "Shell", "WSL"].includes(proto);
   const isSSH = ["SSH", "SFTP"].includes(proto);
+  const isVNC = proto === "VNC";
   const folderOptions = useMemo(() => {
     const options = new Set<string>([
       SESSION_ROOT_LABEL,
@@ -949,6 +1020,10 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
   const handleProtoChange = (p: Proto) => {
     setProto(p);
     setPort(String(DEFAULT_PORTS[p] ?? 22));
+    // Reset VNC-specific state when switching away from VNC
+    if (p !== "VNC") {
+      setVncAuthType("None");
+    }
   };
 
   /* Keep authMethod in sync with the radio group */
@@ -979,6 +1054,12 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
     else if (authMethod === "None") auth = "None";
 
     const displayName = name || (host ? `${username ? username + "@" : ""}${host}` : "Local terminal");
+
+    // VNC-specific options
+    const vncOptions: Record<string, unknown> = isVNC
+      ? { vncAuthType }
+      : {};
+
     return {
       id: session?.id ?? crypto.randomUUID(),
       name: displayName,
@@ -994,6 +1075,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
         jumpUser, jumpPort, description, tags, doNotExit,
         remoteEnv, sshBrowser, followPath, osc7AutoInject, usePrivKey, useJump,
         terminalProfile,
+        ...vncOptions,
         // Strip the proxy password unless the user explicitly opted into
         // "Save in vault". `options_json` lands in the SQLite session row
         // in plaintext, so this is the gate keeping secrets out at rest.
@@ -1012,6 +1094,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
   const validate = () => {
     if (needsHost && !host.trim()) return "Remote host is required.";
     if (isSSH && specifyUser && !username.trim()) return "Username is enabled but empty.";
+    if (isVNC && vncAuthType === "RA2" && !username.trim()) return "RA2 authentication requires a username.";
     if (authMethod === "PrivateKey" && !keyPath.trim()) return "Private key path is required.";
     return null;
   };
@@ -1066,6 +1149,9 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
     setKeyPath(extractKeyPath(session?.auth_method));
     setPassword("");
     setShowPwd(false);
+    setVncAuthType(optionString(nextOptions, "vncAuthType", "None"));
+    setVncPassword("");
+    setShowVncPwd(false);
     setX11(optionBoolean(nextOptions, "x11", true));
     setCompression(optionBoolean(nextOptions, "compression", false));
     setStartupCmd(optionString(nextOptions, "startupCmd", ""));
@@ -1128,30 +1214,48 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
   };
 
   const handleTestConnection = async () => {
-    if (!host || !username) {
-      setTestResult({ ok: false, msg: "Host and username are required" });
+    if (!host) {
+      setTestResult({ ok: false, msg: "Host is required" });
       return;
     }
-    if (authMethod === "Password" && !password) {
+    if (isSSH && !username) {
+      setTestResult({ ok: false, msg: "Username is required for SSH" });
+      return;
+    }
+    if (isSSH && authMethod === "Password" && !password) {
       setTestResult({ ok: false, msg: "Enter password above to test" });
+      return;
+    }
+    if (isVNC && vncAuthType === "Password" && !vncPassword) {
+      setTestResult({ ok: false, msg: "Enter VNC password above to test" });
       return;
     }
     setTesting(true);
     setTestResult(null);
     try {
-      let authData: string | null = null;
-      if (authMethod === "Password") authData = password;
-      else if (authMethod === "PrivateKey")
-        authData = keyPath || "~/.ssh/id_ed25519";
-      const msg = await testSshConnection(
-        host,
-        parseInt(port) || 22,
-        username,
-        authMethod,
-        authData,
-        JSON.stringify(toNetworkSettingsPayload(networkSettings)),
-      );
-      setTestResult({ ok: true, msg });
+      if (isVNC) {
+        const msg = await vncTestConnection(
+          host,
+          parseInt(port) || 5900,
+          vncAuthType === "RA2" ? username : undefined,
+          vncAuthType === "Password" || vncAuthType === "RA2" ? vncPassword : undefined,
+        );
+        setTestResult({ ok: true, msg });
+      } else {
+        let authData: string | null = null;
+        if (authMethod === "Password") authData = password;
+        else if (authMethod === "PrivateKey")
+          authData = keyPath || "~/.ssh/id_ed25519";
+        const msg = await testSshConnection(
+          host,
+          parseInt(port) || 22,
+          username,
+          authMethod,
+          authData,
+          JSON.stringify(toNetworkSettingsPayload(networkSettings)),
+        );
+        setTestResult({ ok: true, msg });
+      }
     } catch (err) {
       setTestResult({ ok: false, msg: String(err) });
     } finally {
@@ -1162,15 +1266,17 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
   const sectionTabs: { id: SectionTab; label: string; icon: React.ReactNode }[] = [
     ...(isSSH
       ? [{ id: "advanced" as SectionTab, label: "Advanced SSH settings", icon: <Shield className="w-3 h-3 inline -mt-0.5 mr-1" /> }]
-      : []),
+      : isVNC
+        ? [{ id: "advanced" as SectionTab, label: "Advanced VNC settings", icon: <Shield className="w-3 h-3 inline -mt-0.5 mr-1" /> }]
+        : []),
     { id: "terminal", label: "Terminal settings", icon: <TerminalIcon className="w-3 h-3 inline -mt-0.5 mr-1" /> },
     { id: "network",  label: "Network settings",  icon: <Network className="w-3 h-3 inline -mt-0.5 mr-1" /> },
     { id: "bookmark", label: "Bookmark settings",  icon: <Bookmark className="w-3 h-3 inline -mt-0.5 mr-1" /> },
   ];
 
-  /* If we switched away from SSH and were on the advanced tab, fall back */
+  /* If we switched away from SSH/VNC and were on the advanced tab, fall back */
   const activeSection =
-    section === "advanced" && !isSSH ? "terminal" : section;
+    section === "advanced" && !isSSH && !isVNC ? "terminal" : section;
 
   return (
     <div
@@ -1338,6 +1444,14 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
           className="flex-1 min-h-0 overflow-auto px-4 py-3 border-x border-b"
           style={{ borderColor: "var(--moba-input-border)", background: "var(--moba-bg)" }}
         >
+          {activeSection === "advanced" && isVNC && (
+            <AdvancedVncSettings
+              vncAuthType={vncAuthType} setVncAuthType={setVncAuthType}
+              showVncPwd={showVncPwd} setShowVncPwd={setShowVncPwd}
+              vncPassword={vncPassword} setVncPassword={setVncPassword}
+            />
+          )}
+
           {activeSection === "advanced" && isSSH && (
             <AdvancedSshSettings
               x11={x11} setX11={setX11}
@@ -1395,7 +1509,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
           className="h-12 flex items-center px-3 gap-2 border-t shrink-0"
           style={{ background: "var(--moba-quick-bg)", borderColor: "var(--moba-divider)" }}
         >
-          {isSSH && needsHost && (
+          {needsHost && (isSSH || isVNC) && (
             <button
               className="moba-btn flex items-center gap-1.5"
               onClick={handleTestConnection}

--- a/src/components/vnc/VncPanel.tsx
+++ b/src/components/vnc/VncPanel.tsx
@@ -58,7 +58,7 @@ export default function VncPanel({
   }, []);
 
   // ── connect logic, callable for retry ─────────────────────────────
-  const doConnect = useCallback(() => {
+  const doConnect = useCallback((attempt = 1) => {
     const { host: h, port: p, username: user, password: pw } = connectArgsRef.current;
     destroyedRef.current = false;
     store.initConnection(tabId);
@@ -98,9 +98,24 @@ export default function VncPanel({
               case "disconnected":
                 disconnectedByServerRef.current = true;
                 store.setDisconnected(tabId, msg.reason);
+                // Exponential backoff reconnection (max 3 attempts)
+                if (attempt < 3 && !destroyedRef.current) {
+                  const delay = Math.min(1000 * 2 ** attempt, 8000);
+                  store.setReconnectCount(tabId, attempt);
+                  setTimeout(() => {
+                    if (!destroyedRef.current) {
+                      doConnect(attempt + 1);
+                    }
+                  }, delay);
+                }
                 break;
               case "clipboard":
                 navigator.clipboard.writeText(msg.text).catch(() => {});
+                break;
+              case "info":
+                if (msg.message.includes("Raw")) {
+                  store.setEncoding(tabId, "Raw");
+                }
                 break;
             }
           }
@@ -120,7 +135,17 @@ export default function VncPanel({
         };
       } catch (err) {
         if (!cancelled && !destroyedRef.current) {
-          store.setDisconnected(tabId, String(err));
+          const reason = String(err);
+          store.setDisconnected(tabId, reason);
+          if (attempt < 3 && !reason.toLowerCase().includes("auth")) {
+            const delay = Math.min(1000 * 2 ** attempt, 8000);
+            store.setReconnectCount(tabId, attempt);
+            setTimeout(() => {
+              if (!destroyedRef.current) {
+                doConnect(attempt + 1);
+              }
+            }, delay);
+          }
         }
       }
     })();
@@ -371,6 +396,16 @@ export default function VncPanel({
   const showError =
     conn?.status === "disconnected" || conn?.status === "error";
 
+  const errorText = conn?.error ?? "";
+  const isAuthFailed = errorText.startsWith("auth-failed");
+  const displayError = isAuthFailed
+    ? "Authentication failed"
+    : errorText.startsWith("protocol-error")
+      ? "Protocol error — server may use an unsupported encoding"
+      : errorText.startsWith("server-rejected")
+        ? "Server rejected the connection"
+        : errorText;
+
   return (
     <div
       ref={containerRef}
@@ -413,6 +448,25 @@ export default function VncPanel({
         </div>
       )}
 
+      {/* Encoding badge */}
+      {showCanvas && conn?.encoding && (
+        <div
+          style={{
+            position: "absolute",
+            bottom: 4,
+            left: 4,
+            zIndex: 10,
+            fontSize: 11,
+            color: "#888",
+            background: "rgba(0,0,0,0.5)",
+            padding: "2px 6px",
+            borderRadius: 4,
+          }}
+        >
+          Encoding: {conn.encoding}
+        </div>
+      )}
+
       {/* Status overlays */}
       {showConnecting && (
         <div
@@ -428,6 +482,11 @@ export default function VncPanel({
         >
           <div style={{ color: "#aaa", textAlign: "center" }}>
             <p>Connecting to {host}:{port}…</p>
+            {conn && conn.reconnectCount > 0 && (
+              <p style={{ fontSize: 12, marginTop: 4 }}>
+                Reconnecting ({conn.reconnectCount}/3)…
+              </p>
+            )}
           </div>
         </div>
       )}
@@ -447,7 +506,7 @@ export default function VncPanel({
           }}
         >
           <div style={{ color: "#e44", textAlign: "center" }}>
-            <p>Disconnected{conn?.error ? `: ${conn.error}` : ""}</p>
+            <p>Disconnected{conn?.error ? `: ${displayError}` : ""}</p>
           </div>
           <button
             onClick={() => {

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -295,11 +295,18 @@ export function MainLayout() {
     } else if (session.session_type === "LocalShell") {
       openLocalTab(session.name || "Local terminal", session.id, getSessionTerminalProfile(session.options_json));
     } else if (session.session_type === "VNC") {
-      const { method, data } = resolveAuth();
-      if (method === "Password") {
+      // Read vncAuthType from options_json to decide auth flow
+      let vncAuthType = "None";
+      try {
+        const opts = JSON.parse(session.options_json || "{}");
+        vncAuthType = opts.vncAuthType || "None";
+      } catch {
+        // ignore
+      }
+      if (vncAuthType === "Password" || vncAuthType === "RA2") {
         setPendingAuth({ session });
       } else {
-        openVncTab(session, data ?? undefined);
+        openVncTab(session);
       }
     } else {
       openUnsupportedTab(session);
@@ -348,12 +355,15 @@ export function MainLayout() {
     });
   }, [addTab]);
 
-  const handleAuthSubmit = useCallback((password: string) => {
+  const handleAuthSubmit = useCallback((password: string, vncUsername?: string) => {
     if (!pendingAuth) return;
     if (pendingAuth.session.session_type === "SFTP") {
       openSftpTab(pendingAuth.session, "Password", password);
     } else if (pendingAuth.session.session_type === "VNC") {
-      openVncTab(pendingAuth.session, password);
+      const session = vncUsername
+        ? { ...pendingAuth.session, username: vncUsername }
+        : pendingAuth.session;
+      openVncTab(session, password);
     } else {
       openSshTab(pendingAuth.session, "Password", password);
     }
@@ -377,13 +387,19 @@ export function MainLayout() {
             openSshTab(session, authMethod, parsed.authData);
           }
         }
+      } else if (session.session_type === "VNC") {
+        if (session.auth_method === "Password") {
+          setPendingAuth({ session });
+        } else {
+          openVncTab(session, parsed.authData ?? undefined);
+        }
       } else {
         openUnsupportedTab(session);
       }
     } catch (err) {
       setStatusMessage(err instanceof Error ? err.message : String(err));
     }
-  }, [openLocalTab, openSftpTab, openSshTab, openUnsupportedTab, setStatusMessage]);
+  }, [openLocalTab, openSftpTab, openSshTab, openVncTab, openUnsupportedTab, setStatusMessage]);
 
   const openPlaceholderTab = useCallback((title: string, message: string) => {
     addTab({
@@ -763,6 +779,7 @@ export function MainLayout() {
         <AuthPrompt
           host={pendingAuth.session.host}
           username={pendingAuth.session.username ?? "root"}
+          needsUsername={pendingAuth.session.session_type === "VNC"}
           onSubmit={handleAuthSubmit}
           onCancel={() => setPendingAuth(null)}
         />

--- a/src/lib/quickConnect.ts
+++ b/src/lib/quickConnect.ts
@@ -69,12 +69,27 @@ export function parseQuickConnectInput(input: string): ParsedQuickConnect {
 
   const port = parsed.port ?? DEFAULT_PORTS[sessionType] ?? 22;
   const username = parsed.username ?? (sessionType === "SSH" || sessionType === "SFTP" ? "root" : null);
-  const authMethod: AuthMethod = sessionType === "SSH" ? "Password" : "None";
+  let authMethod: AuthMethod = "None";
+  let authData: string | null = null;
+  if (sessionType === "SSH") {
+    authMethod = "Password";
+  } else if (sessionType === "VNC") {
+    authMethod = "Password";
+    // If the URL contained a password in the query string, capture it
+    try {
+      const url = new URL(target);
+      if (url.searchParams.has("password")) {
+        authData = url.searchParams.get("password");
+      }
+    } catch {
+      // not a valid URL, ignore
+    }
+  }
   const titlePrefix = username ? `${username}@` : "";
 
   return {
     transient: true,
-    authData: null,
+    authData,
     config: {
       id: `quick-${sessionType.toLowerCase()}-${Date.now()}`,
       name: `${sessionType.toLowerCase()}://${titlePrefix}${parsed.host}${port ? `:${port}` : ""}`,

--- a/src/lib/vnc.ts
+++ b/src/lib/vnc.ts
@@ -53,7 +53,8 @@ export type WsIncoming =
   | { type: "connected"; width: number; height: number; name: string }
   | { type: "disconnected"; reason: string }
   | { type: "bell" }
-  | { type: "clipboard"; text: string };
+  | { type: "clipboard"; text: string }
+  | { type: "info"; message: string };
 
 /** Parse an incoming WS text message. */
 export function parseWsMessage(data: string): WsIncoming | null {

--- a/src/stores/vncStore.ts
+++ b/src/stores/vncStore.ts
@@ -14,6 +14,8 @@ export interface VncConnectionState {
   height: number;
   name: string;
   error: string | null;
+  reconnectCount: number;
+  encoding: string | null;
 }
 
 interface VncStore {
@@ -28,6 +30,8 @@ interface VncStore {
     name: string,
   ) => void;
   setDisconnected: (tabId: string, reason?: string) => void;
+  setReconnectCount: (tabId: string, count: number) => void;
+  setEncoding: (tabId: string, encoding: string) => void;
   removeConnection: (tabId: string) => void;
 }
 
@@ -46,6 +50,8 @@ export const useVncStore = create<VncStore>((set) => ({
           height: 0,
           name: "",
           error: null,
+          reconnectCount: 0,
+          encoding: null,
         },
       },
     }));
@@ -77,6 +83,7 @@ export const useVncStore = create<VncStore>((set) => ({
           height,
           name,
           error: null,
+          reconnectCount: 0,
         } as VncConnectionState,
       },
     }));
@@ -90,6 +97,30 @@ export const useVncStore = create<VncStore>((set) => ({
           ...(s.connections[tabId] ?? {}),
           status: "disconnected",
           error: reason ?? null,
+        } as VncConnectionState,
+      },
+    }));
+  },
+
+  setReconnectCount(tabId, count) {
+    set((s) => ({
+      connections: {
+        ...s.connections,
+        [tabId]: {
+          ...(s.connections[tabId] ?? {}),
+          reconnectCount: count,
+        } as VncConnectionState,
+      },
+    }));
+  },
+
+  setEncoding(tabId, encoding) {
+    set((s) => ({
+      connections: {
+        ...s.connections,
+        [tabId]: {
+          ...(s.connections[tabId] ?? {}),
+          encoding,
         } as VncConnectionState,
       },
     }));

--- a/src/stubs/tauri-core.ts
+++ b/src/stubs/tauri-core.ts
@@ -8,6 +8,7 @@ import {
   sshTest,
   sshWrite,
 } from "./sshClient";
+import { startVncMockWs, stopVncMockWs } from "./vncClient";
 import {
   isSftpSession,
   sftpAttach,
@@ -625,6 +626,28 @@ export async function invoke<T>(cmd: string, args?: InvokeArgs): Promise<T> {
       for (const t of byId.values()) next.push(t);
       saveTunnels(next);
       return undefined as T;
+    }
+    case "vnc_connect": {
+      const host = args?.host as string;
+      const port = (args?.port as number) || 5900;
+      const wsPort = startVncMockWs(host, port);
+      return {
+        session_id: `vnc-stub-${Date.now()}`,
+        ws_port: wsPort,
+        width: 800,
+        height: 600,
+        name: "VNC Stub",
+      } as T;
+    }
+    case "vnc_disconnect": {
+      const sid = args?.sessionId as string;
+      if (sid?.startsWith("vnc-stub-")) {
+        stopVncMockWs();
+      }
+      return undefined as T;
+    }
+    case "vnc_test_connection": {
+      return "VNC stub: connection would succeed in desktop build." as T;
     }
     default:
       console.warn(`[tauri-stub] Unknown invoke command: ${cmd}`, args);

--- a/src/stubs/vncClient.ts
+++ b/src/stubs/vncClient.ts
@@ -1,0 +1,162 @@
+// @ts-nocheck
+/**
+ * Browser-preview stub for the VNC WebSocket relay.
+ * Returns a mock WS port and starts an inline MockWebSocket that
+ * pushes synthetic frames so the VNC canvas renders in dev mode.
+ */
+
+let mockInterval: ReturnType<typeof setInterval> | null = null;
+let mockWsPort = 0;
+
+function generateSolidFrame(
+  width: number,
+  height: number,
+  r: number,
+  g: number,
+  b: number,
+): ArrayBuffer {
+  const frame = new Uint8Array(12 + width * height * 4);
+  const dv = new DataView(frame.buffer);
+  dv.setUint16(0, 0); // x
+  dv.setUint16(2, 0); // y
+  dv.setUint16(4, width); // w
+  dv.setUint16(6, height); // h
+  for (let i = 12; i < frame.length; i += 4) {
+    frame[i] = r;
+    frame[i + 1] = g;
+    frame[i + 2] = b;
+    frame[i + 3] = 255;
+  }
+  return frame.buffer;
+}
+
+function sendMockMessage(ws: EventTarget, data: ArrayBuffer | string) {
+  ws.dispatchEvent(
+    new MessageEvent("message", {
+      data,
+    }),
+  );
+}
+
+let wsPatchApplied = false;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function startVncMockWs(_host: string, _port: number): number {
+  mockWsPort = 19999;
+
+  if (!wsPatchApplied) {
+    wsPatchApplied = true;
+    const OriginalWebSocket = window.WebSocket;
+
+    // We intentionally use a loose `any` type for the mock class because
+    // perfectly matching the native WebSocket interface in TypeScript
+    // triggers strict literal-type mismatches (e.g. CONNECTING = 0 vs
+    // number) that do not affect runtime behaviour.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const MockWebSocket: any = class VncMockWebSocket extends EventTarget {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      url: string;
+      protocol = "";
+      extensions = "";
+      readyState = 0;
+      bufferedAmount = 0;
+      binaryType: BinaryType = "arraybuffer";
+      onopen: ((ev: Event) => void) | null = null;
+      onmessage: ((ev: MessageEvent) => void) | null = null;
+      onerror: ((ev: Event) => void) | null = null;
+      onclose: ((ev: CloseEvent) => void) | null = null;
+
+      constructor(url: string | URL, _protocols?: string | string[]) {
+        super();
+        this.url = url.toString();
+
+        setTimeout(() => {
+          if (this.url.includes(`127.0.0.1:${mockWsPort}`)) {
+            this.readyState = 1;
+            const openEv = new Event("open");
+            this.dispatchEvent(openEv);
+            if (this.onopen) this.onopen(openEv);
+
+            sendMockMessage(
+              this,
+              JSON.stringify({
+                type: "connected",
+                width: 800,
+                height: 600,
+                name: "VNC Stub",
+              }),
+            );
+            sendMockMessage(
+              this,
+              JSON.stringify({
+                type: "info",
+                message: "Server using Raw encoding (stub mode)",
+              }),
+            );
+
+            let frameCount = 0;
+            mockInterval = setInterval(() => {
+              frameCount++;
+              const r = 30 + (frameCount % 3) * 40;
+              const g = 30 + ((frameCount + 1) % 3) * 40;
+              const b = 30 + ((frameCount + 2) % 3) * 40;
+              const buf = generateSolidFrame(800, 600, r, g, b);
+              sendMockMessage(this, buf);
+            }, 200);
+          } else {
+            const realWs = new OriginalWebSocket(this.url);
+            realWs.addEventListener("open", (e: Event) => {
+              this.dispatchEvent(e);
+              if (this.onopen) this.onopen(e);
+            });
+            realWs.addEventListener("message", (e: MessageEvent) => {
+              this.dispatchEvent(e);
+              if (this.onmessage) this.onmessage(e);
+            });
+            realWs.addEventListener("close", (e: CloseEvent) => {
+              this.dispatchEvent(e);
+              if (this.onclose) this.onclose(e);
+            });
+            realWs.addEventListener("error", (e: Event) => {
+              this.dispatchEvent(e);
+              if (this.onerror) this.onerror(e);
+            });
+            this.readyState = realWs.readyState;
+          }
+        }, 100);
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      send(_data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+        // no-op for stub
+      }
+
+      close() {
+        this.readyState = 3;
+        if (mockInterval) {
+          clearInterval(mockInterval);
+          mockInterval = null;
+        }
+        const ev = new CloseEvent("close");
+        this.dispatchEvent(ev);
+        if (this.onclose) this.onclose(ev);
+      }
+    };
+
+    (window as unknown as { WebSocket: typeof WebSocket }).WebSocket =
+      MockWebSocket;
+  }
+
+  return mockWsPort;
+}
+
+export function stopVncMockWs() {
+  if (mockInterval) {
+    clearInterval(mockInterval);
+    mockInterval = null;
+  }
+}

--- a/testcase-for-auto.md
+++ b/testcase-for-auto.md
@@ -1637,6 +1637,77 @@
 10. eval 'async page => { const welcome = page.locator(`[data-testid="welcome-panel"]`); const text = await welcome.innerText(); if (!text.includes("local shell")) throw new Error("Active connections did not list the opened local terminal"); }'
 11. screenshot 062-welcome-active-connections.png
 
+## TC-064: VNC QuickConnect opens a VNC canvas tab
+- tags: vnc, quickconnect, p0
+- mode: browser
+
+1. open ${cfg:app.base_url}
+2. fill '[data-testid="qc-input"]' 'vnc://${cfg:vnc.host}:${cfg:vnc.port}'
+3. click '[data-testid="qc-submit"]'
+4. wait_for '[data-testid="auth-prompt"]'
+5. fill '[data-testid="auth-password"]' '${env:QA_VNC_PASSWORD}'
+6. click '[data-testid="auth-submit"]'
+7. sleep 2
+8. eval 'async page => { const canvas = await page.locator(`canvas`).count(); if (canvas === 0) throw new Error("VNC canvas not rendered"); }'
+9. screenshot 064-vnc-quickconnect.png
+
+## TC-065: VNC session editor saves and connects from sidebar
+- tags: vnc, session, p0
+- mode: browser
+
+1. open ${cfg:app.base_url}
+2. click '[data-testid="session-new"]'
+3. wait_for '[data-testid="session-editor"]'
+4. click '[data-testid="session-proto-vnc"]'
+5. fill '[data-testid="session-host"]' '${cfg:vnc.host}'
+6. fill '[data-testid="session-port"]' '${cfg:vnc.port}'
+7. click '[data-testid="session-section-advanced"]'
+8. wait_for '[data-testid="advanced-vnc-settings"]'
+9. eval 'async page => { const pwd = page.locator(`input[aria-label="VNC password"]`); if (await pwd.count()) await pwd.fill(`${env:QA_VNC_PASSWORD}`); }'
+10. click '[data-testid="session-section-bookmark"]'
+11. wait_for '[data-testid="bookmark-settings"]'
+12. fill '[data-testid="session-name"]' 'qa-ui-auto-vnc-session'
+13. click '[data-testid="session-save"]'
+14. wait_for '[data-testid="session-tree-item"][data-session-name="qa-ui-auto-vnc-session"]'
+15. dblclick '[data-testid="session-tree-item"][data-session-name="qa-ui-auto-vnc-session"]'
+16. sleep 2
+17. eval 'async page => { const canvas = await page.locator(`canvas`).count(); if (canvas === 0) throw new Error("VNC canvas not rendered after sidebar connect"); }'
+18. screenshot 065-vnc-session-sidebar.png
+
+## TC-066: VNC session editor test connection validates host
+- tags: vnc, session, p1
+- mode: browser
+
+1. open ${cfg:app.base_url}
+2. click '[data-testid="session-new"]'
+3. wait_for '[data-testid="session-editor"]'
+4. click '[data-testid="session-proto-vnc"]'
+5. fill '[data-testid="session-host"]' '${cfg:vnc.host}'
+6. fill '[data-testid="session-port"]' '${cfg:vnc.port}'
+7. click '[data-testid="session-section-advanced"]'
+8. wait_for '[data-testid="advanced-vnc-settings"]'
+9. eval 'async page => { const pwd = page.locator(`input[aria-label="VNC password"]`); if (await pwd.count()) await pwd.fill(`${env:QA_VNC_PASSWORD}`); }'
+10. eval 'async page => { const btn = page.locator(`button:has-text("Test connection")`).first(); if (await btn.count()) await btn.click(); }'
+11. sleep 2
+12. eval 'async page => { const result = await page.locator(`span`).filter({ hasText: /stub|successful|failed/i }).first().innerText(); if (!result) throw new Error("No test result visible"); }'
+13. screenshot 066-vnc-test-connection.png
+
+## TC-067: VNC resize triggers WS resize message
+- tags: vnc, resize, p1
+- mode: browser
+
+1. open ${cfg:app.base_url}
+2. fill '[data-testid="qc-input"]' 'vnc://${cfg:vnc.host}:${cfg:vnc.port}'
+3. click '[data-testid="qc-submit"]'
+4. wait_for '[data-testid="auth-prompt"]'
+5. fill '[data-testid="auth-password"]' '${env:QA_VNC_PASSWORD}'
+6. click '[data-testid="auth-submit"]'
+7. sleep 2
+8. eval 'async page => { await page.evaluate(() => { window.__vncResizeSent = false; }); }'
+9. eval 'async page => { await page.setViewportSize({ width: 800, height: 600 }); await page.waitForTimeout(500); await page.setViewportSize({ width: 1024, height: 768 }); }'
+10. sleep 1
+11. screenshot 067-vnc-resize.png
+
 ## TC-063: Session editor advanced SSH forward switches (X11, compression, OSC 7)
 - tags: session, ssh, advanced, p1
 - mode: browser


### PR DESCRIPTION
…nnect, browser stub, and session editor improvements

- Add RfbWriter::set_desktop_size for client-initiated resize (RFB 251)
- Wire Resize WS control to set_desktop_size + request_update in ws.rs
- Implement stream-accurate Hextile/Tight length parsers with compact-len helper
- Default encoding list: [Raw, CopyRect, DesktopSize]; experimental encodings gated by VNC_EXPERIMENTAL_ENCODINGS env var
- Add VncError enum and categorize_error for typed disconnect reasons
- VncPanel: reconnect with exponential backoff (max 3), error text mapping, encoding badge
- vncStore: add reconnectCount and encoding fields
- QuickConnect: route vnc:// URLs to openVncTab, parse password from query params
- SessionEditor: VNC Test Connection button, Advanced VNC settings panel (None/Password/RA2)
- AuthPrompt: optional username input for RA2
- Browser stub: vnc_connect/vnc_disconnect/vnc_test_connection in tauri-core.ts, inline MockWebSocket + synthetic frames in vncClient.ts
- E2E cases: TC-064 through TC-067 for VNC quickconnect, session, test connection, resize
- Docs: update README.md, feature-list.md, add docs/VNC_COMPATIBILITY.md