### PR TITLE
feat: implement MultiExec broadcast mode for terminal tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "newmob",
   "private": true,
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/tabbar/TabBar.tsx
+++ b/src/components/tabbar/TabBar.tsx
@@ -27,6 +27,10 @@ export function TabBar() {
     removeTabs,
     addTab,
     toggleCompactMode,
+    multiExecActive,
+    multiExecSelectedTabIds,
+    toggleMultiExec,
+    toggleMultiExecTab,
   } = useAppStore();
   const ctx = useContextMenu();
 
@@ -81,31 +85,62 @@ export function TabBar() {
       style={{ background: "linear-gradient(to bottom, var(--moba-tab-inactive), var(--moba-chrome-bg))" }}
     >
       {ctx.render}
-      {tabs.map((tab) => (
-        <div
-          key={tab.id}
-          data-testid="tab-item"
-          data-tab-title={tab.title}
-          data-tab-type={tab.type}
-          className="moba-tab"
-          data-active={activeTabId === tab.id}
-          onClick={() => setActiveTab(tab.id)}
-          onMouseDown={(e) => handleMouseDown(e, tab)}
-          onContextMenu={(e) => handleTabContext(e, tab)}
-        >
-          <TabIcon kind={tab.type} ssh={!!tab.ssh} />
-          <span className="truncate max-w-[180px]">{tab.title}</span>
-          {tab.closable && (
-            <X
-              className="w-3 h-3 ml-1 opacity-60 hover:opacity-100"
-              onClick={(e) => {
-                e.stopPropagation();
-                removeTab(tab.id);
-              }}
-            />
-          )}
-        </div>
-      ))}
+      {tabs.map((tab) => {
+        const isSelected = multiExecActive && tab.type === "terminal" && multiExecSelectedTabIds.has(tab.id);
+        return (
+          <div
+            key={tab.id}
+            data-testid="tab-item"
+            data-tab-title={tab.title}
+            data-tab-type={tab.type}
+            data-multiexec-selected={isSelected || undefined}
+            className="moba-tab relative"
+            data-active={activeTabId === tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            onMouseDown={(e) => handleMouseDown(e, tab)}
+            onContextMenu={(e) => handleTabContext(e, tab)}
+          >
+            {multiExecActive && tab.type === "terminal" && (
+              <button
+                type="button"
+                title={isSelected ? "Remove from MultiExec" : "Add to MultiExec"}
+                className="absolute -top-0.5 -left-0.5 w-3 h-3 rounded-full border flex items-center justify-center z-10 flex-shrink-0"
+                style={{
+                  background: isSelected ? "var(--moba-accent)" : "var(--moba-chrome-bg)",
+                  borderColor: isSelected ? "var(--moba-accent)" : "var(--moba-divider)",
+                  fontSize: 7,
+                  color: isSelected ? "#fff" : "var(--moba-text-muted)",
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleMultiExecTab(tab.id);
+                }}
+              >
+                {isSelected ? "✓" : ""}
+              </button>
+            )}
+            <div className="relative flex-shrink-0">
+              <TabIcon kind={tab.type} ssh={!!tab.ssh} />
+              {tab.hasNewOutput && (
+                <span
+                  className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-emerald-500 pointer-events-none"
+                  aria-label="New output"
+                />
+              )}
+            </div>
+            <span className="truncate max-w-[180px]">{tab.title}</span>
+            {tab.closable && (
+              <X
+                className="w-3 h-3 ml-1 opacity-60 hover:opacity-100"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeTab(tab.id);
+                }}
+              />
+            )}
+          </div>
+        );
+      })}
 
       <button
         data-testid="new-local-terminal"
@@ -122,7 +157,12 @@ export function TabBar() {
         {!compactMode && (
           <>
             <IconBtn title="Split view is not active in this phase" icon={<SplitSquareVertical className="w-3.5 h-3.5" />} disabled />
-            <IconBtn title="MultiExec is not active in this phase" icon={<Users className="w-3.5 h-3.5" />} disabled />
+            <IconBtn
+              title={multiExecActive ? "Disable MultiExec" : "Enable MultiExec"}
+              icon={<Users className="w-3.5 h-3.5" />}
+              onClick={toggleMultiExec}
+              active={multiExecActive}
+            />
           </>
         )}
         <IconBtn

--- a/src/components/terminal/MultiExecBar.tsx
+++ b/src/components/terminal/MultiExecBar.tsx
@@ -1,0 +1,508 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import {
+  Users, X, Send, ChevronUp, ChevronDown, Maximize2, Clock, CornerDownLeft,
+} from "lucide-react";
+
+// Module-level history shared between compact bar and expanded panel
+const _history: string[] = [];
+
+export function getMultiExecHistory(): readonly string[] {
+  return _history;
+}
+
+function pushHistory(cmd: string) {
+  const trimmed = cmd.trim();
+  if (!trimmed) return;
+  const idx = _history.indexOf(trimmed);
+  if (idx !== -1) _history.splice(idx, 1);
+  _history.push(trimmed);
+}
+
+// ─── Expanded editor panel ────────────────────────────────────────────────────
+
+const MIN_HEIGHT = 180;
+const MAX_HEIGHT_RATIO = 0.85;
+const DEFAULT_HEIGHT = 340;
+
+interface ExpandedEditorProps {
+  initialValue: string;
+  onSend: (data: string) => void;
+  onClose: () => void;
+  onApplyToBar: (value: string) => void;
+}
+
+function ExpandedEditor({ initialValue, onSend, onClose, onApplyToBar }: ExpandedEditorProps) {
+  const [value, setValue] = useState(initialValue);
+  const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+  const [panelHeight, setPanelHeight] = useState(DEFAULT_HEIGHT);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const dragStartY = useRef<number | null>(null);
+  const dragStartHeight = useRef(DEFAULT_HEIGHT);
+
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  // Keyboard: Escape closes, Enter sends (when not in textarea)
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  // Drag-resize from top edge
+  const handleResizeMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    dragStartY.current = e.clientY;
+    dragStartHeight.current = panelHeight;
+
+    const onMove = (ev: MouseEvent) => {
+      if (dragStartY.current === null) return;
+      const delta = dragStartY.current - ev.clientY; // dragging up = taller
+      const maxH = Math.floor(window.innerHeight * MAX_HEIGHT_RATIO);
+      const next = Math.max(MIN_HEIGHT, Math.min(maxH, dragStartHeight.current + delta));
+      setPanelHeight(next);
+    };
+    const onUp = () => {
+      dragStartY.current = null;
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }, [panelHeight]);
+
+  const handleSend = useCallback(() => {
+    if (!value.trim()) return;
+    pushHistory(value.trim());
+    const lines = value.split("\n");
+    onSend(lines.join("\r\n") + "\r");
+    onClose();
+  }, [value, onSend, onClose]);
+
+  const handleApply = useCallback(() => {
+    onApplyToBar(value);
+    onClose();
+  }, [value, onApplyToBar, onClose]);
+
+  const handleHistoryClick = (cmd: string, idx: number) => {
+    setValue(cmd);
+    setSelectedIdx(idx);
+    textareaRef.current?.focus();
+  };
+
+  const history = getMultiExecHistory();
+  const lineCount = value.split("\n").length;
+
+  return (
+    // True modal backdrop — pointer events blocked, no click-to-close
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center"
+      style={{ background: "rgba(0,0,0,0.45)", pointerEvents: "all" }}
+    >
+      <div
+        className="flex flex-col shadow-2xl overflow-hidden"
+        style={{
+          width: "min(900px, 96vw)",
+          height: panelHeight,
+          background: "var(--moba-bg)",
+          border: "1px solid var(--moba-divider)",
+          borderBottom: "none",
+          borderRadius: "6px 6px 0 0",
+        }}
+      >
+        {/* Drag-resize handle on top edge */}
+        <div
+          className="flex-shrink-0 flex items-center justify-center"
+          style={{
+            height: 6,
+            cursor: "ns-resize",
+            background: "var(--moba-chrome-bg)",
+            borderBottom: "1px solid var(--moba-divider)",
+          }}
+          onMouseDown={handleResizeMouseDown}
+          title="Drag to resize"
+        >
+          <div
+            style={{
+              width: 32,
+              height: 3,
+              borderRadius: 2,
+              background: "var(--moba-divider)",
+            }}
+          />
+        </div>
+
+        {/* Header */}
+        <div
+          className="flex items-center gap-2 px-3 py-1.5 flex-shrink-0"
+          style={{
+            background: "var(--moba-chrome-bg)",
+            borderBottom: "1px solid var(--moba-divider)",
+          }}
+        >
+          <Users className="w-3.5 h-3.5" style={{ color: "#7a3d9d" }} />
+          <span className="text-xs font-semibold" style={{ color: "var(--moba-text)" }}>
+            MultiExec — Command Editor
+          </span>
+          <span className="text-[11px]" style={{ color: "var(--moba-text-muted)" }}>
+            Shift+Enter for newline · Enter to send · Esc to close
+          </span>
+          <div className="flex-1" />
+          <button
+            className="w-5 h-5 inline-flex items-center justify-center rounded hover:bg-[var(--moba-hover)]"
+            onClick={onClose}
+            type="button"
+            title="Close (Esc)"
+          >
+            <X className="w-3 h-3" />
+          </button>
+        </div>
+
+        {/* Body: editor + history sidebar */}
+        <div className="flex flex-1 min-h-0">
+          {/* Editor */}
+          <div className="flex flex-col flex-1 min-w-0 p-2 gap-2">
+            <textarea
+              ref={textareaRef}
+              className="moba-input flex-1 resize-none leading-5 p-2 font-mono text-xs"
+              style={{ height: "100%", minHeight: 0 }}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSend();
+                }
+                // Escape handled by window listener above
+              }}
+              spellCheck={false}
+              placeholder={"Enter command(s) to broadcast…\nShift+Enter for multiple lines"}
+            />
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <button
+                className="moba-btn flex items-center gap-1"
+                data-primary="true"
+                onClick={handleSend}
+                disabled={!value.trim()}
+                type="button"
+              >
+                <Send className="w-3 h-3" />
+                {lineCount > 1 ? `Send (${lineCount} lines)` : "Send"}
+              </button>
+              <button
+                className="moba-btn flex items-center gap-1"
+                onClick={handleApply}
+                type="button"
+                title="Copy to compact bar without sending"
+              >
+                <CornerDownLeft className="w-3 h-3" />
+                Apply to bar
+              </button>
+              <span className="text-[11px]" style={{ color: "var(--moba-text-muted)" }}>
+                {lineCount} line{lineCount !== 1 ? "s" : ""}
+              </span>
+            </div>
+          </div>
+
+          {/* History sidebar */}
+          {history.length > 0 && (
+            <div
+              className="flex flex-col flex-shrink-0 overflow-hidden"
+              style={{ width: 240, borderLeft: "1px solid var(--moba-divider)" }}
+            >
+              <div
+                className="px-2 py-1 text-[11px] font-semibold flex-shrink-0"
+                style={{
+                  background: "var(--moba-chrome-bg)",
+                  borderBottom: "1px solid var(--moba-divider)",
+                  color: "var(--moba-text-muted)",
+                }}
+              >
+                <Clock className="w-3 h-3 inline mr-1" />
+                History ({history.length})
+              </div>
+              <div className="flex-1 overflow-y-auto moba-scroll-y">
+                {[...history].reverse().map((cmd, i) => {
+                  const originalIdx = history.length - 1 - i;
+                  const isSelected = selectedIdx === originalIdx;
+                  const preview = cmd.length > 60 ? cmd.slice(0, 60) + "…" : cmd;
+                  return (
+                    <button
+                      key={originalIdx}
+                      type="button"
+                      className="w-full text-left px-2 py-1.5 flex flex-col gap-0.5"
+                      style={{
+                        background: isSelected ? "var(--moba-selected)" : undefined,
+                        borderBottom: "1px solid var(--moba-divider)",
+                      }}
+                      onMouseEnter={(e) => {
+                        if (!isSelected) (e.currentTarget as HTMLElement).style.background = "var(--moba-hover)";
+                      }}
+                      onMouseLeave={(e) => {
+                        if (!isSelected) (e.currentTarget as HTMLElement).style.background = "";
+                      }}
+                      onClick={() => handleHistoryClick(cmd, originalIdx)}
+                    >
+                      <span
+                        className="text-[11px] font-mono truncate block"
+                        style={{ color: "var(--moba-text)" }}
+                      >
+                        {preview}
+                      </span>
+                      <span className="text-[10px]" style={{ color: "var(--moba-text-muted)" }}>
+                        #{originalIdx + 1}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Compact bar ─────────────────────────────────────────────────────────────
+
+interface MultiExecBarProps {
+  selectedCount: number;
+  totalTerminalCount: number;
+  onSend: (data: string) => void;
+  onSelectAll: () => void;
+  onClearSelection: () => void;
+  onClose: () => void;
+}
+
+export function MultiExecBar({
+  selectedCount,
+  totalTerminalCount,
+  onSend,
+  onSelectAll,
+  onClearSelection,
+  onClose,
+}: MultiExecBarProps) {
+  const [value, setValue] = useState("");
+  const [historyIdx, setHistoryIdx] = useState<number | null>(null);
+  // Stash the in-progress value when navigating history
+  const draftRef = useRef("");
+  const [expanded, setExpanded] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => textareaRef.current?.focus());
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  // Auto-resize textarea
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 100)}px`;
+  }, [value]);
+
+  const handleSend = useCallback(() => {
+    if (!value.trim()) return;
+    pushHistory(value.trim());
+    setHistoryIdx(null);
+    draftRef.current = "";
+    const lines = value.split("\n");
+    onSend(lines.join("\r\n") + "\r");
+    setValue("");
+    const el = textareaRef.current;
+    if (el) el.style.height = "auto";
+    textareaRef.current?.focus();
+  }, [value, onSend]);
+
+  const navigateHistory = useCallback((direction: "up" | "down") => {
+    const history = getMultiExecHistory();
+    if (history.length === 0) return;
+
+    if (historyIdx === null) {
+      // Save current draft before entering history
+      draftRef.current = value;
+    }
+
+    let nextIdx: number | null;
+    if (direction === "up") {
+      if (historyIdx === null) {
+        nextIdx = history.length - 1;
+      } else {
+        nextIdx = historyIdx > 0 ? historyIdx - 1 : historyIdx;
+      }
+    } else {
+      if (historyIdx === null) return;
+      if (historyIdx >= history.length - 1) {
+        // Back to draft
+        nextIdx = null;
+        setValue(draftRef.current);
+        setHistoryIdx(null);
+        return;
+      }
+      nextIdx = historyIdx + 1;
+    }
+
+    setHistoryIdx(nextIdx);
+    if (nextIdx !== null) setValue(history[nextIdx]);
+  }, [historyIdx, value]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    } else if (e.key === "Escape") {
+      onClose();
+    } else if (e.key === "ArrowUp" && !e.shiftKey) {
+      // Only navigate history when on the first line
+      const el = textareaRef.current;
+      if (el && el.selectionStart === 0 && !value.includes("\n")) {
+        e.preventDefault();
+        navigateHistory("up");
+      }
+    } else if (e.key === "ArrowDown" && !e.shiftKey) {
+      const el = textareaRef.current;
+      const atEnd = el && el.selectionStart === el.value.length;
+      if (atEnd && !value.includes("\n")) {
+        e.preventDefault();
+        navigateHistory("down");
+      }
+    }
+  }, [handleSend, onClose, navigateHistory, value]);
+
+  const handleValueChange = (newVal: string) => {
+    setValue(newVal);
+    // If user edits while in history, exit history mode
+    if (historyIdx !== null) {
+      setHistoryIdx(null);
+      draftRef.current = "";
+    }
+  };
+
+  const lineCount = value.split("\n").length;
+  const history = getMultiExecHistory();
+
+  return (
+    <>
+      {expanded && (
+        <ExpandedEditor
+          initialValue={value}
+          onSend={(data) => { onSend(data); }}
+          onClose={() => setExpanded(false)}
+          onApplyToBar={(v) => { setValue(v); setHistoryIdx(null); }}
+        />
+      )}
+      <div
+        className="flex items-start gap-1.5 px-2 py-1 flex-shrink-0"
+        style={{
+          minHeight: 34,
+          background: "var(--moba-chrome-bg)",
+          borderTop: "1px solid var(--moba-divider)",
+        }}
+      >
+        <Users
+          className="w-3.5 h-3.5 flex-shrink-0 mt-1"
+          style={{ color: "#7a3d9d" }}
+        />
+        <div className="flex-1 flex items-start gap-1 min-w-0">
+          <textarea
+            ref={textareaRef}
+            className="moba-input flex-1 resize-none leading-5 py-0.5"
+            style={{ minHeight: 22, maxHeight: 100, overflow: "auto" }}
+            rows={1}
+            placeholder="Send to selected terminals… (Enter to send, Shift+Enter for newline)"
+            value={value}
+            onChange={(e) => handleValueChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            spellCheck={false}
+          />
+          {/* History navigation arrows */}
+          <div className="flex flex-col flex-shrink-0" style={{ marginTop: 1 }}>
+            <button
+              type="button"
+              className="w-4 h-3.5 inline-flex items-center justify-center rounded-t hover:bg-[var(--moba-hover)] disabled:opacity-30"
+              style={{ border: "1px solid var(--moba-divider)", borderBottom: "none", background: "var(--moba-button-to)" }}
+              onClick={() => navigateHistory("up")}
+              disabled={history.length === 0}
+              title="Previous command (↑)"
+            >
+              <ChevronUp className="w-2.5 h-2.5" />
+            </button>
+            <button
+              type="button"
+              className="w-4 h-3.5 inline-flex items-center justify-center rounded-b hover:bg-[var(--moba-hover)] disabled:opacity-30"
+              style={{ border: "1px solid var(--moba-divider)", background: "var(--moba-button-to)" }}
+              onClick={() => navigateHistory("down")}
+              disabled={historyIdx === null}
+              title="Next command (↓)"
+            >
+              <ChevronDown className="w-2.5 h-2.5" />
+            </button>
+          </div>
+          {/* Expand button */}
+          <button
+            type="button"
+            className="w-5 h-5 inline-flex items-center justify-center rounded hover:bg-[var(--moba-hover)] flex-shrink-0 mt-0.5"
+            style={{ border: "1px solid var(--moba-divider)" }}
+            onClick={() => setExpanded(true)}
+            title="Open expanded editor"
+          >
+            <Maximize2 className="w-3 h-3" />
+          </button>
+        </div>
+        <div className="flex items-center gap-1 flex-shrink-0 mt-0.5">
+          <button
+            className="moba-btn flex items-center"
+            data-primary="true"
+            onClick={handleSend}
+            disabled={!value.trim()}
+            type="button"
+            title={lineCount > 1 ? `Send ${lineCount} lines (Enter)` : "Send (Enter)"}
+          >
+            <Send className="w-3 h-3 mr-1" />
+            {lineCount > 1 ? `Send (${lineCount})` : "Send"}
+          </button>
+          <span className="moba-pill flex-shrink-0" style={{ fontSize: 11 }}>
+            {selectedCount} / {totalTerminalCount}
+          </span>
+          <button
+            className="text-[11px] px-1.5 py-0.5 rounded hover:bg-[var(--moba-hover)] flex-shrink-0"
+            style={{ color: "var(--moba-text-muted)" }}
+            onClick={onSelectAll}
+            type="button"
+            title="Select all terminals"
+          >
+            All
+          </button>
+          <button
+            className="text-[11px] px-1.5 py-0.5 rounded hover:bg-[var(--moba-hover)] flex-shrink-0"
+            style={{ color: "var(--moba-text-muted)" }}
+            onClick={onClearSelection}
+            type="button"
+            title="Clear selection"
+          >
+            Clear
+          </button>
+          <button
+            className="w-5 h-5 inline-flex items-center justify-center rounded hover:bg-[var(--moba-hover)] flex-shrink-0"
+            onClick={onClose}
+            type="button"
+            title="Close MultiExec"
+          >
+            <X className="w-3 h-3" />
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -98,6 +98,14 @@ interface TerminalPanelProps {
   cwdRequestToken?: number;
   /** Called once the backend terminal session ID is known (after connect). */
   onSessionReady?: (sessionId: string) => void;
+  /** Called whenever the terminal receives output (for new-output badge). */
+  onOutput?: () => void;
+  /** Whether MultiExec broadcast mode is active globally. */
+  multiExecActive?: boolean;
+  /** Whether this terminal is a selected broadcast target (shows visual indicator). */
+  isMultiExecTarget?: boolean;
+  /** Called with user input when MultiExec is active; parent broadcasts to other terminals. */
+  onInputBroadcast?: (data: string) => void;
 }
 
 const DEFAULT_FONT_SIZE = 14;
@@ -132,13 +140,23 @@ export function TerminalPanel({
   onCwdChange,
   cwdRequestToken = 0,
   onSessionReady,
+  onOutput,
+  multiExecActive,
+  isMultiExecTarget,
+  onInputBroadcast,
 }: TerminalPanelProps) {
   const cwdCallbackRef = useRef<typeof onCwdChange>(onCwdChange);
   const onSessionReadyRef = useRef<typeof onSessionReady>(onSessionReady);
+  const onOutputRef = useRef<typeof onOutput>(onOutput);
+  const onInputBroadcastRef = useRef<typeof onInputBroadcast>(onInputBroadcast);
+  const multiExecActiveRef = useRef(multiExecActive);
   useEffect(() => {
     cwdCallbackRef.current = onCwdChange;
     onSessionReadyRef.current = onSessionReady;
-  }, [onCwdChange, onSessionReady]);
+    onOutputRef.current = onOutput;
+    onInputBroadcastRef.current = onInputBroadcast;
+    multiExecActiveRef.current = multiExecActive;
+  }, [onCwdChange, onSessionReady, onOutput, onInputBroadcast, multiExecActive]);
   const containerRef = useRef<HTMLDivElement>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const searchAddonRef = useRef<SearchAddon | null>(null);
@@ -290,10 +308,22 @@ export function TerminalPanel({
 
   const writeInput = sendTerminalInput;
 
+  // Broadcast-aware input: used for paste and any injected text so that
+  // MultiExec mode forwards the same data to all selected terminals.
+  const writeBroadcastInput = useCallback((data: string) => {
+    if (multiExecActiveRef.current) {
+      onInputBroadcastRef.current?.(data);
+    }
+    sendTerminalInput(data);
+  }, [sendTerminalInput]);
+
   const writeXtermInput = useCallback((data: string) => {
     const filtered = imeGuardRef.current?.filterTerminalData(data) ?? data;
     if (filtered === null) {
       return;
+    }
+    if (multiExecActiveRef.current) {
+      onInputBroadcastRef.current?.(filtered);
     }
     sendTerminalInput(filtered);
   }, [sendTerminalInput]);
@@ -410,12 +440,12 @@ export function TerminalPanel({
       ) {
         return;
       }
-      writeInput(normalizePasteText(text));
+      writeBroadcastInput(normalizePasteText(text));
       focusTerminal();
     } catch (err) {
       setStatusMessage(err instanceof Error ? err.message : "Clipboard paste failed");
     }
-  }, [focusTerminal, multilinePasteConfirm, setStatusMessage, writeInput]);
+  }, [focusTerminal, multilinePasteConfirm, setStatusMessage, writeBroadcastInput]);
 
   const saveBufferToFile = useCallback(() => {
     const term = termRef.current;
@@ -980,6 +1010,7 @@ export function TerminalPanel({
           if (loggingActiveRef.current) {
             outputLogRef.current += new TextDecoder().decode(filtered);
           }
+          onOutputRef.current?.();
           term.write(filtered);
         },
         onStateChange: (state, progress) => {
@@ -1299,7 +1330,10 @@ export function TerminalPanel({
       ref={panelRef}
       data-testid="terminal-pane"
       className={panelClasses}
-      style={{ background: resolvedTheme.background ?? "#1d1f21" }}
+      style={{
+        background: resolvedTheme.background ?? "#1d1f21",
+        ...(isMultiExecTarget ? { borderTop: "2px solid var(--moba-accent)" } : {}),
+      }}
       onWheel={(event) => {
         if (!event.ctrlKey) return;
         event.preventDefault();
@@ -1312,6 +1346,15 @@ export function TerminalPanel({
       onContextMenu={handleTerminalContextMenu}
     >
       <div ref={containerRef} className="w-full h-full" />
+
+      {isMultiExecTarget && (
+        <div
+          className="absolute top-1 right-16 z-40 px-1.5 py-0.5 rounded pointer-events-none"
+          style={{ background: "var(--moba-accent)", color: "#fff", opacity: 0.85, fontSize: 10, fontWeight: 600 }}
+        >
+          ⊕ MultiExec
+        </div>
+      )}
 
       {keywordHighlights.length > 0 && (
         <div className="absolute inset-0 z-20 pointer-events-none">

--- a/src/index.css
+++ b/src/index.css
@@ -235,6 +235,13 @@ body {
 .moba-tab:hover:not([data-active="true"]) {
   background: var(--moba-hover);
 }
+.moba-tab[data-multiexec-selected="true"] {
+  border-left: 2px solid var(--moba-accent);
+  background: color-mix(in srgb, var(--moba-accent) 12%, var(--moba-tab-inactive));
+}
+.moba-tab[data-multiexec-selected="true"][data-active="true"] {
+  background: color-mix(in srgb, var(--moba-accent) 12%, var(--moba-tab-active));
+}
 
 .moba-app-titlebar {
   background: linear-gradient(to bottom, var(--moba-titlebar-from), var(--moba-titlebar-to));

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -16,6 +16,7 @@ import { StatusBar } from "../components/statusbar/StatusBar";
 import { AppTitleBar } from "../components/window/AppTitleBar";
 import { WindowResizeHandles } from "../components/window/WindowResizeHandles";
 import { TerminalPanel } from "../components/terminal/TerminalPanel";
+import { MultiExecBar } from "../components/terminal/MultiExecBar";
 import { SessionEditor } from "../components/session/SessionEditor";
 import { AuthPrompt } from "../components/session/AuthPrompt";
 import { SettingsPanel } from "../components/settings/SettingsPanel";
@@ -62,6 +63,12 @@ export function MainLayout() {
     toggleCompactMode,
     toggleXServer,
     setStatusMessage,
+    multiExecActive,
+    multiExecSelectedTabIds,
+    toggleMultiExec,
+    selectAllTerminalTabs,
+    clearMultiExecSelection,
+    setTabHasNewOutput,
   } = useAppStore();
   const { loadSessions, markConnected, sessions } = useSessionStore();
   const activeTab = tabs.find((t) => t.id === activeTabId);
@@ -117,6 +124,22 @@ export function MainLayout() {
     return true;
   }, [setStatusMessage]);
 
+  const broadcastToSelectedTerminals = useCallback((data: string, sourceTabId?: string) => {
+    const { multiExecSelectedTabIds: selectedIds } = useAppStore.getState();
+    for (const tabId of selectedIds) {
+      if (tabId === sourceTabId) continue; // skip the source terminal — it handles its own input
+      const sessionId = terminalSessionIds.current[tabId];
+      if (sessionId) {
+        writeTerminal(sessionId, encodeBase64(data)).catch(console.error);
+      }
+    }
+  }, []);
+
+  const handleTerminalOutput = useCallback((tabId: string) => {
+    if (tabId === useAppStore.getState().activeTabId) return;
+    setTabHasNewOutput(tabId, true);
+  }, [setTabHasNewOutput]);
+
   const openDetachedSftp = useCallback((params: SftpTabInfo, title: string) => {
     // Use a DIFFERENT session id for the detached window so its backend
     // SFTP channel is independent from the sidebar's. Without this, the
@@ -158,6 +181,10 @@ export function MainLayout() {
   useEffect(() => {
     void loadSessions();
   }, [loadSessions]);
+
+  useEffect(() => {
+    if (activeTabId) setTabHasNewOutput(activeTabId, false);
+  }, [activeTabId, setTabHasNewOutput]);
 
   useEffect(() => {
     tabsRef.current = tabs;
@@ -489,8 +516,10 @@ export function MainLayout() {
         }
         break;
       case "split":
+        setStatusMessage("Split view is not active in this phase");
+        break;
       case "multiexec":
-        setStatusMessage(`${command === "split" ? "Split view" : "MultiExec"} is not active in this phase`);
+        toggleMultiExec();
         break;
       case "exit":
         requestAppExit();
@@ -630,6 +659,16 @@ export function MainLayout() {
           <Panel>
             <div className="h-full flex flex-col min-w-0">
               {!compactMode && <TabBar />}
+              {multiExecActive && (
+                <MultiExecBar
+                  selectedCount={multiExecSelectedTabIds.size}
+                  totalTerminalCount={tabs.filter((t) => t.type === "terminal").length}
+                  onSend={broadcastToSelectedTerminals}
+                  onSelectAll={selectAllTerminalTabs}
+                  onClearSelection={clearMultiExecSelection}
+                  onClose={toggleMultiExec}
+                />
+              )}
               <div className="flex-1 min-h-0 overflow-hidden relative">
                 {/* Welcome panel */}
                 {(activeTab?.type === "welcome" || !activeTab) && (
@@ -660,6 +699,10 @@ export function MainLayout() {
                         onCwdChange={tab.ssh ? (cwd) => handleTerminalCwd(tab.id, cwd) : undefined}
                         cwdRequestToken={terminalCwdRequestTokens[tab.id] ?? 0}
                         onSessionReady={(sid) => { terminalSessionIds.current[tab.id] = sid; }}
+                        onOutput={() => handleTerminalOutput(tab.id)}
+                        multiExecActive={multiExecActive}
+                        isMultiExecTarget={multiExecActive && multiExecSelectedTabIds.has(tab.id)}
+                        onInputBroadcast={isActive && multiExecActive ? (data) => broadcastToSelectedTerminals(data, tab.id) : undefined}
                       />
                       {tab.ssh && (
                         <button

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -13,6 +13,8 @@ interface AppState {
   activeSideTab: SideTab;
   xServerEnabled: boolean;
   statusMessage: string;
+  multiExecActive: boolean;
+  multiExecSelectedTabIds: Set<string>;
 
   addTab: (tab: Tab) => void;
   removeTab: (id: string) => void;
@@ -26,6 +28,11 @@ interface AppState {
   setActiveSideTab: (tab: SideTab) => void;
   toggleXServer: () => void;
   setStatusMessage: (message: string) => void;
+  toggleMultiExec: () => void;
+  toggleMultiExecTab: (tabId: string) => void;
+  selectAllTerminalTabs: () => void;
+  clearMultiExecSelection: () => void;
+  setTabHasNewOutput: (tabId: string, hasNewOutput: boolean) => void;
 }
 
 function readCompactMode() {
@@ -59,6 +66,8 @@ export const useAppStore = create<AppState>((set) => ({
   activeSideTab: "sessions",
   xServerEnabled: false,
   statusMessage: "Ready",
+  multiExecActive: false,
+  multiExecSelectedTabIds: new Set(),
 
   addTab: (tab) =>
     set((s) => ({
@@ -125,4 +134,43 @@ export const useAppStore = create<AppState>((set) => ({
     })),
 
   setStatusMessage: (message) => set({ statusMessage: message }),
+
+  toggleMultiExec: () =>
+    set((s) => {
+      const next = !s.multiExecActive;
+      return {
+        multiExecActive: next,
+        multiExecSelectedTabIds: new Set(),
+        tabs: next ? s.tabs : s.tabs.map((t) => ({ ...t, hasNewOutput: false })),
+        statusMessage: next ? "MultiExec enabled" : "MultiExec disabled",
+      };
+    }),
+
+  toggleMultiExecTab: (tabId) =>
+    set((s) => {
+      const next = new Set(s.multiExecSelectedTabIds);
+      if (next.has(tabId)) {
+        next.delete(tabId);
+      } else {
+        next.add(tabId);
+      }
+      return { multiExecSelectedTabIds: next };
+    }),
+
+  selectAllTerminalTabs: () =>
+    set((s) => ({
+      multiExecSelectedTabIds: new Set(
+        s.tabs.filter((t) => t.type === "terminal").map((t) => t.id),
+      ),
+    })),
+
+  clearMultiExecSelection: () =>
+    set({ multiExecSelectedTabIds: new Set() }),
+
+  setTabHasNewOutput: (tabId, hasNewOutput) =>
+    set((s) => {
+      const tab = s.tabs.find((t) => t.id === tabId);
+      if (!tab || tab.hasNewOutput === hasNewOutput) return s;
+      return { tabs: s.tabs.map((t) => (t.id === tabId ? { ...t, hasNewOutput } : t)) };
+    }),
 }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,7 @@ export interface Tab {
   message?: string;
   sftp?: SftpTabInfo;
   vnc?: VncConnectInfo;
+  hasNewOutput?: boolean;
 }
 
 export interface SftpTabInfo {


### PR DESCRIPTION
Add MultiExec feature allowing simultaneous input broadcast to multiple selected terminal tabs, inspired by MobaXterm/XShell multi-exec design.

- New MultiExecBar component: compact bar with auto-resize textarea, up/down history navigation, and expandable editor popup
- Expanded editor: drag-resizable modal (top-edge handle), history sidebar with click-to-load, Send and Apply-to-bar actions
- Module-level command history with deduplication (shared across bar and expanded editor)
- Tab selection indicators in TabBar with per-tab toggle circles
- Output badge (green dot) on inactive tabs receiving new output
- Broadcast architecture: active terminal sends via onInputBroadcast callback; source tab skipped to prevent duplicate input
- Paste broadcasting fixed via writeBroadcastInput helper
- Visual indicator (accent border + badge) on MultiExec-targeted terminals
- appStore: multiExecActive, multiExecSelectedTabIds, and 5 new actions
- True modal behavior: only closable via X button or Escape key