### PR TITLE
add inline command history suggestions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "newmob",
   "private": true,
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/src/history.rs
+++ b/src-tauri/src/history.rs
@@ -1,0 +1,130 @@
+use crate::state::AppState;
+use rusqlite::params;
+use tauri::State;
+
+const MAX_LIMIT: i64 = 50_000;
+const MIN_LIMIT: i64 = 100;
+
+fn clamp_cap(cap: i64) -> i64 {
+    cap.clamp(MIN_LIMIT, MAX_LIMIT)
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[tauri::command]
+pub async fn history_append(
+    host_key: String,
+    command: String,
+    max: i64,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let trimmed = command.trim_matches(|c: char| c == '\r' || c == '\n');
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+
+    let cap = clamp_cap(max);
+    let ts = now_secs();
+
+    let mut db = state.db.lock().map_err(|e| e.to_string())?;
+    let tx = db.transaction().map_err(|e| e.to_string())?;
+
+    tx.execute(
+        "INSERT INTO command_history (host_key, command, last_used_at, use_count)
+         VALUES (?1, ?2, ?3, 1)
+         ON CONFLICT(host_key, command)
+         DO UPDATE SET last_used_at = excluded.last_used_at,
+                       use_count = use_count + 1",
+        params![host_key, trimmed, ts],
+    )
+    .map_err(|e| e.to_string())?;
+
+    tx.execute(
+        "DELETE FROM command_history
+         WHERE host_key = ?1
+           AND id NOT IN (
+               SELECT id FROM command_history
+               WHERE host_key = ?1
+               ORDER BY last_used_at DESC
+               LIMIT ?2
+           )",
+        params![host_key, cap],
+    )
+    .map_err(|e| e.to_string())?;
+
+    tx.commit().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn history_match_prefix(
+    host_key: String,
+    prefix: String,
+    limit: i64,
+    state: State<'_, AppState>,
+) -> Result<Vec<String>, String> {
+    let limit = limit.clamp(1, 500);
+    let db = state.db.lock().map_err(|e| e.to_string())?;
+    let mut stmt = db
+        .prepare(
+            "SELECT command FROM command_history
+             WHERE host_key = ?1 AND substr(command, 1, ?2) = ?3
+             ORDER BY last_used_at DESC
+             LIMIT ?4",
+        )
+        .map_err(|e| e.to_string())?;
+
+    let prefix_len = prefix.chars().count() as i64;
+    let rows = stmt
+        .query_map(params![host_key, prefix_len, prefix, limit], |row| {
+            row.get::<_, String>(0)
+        })
+        .map_err(|e| e.to_string())?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn history_list_recent(
+    host_key: String,
+    limit: i64,
+    state: State<'_, AppState>,
+) -> Result<Vec<String>, String> {
+    let limit = limit.clamp(1, 2000);
+    let db = state.db.lock().map_err(|e| e.to_string())?;
+    let mut stmt = db
+        .prepare(
+            "SELECT command FROM command_history
+             WHERE host_key = ?1
+             ORDER BY last_used_at DESC
+             LIMIT ?2",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map(params![host_key, limit], |row| row.get::<_, String>(0))
+        .map_err(|e| e.to_string())?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn history_clear(
+    host_key: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = state.db.lock().map_err(|e| e.to_string())?;
+    match host_key {
+        Some(h) => {
+            db.execute("DELETE FROM command_history WHERE host_key = ?1", params![h])
+                .map_err(|e| e.to_string())?;
+        }
+        None => {
+            db.execute("DELETE FROM command_history", [])
+                .map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod serial;
 mod config;
 mod appearance;
 mod vnc;
+mod history;
 
 use state::AppState;
 use tauri::{AppHandle, Manager, WebviewWindowBuilder};
@@ -127,6 +128,10 @@ pub fn run() {
             vnc::vnc_connect,
             vnc::vnc_disconnect,
             vnc::vnc_test_connection,
+            history::history_append,
+            history::history_match_prefix,
+            history::history_list_recent,
+            history::history_clear,
             exit_app,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/session/db.rs
+++ b/src-tauri/src/session/db.rs
@@ -28,8 +28,19 @@ pub fn init_db(conn: &Connection) -> SqlResult<()> {
             FOREIGN KEY (parent_id) REFERENCES session_groups(id)
         );
 
+        CREATE TABLE IF NOT EXISTS command_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            host_key TEXT NOT NULL,
+            command TEXT NOT NULL,
+            last_used_at INTEGER NOT NULL,
+            use_count INTEGER NOT NULL DEFAULT 1,
+            UNIQUE(host_key, command)
+        );
+
         CREATE INDEX IF NOT EXISTS idx_sessions_group ON sessions(group_path);
-        CREATE INDEX IF NOT EXISTS idx_sessions_type ON sessions(session_type);",
+        CREATE INDEX IF NOT EXISTS idx_sessions_type ON sessions(session_type);
+        CREATE INDEX IF NOT EXISTS idx_history_host_time
+            ON command_history(host_key, last_used_at DESC);",
     )
 }
 

--- a/src/components/terminal/TerminalAppearanceSettings.test.tsx
+++ b/src/components/terminal/TerminalAppearanceSettings.test.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_TERMINAL_PROFILE, type TerminalProfile } from "../../lib/termin
 
 const ipcMocks = vi.hoisted(() => ({
   listSystemFonts: vi.fn(),
+  historyClear: vi.fn(async () => undefined),
 }));
 
 vi.mock("../../lib/ipc", () => ({

--- a/src/components/terminal/TerminalAppearanceSettings.tsx
+++ b/src/components/terminal/TerminalAppearanceSettings.tsx
@@ -19,6 +19,7 @@ import {
   useSystemFonts,
   useTerminalFontOptions,
 } from "../../lib/systemFonts";
+import { historyClear } from "../../lib/ipc";
 
 interface TerminalAppearanceSettingsProps {
   profile: TerminalProfile;
@@ -58,6 +59,10 @@ export function TerminalAppearanceSettings({
   const [fg, setFg] = useState(colors.foreground);
   const [fontSizeText, setFontSizeText] = useState(String(profile.fontSize));
   const [scrollbackText, setScrollbackText] = useState(String(profile.scrollback));
+  const [inlineSuggestionsMaxText, setInlineSuggestionsMaxText] = useState(
+    String(profile.inlineSuggestionsMax),
+  );
+  const [clearingHistory, setClearingHistory] = useState(false);
   const draftProfileRef = useRef(profile);
 
   useEffect(() => {
@@ -77,6 +82,10 @@ export function TerminalAppearanceSettings({
   useEffect(() => {
     setScrollbackText(String(profile.scrollback));
   }, [profile.scrollback]);
+
+  useEffect(() => {
+    setInlineSuggestionsMaxText(String(profile.inlineSuggestionsMax));
+  }, [profile.inlineSuggestionsMax]);
 
   const updateProfile = (patch: Partial<TerminalProfile>) => {
     const next = { ...draftProfileRef.current, ...patch };
@@ -340,6 +349,75 @@ export function TerminalAppearanceSettings({
               checked={profile.loggingEnabled}
               onChange={(checked) => updateProfile({ loggingEnabled: checked })}
             />
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-md border border-[var(--moba-divider)] bg-[var(--moba-panel-bg)] p-3">
+        <div className="text-[12px] font-semibold mb-2">Inline command suggestions</div>
+        <div className="grid grid-cols-12 gap-x-3 gap-y-3 text-[12px] items-end">
+          <div className="col-span-12 md:col-span-7">
+            <CheckControl
+              label="Show ghost-text suggestions from command history"
+              checked={profile.inlineSuggestions}
+              onChange={(checked) => updateProfile({ inlineSuggestions: checked })}
+            />
+            <p className="mt-1 text-[11px] text-[var(--moba-text-muted)] leading-snug">
+              Press → or End at the end of the line to accept. Recommended with a bar or
+              underline cursor. Ignored for local PowerShell (its PSReadLine already provides
+              predictions).
+            </p>
+          </div>
+
+          <label className="col-span-8 md:col-span-3">
+            <span className="block mb-1 text-[var(--moba-text-muted)]">Max entries per host</span>
+            <input
+              className="moba-input w-28"
+              value={inlineSuggestionsMaxText}
+              aria-label="Maximum command history entries per host"
+              inputMode="numeric"
+              disabled={!profile.inlineSuggestions}
+              onChange={(event) => {
+                const next = event.target.value;
+                if (!/^\d*$/.test(next)) return;
+                setInlineSuggestionsMaxText(next);
+                const parsed = Number(next);
+                if (Number.isFinite(parsed) && parsed >= 100 && parsed <= 50000) {
+                  updateProfile({ inlineSuggestionsMax: Math.round(parsed) });
+                }
+              }}
+              onBlur={() => {
+                const parsed = Number(inlineSuggestionsMaxText);
+                if (Number.isFinite(parsed) && parsed > 0) {
+                  const clamped = Math.max(100, Math.min(50000, Math.round(parsed)));
+                  setInlineSuggestionsMaxText(String(clamped));
+                  updateProfile({ inlineSuggestionsMax: clamped });
+                } else {
+                  setInlineSuggestionsMaxText(String(profile.inlineSuggestionsMax));
+                }
+              }}
+            />
+          </label>
+
+          <div className="col-span-12 md:col-span-2 flex md:justify-end">
+            <button
+              type="button"
+              className="moba-btn h-8 px-2 text-[11px]"
+              disabled={clearingHistory}
+              onClick={() => {
+                if (!window.confirm("Clear all command history? This affects every host.")) {
+                  return;
+                }
+                setClearingHistory(true);
+                historyClear(null)
+                  .catch((err) => {
+                    console.error("Failed to clear history", err);
+                  })
+                  .finally(() => setClearingHistory(false));
+              }}
+            >
+              Clear all history
+            </button>
           </div>
         </div>
       </section>

--- a/src/components/terminal/TerminalPanel.test.tsx
+++ b/src/components/terminal/TerminalPanel.test.tsx
@@ -71,6 +71,10 @@ const ipcMocks = vi.hoisted(() => ({
   writeStreamClose: vi.fn(async () => undefined),
   writeStreamOpen: vi.fn(async () => "stream-handle"),
   checkFileExists: vi.fn(async () => false),
+  historyAppend: vi.fn(async () => undefined),
+  historyMatchPrefix: vi.fn(async () => [] as string[]),
+  historyListRecent: vi.fn(async () => [] as string[]),
+  historyClear: vi.fn(async () => undefined),
 }));
 
 vi.mock("@xterm/xterm", () => ({

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -33,6 +33,7 @@ import {
   createInputEchoSuppressor,
   type InputEchoSuppressor,
 } from "../../lib/terminalOutputFilter";
+import { makeHostKey, useCommandHistory } from "../../lib/history";
 import {
   createTerminalSessionId,
   createLocalTerminal,
@@ -193,6 +194,8 @@ export function TerminalPanel({
   const [rightClickBehavior, setRightClickBehavior] = useState(initialProfile.rightClickBehavior);
   const [loggingActive, setLoggingActive] = useState(initialProfile.loggingEnabled);
   const [multilinePasteConfirm, setMultilinePasteConfirm] = useState(initialProfile.multilinePasteConfirm);
+  const [inlineSuggestionsEnabled, setInlineSuggestionsEnabled] = useState(initialProfile.inlineSuggestions);
+  const [inlineSuggestionsMax, setInlineSuggestionsMax] = useState(initialProfile.inlineSuggestionsMax);
   const [fullscreen, setFullscreen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [eventLogOpen, setEventLogOpen] = useState(false);
@@ -280,6 +283,8 @@ export function TerminalPanel({
     multilinePasteConfirm,
     syntaxMode,
     loggingEnabled: loggingActive,
+    inlineSuggestions: inlineSuggestionsEnabled,
+    inlineSuggestionsMax,
   }), [
     cursorBlink,
     cursorStyle,
@@ -294,8 +299,147 @@ export function TerminalPanel({
     scrollback,
     showScrollbar,
     syntaxMode,
+    inlineSuggestionsEnabled,
+    inlineSuggestionsMax,
     themeName,
   ]);
+
+  // Per-host command history for inline ghost-text suggestions.
+  const historyHostKey = useMemo(() => makeHostKey(ssh), [ssh]);
+  const isLocalPowerShell = useMemo(
+    () => !ssh && (localShell?.id === "powershell" || localShell?.id === "windows-powershell"),
+    [ssh, localShell?.id],
+  );
+  const suggestionsActive = inlineSuggestionsEnabled && !isLocalPowerShell;
+  const history = useCommandHistory(historyHostKey, inlineSuggestionsMax);
+
+  // Refs decouple the once-mounted xterm.onData callback from the live
+  // history/enabled values. Without this, the initial writeXtermInput closure
+  // captures the empty prewarm cache and never sees later state changes.
+  const historyRef = useRef(history);
+  const suggestionsActiveRef = useRef(suggestionsActive);
+  useEffect(() => {
+    historyRef.current = history;
+    suggestionsActiveRef.current = suggestionsActive;
+  }, [history, suggestionsActive]);
+
+  // State shared between onData tracking and the ghost renderer.
+  const pendingRef = useRef("");
+  const invalidatedRef = useRef(false);
+  const suggestionRef = useRef<string | null>(null);
+  const [ghostTick, setGhostTick] = useState(0);
+  const ghostVisibleRef = useRef(false);
+
+  const bumpGhost = useCallback(() => setGhostTick((v) => v + 1), []);
+
+  const refreshSuggestion = useCallback(() => {
+    if (!suggestionsActiveRef.current || invalidatedRef.current || pendingRef.current === "") {
+      if (suggestionRef.current !== null) {
+        suggestionRef.current = null;
+      }
+      bumpGhost();
+      return;
+    }
+    const prefix = pendingRef.current;
+    const matches = historyRef.current.match(prefix, 1);
+    const next = matches[0] && matches[0].length > prefix.length ? matches[0] : null;
+    suggestionRef.current = next;
+    bumpGhost();
+  }, [bumpGhost]);
+
+  const invalidatePending = useCallback(() => {
+    if (invalidatedRef.current && suggestionRef.current === null) return;
+    invalidatedRef.current = true;
+    suggestionRef.current = null;
+    bumpGhost();
+  }, [bumpGhost]);
+
+  const trackPending = useCallback((data: string) => {
+    if (!suggestionsActiveRef.current) return;
+
+    // Bracketed paste: whole block is shell input, never a typed command.
+    if (data.startsWith("\x1b[200~")) {
+      invalidatePending();
+      return;
+    }
+
+    // Defensive: large chunk with any control char → treat as paste, invalidate.
+    if (data.length > 64) {
+      invalidatePending();
+      return;
+    }
+
+    let changed = false;
+    for (let i = 0; i < data.length; i++) {
+      const code = data.charCodeAt(i);
+
+      // CR / LF → Enter: commit the actual command on screen (handles Tab
+      // completion, history recall, etc.), fall back to tracked pending.
+      if (code === 0x0d || code === 0x0a) {
+        let committed: string | null = null;
+        const term = termRef.current;
+        if (term && term.buffer.active.type !== "alternate") {
+          const fromBuffer = captureBufferCommand(term);
+          if (fromBuffer) committed = fromBuffer;
+        }
+        if (!committed && pendingRef.current !== "" && !invalidatedRef.current) {
+          committed = pendingRef.current;
+        }
+        if (committed) historyRef.current.commit(committed);
+        pendingRef.current = "";
+        invalidatedRef.current = false;
+        changed = true;
+        continue;
+      }
+
+      // Ctrl+C: cancel current line entirely, but re-enable suggestions immediately.
+      if (code === 0x03) {
+        pendingRef.current = "";
+        invalidatedRef.current = false;
+        changed = true;
+        continue;
+      }
+
+      // Backspace / DEL.
+      if (code === 0x08 || code === 0x7f) {
+        if (!invalidatedRef.current && pendingRef.current.length > 0) {
+          pendingRef.current = pendingRef.current.slice(0, -1);
+          changed = true;
+        }
+        continue;
+      }
+
+      // Escape or any CSI-like sequence — arrows, Home/End, Tab completion, function
+      // keys: give up on the current line until the next Enter.
+      if (code === 0x1b || code === 0x09) {
+        invalidatedRef.current = true;
+        changed = true;
+        // Skip rest of this data chunk; it's almost certainly a single escape seq.
+        break;
+      }
+
+      // Other C0 control chars (Ctrl+A/E/U/W/K/L/R/...) → invalidate.
+      if (code < 0x20) {
+        invalidatedRef.current = true;
+        changed = true;
+        break;
+      }
+
+      // Printable: append unless we're already invalidated.
+      if (!invalidatedRef.current) {
+        pendingRef.current += data[i];
+        changed = true;
+      }
+    }
+
+    if (changed) refreshSuggestion();
+  }, [invalidatePending, refreshSuggestion]);
+
+  // Rerun suggestion matching whenever the live cache or the on/off toggles
+  // change — this is what picks up a freshly-prewarmed history list.
+  useEffect(() => {
+    refreshSuggestion();
+  }, [suggestionsActive, history, refreshSuggestion]);
 
   const sendTerminalInput = useCallback((data: string) => {
     const sid = sessionIdRef.current;
@@ -311,22 +455,24 @@ export function TerminalPanel({
   // Broadcast-aware input: used for paste and any injected text so that
   // MultiExec mode forwards the same data to all selected terminals.
   const writeBroadcastInput = useCallback((data: string) => {
+    trackPending(data);
     if (multiExecActiveRef.current) {
       onInputBroadcastRef.current?.(data);
     }
     sendTerminalInput(data);
-  }, [sendTerminalInput]);
+  }, [sendTerminalInput, trackPending]);
 
   const writeXtermInput = useCallback((data: string) => {
     const filtered = imeGuardRef.current?.filterTerminalData(data) ?? data;
     if (filtered === null) {
       return;
     }
+    trackPending(filtered);
     if (multiExecActiveRef.current) {
       onInputBroadcastRef.current?.(filtered);
     }
     sendTerminalInput(filtered);
-  }, [sendTerminalInput]);
+  }, [sendTerminalInput, trackPending]);
 
   const writeBinaryInput = useCallback((data: string) => {
     const sid = sessionIdRef.current;
@@ -653,6 +799,39 @@ export function TerminalPanel({
     focusTerminal();
   }, [appendEvent, focusTerminal, setStatusMessage, writeInput]);
 
+  // Sends raw input to the terminal (and broadcasts when MultiExec is active)
+  // WITHOUT running the pending-command tracker. Used by inline-suggestion
+  // accept, which manages pending state explicitly.
+  const sendUntrackedInput = useCallback((data: string) => {
+    if (multiExecActiveRef.current) {
+      onInputBroadcastRef.current?.(data);
+    }
+    sendTerminalInput(data);
+  }, [sendTerminalInput]);
+
+  const acceptInlineSuggestion = useCallback((): boolean => {
+    if (!suggestionsActiveRef.current) return false;
+    const term = termRef.current;
+    if (!term || term.buffer.active.type === "alternate") return false;
+    const suggestion = suggestionRef.current;
+    const pending = pendingRef.current;
+    if (!suggestion || !pending || suggestion.length <= pending.length) return false;
+    if (invalidatedRef.current) return false;
+    if (!ghostVisibleRef.current) return false;
+
+    const suffix = suggestion.slice(pending.length);
+    if (suffix.length === 0) return false;
+
+    sendUntrackedInput(suffix);
+
+    pendingRef.current = suggestion;
+    invalidatedRef.current = false;
+    suggestionRef.current = null;
+    refreshSuggestion();
+    bumpGhost();
+    return true;
+  }, [sendUntrackedInput, refreshSuggestion, bumpGhost]);
+
   const handleShortcutKey = useCallback((event: KeyboardEvent): boolean => {
     if (event.key === "F11") {
       event.preventDefault();
@@ -699,8 +878,18 @@ export function TerminalPanel({
       closeSearch();
       return false;
     }
+    if (
+      (event.key === "ArrowRight" || event.key === "End") &&
+      !event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey
+    ) {
+      if (acceptInlineSuggestion()) {
+        event.preventDefault();
+        return false;
+      }
+    }
     return true;
   }, [
+    acceptInlineSuggestion,
     closeSearch,
     decreaseFontSize,
     executeMacro,
@@ -893,6 +1082,8 @@ export function TerminalPanel({
     setRightClickBehavior(terminalProfile.rightClickBehavior);
     setLoggingActive(terminalProfile.loggingEnabled);
     setMultilinePasteConfirm(terminalProfile.multilinePasteConfirm);
+    setInlineSuggestionsEnabled(terminalProfile.inlineSuggestions);
+    setInlineSuggestionsMax(terminalProfile.inlineSuggestionsMax);
   }, [terminalProfile, theme]);
 
   useEffect(() => {
@@ -1303,6 +1494,26 @@ export function TerminalPanel({
     [fontSize, fullscreen, showScrollbar, syntaxMode, viewportVersion],
   );
 
+  const inlineGhost = useMemo(
+    () => computeInlineGhost(
+      termRef.current,
+      panelRef.current,
+      containerRef.current,
+      suggestionsActive,
+      pendingRef.current,
+      suggestionRef.current,
+      invalidatedRef.current,
+    ),
+    // ghostTick bumps on pending/suggestion changes; viewportVersion on scroll/render.
+    // fontSize/fullscreen/showScrollbar also force recompute on layout shifts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [ghostTick, viewportVersion, suggestionsActive, fontSize, fullscreen, showScrollbar],
+  );
+
+  useEffect(() => {
+    ghostVisibleRef.current = inlineGhost !== null;
+  }, [inlineGhost]);
+
   const panelClasses = [
     "relative w-full h-full",
     fullscreen ? "fixed inset-0 z-[9000]" : "",
@@ -1387,6 +1598,25 @@ export function TerminalPanel({
               }}
             />
           ))}
+        </div>
+      )}
+
+      {inlineGhost && (
+        <div
+          className="terminal-inline-ghost"
+          aria-hidden
+          style={{
+            left: inlineGhost.left,
+            top: inlineGhost.top,
+            height: inlineGhost.height,
+            maxWidth: inlineGhost.maxWidth,
+            fontFamily,
+            fontSize,
+            lineHeight: `${inlineGhost.height}px`,
+            color: resolvedTheme.foreground ?? "#eaeaea",
+          }}
+        >
+          {inlineGhost.text}
         </div>
       )}
 
@@ -1641,6 +1871,88 @@ function lineToSearchText(line: IBufferLine): { text: string; stringIndexToCell:
     text: text.slice(0, trimmedLength),
     stringIndexToCell: stringIndexToCell.slice(0, trimmedLength),
   };
+}
+
+function captureBufferCommand(term: Terminal): string {
+  const buffer = term.buffer.active;
+  const cursorRow = buffer.baseY + buffer.cursorY;
+
+  // Walk up through wrapped lines to find the start of the logical row.
+  let start = cursorRow;
+  while (start > 0) {
+    const line = buffer.getLine(start);
+    if (line?.isWrapped) start -= 1;
+    else break;
+  }
+
+  let text = "";
+  for (let row = start; row <= cursorRow; row += 1) {
+    const line = buffer.getLine(row);
+    if (!line) continue;
+    if (row === cursorRow) {
+      const segment = line.translateToString(false).slice(0, buffer.cursorX);
+      text += segment;
+    } else {
+      text += line.translateToString(false);
+    }
+  }
+
+  const trimmed = text.replace(/\s+$/, "");
+
+  // Heuristic prompt removal: take the tail after the last common shell
+  // prompt terminator. Covers bash/zsh ("$ "/"# "), fish/tcsh ("% "),
+  // PowerShell ("> "). If no terminator is found, return the whole line.
+  const markers = ["$ ", "# ", "> ", "% "];
+  let best = -1;
+  for (const marker of markers) {
+    const idx = trimmed.lastIndexOf(marker);
+    if (idx > best) best = idx + marker.length;
+  }
+
+  const command = best >= 0 ? trimmed.slice(best) : trimmed;
+  return command.trim();
+}
+
+function computeInlineGhost(
+  term: Terminal | null,
+  panel: HTMLDivElement | null,
+  container: HTMLDivElement | null,
+  enabled: boolean,
+  pending: string,
+  suggestion: string | null,
+  invalidated: boolean,
+): { left: number; top: number; maxWidth: number; height: number; text: string } | null {
+  if (!enabled || !term || !panel || !container) return null;
+  if (invalidated || !pending || !suggestion) return null;
+  if (!suggestion.startsWith(pending) || suggestion.length <= pending.length) return null;
+  if (term.buffer.active.type === "alternate") return null;
+
+  const screen = container.querySelector<HTMLElement>(".xterm-screen");
+  if (!screen) return null;
+
+  const screenRect = screen.getBoundingClientRect();
+  const panelRect = panel.getBoundingClientRect();
+  if (screenRect.width === 0 || screenRect.height === 0 || term.cols === 0 || term.rows === 0) {
+    return null;
+  }
+
+  // Only render when the cursor row is actually on screen (user hasn't scrolled away).
+  const cursorX = term.buffer.active.cursorX;
+  const cursorY = term.buffer.active.cursorY;
+  if (cursorY < 0 || cursorY >= term.rows) return null;
+
+  const cellWidth = screenRect.width / term.cols;
+  const cellHeight = screenRect.height / term.rows;
+  const baseLeft = screenRect.left - panelRect.left;
+  const baseTop = screenRect.top - panelRect.top;
+
+  const left = baseLeft + cursorX * cellWidth;
+  const top = baseTop + cursorY * cellHeight;
+  const maxWidth = Math.max(0, (term.cols - cursorX) * cellWidth);
+  if (maxWidth <= 0) return null;
+
+  const text = suggestion.slice(pending.length);
+  return { left, top, maxWidth, height: cellHeight, text };
 }
 
 function getVisibleSearchHighlights(

--- a/src/index.css
+++ b/src/index.css
@@ -476,6 +476,17 @@ body {
   box-shadow: inset 0 0 0 1px rgba(80, 210, 120, 0.7);
 }
 
+.terminal-inline-ghost {
+  position: absolute;
+  pointer-events: none;
+  z-index: 25;
+  white-space: pre;
+  overflow: hidden;
+  opacity: 0.45;
+  color: currentColor;
+  font-style: italic;
+}
+
 html[data-app-theme="dark"] .bg-white {
   background-color: var(--moba-panel-bg) !important;
 }

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  historyAppend as ipcHistoryAppend,
+  historyClear as ipcHistoryClear,
+  historyListRecent,
+} from "./ipc";
+
+const PREWARM_LIMIT = 500;
+
+export interface CommandHistory {
+  /** Returns up to `limit` items whose prefix matches `prefix`, most-recent first. */
+  match: (prefix: string, limit?: number) => string[];
+  /** Records the command as "just used". Updates cache + DB async. */
+  commit: (command: string) => void;
+  /** Drops the history for the current host only. */
+  clearHost: () => Promise<void>;
+  /** Drops history for every host. */
+  clearAll: () => Promise<void>;
+}
+
+/**
+ * Keeps an in-memory, recency-ordered list of the top-N recent commands for
+ * `hostKey` and answers prefix queries from it. Cheap + offline.
+ *
+ * Cache is scoped to this hook instance (per-tab). Multiple tabs on the same
+ * host each prewarm their own copy; that's fine — DB is the source of truth
+ * and `commit` updates both.
+ */
+export function useCommandHistory(hostKey: string, maxEntries: number): CommandHistory {
+  // The ref is the authoritative cache: mutations visible within the same tick,
+  // so a command committed on Enter is matchable on the very next keystroke.
+  // `cacheVersion` just forces re-render when the list changes, so consumers'
+  // effects (e.g. refreshSuggestion after prewarm) rerun.
+  const cacheRef = useRef<string[]>([]);
+  const [, setCacheVersion] = useState(0);
+  const bumpCache = useCallback(() => setCacheVersion((v) => v + 1), []);
+  const hostKeyRef = useRef(hostKey);
+  const maxRef = useRef(maxEntries);
+
+  useEffect(() => {
+    hostKeyRef.current = hostKey;
+    maxRef.current = maxEntries;
+  }, [hostKey, maxEntries]);
+
+  useEffect(() => {
+    let cancelled = false;
+    cacheRef.current = [];
+    bumpCache();
+    historyListRecent(hostKey, PREWARM_LIMIT)
+      .then((items) => {
+        if (cancelled) return;
+        cacheRef.current = items;
+        bumpCache();
+      })
+      .catch(() => {
+        if (cancelled) return;
+        cacheRef.current = [];
+        bumpCache();
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [hostKey, bumpCache]);
+
+  const match = useCallback((prefix: string, limit = 1): string[] => {
+    if (!prefix) return [];
+    const out: string[] = [];
+    const cache = cacheRef.current;
+    for (const item of cache) {
+      if (item.length > prefix.length && item.startsWith(prefix)) {
+        out.push(item);
+        if (out.length >= limit) break;
+      }
+    }
+    return out;
+  }, []);
+
+  const commit = useCallback((command: string) => {
+    const trimmed = command.replace(/[\r\n]+$/, "");
+    if (!trimmed) return;
+    const prev = cacheRef.current;
+    const filtered = prev.filter((c) => c !== trimmed);
+    filtered.unshift(trimmed);
+    cacheRef.current =
+      filtered.length > PREWARM_LIMIT ? filtered.slice(0, PREWARM_LIMIT) : filtered;
+    bumpCache();
+    ipcHistoryAppend(hostKeyRef.current, trimmed, maxRef.current).catch(() => {
+      // Persistence failure is non-fatal for UX; the in-memory cache still
+      // serves this session.
+    });
+  }, [bumpCache]);
+
+  const clearHost = useCallback(async () => {
+    await ipcHistoryClear(hostKeyRef.current);
+    cacheRef.current = [];
+    bumpCache();
+  }, [bumpCache]);
+
+  const clearAll = useCallback(async () => {
+    await ipcHistoryClear(null);
+    cacheRef.current = [];
+    bumpCache();
+  }, [bumpCache]);
+
+  return useMemo(
+    () => ({ match, commit, clearHost, clearAll }),
+    [match, commit, clearHost, clearAll],
+  );
+}
+
+/** Build a stable host key from SSH connection info (or "local"). */
+export function makeHostKey(ssh?: { host: string; port: number; username: string }): string {
+  if (!ssh) return "local";
+  return `ssh:${ssh.host.toLowerCase()}:${ssh.port}:${ssh.username}`;
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -287,6 +287,35 @@ export async function checkFileExists(path: string): Promise<boolean> {
   return invoke<boolean>("check_file_exists", { path });
 }
 
+// --- Command history ────────────────────────────────────────────────
+
+export async function historyAppend(
+  hostKey: string,
+  command: string,
+  max: number,
+): Promise<void> {
+  return invoke("history_append", { hostKey, command, max });
+}
+
+export async function historyMatchPrefix(
+  hostKey: string,
+  prefix: string,
+  limit: number,
+): Promise<string[]> {
+  return invoke<string[]>("history_match_prefix", { hostKey, prefix, limit });
+}
+
+export async function historyListRecent(
+  hostKey: string,
+  limit: number,
+): Promise<string[]> {
+  return invoke<string[]>("history_list_recent", { hostKey, limit });
+}
+
+export async function historyClear(hostKey: string | null): Promise<void> {
+  return invoke("history_clear", { hostKey });
+}
+
 // --- VNC ────────────────────────────────────────────────────────────
 
 export interface VncConnectResult {

--- a/src/lib/terminalProfile.ts
+++ b/src/lib/terminalProfile.ts
@@ -23,6 +23,8 @@ export interface TerminalProfile {
   syntaxMode: TerminalSyntaxMode;
   loggingEnabled: boolean;
   logPath?: string;
+  inlineSuggestions: boolean;
+  inlineSuggestionsMax: number;
 }
 
 export const DEFAULT_TERMINAL_PROFILE: TerminalProfile = {
@@ -41,6 +43,8 @@ export const DEFAULT_TERMINAL_PROFILE: TerminalProfile = {
   multilinePasteConfirm: true,
   syntaxMode: "default",
   loggingEnabled: false,
+  inlineSuggestions: true,
+  inlineSuggestionsMax: 2000,
 };
 
 const TERMINAL_PROFILE_STORAGE_KEY = "newmob.terminalProfile.v1";
@@ -116,6 +120,13 @@ export function normalizeTerminalProfile(input: unknown): TerminalProfile {
       DEFAULT_TERMINAL_PROFILE.syntaxMode,
     ),
     loggingEnabled: readBoolean(source.loggingEnabled, DEFAULT_TERMINAL_PROFILE.loggingEnabled),
+    inlineSuggestions: readBoolean(source.inlineSuggestions, DEFAULT_TERMINAL_PROFILE.inlineSuggestions),
+    inlineSuggestionsMax: clampInteger(
+      source.inlineSuggestionsMax,
+      DEFAULT_TERMINAL_PROFILE.inlineSuggestionsMax,
+      100,
+      50000,
+    ),
   };
 
   const logPath = readOptionalString(source.logPath);

--- a/src/stubs/tauri-core.ts
+++ b/src/stubs/tauri-core.ts
@@ -731,6 +731,15 @@ export async function invoke<T>(cmd: string, args?: any, options?: InvokeOptions
     }
     default:
       console.warn(`[tauri-stub] Unknown invoke command: ${cmd}`, args);
+      if (cmd === "history_match_prefix" || cmd === "history_list_recent") {
+        return ([] as unknown) as T;
+      }
+      if (
+        cmd === "history_append" ||
+        cmd === "history_clear"
+      ) {
+        return undefined as T;
+      }
       return undefined as T;
   }
 }


### PR DESCRIPTION
PowerShell PSReadLine / WindTerm style: typing shows a ghost-text completion drawn from per-host command history; → or End accepts it.

- SQLite-backed, keyed by ssh:<host>:<port>:<user> or "local"
- Prefix match against an in-memory top-500 prewarmed cache so every keystroke resolves locally, no IPC round-trip
- Skipped automatically for local PowerShell (PSReadLine already does it) and for alternate-buffer apps (vim/less/htop)
- Multi-exec accept broadcasts the suffix so source and targets stay in sync, matching the rest of the broadcast path
- Enter captures the final command line from the xterm buffer so Tab-completed and ↑-recalled commands enter history
- Settings: on/off toggle, max-entries-per-host, clear-all button