### PR TITLE
add About dialog, app version display, and title-bar theme/compact to…

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,10 @@
 packages:
   - "."
 
+allowBuilds:
+  cpu-features: true
+  esbuild: true
+  ssh2: true
+
 onlyBuiltDependencies:
   - esbuild

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from "react";
+
+export interface AboutDialogProps {
+  onClose: () => void;
+}
+
+export function AboutDialog({ onClose }: AboutDialogProps) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    closeRef.current?.focus();
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: "rgba(0,0,0,0.4)" }}
+      onClick={onClose}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        role="dialog"
+        aria-label="About NewMob"
+        aria-modal="true"
+        data-testid="about-dialog"
+        className="w-[380px] rounded shadow-lg p-5"
+        style={{ background: "var(--moba-bg)", border: "1px solid var(--moba-card-border)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 mb-3">
+          <div
+            className="w-12 h-12 rounded-lg flex items-center justify-center text-white font-bold text-xl shrink-0"
+            style={{ background: "linear-gradient(135deg, #1e5fa8, #62d36f)" }}
+          >
+            N
+          </div>
+          <div>
+            <div className="text-lg font-semibold">NewMob</div>
+            <div
+              data-testid="about-version"
+              className="text-[12px] moba-mono"
+              style={{ color: "var(--moba-text-muted)" }}
+            >
+              Version {__APP_VERSION__}
+            </div>
+          </div>
+        </div>
+
+        <div className="text-[12px] mb-4" style={{ color: "var(--moba-text-muted)" }}>
+          A cross‑platform port of the MobaXterm experience — Linux • macOS • Windows.
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            ref={closeRef}
+            type="button"
+            className="moba-btn h-8 px-4"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WelcomePanel.tsx
+++ b/src/components/WelcomePanel.tsx
@@ -10,7 +10,6 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 import { parseOpenSshConfig } from "../lib/quickConnect";
 import { listLocalShells, openLocalShellAsAdministrator, type LocalShellOption } from "../lib/ipc";
-import { AppThemeIconButton } from "./settings/AppThemeSwitcher";
 import { useAppStore } from "../stores/appStore";
 import { useSessionStore } from "../stores/sessionStore";
 import type { LocalShellSelection } from "../types";
@@ -104,9 +103,13 @@ export function WelcomePanel({ onStartLocalTerminal, onNewSession }: WelcomePane
               <div className="text-[12px] text-[var(--moba-text-muted)]">
                 A cross‑platform port of the MobaXterm experience — Linux • macOS • Windows
               </div>
-            </div>
-            <div className="ml-auto">
-              <AppThemeIconButton />
+              <div
+                data-testid="welcome-version"
+                className="text-[11px] mt-0.5 moba-mono"
+                style={{ color: "var(--moba-text-muted)" }}
+              >
+                Version {__APP_VERSION__}
+              </div>
             </div>
           </div>
 
@@ -155,6 +158,18 @@ export function WelcomePanel({ onStartLocalTerminal, onNewSession }: WelcomePane
               <li>Right‑click any session in the sidebar to connect, edit, duplicate, or delete it.</li>
               <li>Drag a session onto a folder in the tree to update its group.</li>
             </ul>
+          </div>
+
+          <div
+            data-testid="welcome-version-footer"
+            className="mt-6 pt-3 flex items-center justify-between text-[11px] moba-mono"
+            style={{
+              borderTop: "1px solid var(--moba-divider)",
+              color: "var(--moba-text-muted)",
+            }}
+          >
+            <span>NewMob</span>
+            <span>v{__APP_VERSION__}</span>
           </div>
         </div>
       </div>

--- a/src/components/menubar/MenuBar.tsx
+++ b/src/components/menubar/MenuBar.tsx
@@ -9,7 +9,6 @@ import {
   X,
 } from "lucide-react";
 import { useContextMenu } from "../ContextMenu";
-import { AppThemeIconButton } from "../settings/AppThemeSwitcher";
 import type { RibbonCommand } from "./Ribbon";
 
 interface MenuBarProps {
@@ -92,9 +91,6 @@ export function MenuBar({ activeTabClosable, onCommand }: MenuBarProps) {
           </span>
         </button>
       ))}
-      <div className="ml-auto">
-        <AppThemeIconButton />
-      </div>
     </div>
   );
 }

--- a/src/components/tabbar/CompactTitleBar.tsx
+++ b/src/components/tabbar/CompactTitleBar.tsx
@@ -15,6 +15,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { TabBar } from "./TabBar";
 import { useContextMenu } from "../ContextMenu";
 import { WindowControls } from "../window/WindowControls";
+import { TitleBarTrayControls } from "../window/TitleBarTrayControls";
 import type { RibbonCommand } from "../menubar/Ribbon";
 
 type CompactCommand = RibbonCommand | "close-active" | "reload-sessions";
@@ -88,6 +89,7 @@ export function CompactTitleBar({
         <TabBar />
       </div>
       <div data-window-drag className="w-10 self-stretch shrink-0" />
+      <TitleBarTrayControls />
       <WindowControls />
     </div>
   );

--- a/src/components/tabbar/TabBar.tsx
+++ b/src/components/tabbar/TabBar.tsx
@@ -165,13 +165,6 @@ export function TabBar() {
             />
           </>
         )}
-        <IconBtn
-          title={compactMode ? "Exit compact mode" : "Enter compact mode"}
-          icon={compactMode ? <PanelTopOpen className="w-3.5 h-3.5" /> : <PanelTopClose className="w-3.5 h-3.5" />}
-          onClick={toggleCompactMode}
-          active={compactMode}
-          compactToggle
-        />
         <IconBtn title="More" icon={<MoreHorizontal className="w-3.5 h-3.5" />} onClick={handleMore} />
       </div>
     </div>
@@ -203,21 +196,18 @@ function IconBtn({
   onClick,
   disabled,
   active,
-  compactToggle,
 }: {
   icon: React.ReactNode;
   title: string;
   onClick?: (event: React.MouseEvent) => void;
   disabled?: boolean;
   active?: boolean;
-  compactToggle?: boolean;
 }) {
   return (
     <button
       title={title}
       aria-label={title}
       data-active={active || undefined}
-      data-compact-toggle={compactToggle || undefined}
       className="w-6 h-6 inline-flex items-center justify-center rounded hover:bg-[var(--moba-hover)] disabled:opacity-40 disabled:cursor-default"
       style={active ? { background: "var(--moba-selected)", color: "var(--moba-accent)" } : undefined}
       onClick={onClick}

--- a/src/components/window/AppTitleBar.tsx
+++ b/src/components/window/AppTitleBar.tsx
@@ -1,5 +1,6 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { WindowControls } from "./WindowControls";
+import { TitleBarTrayControls } from "./TitleBarTrayControls";
 
 export function AppTitleBar() {
   const startDrag = (event: React.MouseEvent) => {
@@ -22,6 +23,7 @@ export function AppTitleBar() {
     >
       <div className="w-28 shrink-0" />
       <div className="flex-1 text-center text-[12px] font-semibold truncate">NewMob</div>
+      <TitleBarTrayControls />
       <WindowControls />
     </div>
   );

--- a/src/components/window/TitleBarTrayControls.tsx
+++ b/src/components/window/TitleBarTrayControls.tsx
@@ -1,0 +1,67 @@
+import { Monitor, Moon, Sun, PanelTopClose, PanelTopOpen } from "lucide-react";
+import { appThemeModeLabel, useAppTheme, type AppThemeMode } from "../../lib/appTheme";
+import { useAppStore } from "../../stores/appStore";
+
+const THEME_MODES: Array<{ mode: AppThemeMode; icon: React.ReactNode }> = [
+  { mode: "light", icon: <Sun className="w-3.5 h-3.5" /> },
+  { mode: "dark", icon: <Moon className="w-3.5 h-3.5" /> },
+  { mode: "system", icon: <Monitor className="w-3.5 h-3.5" /> },
+];
+
+export function TitleBarTrayControls() {
+  const { mode, resolvedTheme, setMode } = useAppTheme();
+  const compactMode = useAppStore((s) => s.compactMode);
+  const toggleCompactMode = useAppStore((s) => s.toggleCompactMode);
+
+  const currentIndex = THEME_MODES.findIndex((item) => item.mode === mode);
+  const current = THEME_MODES[currentIndex] ?? THEME_MODES[0];
+  const next = THEME_MODES[(currentIndex + 1) % THEME_MODES.length] ?? THEME_MODES[0];
+
+  return (
+    <div className="moba-titlebar-tray flex items-stretch self-stretch shrink-0">
+      <TrayButton
+        title={`Theme: ${appThemeModeLabel(mode)} (${resolvedTheme}). Click for ${appThemeModeLabel(next.mode)}.`}
+        ariaLabel="Cycle application theme"
+        onClick={() => setMode(next.mode)}
+      >
+        {current.icon}
+      </TrayButton>
+      <TrayButton
+        title={compactMode ? "Exit compact mode" : "Enter compact mode"}
+        ariaLabel={compactMode ? "Exit compact mode" : "Enter compact mode"}
+        active={compactMode}
+        onClick={toggleCompactMode}
+      >
+        {compactMode ? <PanelTopOpen className="w-3.5 h-3.5" /> : <PanelTopClose className="w-3.5 h-3.5" />}
+      </TrayButton>
+    </div>
+  );
+}
+
+function TrayButton({
+  children,
+  title,
+  ariaLabel,
+  onClick,
+  active,
+}: {
+  children: React.ReactNode;
+  title: string;
+  ariaLabel: string;
+  onClick: () => void;
+  active?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      aria-label={ariaLabel}
+      data-active={active || undefined}
+      className="moba-titlebar-tray-btn h-full w-10 inline-flex items-center justify-center hover:bg-[var(--moba-hover)]"
+      style={{ color: "var(--moba-text)" }}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -282,12 +282,17 @@ body {
   color: #fff;
 }
 
-.moba-tabbar button[data-compact-toggle="true"] {
-  border: 1px solid color-mix(in srgb, var(--moba-accent) 55%, transparent);
+.moba-titlebar-tray {
+  border-left: 1px solid color-mix(in srgb, var(--moba-divider) 80%, transparent);
 }
 
-.moba-tabbar button[data-compact-toggle="true"][data-active="true"] {
-  background: color-mix(in srgb, var(--moba-accent) 15%, var(--moba-input-bg));
+.moba-titlebar-tray-btn + .moba-titlebar-tray-btn {
+  border-left: 1px solid color-mix(in srgb, var(--moba-divider) 80%, transparent);
+}
+
+.moba-titlebar-tray-btn[data-active="true"] {
+  background: color-mix(in srgb, var(--moba-accent) 15%, transparent);
+  color: var(--moba-accent);
 }
 
 .moba-compact-root .moba-tab {

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -37,6 +37,7 @@ import type { SftpTabInfo } from "../types";
 import { useAppStore } from "../stores/appStore";
 import { useSessionStore } from "../stores/sessionStore";
 import { WelcomePanel } from "../components/WelcomePanel";
+import { AboutDialog } from "../components/AboutDialog";
 import { parseQuickConnectInput } from "../lib/quickConnect";
 import { exitApp, type SessionConfig } from "../lib/ipc";
 import { getSessionTerminalProfile, type TerminalProfile } from "../lib/terminalProfile";
@@ -87,6 +88,7 @@ export function MainLayout() {
   const [newSessionGroupPath, setNewSessionGroupPath] = useState<string | null>(null);
   const [newSessionInitialProto, setNewSessionInitialProto] = useState<string | undefined>();
   const [pendingAuth, setPendingAuth] = useState<PendingAuth | null>(null);
+  const [showAbout, setShowAbout] = useState(false);
   const [attachedSidebars, setAttachedSidebars] = useState<Record<string, boolean>>({});
   const [compactSidebarOpen, setCompactSidebarOpen] = useState(false);
   const [terminalCwds, setTerminalCwds] = useState<Record<string, string>>({});
@@ -552,7 +554,7 @@ export function MainLayout() {
         openPlaceholderTab(command === "games" ? "Games" : "Macros", "This module is intentionally inactive in the MVP.");
         break;
       case "help":
-        setActiveTab("welcome");
+        setShowAbout(true);
         break;
       default:
         setStatusMessage("Command is not available in this phase");
@@ -898,6 +900,8 @@ export function MainLayout() {
           onCancel={() => setPendingAuth(null)}
         />
       )}
+
+      {showAbout && <AboutDialog onClose={() => setShowAbout(false)} />}
     </div>
   );
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { resolve } from "path";
+import { readFileSync } from "fs";
 import { sshProxyPlugin } from "./vite-plugins/sshProxy";
 import { sftpProxyPlugin } from "./vite-plugins/sftpProxy";
 
@@ -8,9 +9,16 @@ const isTauriBuild = !!process.env.TAURI_ENV_PLATFORM;
 
 const devPort = isTauriBuild ? 1420 : 5000;
 
+const pkg = JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf-8")) as {
+  version: string;
+};
+
 export default defineConfig({
   plugins: [react(), ...(isTauriBuild ? [] : [sshProxyPlugin(), sftpProxyPlugin()])],
   clearScreen: false,
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   optimizeDeps: {
     include: ["zmodem.js"],
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,17 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const pkg = JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf-8")) as {
+  version: string;
+};
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   test: {
     environment: "jsdom",
     setupFiles: ["src/test/setup.ts"],


### PR DESCRIPTION
…ggles

- Inject `__APP_VERSION__` from package.json via Vite define so the version is available at runtime
- Add About dialog (Help → About NewMob) showing the current version
- Show version in the Welcome header and a footer line on the welcome page
- Move theme cycle and compact-mode toggle into a shared title-bar tray rendered to the left of the window controls in both normal and compact title bars; remove the now-duplicated theme button from the menu bar / welcome header and the compact toggle from the tab bar