### PR TITLE
fix(filebrowser): navigate into symlinked directories instead of xdg-…

### DIFF
--- a/src-tauri/src/filebrowser/local.rs
+++ b/src-tauri/src/filebrowser/local.rs
@@ -221,6 +221,22 @@ fn entry_for(path: &Path) -> Result<FileEntryDto, String> {
     } else {
         None
     };
+    // For symlinks, follow one level to record the *target*'s type so that
+    // callers can route a "symlink → dir" double-click into a directory
+    // navigation instead of handing it to the OS file manager via xdg-open.
+    let target_file_type = if meta.file_type().is_symlink() {
+        fs::metadata(path).ok().map(|m| {
+            if m.is_dir() {
+                "dir".to_string()
+            } else if m.is_file() {
+                "file".to_string()
+            } else {
+                "unknown".to_string()
+            }
+        })
+    } else {
+        None
+    };
 
     Ok(FileEntryDto {
         name: name.clone(),
@@ -229,6 +245,7 @@ fn entry_for(path: &Path) -> Result<FileEntryDto, String> {
         mtime,
         mode,
         file_type: file_type.into(),
+        target_file_type,
         is_hidden: name.starts_with('.'),
         symlink_target,
         owner: None,

--- a/src-tauri/src/filebrowser/sftp.rs
+++ b/src-tauri/src/filebrowser/sftp.rs
@@ -29,6 +29,12 @@ pub struct FileEntryDto {
     pub mode: u32,
     #[serde(rename = "fileType")]
     pub file_type: String,
+    /// Effective type after one level of symlink resolution. `None` for
+    /// non-symlinks; `"dir"` / `"file"` / `"unknown"` when the link target
+    /// could be stat'd; left as `None` for broken or permission-denied
+    /// links (callers fall back to `file_type`).
+    #[serde(rename = "targetFileType", skip_serializing_if = "Option::is_none")]
+    pub target_file_type: Option<String>,
     #[serde(rename = "isHidden")]
     pub is_hidden: bool,
     #[serde(rename = "symlinkTarget")]
@@ -100,6 +106,19 @@ impl ActiveSftp {
                 let sftp = self.sftp.lock().await;
                 if let Ok(target) = sftp.read_link(full.clone()).await {
                     dto.symlink_target = Some(target);
+                }
+                // STAT (vs LSTAT used by read_dir) follows the link — the
+                // returned attrs describe the *target*. We only need its
+                // type so callers can distinguish "symlink → dir" from
+                // "symlink → file" when handling double-click / open.
+                if let Ok(target_attrs) = sftp.metadata(full.clone()).await {
+                    let t = match target_attrs.file_type() {
+                        SftpFileType::Dir => "dir",
+                        SftpFileType::File => "file",
+                        SftpFileType::Symlink => "symlink",
+                        SftpFileType::Other => "unknown",
+                    };
+                    dto.target_file_type = Some(t.into());
                 }
             }
             entries.push(dto);
@@ -775,6 +794,7 @@ fn entry_from_attrs(
         mtime,
         mode,
         file_type: file_type.into(),
+        target_file_type: None,
         symlink_target: None,
         owner: attrs.uid.map(|u| u.to_string()),
         group: attrs.gid.map(|g| g.to_string()),

--- a/src/components/filebrowser/FileBrowser.tsx
+++ b/src/components/filebrowser/FileBrowser.tsx
@@ -19,7 +19,7 @@ import { FileTransferQueue } from "./FileTransferQueue";
 import { ChmodDialog } from "./ChmodDialog";
 import { useSftpStore, type PaneSide } from "../../stores/sftpStore";
 import { useSftpController } from "../../lib/sftpController";
-import { joinPath, basename, sftpStat, type FileEntry, type FsSide } from "../../lib/sftp";
+import { joinPath, basename, sftpStat, effectiveFileType, type FileEntry, type FsSide } from "../../lib/sftp";
 import type { MenuItem } from "../ContextMenu";
 import { useAppStore } from "../../stores/appStore";
 
@@ -216,7 +216,7 @@ export function FileBrowser(props: FileBrowserProps) {
 
   const handleDoubleClick = useCallback(
     async (side: PaneSide, entry: FileEntry) => {
-      if (entry.fileType === "dir") {
+      if (effectiveFileType(entry) === "dir") {
         await navigate(props.sessionId, side, entry.path);
         if (side === "remote") props.onTerminalSync?.(entry.path);
         return;
@@ -248,7 +248,7 @@ export function FileBrowser(props: FileBrowserProps) {
     async (entries: FileEntry[]) => {
       const { sftpOpenPath } = await import("../../lib/sftp");
       for (const entry of entries) {
-        if (entry.fileType === "dir") {
+        if (effectiveFileType(entry) === "dir") {
           await navigate(props.sessionId, "local", entry.path);
           return;
         }
@@ -269,7 +269,7 @@ export function FileBrowser(props: FileBrowserProps) {
       const multi = targets.length > 1;
       const items: MenuItem[] = [];
       items.push({
-        label: entry.fileType === "dir"
+        label: effectiveFileType(entry) === "dir"
           ? "Open folder"
           : multi
             ? `Open ${targets.length} files`

--- a/src/components/filebrowser/LocalFileBrowserPanel.tsx
+++ b/src/components/filebrowser/LocalFileBrowserPanel.tsx
@@ -3,7 +3,7 @@ import { FilePanel } from "./FilePanel";
 import { ChmodDialog } from "./ChmodDialog";
 import { useSftpStore } from "../../stores/sftpStore";
 import { useSftpController } from "../../lib/sftpController";
-import { sftpOpenPath, type FileEntry } from "../../lib/sftp";
+import { sftpOpenPath, effectiveFileType, type FileEntry } from "../../lib/sftp";
 import { useAppStore } from "../../stores/appStore";
 import type { MenuItem } from "../ContextMenu";
 
@@ -45,7 +45,7 @@ export function LocalFileBrowserPanel({ tabId, initialPath }: Props) {
 
   const handleOpen = useCallback(async (entries: FileEntry[]) => {
     for (const entry of entries) {
-      if (entry.fileType === "dir") {
+      if (effectiveFileType(entry) === "dir") {
         await navigate(tabId, "local", entry.path);
         return;
       }
@@ -58,7 +58,7 @@ export function LocalFileBrowserPanel({ tabId, initialPath }: Props) {
   }, [navigate, setStatus, tabId]);
 
   const handleDoubleClick = useCallback(async (entry: FileEntry) => {
-    if (entry.fileType === "dir") {
+    if (effectiveFileType(entry) === "dir") {
       await navigate(tabId, "local", entry.path);
       return;
     }
@@ -75,8 +75,9 @@ export function LocalFileBrowserPanel({ tabId, initialPath }: Props) {
       const target = targets[0] ?? entry;
       const multi = targets.length > 1;
       const items: MenuItem[] = [];
+      const effective = effectiveFileType(entry);
       items.push({
-        label: entry.fileType === "dir"
+        label: effective === "dir"
           ? "Open folder"
           : multi
             ? `Open ${targets.length} files`
@@ -87,7 +88,7 @@ export function LocalFileBrowserPanel({ tabId, initialPath }: Props) {
         items.push({
           label: "Reveal in OS file manager",
           onClick: () => {
-            const path = target.fileType === "dir" ? target.path : (session?.local.path ?? "");
+            const path = effective === "dir" ? target.path : (session?.local.path ?? "");
             void sftpOpenPath(path).catch((err) => setStatus(`Open failed: ${err}`));
           },
         });

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -26,7 +26,7 @@ import { LocalFileBrowserPanel } from "../components/filebrowser/LocalFileBrowse
 import { SftpSidebar } from "../components/filebrowser/SftpSidebar";
 import { isTauriRuntime } from "../lib/runtime";
 import { openSftpWindow } from "../lib/sftp";
-import { sftpOpenPath, sftpStat } from "../lib/sftp";
+import { sftpOpenPath, sftpStat, effectiveFileType } from "../lib/sftp";
 import { writeTerminal } from "../lib/ipc";
 import { encodeBase64 } from "../lib/ipc";
 import {
@@ -425,7 +425,7 @@ export function MainLayout() {
     let isDir = false;
     try {
       const info = await sftpStat("", trimmed, "local");
-      isDir = info.fileType === "dir";
+      isDir = effectiveFileType(info) === "dir";
     } catch (err) {
       setStatusMessage(`Stat failed: ${err instanceof Error ? err.message : String(err)}`);
       return;

--- a/src/lib/sftp.ts
+++ b/src/lib/sftp.ts
@@ -21,6 +21,13 @@ export interface FileEntry {
   mtime: number;
   mode: number;
   fileType: FileType;
+  /**
+   * Effective type after one level of symlink resolution. Only populated
+   * when `fileType === "symlink"` AND the target was reachable. Lets the
+   * UI decide whether a double-click on a symlink should navigate (target
+   * is a directory) or be handed to the OS opener (target is a file).
+   */
+  targetFileType?: FileType | null;
   isHidden: boolean;
   symlinkTarget?: string | null;
   owner?: string | null;
@@ -261,6 +268,20 @@ export async function openSftpWindow(
 
 export async function sftpOpenPath(path: string): Promise<void> {
   return invoke("sftp_open_path", { path });
+}
+
+/**
+ * Returns the *effective* type for navigation/open routing. A symlink
+ * whose target stat'd as a directory should be treated like a directory
+ * (so double-click navigates inside it instead of falling through to
+ * `xdg-open`, which would launch the system file manager). Falls back
+ * to the link's own type when the target is unreachable.
+ */
+export function effectiveFileType(entry: FileEntry): FileType {
+  if (entry.fileType === "symlink" && entry.targetFileType) {
+    return entry.targetFileType;
+  }
+  return entry.fileType;
 }
 
 export async function sftpReadFileText(


### PR DESCRIPTION
…open

Double-clicking or "Open"-ing a symlink that points to a directory used to fall through to the OS file manager (xdg-open on Linux) because the backend reported `fileType: "symlink"` and the frontend only treated `"dir"` as navigable.

The DTO now carries an optional `targetFileType` resolved by following one level of the link (best-effort; broken/permission-denied links stay empty). Open/double-click handlers route through a new `effectiveFileType()` helper so a symlink-to-dir navigates inside the pane, matching how a real directory behaves. Same fix applies to the remote SFTP pane and the menu-bar "Open" entry point.