### PR TITLE
fix(drag-drop): enable OS file drop on Windows by replacing HTML5 DnD

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,13 +56,11 @@ pub fn run() {
             }
 
             if let Some(main_window_config) = app.config().app.windows.first().cloned() {
-                let builder = WebviewWindowBuilder::from_config(app.handle(), &main_window_config)?
+                WebviewWindowBuilder::from_config(app.handle(), &main_window_config)?
                     // Required on Linux/Windows for navigator.clipboard.readText().
                     // Terminal right-click paste and Shift+Insert use that API.
-                    .enable_clipboard_access();
-                #[cfg(windows)]
-                let builder = builder.disable_drag_drop_handler();
-                builder.build()?;
+                    .enable_clipboard_access()
+                    .build()?;
             }
             Ok(())
         })

--- a/src/components/filebrowser/FilePanel.tsx
+++ b/src/components/filebrowser/FilePanel.tsx
@@ -18,6 +18,19 @@ import {
   droppedFiles,
   isOsFileDrag,
 } from "../../lib/osFileDrop";
+import {
+  startCustomDrag,
+  useCustomDropTarget,
+  type CustomDragData,
+} from "../../lib/customDnD";
+
+const CROSS_PANE_DRAG_MIME = "newmob/sftp-files";
+
+interface CrossPaneDragPayload {
+  sessionId: string;
+  side: PaneSide;
+  paths: string[];
+}
 
 interface ColWidths {
   name: number;
@@ -265,6 +278,28 @@ export function FilePanel({
     firstSelected.fileType === "file"
   );
 
+  useCustomDropTarget<HTMLDivElement>(listRef, {
+    accepts: (data: CustomDragData) => {
+      if (!acceptCrossPane) return false;
+      if (data.mime !== CROSS_PANE_DRAG_MIME) return false;
+      const payload = data.payload as CrossPaneDragPayload | null;
+      if (!payload) return false;
+      // Reject same-pane drags so dropping back doesn't trigger a copy.
+      return !(payload.sessionId === sessionId && payload.side === side);
+    },
+    onDragEnter: () => setDraggingOver(true),
+    onDragLeave: () => setDraggingOver(false),
+    onDrop: (detail) => {
+      setDraggingOver(false);
+      const payload = detail.data.payload as CrossPaneDragPayload | null;
+      if (!payload) return;
+      const otherPane = useSftpStore.getState().sessions[payload.sessionId]?.[payload.side];
+      if (!otherPane) return;
+      const entries = otherPane.entries.filter((entry) => payload.paths.includes(entry.path));
+      if (entries.length > 0) onCrossPaneDrop?.(entries);
+    },
+  });
+
   if (!pane) {
     return (
       <div className="flex-1 flex items-center justify-center text-[12px] text-[var(--moba-text-muted)]">
@@ -328,27 +363,30 @@ export function FilePanel({
     setSelection(sessionId, side, []);
   };
 
-  const handleDragStart = (entry: FileEntry, e: DragEvent) => {
+  const handleRowPointerDown = (entry: FileEntry, e: React.PointerEvent<HTMLTableRowElement>) => {
+    if (e.button !== 0) return;
     const sel = pane.selection.includes(entry.path) ? pane.selection : [entry.path];
-    const payload = JSON.stringify({
-      sessionId,
-      side,
-      paths: sel,
+    const ghostText = sel.length === 1 ? entry.name : `${sel.length} items`;
+    startCustomDrag({
+      event: e,
+      data: {
+        mime: CROSS_PANE_DRAG_MIME,
+        payload: {
+          sessionId,
+          side,
+          paths: sel,
+        } satisfies CrossPaneDragPayload,
+      },
+      ghostText,
     });
-    e.dataTransfer.setData("application/x-newmob-files", payload);
-    e.dataTransfer.setData("text/plain", sel.join("\n"));
-    e.dataTransfer.effectAllowed = "copy";
   };
 
+  // Browser dev mode: OS file drag delivers `File` objects through HTML5 DnD.
+  // Inside Tauri, OS file drops arrive via `NATIVE_FILE_DROP_EVENT` instead
+  // (because dragDropEnabled=true intercepts HTML5 file drops on Windows).
+  // Cross-pane intra-app drag is handled by useCustomDropTarget below.
   const handleDragOver = (e: DragEvent) => {
     if (side === "remote" && onUploadFromDisk && isOsFileDrag(e.dataTransfer)) {
-      e.preventDefault();
-      e.dataTransfer.dropEffect = "copy";
-      setDraggingOver(true);
-      return;
-    }
-
-    if (acceptCrossPane && e.dataTransfer.types.includes("application/x-newmob-files")) {
       e.preventDefault();
       e.dataTransfer.dropEffect = "copy";
       setDraggingOver(true);
@@ -360,28 +398,11 @@ export function FilePanel({
   };
 
   const handleDrop = (e: DragEvent) => {
-    e.preventDefault();
-    setDraggingOver(false);
-
     if (side === "remote" && onUploadFromDisk && isOsFileDrag(e.dataTransfer)) {
+      e.preventDefault();
+      setDraggingOver(false);
       const files = droppedFiles(e.dataTransfer);
       if (files.length > 0) onUploadFromDisk(files);
-      return;
-    }
-
-    if (acceptCrossPane) {
-      const raw = e.dataTransfer.getData("application/x-newmob-files");
-      if (!raw) return;
-      try {
-        const data = JSON.parse(raw) as { sessionId: string; side: PaneSide; paths: string[] };
-        if (data.side === side && data.sessionId === sessionId) return;
-        const otherPane = useSftpStore.getState().sessions[data.sessionId]?.[data.side];
-        if (!otherPane) return;
-        const entries = otherPane.entries.filter((entry) => data.paths.includes(entry.path));
-        if (entries.length > 0) onCrossPaneDrop?.(entries);
-      } catch {
-        /* ignore malformed drag */
-      }
     }
   };
 
@@ -636,8 +657,7 @@ export function FilePanel({
               <tr
                 key={entry.path}
                 data-row
-                draggable
-                onDragStart={(e) => handleDragStart(entry, e)}
+                onPointerDown={(e) => handleRowPointerDown(entry, e)}
                 className="cursor-default select-none"
                 style={{
                   background: pane.selection.includes(entry.path)

--- a/src/components/sidebar/SessionTree.tsx
+++ b/src/components/sidebar/SessionTree.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Terminal as TerminalIcon,
   Monitor,
@@ -25,6 +25,11 @@ import { useContextMenu, type MenuItem } from "../ContextMenu";
 import { FolderNameDialog } from "./FolderNameDialog";
 import type { SessionConfig, SessionGroup } from "../../lib/ipc";
 import {
+  startCustomDrag,
+  useCustomDropTarget,
+  type CustomDragData,
+} from "../../lib/customDnD";
+import {
   parseCsvSessions,
   parseMobaXtermSessions,
   parseNewMobSessions,
@@ -45,6 +50,12 @@ import {
   splitGroupPath,
   toStoredGroupPath,
 } from "../../lib/sessionPaths";
+
+const SESSION_DRAG_MIME = "newmob/session";
+
+interface SessionDragPayload {
+  sessionId: string;
+}
 
 interface SessionTreeProps {
   onNewSession?: (groupPath?: string | null) => void;
@@ -116,20 +127,14 @@ export function SessionTree({ onNewSession, onConnectSession, onEditSession }: S
     });
   };
 
-  const handleDrop = (event: React.DragEvent, groupPath: string | null) => {
-    event.preventDefault();
-    event.stopPropagation();
-    const sessionId = event.dataTransfer.getData("application/x-newmob-session");
+  const handleDrop = (groupPath: string | null, sessionId: string) => {
     setDragOverGroup(null);
-    if (sessionId) {
-      void moveSessionToGroup(sessionId, groupPath);
-      expandPath(groupPath);
-    }
+    if (!sessionId) return;
+    void moveSessionToGroup(sessionId, groupPath);
+    expandPath(groupPath);
   };
 
-  const handleDragOver = (event: React.DragEvent, groupPath: string | null) => {
-    event.preventDefault();
-    event.stopPropagation();
+  const handleDragOver = (groupPath: string | null) => {
     setDragOverGroup(folderKey(groupPath));
   };
 
@@ -426,8 +431,8 @@ export function SessionTree({ onNewSession, onConnectSession, onEditSession }: S
         open={expanded.root !== false}
         onToggle={() => toggle("root")}
         onContextMenu={(event) => folderContextMenu(event, null)}
-        onDrop={(event) => handleDrop(event, null)}
-        onDragOver={(event) => handleDragOver(event, null)}
+        onDropSession={(sessionId) => handleDrop(null, sessionId)}
+        onDragOverFolder={() => handleDragOver(null)}
         onDragLeave={() => setDragOverGroup(null)}
         dragOver={dragOverGroup === "root"}
       >
@@ -440,8 +445,8 @@ export function SessionTree({ onNewSession, onConnectSession, onEditSession }: S
           onToggle={toggle}
           onFolderContextMenu={folderContextMenu}
           onSessionContextMenu={sessionContextMenu}
-          onDrop={handleDrop}
-          onDragOver={handleDragOver}
+          onDropSession={handleDrop}
+          onDragOverFolder={handleDragOver}
           onDragLeave={() => setDragOverGroup(null)}
           onSelectSession={setSelectedSession}
           onConnectSession={onConnectSession}
@@ -467,8 +472,8 @@ function FolderContents({
   onToggle,
   onFolderContextMenu,
   onSessionContextMenu,
-  onDrop,
-  onDragOver,
+  onDropSession,
+  onDragOverFolder,
   onDragLeave,
   onSelectSession,
   onConnectSession,
@@ -481,8 +486,8 @@ function FolderContents({
   onToggle: (key: string) => void;
   onFolderContextMenu: (event: React.MouseEvent, path: string | null) => void;
   onSessionContextMenu: (event: React.MouseEvent, session: SessionConfig) => void;
-  onDrop: (event: React.DragEvent, groupPath: string | null) => void;
-  onDragOver: (event: React.DragEvent, groupPath: string | null) => void;
+  onDropSession: (groupPath: string | null, sessionId: string) => void;
+  onDragOverFolder: (groupPath: string | null) => void;
   onDragLeave: () => void;
   onSelectSession: (id: string | null) => void;
   onConnectSession?: (session: SessionConfig) => void;
@@ -501,8 +506,8 @@ function FolderContents({
             open={isOpen}
             onToggle={() => onToggle(key)}
             onContextMenu={(event) => onFolderContextMenu(event, folder.path)}
-            onDrop={(event) => onDrop(event, folder.path)}
-            onDragOver={(event) => onDragOver(event, folder.path)}
+            onDropSession={(sessionId) => onDropSession(folder.path, sessionId)}
+            onDragOverFolder={() => onDragOverFolder(folder.path)}
             onDragLeave={onDragLeave}
             dragOver={dragOverGroup === key}
           >
@@ -515,8 +520,8 @@ function FolderContents({
               onToggle={onToggle}
               onFolderContextMenu={onFolderContextMenu}
               onSessionContextMenu={onSessionContextMenu}
-              onDrop={onDrop}
-              onDragOver={onDragOver}
+              onDropSession={onDropSession}
+              onDragOverFolder={onDragOverFolder}
               onDragLeave={onDragLeave}
               onSelectSession={onSelectSession}
               onConnectSession={onConnectSession}
@@ -546,8 +551,8 @@ function TreeFolder({
   onToggle,
   children,
   onContextMenu,
-  onDrop,
-  onDragOver,
+  onDropSession,
+  onDragOverFolder,
   onDragLeave,
   dragOver,
 }: {
@@ -557,25 +562,36 @@ function TreeFolder({
   onToggle: () => void;
   children?: React.ReactNode;
   onContextMenu?: (event: React.MouseEvent) => void;
-  onDrop?: (event: React.DragEvent) => void;
-  onDragOver?: (event: React.DragEvent) => void;
+  onDropSession?: (sessionId: string) => void;
+  onDragOverFolder?: () => void;
   onDragLeave?: () => void;
   dragOver?: boolean;
 }) {
   const isRoot = node.path === null;
   const hasChildren = node.folders.length > 0 || node.sessions.length > 0;
+  const headerRef = useRef<HTMLDivElement>(null);
+
+  useCustomDropTarget<HTMLDivElement>(headerRef, {
+    accepts: (data: CustomDragData) =>
+      data.mime === SESSION_DRAG_MIME && !!onDropSession,
+    onDragEnter: () => onDragOverFolder?.(),
+    onDragOver: () => onDragOverFolder?.(),
+    onDragLeave: () => onDragLeave?.(),
+    onDrop: (detail) => {
+      const payload = detail.data.payload as SessionDragPayload | null;
+      if (payload?.sessionId) onDropSession?.(payload.sessionId);
+    },
+  });
 
   return (
     <div>
       <div
+        ref={headerRef}
         className="flex items-center gap-1 px-1 py-0.5 cursor-pointer hover:bg-[var(--moba-hover)]"
         data-drag-over={dragOver}
         style={dragOver ? { background: "var(--moba-selected)" } : undefined}
         onClick={onToggle}
         onContextMenu={onContextMenu}
-        onDrop={onDrop}
-        onDragOver={onDragOver}
-        onDragLeave={onDragLeave}
       >
         {open ? (
           <ChevronDown className="w-3 h-3 text-slate-500" />
@@ -611,20 +627,33 @@ function SessionItem({
   onContextMenu: (e: React.MouseEvent) => void;
 }) {
   const icon = sessionIcon(session.session_type);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return;
+    const el = ref.current;
+    if (!el) return;
+    startCustomDrag({
+      event: e,
+      data: {
+        mime: SESSION_DRAG_MIME,
+        payload: { sessionId: session.id } satisfies SessionDragPayload,
+      },
+      ghostText: session.name,
+      ghostElement: el,
+    });
+  };
 
   return (
     <div
+      ref={ref}
       data-testid="session-tree-item"
       data-session-name={session.name}
       data-session-type={session.session_type}
       className="flex items-center gap-1 px-1 py-0.5 cursor-pointer hover:bg-[var(--moba-hover)] group"
       data-selected={selected}
       style={selected ? { background: "var(--moba-selected)" } : undefined}
-      draggable
-      onDragStart={(event) => {
-        event.dataTransfer.setData("application/x-newmob-session", session.id);
-        event.dataTransfer.effectAllowed = "move";
-      }}
+      onPointerDown={handlePointerDown}
       onClick={onClick}
       onDoubleClick={onDoubleClick}
       onContextMenu={onContextMenu}

--- a/src/components/tabbar/TabBar.tsx
+++ b/src/components/tabbar/TabBar.tsx
@@ -15,12 +15,19 @@ import {
   FileText,
   Pencil,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAppStore } from "../../stores/appStore";
 import { useContextMenu } from "../ContextMenu";
+import {
+  startCustomDrag,
+  useCustomDropTarget,
+  type CustomDragData,
+} from "../../lib/customDnD";
 import type { Tab, TabKind } from "../../types";
 
 type DropIndicator = { tabId: string; side: "before" | "after" } | null;
+
+const TAB_DRAG_MIME = "newmob/tab";
 
 export function TabBar() {
   const {
@@ -119,9 +126,8 @@ export function TabBar() {
     ]);
   };
 
-  const computeDropSide = (event: React.DragEvent<HTMLElement>): "before" | "after" => {
-    const rect = event.currentTarget.getBoundingClientRect();
-    return event.clientX < rect.left + rect.width / 2 ? "before" : "after";
+  const computeDropSide = (rect: DOMRect, clientX: number): "before" | "after" => {
+    return clientX < rect.left + rect.width / 2 ? "before" : "after";
   };
 
   const clearDragState = () => {
@@ -129,44 +135,21 @@ export function TabBar() {
     setDropIndicator(null);
   };
 
-  const handleDragStart = (e: React.DragEvent<HTMLDivElement>, tab: Tab) => {
-    setDraggedId(tab.id);
-    if (e.dataTransfer) {
-      e.dataTransfer.effectAllowed = "move";
-      try {
-        e.dataTransfer.setData("application/x-newmob-tab", tab.id);
-      } catch {
-        // Some browsers reject custom MIME types; the in-memory state is the source of truth.
-      }
-    }
-  };
-
-  const handleDragOver = (e: React.DragEvent<HTMLDivElement>, tab: Tab) => {
-    if (!draggedId) return;
-    e.preventDefault();
-    if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
-    const side = computeDropSide(e);
-    if (draggedId === tab.id) {
-      setDropIndicator(null);
-      return;
-    }
-    setDropIndicator((prev) => {
-      if (prev && prev.tabId === tab.id && prev.side === side) return prev;
-      return { tabId: tab.id, side };
+  const handleTabPointerDown = (
+    e: React.PointerEvent<HTMLDivElement>,
+    tab: Tab,
+    el: HTMLDivElement,
+  ) => {
+    if (editingTabId === tab.id) return;
+    if (e.button !== 0) return;
+    startCustomDrag({
+      event: e,
+      data: { mime: TAB_DRAG_MIME, payload: { tabId: tab.id } },
+      ghostText: tab.title,
+      ghostElement: el,
+      onActivate: () => setDraggedId(tab.id),
+      onEnd: clearDragState,
     });
-  };
-
-  const handleDrop = (e: React.DragEvent<HTMLDivElement>, tab: Tab) => {
-    if (!draggedId) {
-      clearDragState();
-      return;
-    }
-    e.preventDefault();
-    const side = computeDropSide(e);
-    if (draggedId !== tab.id) {
-      moveTab(draggedId, tab.id, side);
-    }
-    clearDragState();
   };
 
   return (
@@ -181,121 +164,53 @@ export function TabBar() {
         const isSelected = multiExecActive && tab.type === "terminal" && multiExecSelectedTabIds.has(tab.id);
         const dropSide = dropIndicator && dropIndicator.tabId === tab.id ? dropIndicator.side : undefined;
         return (
-          <div
+          <TabItem
             key={tab.id}
-            data-testid="tab-item"
-            data-tab-id={tab.id}
-            data-tab-title={tab.title}
-            data-tab-type={tab.type}
-            data-multiexec-selected={isSelected || undefined}
-            data-dragging={draggedId === tab.id || undefined}
-            data-drop-side={dropSide}
-            className="moba-tab relative"
-            data-active={activeTabId === tab.id}
-            draggable={editingTabId !== tab.id}
-            onClick={() => {
-              if (editingTabId === tab.id) return;
-              setActiveTab(tab.id);
-            }}
-            onMouseDown={(e) => {
-              if (editingTabId === tab.id) return;
-              handleMouseDown(e, tab);
-            }}
-            onContextMenu={(e) => handleTabContext(e, tab)}
-            onDragStart={(e) => {
-              if (editingTabId === tab.id) {
-                e.preventDefault();
+            tab={tab}
+            active={activeTabId === tab.id}
+            multiExecSelected={!!isSelected}
+            multiExecActive={multiExecActive}
+            dragging={draggedId === tab.id}
+            draggedId={draggedId}
+            dropSide={dropSide}
+            editing={editingTabId === tab.id}
+            draftTitle={draftTitle}
+            onStartDrag={handleTabPointerDown}
+            onDragOverTab={(t, rect, clientX) => {
+              if (!draggedId || draggedId === t.id) {
+                setDropIndicator(null);
                 return;
               }
-              handleDragStart(e, tab);
+              const side = computeDropSide(rect, clientX);
+              setDropIndicator((prev) => {
+                if (prev && prev.tabId === t.id && prev.side === side) return prev;
+                return { tabId: t.id, side };
+              });
             }}
-            onDragOver={(e) => handleDragOver(e, tab)}
-            onDragLeave={() =>
-              setDropIndicator((prev) => (prev && prev.tabId === tab.id ? null : prev))
+            onDragLeaveTab={(t) =>
+              setDropIndicator((prev) => (prev && prev.tabId === t.id ? null : prev))
             }
-            onDrop={(e) => handleDrop(e, tab)}
-            onDragEnd={clearDragState}
-          >
-            {multiExecActive && tab.type === "terminal" && (
-              <button
-                type="button"
-                title={isSelected ? "Remove from MultiExec" : "Add to MultiExec"}
-                className="absolute -top-0.5 -left-0.5 w-3 h-3 rounded-full border flex items-center justify-center z-10 flex-shrink-0"
-                style={{
-                  background: isSelected ? "var(--moba-accent)" : "var(--moba-chrome-bg)",
-                  borderColor: isSelected ? "var(--moba-accent)" : "var(--moba-divider)",
-                  fontSize: 7,
-                  color: isSelected ? "#fff" : "var(--moba-text-muted)",
-                }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  toggleMultiExecTab(tab.id);
-                }}
-              >
-                {isSelected ? "✓" : ""}
-              </button>
-            )}
-            <div className="relative flex-shrink-0">
-              <TabIcon kind={tab.type} ssh={!!tab.ssh} />
-              {tab.hasNewOutput && (
-                <span
-                  className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-emerald-500 pointer-events-none"
-                  aria-label="New output"
-                />
-              )}
-            </div>
-            <span
-              data-testid="tab-title"
-              className="truncate max-w-[180px]"
-              onDoubleClick={(e) => {
-                e.stopPropagation();
-                startRename(tab);
-              }}
-            >
-              {editingTabId === tab.id ? (
-                <input
-                  data-testid="tab-title-input"
-                  autoFocus
-                  type="text"
-                  value={draftTitle}
-                  onChange={(e) => setDraftTitle(e.target.value)}
-                  onClick={(e) => e.stopPropagation()}
-                  onMouseDown={(e) => e.stopPropagation()}
-                  onDoubleClick={(e) => e.stopPropagation()}
-                  onDragStart={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  draggable={false}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      e.preventDefault();
-                      commitRename();
-                    } else if (e.key === "Escape") {
-                      e.preventDefault();
-                      cancelRename();
-                    }
-                    e.stopPropagation();
-                  }}
-                  onFocus={(e) => e.currentTarget.select()}
-                  onBlur={commitRename}
-                  className="bg-transparent border-b border-[var(--moba-accent)] outline-none text-[12px] leading-none w-[160px] px-0"
-                  style={{ color: "inherit", font: "inherit" }}
-                />
-              ) : (
-                tab.title
-              )}
-            </span>
-            {tab.closable && (
-              <X
-                className="w-3 h-3 ml-1 opacity-60 hover:opacity-100"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  removeTab(tab.id);
-                }}
-              />
-            )}
-          </div>
+            onDropOnTab={(t, rect, clientX) => {
+              if (!draggedId) return;
+              const side = computeDropSide(rect, clientX);
+              if (draggedId !== t.id) {
+                moveTab(draggedId, t.id, side);
+              }
+              clearDragState();
+            }}
+            onActivate={(t) => {
+              if (editingTabId === t.id) return;
+              setActiveTab(t.id);
+            }}
+            onMouseDown={handleMouseDown}
+            onContextMenu={handleTabContext}
+            onDraftTitleChange={setDraftTitle}
+            onCommitRename={commitRename}
+            onCancelRename={cancelRename}
+            onStartRename={startRename}
+            onToggleMultiExecTab={toggleMultiExecTab}
+            onRemove={removeTab}
+          />
         );
       })}
 
@@ -379,5 +294,179 @@ function IconBtn({
     >
       {icon}
     </button>
+  );
+}
+
+interface TabItemProps {
+  tab: Tab;
+  active: boolean;
+  multiExecActive: boolean;
+  multiExecSelected: boolean;
+  dragging: boolean;
+  draggedId: string | null;
+  dropSide: "before" | "after" | undefined;
+  editing: boolean;
+  draftTitle: string;
+  onStartDrag: (e: React.PointerEvent<HTMLDivElement>, tab: Tab, el: HTMLDivElement) => void;
+  onDragOverTab: (tab: Tab, rect: DOMRect, clientX: number) => void;
+  onDragLeaveTab: (tab: Tab) => void;
+  onDropOnTab: (tab: Tab, rect: DOMRect, clientX: number) => void;
+  onActivate: (tab: Tab) => void;
+  onMouseDown: (e: React.MouseEvent, tab: Tab) => void;
+  onContextMenu: (e: React.MouseEvent, tab: Tab) => void;
+  onDraftTitleChange: (next: string) => void;
+  onCommitRename: () => void;
+  onCancelRename: () => void;
+  onStartRename: (tab: Tab) => void;
+  onToggleMultiExecTab: (id: string) => void;
+  onRemove: (id: string) => void;
+}
+
+function TabItem(props: TabItemProps) {
+  const {
+    tab,
+    active,
+    multiExecActive,
+    multiExecSelected,
+    dragging,
+    draggedId,
+    dropSide,
+    editing,
+    draftTitle,
+    onStartDrag,
+    onDragOverTab,
+    onDragLeaveTab,
+    onDropOnTab,
+    onActivate,
+    onMouseDown,
+    onContextMenu,
+    onDraftTitleChange,
+    onCommitRename,
+    onCancelRename,
+    onStartRename,
+    onToggleMultiExecTab,
+    onRemove,
+  } = props;
+
+  const ref = useRef<HTMLDivElement>(null);
+
+  useCustomDropTarget<HTMLDivElement>(ref, {
+    accepts: (data: CustomDragData) => data.mime === TAB_DRAG_MIME && draggedId !== null,
+    onDragOver: (detail) => {
+      const el = ref.current;
+      if (!el) return;
+      onDragOverTab(tab, el.getBoundingClientRect(), detail.clientX);
+    },
+    onDragLeave: () => onDragLeaveTab(tab),
+    onDrop: (detail) => {
+      const el = ref.current;
+      if (!el) return;
+      onDropOnTab(tab, el.getBoundingClientRect(), detail.clientX);
+    },
+  });
+
+  return (
+    <div
+      ref={ref}
+      data-testid="tab-item"
+      data-tab-id={tab.id}
+      data-tab-title={tab.title}
+      data-tab-type={tab.type}
+      data-multiexec-selected={multiExecSelected || undefined}
+      data-dragging={dragging || undefined}
+      data-drop-side={dropSide}
+      className="moba-tab relative"
+      data-active={active}
+      onClick={() => onActivate(tab)}
+      onMouseDown={(e) => {
+        if (editing) return;
+        onMouseDown(e, tab);
+      }}
+      onPointerDown={(e) => {
+        if (editing) return;
+        const el = ref.current;
+        if (!el) return;
+        onStartDrag(e, tab, el);
+      }}
+      onContextMenu={(e) => onContextMenu(e, tab)}
+    >
+      {multiExecActive && tab.type === "terminal" && (
+        <button
+          type="button"
+          title={multiExecSelected ? "Remove from MultiExec" : "Add to MultiExec"}
+          className="absolute -top-0.5 -left-0.5 w-3 h-3 rounded-full border flex items-center justify-center z-10 flex-shrink-0"
+          style={{
+            background: multiExecSelected ? "var(--moba-accent)" : "var(--moba-chrome-bg)",
+            borderColor: multiExecSelected ? "var(--moba-accent)" : "var(--moba-divider)",
+            fontSize: 7,
+            color: multiExecSelected ? "#fff" : "var(--moba-text-muted)",
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleMultiExecTab(tab.id);
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          {multiExecSelected ? "✓" : ""}
+        </button>
+      )}
+      <div className="relative flex-shrink-0">
+        <TabIcon kind={tab.type} ssh={!!tab.ssh} />
+        {tab.hasNewOutput && (
+          <span
+            className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-emerald-500 pointer-events-none"
+            aria-label="New output"
+          />
+        )}
+      </div>
+      <span
+        data-testid="tab-title"
+        className="truncate max-w-[180px]"
+        onDoubleClick={(e) => {
+          e.stopPropagation();
+          onStartRename(tab);
+        }}
+      >
+        {editing ? (
+          <input
+            data-testid="tab-title-input"
+            autoFocus
+            type="text"
+            value={draftTitle}
+            onChange={(e) => onDraftTitleChange(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            onDoubleClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                onCommitRename();
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                onCancelRename();
+              }
+              e.stopPropagation();
+            }}
+            onFocus={(e) => e.currentTarget.select()}
+            onBlur={onCommitRename}
+            className="bg-transparent border-b border-[var(--moba-accent)] outline-none text-[12px] leading-none w-[160px] px-0"
+            style={{ color: "inherit", font: "inherit" }}
+          />
+        ) : (
+          tab.title
+        )}
+      </span>
+      {tab.closable && (
+        <X
+          className="w-3 h-3 ml-1 opacity-60 hover:opacity-100"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove(tab.id);
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+        />
+      )}
+    </div>
   );
 }

--- a/src/lib/customDnD.ts
+++ b/src/lib/customDnD.ts
@@ -1,0 +1,325 @@
+// Pointer-driven drag-and-drop, kept independent of the HTML5 DnD API.
+//
+// Why: with `dragDropEnabled: true` (Tauri 2's default + required for OS file
+// drop into the webview on Windows), the native drag-drop handler intercepts
+// HTML5 dragstart/drop events on Windows. That breaks intra-app drags built on
+// `draggable`/`onDragStart`/`onDrop`. We re-implement just enough of HTML5
+// drag semantics on top of pointer events so SFTP cross-pane, tab reorder, and
+// session→folder drags keep working without touching the Tauri flag.
+//
+// Drop targets register via `useCustomDropTarget`, which subscribes to the
+// global pointer stream and self-filters by hit-testing its own element.
+
+import { useEffect, useRef, type RefObject } from "react";
+
+export interface CustomDragData {
+  /** Application-defined key (e.g. "newmob/tab", "newmob/session"). */
+  mime: string;
+  /** Arbitrary serialisable payload — drop targets read this. */
+  payload: unknown;
+}
+
+export interface CustomDragEventDetail {
+  data: CustomDragData;
+  clientX: number;
+  clientY: number;
+  /** Topmost element under the cursor at the time of dispatch. */
+  target: Element | null;
+}
+
+const POINTER_EVENT = "newmob:custom-drag-pointer";
+const END_EVENT = "newmob:custom-drag-end";
+
+interface PointerEventDetail extends CustomDragEventDetail {
+  phase: "move" | "drop" | "cancel";
+}
+
+interface ActiveDrag {
+  data: CustomDragData;
+  startX: number;
+  startY: number;
+  threshold: number;
+  activated: boolean;
+  ghost: HTMLElement | null;
+  ghostOffsetX: number;
+  ghostOffsetY: number;
+  pointerId: number;
+  onEnd?: () => void;
+  onCancel?: () => void;
+  cleanup: () => void;
+}
+
+let active: ActiveDrag | null = null;
+
+export function isCustomDragActive(): boolean {
+  return !!active?.activated;
+}
+
+export function getActiveCustomDragData(): CustomDragData | null {
+  return active ? active.data : null;
+}
+
+interface StartOpts {
+  /** The pointerdown / mousedown event that initiated the drag. */
+  event: { clientX: number; clientY: number; pointerId?: number; button?: number };
+  data: CustomDragData;
+  /** Pixels of pointer travel before activation. Default 4. */
+  thresholdPx?: number;
+  /** Optional ghost text shown next to the cursor while dragging. */
+  ghostText?: string;
+  /** Optional element cloned as ghost (overrides ghostText if both given). */
+  ghostElement?: HTMLElement | null;
+  /** Fired the first time the threshold is crossed (real drag begins). */
+  onActivate?: () => void;
+  /** Fired after pointerup or cancel. */
+  onEnd?: () => void;
+  /** Fired only on cancellation (Escape, blur, pointercancel). */
+  onCancel?: () => void;
+}
+
+export function startCustomDrag(opts: StartOpts): void {
+  if (opts.event.button != null && opts.event.button !== 0) return;
+  if (active) cancelActive();
+
+  const drag: ActiveDrag = {
+    data: opts.data,
+    startX: opts.event.clientX,
+    startY: opts.event.clientY,
+    threshold: opts.thresholdPx ?? 4,
+    activated: false,
+    ghost: null,
+    ghostOffsetX: 12,
+    ghostOffsetY: 12,
+    pointerId: opts.event.pointerId ?? -1,
+    onEnd: opts.onEnd,
+    onCancel: opts.onCancel,
+    cleanup: () => {
+      window.removeEventListener("pointermove", onPointerMove, true);
+      window.removeEventListener("pointerup", onPointerUp, true);
+      window.removeEventListener("pointercancel", onPointerCancel, true);
+      window.removeEventListener("keydown", onKeyDown, true);
+      window.removeEventListener("blur", onBlur, true);
+    },
+  };
+  active = drag;
+
+  const ensureActivated = (clientX: number, clientY: number): boolean => {
+    if (drag.activated) return true;
+    const dx = clientX - drag.startX;
+    const dy = clientY - drag.startY;
+    if (dx * dx + dy * dy < drag.threshold * drag.threshold) return false;
+    drag.activated = true;
+    drag.ghost = createGhost(opts.ghostElement ?? null, opts.ghostText ?? null);
+    if (drag.ghost) {
+      document.body.appendChild(drag.ghost);
+      positionGhost(drag, clientX, clientY);
+    }
+    suppressNextClick();
+    opts.onActivate?.();
+    return true;
+  };
+
+  const onPointerMove = (ev: PointerEvent) => {
+    if (!ensureActivated(ev.clientX, ev.clientY)) return;
+    ev.preventDefault();
+    positionGhost(drag, ev.clientX, ev.clientY);
+    emit({
+      phase: "move",
+      data: drag.data,
+      clientX: ev.clientX,
+      clientY: ev.clientY,
+      target: pointerTarget(ev.clientX, ev.clientY, drag.ghost),
+    });
+  };
+
+  const finish = (clientX: number, clientY: number, dropped: boolean) => {
+    if (!active || active !== drag) return;
+    if (drag.activated) {
+      const target = pointerTarget(clientX, clientY, drag.ghost);
+      emit({
+        phase: dropped ? "drop" : "cancel",
+        data: drag.data,
+        clientX,
+        clientY,
+        target,
+      });
+      window.dispatchEvent(
+        new CustomEvent<CustomDragEventDetail>(END_EVENT, {
+          detail: { data: drag.data, clientX, clientY, target },
+        }),
+      );
+    }
+    drag.cleanup();
+    if (drag.ghost && drag.ghost.parentNode) {
+      drag.ghost.parentNode.removeChild(drag.ghost);
+    }
+    active = null;
+    if (!dropped) drag.onCancel?.();
+    drag.onEnd?.();
+  };
+
+  const onPointerUp = (ev: PointerEvent) => {
+    finish(ev.clientX, ev.clientY, true);
+  };
+
+  const onPointerCancel = (ev: PointerEvent) => {
+    finish(ev.clientX, ev.clientY, false);
+  };
+
+  const onKeyDown = (ev: KeyboardEvent) => {
+    if (ev.key === "Escape" && active === drag) {
+      ev.preventDefault();
+      finish(drag.startX, drag.startY, false);
+    }
+  };
+
+  const onBlur = () => {
+    if (active === drag) finish(drag.startX, drag.startY, false);
+  };
+
+  window.addEventListener("pointermove", onPointerMove, true);
+  window.addEventListener("pointerup", onPointerUp, true);
+  window.addEventListener("pointercancel", onPointerCancel, true);
+  window.addEventListener("keydown", onKeyDown, true);
+  window.addEventListener("blur", onBlur, true);
+}
+
+function emit(detail: PointerEventDetail) {
+  window.dispatchEvent(new CustomEvent<PointerEventDetail>(POINTER_EVENT, { detail }));
+}
+
+function cancelActive() {
+  if (!active) return;
+  active.cleanup();
+  if (active.ghost && active.ghost.parentNode) {
+    active.ghost.parentNode.removeChild(active.ghost);
+  }
+  active = null;
+}
+
+function pointerTarget(x: number, y: number, ghost: HTMLElement | null): Element | null {
+  // Hide the ghost briefly so elementFromPoint sees the real target underneath.
+  let prevDisplay: string | null = null;
+  if (ghost) {
+    prevDisplay = ghost.style.display;
+    ghost.style.display = "none";
+  }
+  const target = document.elementFromPoint(x, y);
+  if (ghost) ghost.style.display = prevDisplay ?? "";
+  return target;
+}
+
+function createGhost(element: HTMLElement | null, text: string | null): HTMLElement | null {
+  if (!element && !text) return null;
+  const wrapper = document.createElement("div");
+  wrapper.style.position = "fixed";
+  wrapper.style.left = "0";
+  wrapper.style.top = "0";
+  wrapper.style.pointerEvents = "none";
+  wrapper.style.zIndex = "2147483647";
+  wrapper.style.opacity = "0.85";
+  wrapper.style.transformOrigin = "0 0";
+  wrapper.dataset.customDragGhost = "true";
+
+  if (element) {
+    const clone = element.cloneNode(true) as HTMLElement;
+    const rect = element.getBoundingClientRect();
+    clone.style.width = `${rect.width}px`;
+    clone.style.height = `${rect.height}px`;
+    clone.style.margin = "0";
+    clone.style.boxShadow = "0 4px 12px rgba(0,0,0,0.25)";
+    wrapper.appendChild(clone);
+  } else if (text) {
+    wrapper.textContent = text;
+    wrapper.style.padding = "2px 8px";
+    wrapper.style.background = "var(--moba-accent, #2b5d8b)";
+    wrapper.style.color = "#fff";
+    wrapper.style.font = "12px system-ui, sans-serif";
+    wrapper.style.borderRadius = "3px";
+    wrapper.style.boxShadow = "0 2px 6px rgba(0,0,0,0.2)";
+    wrapper.style.whiteSpace = "nowrap";
+    wrapper.style.maxWidth = "240px";
+    wrapper.style.overflow = "hidden";
+    wrapper.style.textOverflow = "ellipsis";
+  }
+
+  return wrapper;
+}
+
+function positionGhost(drag: ActiveDrag, x: number, y: number) {
+  if (!drag.ghost) return;
+  drag.ghost.style.transform = `translate(${x + drag.ghostOffsetX}px, ${y + drag.ghostOffsetY}px)`;
+}
+
+// HTML5 drag suppresses the click that would otherwise fire on pointerup.
+// Mirror that so callers don't see a stray select / activate after a drop.
+function suppressNextClick() {
+  const onClick = (ev: Event) => {
+    ev.stopPropagation();
+    ev.preventDefault();
+    window.removeEventListener("click", onClick, true);
+  };
+  window.addEventListener("click", onClick, true);
+  window.setTimeout(() => window.removeEventListener("click", onClick, true), 0);
+}
+
+export interface CustomDropHandlers {
+  /** Return true if the drop target accepts the dragged data. */
+  accepts: (data: CustomDragData) => boolean;
+  onDragEnter?: (detail: CustomDragEventDetail) => void;
+  onDragOver?: (detail: CustomDragEventDetail) => void;
+  onDragLeave?: () => void;
+  onDrop: (detail: CustomDragEventDetail) => void;
+}
+
+export function useCustomDropTarget<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  handlers: CustomDropHandlers,
+): void {
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  useEffect(() => {
+    let entered = false;
+
+    const onPointer = (ev: Event) => {
+      const detail = (ev as CustomEvent<PointerEventDetail>).detail;
+      const el = ref.current;
+      const target = detail.target;
+      const inside = !!(el && target && (el === target || el.contains(target)));
+      const accepted = inside && handlersRef.current.accepts(detail.data);
+
+      if (detail.phase === "move") {
+        if (accepted) {
+          if (!entered) {
+            entered = true;
+            handlersRef.current.onDragEnter?.(detail);
+          }
+          handlersRef.current.onDragOver?.(detail);
+        } else if (entered) {
+          entered = false;
+          handlersRef.current.onDragLeave?.();
+        }
+        return;
+      }
+      // drop or cancel
+      if (detail.phase === "drop" && accepted) {
+        entered = false;
+        handlersRef.current.onDrop(detail);
+      } else if (entered) {
+        entered = false;
+        handlersRef.current.onDragLeave?.();
+      }
+    };
+
+    window.addEventListener(POINTER_EVENT, onPointer);
+    return () => {
+      window.removeEventListener(POINTER_EVENT, onPointer);
+    };
+  }, [ref]);
+}
+
+export const __customDragTesting = {
+  POINTER_EVENT,
+  END_EVENT,
+};


### PR DESCRIPTION
Tauri's native drag-drop handler is exclusive with HTML5 DnD on Windows: keeping it disabled (the previous workaround) preserved intra-app drags but blocked OS file drop into the terminal and remote SFTP pane.

Re-enable the native handler and rebuild every intra-app drag on a pointer-driven custom DnD layer (src/lib/customDnD.ts) that does not touch HTML5 dataTransfer at all. Migrated: tab reorder, session→folder move, SFTP cross-pane copy. OS file drop into the SFTP remote pane keeps its HTML5 fallback for browser dev mode.

Also moves useCustomDropTarget above the early-return in FilePanel to satisfy the Rules of Hooks when the SFTP session is still attaching.