### PR TITLE
fix(sidebar): replace window.confirm with in-app dialog so macOS WKWe…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "newmob",
   "private": true,
-  "version": "0.1.28",
+  "version": "0.1.29",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/sidebar/ConfirmDialog.tsx
+++ b/src/components/sidebar/ConfirmDialog.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from "react";
+
+export interface ConfirmDialogProps {
+  title?: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  danger?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+// Drop-in replacement for window.confirm. Tauri 2's macOS WKWebView ignores
+// window.confirm/alert by default, so any flow that relied on them silently
+// no-ops on macOS. This in-app dialog renders as a normal React modal so it
+// works uniformly on every platform without pulling in tauri-plugin-dialog.
+export function ConfirmDialog({
+  title = "Confirm",
+  message,
+  confirmLabel = "OK",
+  cancelLabel = "Cancel",
+  danger = false,
+  onCancel,
+  onConfirm,
+}: ConfirmDialogProps) {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    confirmRef.current?.focus();
+  }, []);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      onCancel();
+    } else if (event.key === "Enter") {
+      const target = event.target as HTMLElement;
+      if (target.tagName !== "BUTTON") {
+        event.preventDefault();
+        onConfirm();
+      }
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: "rgba(0,0,0,0.4)" }}
+      onClick={onCancel}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        role="dialog"
+        aria-label={title}
+        aria-modal="true"
+        data-testid="confirm-dialog"
+        className="w-[420px] rounded shadow-lg p-4"
+        style={{ background: "var(--moba-bg)", border: "1px solid var(--moba-card-border)" }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="text-sm font-semibold mb-3">{title}</div>
+        <div
+          data-testid="confirm-dialog-message"
+          className="text-[12px] mb-4 whitespace-pre-line"
+          style={{ color: "var(--moba-text)" }}
+        >
+          {message}
+        </div>
+        <div className="flex gap-2 justify-end">
+          <button
+            type="button"
+            data-testid="confirm-dialog-cancel"
+            className="px-3 py-1 text-[12px] rounded hover:bg-[var(--moba-hover)]"
+            onClick={onCancel}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            data-testid="confirm-dialog-confirm"
+            className="px-3 py-1 text-[12px] rounded text-white"
+            style={{ background: danger ? "#b22222" : "var(--moba-accent)" }}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sidebar/SessionTree.tsx
+++ b/src/components/sidebar/SessionTree.tsx
@@ -82,6 +82,7 @@ import {
 } from "../../lib/sessionPaths";
 import { SessionImportPreview } from "../session/SessionImportPreview";
 import { ExternalVaultUnlockDialog } from "../session/ExternalVaultUnlockDialog";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 const SESSION_DRAG_MIME = "newmob/session";
 
@@ -140,6 +141,13 @@ export function SessionTree({ onNewSession, onConnectSession, onEditSession }: S
     errorMessage: string | null;
     onSubmit: (password: string) => Promise<void>;
     onSkip: () => void;
+  } | null>(null);
+  const [confirmPrompt, setConfirmPrompt] = useState<{
+    title?: string;
+    message: string;
+    confirmLabel?: string;
+    danger?: boolean;
+    onConfirm: () => void;
   } | null>(null);
   const ctx = useContextMenu();
 
@@ -233,15 +241,24 @@ export function SessionTree({ onNewSession, onConnectSession, onEditSession }: S
     }
   };
 
-  const deleteFolder = async (folderPath: string) => {
+  const deleteFolder = (folderPath: string) => {
     const affected = sessionsInFolder(sessions, folderPath);
     const suffix = affected.length > 0
       ? ` and ${affected.length} session${affected.length === 1 ? "" : "s"} inside it`
       : "";
-    if (!window.confirm(`Delete folder "${folderOptionLabel(folderPath)}"${suffix}?`)) return;
-
-    await deleteFolderPath(folderPath);
-    setStatusMessage(`Deleted folder ${folderOptionLabel(folderPath)}`);
+    setConfirmPrompt({
+      title: "Delete folder",
+      message: `Delete folder "${folderOptionLabel(folderPath)}"${suffix}?`,
+      confirmLabel: "Delete",
+      danger: true,
+      onConfirm: () => {
+        setConfirmPrompt(null);
+        void (async () => {
+          await deleteFolderPath(folderPath);
+          setStatusMessage(`Deleted folder ${folderOptionLabel(folderPath)}`);
+        })();
+      },
+    });
   };
 
   const exportFolder = (folderPath: string | null) => {
@@ -1052,14 +1069,15 @@ export function SessionTree({ onNewSession, onConnectSession, onEditSession }: S
       { label: "New session", icon: <Plus className="w-3 h-3" />, onClick: () => onNewSession?.(toStoredGroupPath(folderPath)) },
       { label: "New folder", icon: <FolderPlus className="w-3 h-3" />, onClick: () => createFolder(folderPath) },
       { label: "Edit folder", icon: <Edit3 className="w-3 h-3" />, disabled: isRoot, onClick: () => { if (normalized) renameFolder(normalized); } },
-      { label: "Delete folder", icon: <Trash2 className="w-3 h-3" />, danger: true, disabled: isRoot, onClick: () => normalized && void deleteFolder(normalized) },
+      { label: "Delete folder", icon: <Trash2 className="w-3 h-3" />, danger: true, disabled: isRoot, onClick: () => { if (normalized) deleteFolder(normalized); } },
       { label: "Create a desktop shortcut", icon: <Star className="w-3 h-3" />, onClick: () => unavailable("Create a desktop shortcut") },
       { label: "", separator: true },
       { label: "Import NewMob sessions", icon: <Upload className="w-3 h-3" />, onClick: () => importJson(folderPath) },
+      { label: "Import sessions from third-party programs", icon: <Upload className="w-3 h-3" />, children: importChildren },
+      { label: "", separator: true },
       { label: "Export NewMob sessions", icon: <Download className="w-3 h-3" />, disabled: folderSessions.length === 0, onClick: () => exportFolder(folderPath) },
       { label: "Export MobaXterm sessions", icon: <Download className="w-3 h-3" />, disabled: folderSessions.length === 0, onClick: () => exportMobaFolder(folderPath) },
       { label: "Export sessions as CSV", icon: <FileText className="w-3 h-3" />, disabled: folderSessions.length === 0, onClick: () => exportCsvFolder(folderPath) },
-      { label: "Import sessions from third-party programs", icon: <Upload className="w-3 h-3" />, children: importChildren },
       { label: "Generate HTML web page", icon: <FileText className="w-3 h-3" />, disabled: folderSessions.length === 0, onClick: () => generateHtml(folderPath) },
       { label: "", separator: true },
       { label: "Execute all sessions from this folder", icon: <Play className="w-3 h-3" />, disabled: folderSessions.length === 0 || !onConnectSession, onClick: () => executeFolder(folderPath) },
@@ -1119,6 +1137,16 @@ export function SessionTree({ onNewSession, onConnectSession, onEditSession }: S
           errorMessage={externalVaultPrompt.errorMessage}
           onSubmit={externalVaultPrompt.onSubmit}
           onSkip={externalVaultPrompt.onSkip}
+        />
+      )}
+      {confirmPrompt && (
+        <ConfirmDialog
+          title={confirmPrompt.title}
+          message={confirmPrompt.message}
+          confirmLabel={confirmPrompt.confirmLabel}
+          danger={confirmPrompt.danger}
+          onCancel={() => setConfirmPrompt(null)}
+          onConfirm={confirmPrompt.onConfirm}
         />
       )}
       <div

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -13,7 +13,9 @@ import {
   Bot,
   FolderTree,
 } from "lucide-react";
+import { useState } from "react";
 import { SessionTree } from "./SessionTree";
+import { ConfirmDialog } from "./ConfirmDialog";
 import { useAppStore, type SideTab } from "../../stores/appStore";
 import { useSessionStore } from "../../stores/sessionStore";
 import type { SessionConfig } from "../../lib/ipc";
@@ -48,11 +50,11 @@ export function Sidebar({ onNewSession, onNewSftpSession, onEditSession, onConne
     .sort((a, b) => (b.last_connected_at ?? 0) - (a.last_connected_at ?? 0))
     .slice(0, 6);
 
+  const [deleteConfirm, setDeleteConfirm] = useState<SessionConfig | null>(null);
+
   const handleDelete = () => {
     if (!selectedSession) return;
-    if (window.confirm(`Delete session "${selectedSession.name}"?`)) {
-      void removeSession(selectedSession.id);
-    }
+    setDeleteConfirm(selectedSession);
   };
 
   const handleFavorite = () => {
@@ -89,6 +91,7 @@ export function Sidebar({ onNewSession, onNewSftpSession, onEditSession, onConne
   };
 
   return (
+    <>
     <div data-testid="sidebar" className="h-full flex">
       <div
         className="w-[26px] flex flex-col shrink-0"
@@ -188,6 +191,21 @@ export function Sidebar({ onNewSession, onNewSftpSession, onEditSession, onConne
       </div>
       )}
     </div>
+    {deleteConfirm && (
+      <ConfirmDialog
+        title="Delete session"
+        message={`Delete session "${deleteConfirm.name}"?`}
+        confirmLabel="Delete"
+        danger
+        onCancel={() => setDeleteConfirm(null)}
+        onConfirm={() => {
+          const id = deleteConfirm.id;
+          setDeleteConfirm(null);
+          void removeSession(id);
+        }}
+      />
+    )}
+    </>
   );
 }
 


### PR DESCRIPTION
…bView shows confirmations

Tauri 2's macOS WKWebView ignores window.confirm/alert by default, so the folder/session delete confirmations silently no-op'd. Replaced with a small ConfirmDialog component (mirrors FolderNameDialog) used by SessionTree's deleteFolder and Sidebar's toolbar delete.

Also regrouped the folder context menu so Import items sit together (always enabled) and Export/Generate items sit together (disabled when the folder is empty), removing the visual impression that imports were grayed out.

Bumps version to 0.1.29.