### PR TITLE
fix(terminal): suppress NewMob ghost on PowerShell using backend-reso…

### DIFF
--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -6,6 +6,7 @@ pub mod ssh;
 use crate::state::AppState;
 use base64::{engine::general_purpose::STANDARD as B64, Engine};
 use russh::Sig;
+use serde::Serialize;
 use std::io::{Read, Write};
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -46,6 +47,17 @@ pub fn open_local_shell_as_administrator(shell: Option<String>) -> Result<(), St
     pty::open_shell_as_administrator(shell)
 }
 
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalTerminalCreated {
+    pub session_id: String,
+    /// `LocalShellOption.id` of the shell that was actually launched. Lets the
+    /// frontend skip features (e.g. inline history suggestions) that conflict
+    /// with shells that already provide them, even when the caller didn't pass
+    /// an explicit `shell` arg and we resolved a default.
+    pub shell_id: String,
+}
+
 #[tauri::command]
 pub async fn create_local_terminal(
     session_id: String,
@@ -56,9 +68,9 @@ pub async fn create_local_terminal(
     on_output: TerminalOutputChannel,
     state: State<'_, AppState>,
     app_handle: AppHandle,
-) -> Result<String, String> {
+) -> Result<LocalTerminalCreated, String> {
     validate_session_id(&session_id)?;
-    let (handle, reader) = pty::create_pty(cols, rows, shell, cwd)?;
+    let (handle, reader, shell_id) = pty::create_pty(cols, rows, shell, cwd)?;
 
     let terminal = ActiveTerminal::Local {
         writer: Mutex::new(handle.writer),
@@ -80,7 +92,10 @@ pub async fn create_local_terminal(
         read_loop_local(reader, sid, app, on_output);
     });
 
-    Ok(session_id)
+    Ok(LocalTerminalCreated {
+        session_id,
+        shell_id,
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/terminal/pty.rs
+++ b/src-tauri/src/terminal/pty.rs
@@ -56,6 +56,14 @@ pub fn list_local_shells() -> Vec<LocalShellOption> {
 }
 
 pub fn resolve_shell(shell: Option<String>) -> ShellLaunch {
+    resolve_shell_with_id(shell).0
+}
+
+/// Same as `resolve_shell`, but also reports the `LocalShellOption.id` that was
+/// matched. Returns `"custom"` when the caller passed an explicit shell path
+/// that didn't correspond to any enumerated option, and `"default"` when we
+/// fell back to the platform fallback because no shells were detected.
+pub fn resolve_shell_with_id(shell: Option<String>) -> (ShellLaunch, String) {
     if let Some(raw) = shell {
         let requested = raw.trim();
         if !requested.is_empty() {
@@ -63,27 +71,38 @@ pub fn resolve_shell(shell: Option<String>) -> ShellLaunch {
                 .into_iter()
                 .find(|option| option.id == requested)
             {
-                return ShellLaunch {
-                    program: option.path,
-                    args: option.args,
-                };
+                let id = option.id;
+                return (
+                    ShellLaunch {
+                        program: option.path,
+                        args: option.args,
+                    },
+                    id,
+                );
             }
 
-            return ShellLaunch {
-                program: requested.to_string(),
-                args: Vec::new(),
-            };
+            return (
+                ShellLaunch {
+                    program: requested.to_string(),
+                    args: Vec::new(),
+                },
+                "custom".to_string(),
+            );
         }
     }
 
-    list_local_shells()
-        .into_iter()
-        .find(|option| option.is_default)
-        .map(|option| ShellLaunch {
-            program: option.path,
-            args: option.args,
-        })
-        .unwrap_or_else(fallback_shell_launch)
+    if let Some(option) = list_local_shells().into_iter().find(|opt| opt.is_default) {
+        let id = option.id;
+        return (
+            ShellLaunch {
+                program: option.path,
+                args: option.args,
+            },
+            id,
+        );
+    }
+
+    (fallback_shell_launch(), "default".to_string())
 }
 
 pub fn open_shell_as_administrator(shell: Option<String>) -> Result<(), String> {
@@ -416,7 +435,7 @@ pub fn create_pty(
     rows: u16,
     shell: Option<String>,
     cwd: Option<String>,
-) -> Result<(PtyHandle, Box<dyn Read + Send>), String> {
+) -> Result<(PtyHandle, Box<dyn Read + Send>, String), String> {
     let pty_system = native_pty_system();
 
     let size = PtySize {
@@ -430,7 +449,7 @@ pub fn create_pty(
         .openpty(size)
         .map_err(|e| format!("Failed to open PTY: {}", e))?;
 
-    let shell_launch = resolve_shell(shell);
+    let (shell_launch, shell_id) = resolve_shell_with_id(shell);
     let mut cmd = CommandBuilder::new(&shell_launch.program);
     for arg in &shell_launch.args {
         cmd.arg(arg);
@@ -468,7 +487,7 @@ pub fn create_pty(
         master: pair.master,
     };
 
-    Ok((handle, reader))
+    Ok((handle, reader, shell_id))
 }
 
 pub fn resize_pty(master: &dyn portable_pty::MasterPty, cols: u16, rows: u16) -> Result<(), String> {

--- a/src/components/terminal/TerminalPanel.test.tsx
+++ b/src/components/terminal/TerminalPanel.test.tsx
@@ -53,7 +53,7 @@ const fitMocks = vi.hoisted(() => ({
 
 const ipcMocks = vi.hoisted(() => ({
   closeTerminal: vi.fn(async () => undefined),
-  createLocalTerminal: vi.fn(async (sessionId: string) => sessionId),
+  createLocalTerminal: vi.fn(async (sessionId: string) => ({ sessionId, shellId: "default" })),
   createSshTerminal: vi.fn(async (sessionId: string) => sessionId),
   createTerminalSessionId: vi.fn(() => "terminal-session"),
   encodeBase64: vi.fn((value: string) => btoa(value)),

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -338,9 +338,17 @@ export function TerminalPanel({
   // Per-host command history for inline ghost-text suggestions.
   const historyHostKey = useMemo(() => makeHostKey(ssh), [ssh]);
   const isLocal = !ssh;
+  // Tracks which local shell the backend actually launched. Lets us suppress
+  // inline history suggestions on shells that already provide their own
+  // (PSReadLine on PowerShell). Resolved on connect — the prop only carries
+  // the user's selection, which can be missing when opening a saved
+  // LocalShell session, so we trust the backend's resolved id instead.
+  const [resolvedLocalShellId, setResolvedLocalShellId] = useState<string | null>(null);
   const isLocalPowerShell = useMemo(
-    () => !ssh && (localShell?.id === "powershell" || localShell?.id === "windows-powershell"),
-    [ssh, localShell?.id],
+    () =>
+      isLocal &&
+      (resolvedLocalShellId === "powershell" || resolvedLocalShellId === "windows-powershell"),
+    [isLocal, resolvedLocalShellId],
   );
   const suggestionsActive = inlineSuggestionsEnabled && !isLocalPowerShell;
   const history = useCommandHistory(historyHostKey, inlineSuggestionsMax);
@@ -1381,7 +1389,10 @@ export function TerminalPanel({
             return JSON.stringify(toNetworkSettingsPayload(ns));
           })(),
           (raw) => zmodem.consume(raw),
-        )
+        ).then<{ sessionId: string; shellId: string | null }>((sessionId) => ({
+          sessionId,
+          shellId: null,
+        }))
       : createLocalTerminal(
           sid,
           cols,
@@ -1389,7 +1400,7 @@ export function TerminalPanel({
           localShell?.id,
           undefined,
           (raw) => zmodem.consume(raw),
-        );
+        ).then(({ sessionId, shellId }) => ({ sessionId, shellId }));
 
     if (ssh) {
       appendEvent("connection", `Connecting to ${ssh.username}@${ssh.host}:${ssh.port}`);
@@ -1400,13 +1411,14 @@ export function TerminalPanel({
     }
 
     connectPromise
-      .then(async (connectedSid) => {
+      .then(async ({ sessionId: connectedSid, shellId }) => {
         if (destroyed) {
           closeTerminal(connectedSid).catch(() => {});
           return;
         }
         sessionIdRef.current = connectedSid;
         zmodemRef.current = zmodem;
+        if (shellId) setResolvedLocalShellId(shellId);
         onSessionReadyRef.current?.(connectedSid);
         appendEvent("connection", `Connected (${connectedSid})`);
         if (ssh) {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -30,6 +30,12 @@ function createBinaryOutputChannel(callback: (data: Uint8Array) => void): Channe
   return channel;
 }
 
+export interface LocalTerminalCreated {
+  sessionId: string;
+  /** `LocalShellOption.id` of the shell the backend actually launched. */
+  shellId: string;
+}
+
 export async function createLocalTerminal(
   sessionId: string,
   cols: number,
@@ -37,8 +43,8 @@ export async function createLocalTerminal(
   shell?: string,
   cwd?: string,
   onOutput?: (data: Uint8Array) => void,
-): Promise<string> {
-  return invoke<string>("create_local_terminal", {
+): Promise<LocalTerminalCreated> {
+  return invoke<LocalTerminalCreated>("create_local_terminal", {
     sessionId,
     cols,
     rows,


### PR DESCRIPTION
…lved shell id

NewMob's inline history ghost-text was doubling up with PSReadLine's own predictions on local PowerShell tabs because the suppression check ran off the `localShell` prop, which is unset on two common paths: opening a saved LocalShell session from the sidebar, and the Welcome panel's default shell when no explicit pick is made (id falls through to "default" / COMSPEC).

Move the source of truth to the backend: `create_local_terminal` now returns `{ sessionId, shellId }` where shellId is the resolved `LocalShellOption.id` actually launched (or "custom" / "default" for fallbacks). TerminalPanel keys the PowerShell check off this value, so PSReadLine-bearing shells are detected regardless of how the tab was opened.