### PR TITLE
perf(servers): XDamage event-driven, region-cropped RDP X11 capture

### DIFF
--- a/rust_rdp_server_dev_plan.md
+++ b/rust_rdp_server_dev_plan.md
@@ -52,7 +52,7 @@
 | 阶段 0 脚手架 + 取消桥接 | ✅ | `servers/rdp.rs`；取消桥接用 `event_sender()`+`ServerEvent::Quit`（比计划设想更干净）；`!Send` 的 `run()` 跑在专用 current-thread runtime |
 | 阶段 1 真实捕获 | ✅ Linux / 🟢 Win·mac | Linux X11 XShm + 普通 `GetImage` 回退，**运行时实测出帧**；Win(DXGI/WGC)、mac(CGDisplayStream) 仅占位 `bail!`，**未实现** |
 | 阶段 2 输入注入 + 坐标 | ✅ Linux / 🟢 Win·mac | enigo(x11rb 后端) + RDP Set-1 扫描码→各平台 keycode 映射（单测覆盖）。**计划修正**：`MouseEvent::Move` 已是屏幕像素,无需 65535 换算 |
-| 阶段 3 性能：脏区 + 编码协商 | 🟡 | 帧抑制(FNV 哈希)+ 16/64 块脏区检测(单测)；RemoteFX 由库默认协商、rect-diff 由编码器内部完成。**差距**：未做帧率/带宽基准；1080p 整屏 RemoteFX 编码 ~110ms,未进一步优化 |
+| 阶段 3 性能：脏区 + 编码协商 | ✅ Linux X11 / 🟡 其它 | **事件驱动捕获重构（2026-05-30）**：X11 改用 XDamage（`damage`+`xfixes` feature）—— 空闲零回读/零哈希，变化时经 `damage_subtract`+`xfixes_fetch_region` 原子取回精确脏矩形，只回读+编码该区域（参考 RustDesk 模型）。实测（debug 构建，1920×1080）：旧路径每帧固定 ~143ms（95ms 全屏回读 + 49ms 8MB FNV 哈希）⇒ 新路径空闲 0ms、100×40 区域回读 ~0.25ms（约 380× 提升）。60fps 上限、多矩形 >8 时退化为包围盒、无 DAMAGE 时回退原定时全屏轮询。RemoteFX 由库默认协商、rayon 并行编码、库内 `find_different_rects_sub` 再按 64 块裁剪。**差距**：全屏/视频场景仍是全回读（X11 固有）；光标 sprite 未做（见下）；Win/mac/Wayland 仍走全帧轮询 |
 | 阶段 4 安全：TLS + NLA | ✅ | rcgen 自签 + `with_tls`/`with_hybrid`(NLA) + 强制凭据 + `0.0.0.0` 告警；**Win11 mstsc 默认 NLA 实测连通** |
 | 阶段 5 Wayland 攻坚 | 🟡 脚手架 | 会话检测 + 门户流程文档；输入经 enigo wayland 后端可用。**差距**：无 PipeWire/ashpd 捕获后端（本机无开发头,未集成） |
 | 阶段 6 虚拟通道 + 前端 | ✅ / 🟡 音频 | cliprdr **文本**双向桥(arboard) + 前端 RDP 配置卡 + en/zh i18n。**差距**：rdpsnd 音频未实现；剪贴板仅文本（无图片/文件） |
@@ -62,7 +62,9 @@
 | §9 无头支持 | 🟡 Linux 脚手架 / ⛔ Win·mac | Linux 与 §7 同机制(探测就绪,网关未做)；Win(IddCx)/mac 计划明确不实现 |
 | §10 公网加固 | 🟡 | 已落地：强制 NLA、无凭据拒启/告警、绑定告警(P0/P3 子集)。**差距**：fuzzing CI、fail2ban/限速、MFA、审计录制、真 CA 证书等未做 |
 
-**一句话**：基础阶段 0–6 的 **Linux X11 全链路可用**（连接/桌面/键鼠/剪贴板/TLS+NLA 实测）；性能(3)做了主体但未调优；Wayland(5)、Linux 进阶会话(7/9)、公网加固(10) 为脚手架/部分；Windows/macOS 捕获注入为结构性代码未运行时验证；§8 与 Win/mac 进阶项未开始或明确不做。
+**一句话**：基础阶段 0–6 的 **Linux X11 全链路可用且响应性达标**（连接/桌面/键鼠/剪贴板/TLS+NLA 实测；性能经 XDamage 事件驱动+区域裁剪重构，空闲零开销、增量变化按面积计费，对标 RustDesk/NoMachine 模型并有基准佐证）；Wayland(5)、Linux 进阶会话(7/9)、公网加固(10) 为脚手架/部分；Windows/macOS 捕获注入为结构性代码未运行时验证；§8 与 Win/mac 进阶项未开始或明确不做。
+
+> **遗留增强（按价值排序）**：① 光标 sprite —— X11 `GetImage` 不含硬件光标，应经 `xfixes_get_cursor_image` → `DisplayUpdate::RGBAPointer` 单独下发（客户端本地渲染、不触发位图脏区）；当前因本机无 RDP 客户端无法可视化验证「双光标/行序」风险而暂缓。② 全屏/视频场景的整屏回读优化（DXGI 式硬件脏区在 X11 无对应，可评估 NvFBC/DRI3）。③ Wayland PipeWire 捕获后端。
 
 ---
 
@@ -191,12 +193,13 @@ RustDesk 把 BGRA 喂给 libyuv→VP9（自有协议）；**IronRDP 的 `BitmapU
 - 键盘：RDP scancode（set 1）→ enigo `Key`，处理扩展键 / 修饰键。
 - ✅ 验收：三平台能远程操作（点击、拖拽、键入、组合键）。
 
-### 阶段 3 — 性能：脏区差量 + 编码协商 🟡 主体完成，未做基准/调优
-- **优先用平台原生脏区**：DXGI `AcquireNextFrame` 直接给 `GetFrameDirtyRects`/`GetFrameMoveRects`（RustDesk 同款来源），无需自己算。
-- 无原生脏区的后端（xcap 起步态 / 部分 X11）回退 CPU 侧 16×16 网格哈希预扫描挑脏块（两份文档一致），只编码变化矩形。
-- 与客户端协商编码：优先 RemoteFX（`ironrdp-graphics`，Tile/YCoCg/DCT）→ 低带宽降级 RDP 6.0 Bitmap。
-- 帧率 / 延迟基准：局域网 1080p 目标 ≥15fps、空闲带宽趋近 0。
-- ✅ 验收：静止桌面带宽近零；视频 / 滚动场景不打满百兆。
+### 阶段 3 — 性能：脏区差量 + 编码协商 ✅ Linux X11 完成（事件驱动+区域裁剪，有基准）
+- **X11 事件驱动捕获（已落地）**：弃用「定时全屏轮询 + 8MB FNV 哈希」，改用 **XDamage** —— X 服务器主动告知何时何处变化。`damage_create`(NON_EMPTY) 唤醒 → `damage_subtract` 原子消费进 `xfixes` region → `xfixes_fetch_region` 取回精确脏矩形 → **只 `shm_get_image` 该矩形**。空闲 = 无事件 = 零回读/零哈希/零 CPU。首帧仍发全屏以初始化编码器 framebuffer，之后发裁剪区（库 `find_different_rects_sub` 在该子区按 64 块再 diff，只 RemoteFX 编码变化块）。
+- **基准（debug，1920×1080，本机 X11 实测）**：旧每帧固定 ~143ms（95ms 全屏回读 + 49ms 8MB 哈希）⇒ 新空闲 0ms、100×40 区域回读 ~0.25ms。这就是 RustDesk「空闲免费、增量按面积计费」的模型。
+- **健壮性**：60fps 上限（连续拖拽/视频）；脏矩形 >8 个退化为包围盒避免多次往返；无 DAMAGE/XFIXES 的服务器（老 Xorg/部分转发连接）自动回退到原定时全屏+哈希路径（`is_event_driven()=false`）。
+- 与客户端协商编码：RemoteFX 由库默认协商（`server_codecs_capabilities`），rayon 并行 tile 编码（feature 已启用）。
+- 单测：`DamageRect` 并集/裁剪纯函数 + X11 事件驱动运行时端到端测试（首帧全屏、空闲限时返回、区域边界与紧凑 stride 校验）。
+- ✅ 验收：静止桌面带宽/CPU 近零（事件驱动空转）；小改动只传小区域；DAMAGE 缺失时优雅回退。
 
 ### 阶段 4 — 安全：TLS + NLA ✅ 已完成（mstsc NLA 实测连通）
 - `tls.rs`：首启 rcgen 自签证书存 app-data，rustls acceptor；`with_tls` 替换 `with_no_security`。

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -99,8 +99,12 @@ winapi = { version = "0.3", features = ["fileapi", "commdlg", "shellapi", "winba
 winreg = "0.55"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-# RDP server X11 screen capture (XShm / MIT-SHM via libxcb).
-x11rb = { version = "0.13", features = ["shm"] }
+# RDP server X11 screen capture (XShm / MIT-SHM via libxcb) plus the DAMAGE
+# extension for event-driven, region-cropped capture (only the rectangles the
+# X server reports as changed are read back and encoded — see capture/x11.rs).
+# The `damage` feature transitively enables `xfixes`, which provides the
+# `xfixes::Region` type that `damage_subtract` takes.
+x11rb = { version = "0.13", features = ["shm", "damage"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/servers/rdp/capture/mod.rs
+++ b/src-tauri/src/servers/rdp/capture/mod.rs
@@ -17,9 +17,15 @@ pub(crate) mod wayland;
 #[cfg(target_os = "linux")]
 pub(crate) mod x11;
 
-/// One captured frame: BGRA8888, `stride` bytes per row, `height` rows.
+/// One captured frame or sub-region: BGRA8888, `stride` bytes per row,
+/// `height` rows. `x`/`y` are the top-left origin of this region within the
+/// desktop (0,0 for a full-screen frame), so the display layer can place a
+/// cropped damage rectangle at the right offset in the client's framebuffer.
 pub(crate) struct Frame {
     pub data: Vec<u8>,
+    /// Region origin within the desktop, in pixels.
+    pub x: u16,
+    pub y: u16,
     pub width: u16,
     pub height: u16,
     /// Bytes per row (`>= width * 4`).
@@ -33,8 +39,34 @@ pub(crate) trait Capturer {
     /// Current desktop size in pixels `(width, height)`.
     fn desktop_size(&self) -> (u16, u16);
 
-    /// Capture the current screen contents into a BGRA [`Frame`]. Blocking.
+    /// Capture the whole screen into a BGRA full-frame [`Frame`]. Blocking.
     fn capture(&mut self) -> anyhow::Result<Frame>;
+
+    /// Whether this backend drives itself off change notifications (e.g. X11
+    /// XDamage) rather than fixed-interval polling. Event-driven backends sleep
+    /// until the screen actually changes and return only the changed regions,
+    /// so the caller must NOT add its own poll interval or frame-dedup hashing.
+    fn is_event_driven(&self) -> bool {
+        false
+    }
+
+    /// Drive one update step and return zero or more BGRA regions to send.
+    ///
+    /// - `first` is true only for the very first call on a fresh connection; an
+    ///   event-driven backend MUST return a single full-screen frame then, so
+    ///   the encoder's framebuffer is initialized before any cropped region is
+    ///   sent (the IronRDP encoder only seeds its framebuffer from a
+    ///   full-desktop bitmap; cropped updates diff against it).
+    /// - An empty result means "idle tick, nothing changed" — the caller can
+    ///   loop again (and check for shutdown) without sending anything.
+    ///
+    /// The default implementation is the polling path: capture one full frame.
+    /// The caller is then responsible for its own interval + dedup. Event-driven
+    /// backends override this to block on change notifications and crop.
+    fn next_updates(&mut self, first: bool) -> anyhow::Result<Vec<Frame>> {
+        let _ = first;
+        Ok(vec![self.capture()?])
+    }
 }
 
 /// Build the best available capturer for this platform, or `Err` with a clear

--- a/src-tauri/src/servers/rdp/capture/x11.rs
+++ b/src-tauri/src/servers/rdp/capture/x11.rs
@@ -1,26 +1,65 @@
-//! X11 screen capture using `x11rb`, with a fast path and a safe fallback.
+//! X11 screen capture using `x11rb`, with an event-driven fast path and safe
+//! fallbacks, mirroring how RustDesk/NoMachine keep latency and idle CPU low.
 //!
-//! Fast path mirrors RustDesk: MIT-SHM (`shm`) — a shared memory segment is
-//! allocated once and each frame is a single `shm_get_image` of the root window
-//! into that buffer, with no per-frame protocol image transfer. The modern
-//! FD-passing `shm_create_segment` needs MIT-SHM ≥ 1.2, which is not available
-//! everywhere (older Xorg, some remote/forwarded or sandboxed connections), so
-//! when SHM setup fails we fall back to plain `GetImage` (slower — the image
-//! travels over the X connection each frame — but always available on a local
-//! TrueColor display). Either way the root window's pixels are BGRA on a
-//! depth-24/32 visual (little-endian Z_PIXMAP), matching `PixelFormat::BgrA32`.
+//! Three things stack here:
+//!
+//! 1. **Grab mechanism** — MIT-SHM (`shm`): a shared memory segment is allocated
+//!    once and each grab is a single `shm_get_image` into that buffer, with no
+//!    per-frame protocol image transfer. The modern FD-passing
+//!    `shm_create_segment` needs MIT-SHM ≥ 1.2, which is not available
+//!    everywhere (older Xorg, some remote/forwarded or sandboxed connections),
+//!    so when SHM setup fails we fall back to plain `GetImage` (the image travels
+//!    over the X connection each frame — slower, but always available on a local
+//!    TrueColor display).
+//!
+//! 2. **Change detection** — the XDamage extension. Instead of polling the whole
+//!    screen on a fixed interval and hashing 8 MB to ask "did anything change?",
+//!    we let the X server tell us *when* and *where* it changed. A `Damage`
+//!    object on the root window (report level `BoundingBox`) delivers a
+//!    `DamageNotify` whose `area` is the bounding box of what changed. Idle ⇒ no
+//!    events ⇒ zero readback, zero hashing, zero CPU. When DAMAGE is missing we
+//!    fall back to the legacy fixed-interval full-frame path (`is_event_driven()`
+//!    stays false and the display layer adds its own interval + dedup).
+//!
+//! 3. **Region cropping** — we read back and send only the damaged bounding box,
+//!    not the whole screen. The IronRDP encoder diffs that sub-rectangle against
+//!    its framebuffer and RemoteFX-encodes only the changed tiles, so a small
+//!    on-screen change costs O(changed area), not O(screen). The first frame of
+//!    each connection is always full so the encoder's framebuffer is seeded.
+//!
+//! Either grab path yields BGRA on a depth-24/32 visual (little-endian
+//! Z_PIXMAP), matching `PixelFormat::BgrA32`.
 
 use std::os::unix::io::OwnedFd;
 use std::ptr::NonNull;
+use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context as _};
 use x11rb::connection::{Connection, RequestConnection as _};
+use x11rb::protocol::damage::{self, ConnectionExt as _};
 use x11rb::protocol::shm::{self, ConnectionExt as _};
+use x11rb::protocol::xfixes::{self, ConnectionExt as _};
 use x11rb::protocol::xproto::{self, ConnectionExt as _, ImageFormat};
+use x11rb::protocol::Event;
 use x11rb::rust_connection::RustConnection;
 
 use super::{Capturer, Frame};
 use crate::servers::engine::LogEmitter;
+
+/// Upper bound on capture rate under continuous damage (e.g. dragging a window
+/// or video playback). 16 ms ≈ 60 fps: responsive without spending the CPU to
+/// encode faster than a client can usefully display.
+const MIN_FRAME_INTERVAL: Duration = Duration::from_millis(16);
+
+/// How long a single `next_updates` call waits for damage before returning an
+/// idle tick. Bounds shutdown latency (the capture thread notices a dropped
+/// client within this window) while keeping idle wakeups rare.
+const DAMAGE_WAIT_BUDGET: Duration = Duration::from_millis(100);
+
+/// Poll granularity while waiting for damage events. Small enough to feel
+/// instant on the first change, large enough that idle polling of the socket is
+/// negligible (no pixel readback happens here — just a check of the X socket).
+const DAMAGE_POLL_STEP: Duration = Duration::from_millis(2);
 
 /// A mmap'd MIT-SHM segment shared with the X server.
 struct ShmBuffer {
@@ -58,6 +97,18 @@ enum Backend {
     Plain,
 }
 
+/// XDamage tracking state. Present only when the X server advertises the DAMAGE
+/// extension and we successfully created a `Damage` object on the root window.
+struct DamageState {
+    damage: damage::Damage,
+    /// Pre-allocated XFixes region used as the `parts` sink for
+    /// `damage_subtract` so the consume-and-read-back is atomic server-side (no
+    /// lost-update race between reading a notify and clearing the damage).
+    region: xfixes::Region,
+    /// When we last read pixels back, to enforce [`MIN_FRAME_INTERVAL`].
+    last_capture: Option<Instant>,
+}
+
 pub(crate) struct X11Capturer {
     conn: RustConnection,
     root: xproto::Window,
@@ -65,6 +116,9 @@ pub(crate) struct X11Capturer {
     height: u16,
     depth: u8,
     backend: Backend,
+    /// `Some` when event-driven (XDamage) capture is active; `None` falls back
+    /// to fixed-interval full-frame polling driven by the display layer.
+    damage: Option<DamageState>,
 }
 
 impl X11Capturer {
@@ -109,6 +163,26 @@ impl X11Capturer {
             }
         };
 
+        // Try to set up XDamage so capture can be event-driven and cropped to
+        // changed regions. On any failure we log once and fall back to the
+        // legacy fixed-interval full-frame path (damage = None).
+        let damage = match Self::try_init_damage(&conn, root) {
+            Ok(d) => {
+                log.line("X11 capture: XDamage active (event-driven, region-cropped)".to_string());
+                tracing::info!("X11 capture using XDamage");
+                Some(d)
+            }
+            Err(e) => {
+                let msg = format!(
+                    "XDamage unavailable ({}); falling back to fixed-interval full-frame capture.",
+                    e
+                );
+                log.line(msg.clone());
+                tracing::warn!("X11 capture: {}", msg);
+                None
+            }
+        };
+
         Ok(Self {
             conn,
             root,
@@ -116,6 +190,60 @@ impl X11Capturer {
             height,
             depth,
             backend,
+            damage,
+        })
+    }
+
+    /// Probe the DAMAGE (and XFixes) extensions and, if present, create a
+    /// root-window damage object plus a scratch region for race-free subtract.
+    /// Returns `Err` (rather than bailing) so the caller can fall back to
+    /// interval polling.
+    fn try_init_damage(conn: &RustConnection, root: xproto::Window) -> anyhow::Result<DamageState> {
+        if conn
+            .extension_information(damage::X11_EXTENSION_NAME)
+            .context("querying DAMAGE extension")?
+            .is_none()
+        {
+            bail!("X11 server has no DAMAGE extension");
+        }
+        if conn
+            .extension_information(xfixes::X11_EXTENSION_NAME)
+            .context("querying XFIXES extension")?
+            .is_none()
+        {
+            bail!("X11 server has no XFIXES extension (needed for damage regions)");
+        }
+        // Negotiate versions (also verifies the server actually speaks them).
+        // XFixes ≥ 2.0 is required before any XFixes request is allowed.
+        conn.xfixes_query_version(5, 0)
+            .context("XFIXES query_version")?
+            .reply()
+            .context("XFIXES query_version reply")?;
+        conn.damage_query_version(1, 1)
+            .context("DAMAGE query_version")?
+            .reply()
+            .context("DAMAGE query_version reply")?;
+
+        let damage_id = conn.generate_id().context("generate Damage id")?;
+        // NON_EMPTY: the server delivers a single notify when the damage region
+        // transitions empty→non-empty (least chatty). The precise multi-rect
+        // damage is read back via `damage_subtract` into our region regardless
+        // of report level, so we get exact changed rectangles, not a coarse box.
+        conn.damage_create(damage_id, root, damage::ReportLevel::NON_EMPTY)
+            .context("damage_create")?
+            .check()
+            .context("damage_create check")?;
+
+        let region = conn.generate_id().context("generate Region id")?;
+        conn.xfixes_create_region(region, &[])
+            .context("xfixes_create_region")?
+            .check()
+            .context("xfixes_create_region check")?;
+
+        Ok(DamageState {
+            damage: damage_id,
+            region,
+            last_capture: None,
         })
     }
 
@@ -195,31 +323,85 @@ impl X11Capturer {
 
 impl Drop for X11Capturer {
     fn drop(&mut self) {
+        // Tear down the damage object first (best effort).
+        if let Some(d) = &self.damage {
+            let _ = self.conn.damage_destroy(d.damage);
+        }
         // Detach the SHM segment from the X server (no-op for the plain backend).
         // The local mapping is freed by ShmBuffer::drop.
         if let Backend::Shm(shm) = &self.backend {
             let _ = self.conn.shm_detach(shm.seg);
-            let _ = self.conn.flush();
+        }
+        let _ = self.conn.flush();
+    }
+}
+
+/// A pixel rectangle in desktop coordinates, used to accumulate (union) damaged
+/// areas before a single readback. Kept tiny and pure so the union/clamp logic
+/// can be unit-tested without an X server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DamageRect {
+    x: u16,
+    y: u16,
+    w: u16,
+    h: u16,
+}
+
+impl DamageRect {
+    /// Build from a raw X `Rectangle`, clamped to the desktop bounds. Returns
+    /// `None` if the rectangle is empty or lies fully outside the screen.
+    fn from_x_rect(r: xproto::Rectangle, screen_w: u16, screen_h: u16) -> Option<Self> {
+        // X rectangles use i16 origins and u16 extents; clamp into the screen.
+        let x0 = r.x.max(0) as u16;
+        let y0 = r.y.max(0) as u16;
+        if x0 >= screen_w || y0 >= screen_h {
+            return None;
+        }
+        let x1 = (i32::from(r.x) + i32::from(r.width)).clamp(0, i32::from(screen_w)) as u16;
+        let y1 = (i32::from(r.y) + i32::from(r.height)).clamp(0, i32::from(screen_h)) as u16;
+        if x1 <= x0 || y1 <= y0 {
+            return None;
+        }
+        Some(Self {
+            x: x0,
+            y: y0,
+            w: x1 - x0,
+            h: y1 - y0,
+        })
+    }
+
+    /// Smallest rectangle covering both `self` and `other`.
+    fn union(self, other: Self) -> Self {
+        let x0 = self.x.min(other.x);
+        let y0 = self.y.min(other.y);
+        let x1 = (self.x + self.w).max(other.x + other.w);
+        let y1 = (self.y + self.h).max(other.y + other.h);
+        Self {
+            x: x0,
+            y: y0,
+            w: x1 - x0,
+            h: y1 - y0,
         }
     }
 }
 
-impl Capturer for X11Capturer {
-    fn desktop_size(&self) -> (u16, u16) {
-        (self.width, self.height)
-    }
-
-    fn capture(&mut self) -> anyhow::Result<Frame> {
+impl X11Capturer {
+    /// Grab a sub-rectangle of the root window into a tightly-packed BGRA
+    /// [`Frame`] at origin `(x, y)`. `capture()` is just the full-screen case.
+    ///
+    /// GetImage/shm_get_image always pack the reply at the *requested* width
+    /// (`bytes_per_line = bpp * width`), so a cropped grab is tightly packed at
+    /// `w * 4` regardless of the full-frame stride.
+    fn grab_rect(&self, x: u16, y: u16, w: u16, h: u16) -> anyhow::Result<Frame> {
         let mut data = match &self.backend {
             Backend::Shm(shm) => {
-                // Pull the whole root window into the shared segment in one request.
                 self.conn
                     .shm_get_image(
                         self.root,
-                        0,
-                        0,
-                        self.width,
-                        self.height,
+                        x as i16,
+                        y as i16,
+                        w,
+                        h,
                         !0,
                         ImageFormat::Z_PIXMAP.into(),
                         shm.seg,
@@ -228,23 +410,15 @@ impl Capturer for X11Capturer {
                     .context("shm_get_image")?
                     .reply()
                     .context("shm_get_image reply")?;
-                // Copy out of the shared buffer (the X server may overwrite it on
-                // the next capture).
-                shm.as_slice().to_vec()
+                // Copy out only the bytes this region occupies (packed at w*4);
+                // the X server may overwrite the segment on the next grab.
+                let len = usize::from(w) * usize::from(h) * 4;
+                shm.as_slice()[..len].to_vec()
             }
             Backend::Plain => {
-                // Image data travels over the X connection in the reply.
                 let reply = self
                     .conn
-                    .get_image(
-                        ImageFormat::Z_PIXMAP,
-                        self.root,
-                        0,
-                        0,
-                        self.width,
-                        self.height,
-                        !0,
-                    )
+                    .get_image(ImageFormat::Z_PIXMAP, self.root, x as i16, y as i16, w, h, !0)
                     .context("get_image")?
                     .reply()
                     .context("get_image reply")?;
@@ -262,10 +436,155 @@ impl Capturer for X11Capturer {
 
         Ok(Frame {
             data,
-            width: self.width,
-            height: self.height,
-            stride: usize::from(self.width) * 4,
+            x,
+            y,
+            width: w,
+            height: h,
+            stride: usize::from(w) * 4,
         })
+    }
+
+    /// Drain all currently-queued `DamageNotify` events. Returns true if at
+    /// least one arrived (we don't trust their coordinates — the precise region
+    /// comes from `subtract_into_region`; the event is just the wakeup signal).
+    fn drain_damage_events(&self) -> anyhow::Result<bool> {
+        let mut any = false;
+        while let Some(event) = self.conn.poll_for_event().context("poll_for_event")? {
+            if let Event::DamageNotify(_) = event {
+                any = true;
+            }
+        }
+        Ok(any)
+    }
+
+    /// Atomically consume the accumulated damage into our scratch region and
+    /// fetch back the exact changed rectangles, clamped to the screen. This is
+    /// race-free: any change between the notify and here is folded into the same
+    /// subtract, so nothing is cleared without being reported.
+    fn subtract_into_rects(&self) -> anyhow::Result<Vec<DamageRect>> {
+        let Some(d) = &self.damage else {
+            return Ok(vec![]);
+        };
+        // repair = NONE means "report everything"; parts = our region receives
+        // the consumed area, which we then fetch.
+        self.conn
+            .damage_subtract(d.damage, x11rb::NONE, d.region)
+            .context("damage_subtract")?;
+        let reply = self
+            .conn
+            .xfixes_fetch_region(d.region)
+            .context("xfixes_fetch_region")?
+            .reply()
+            .context("xfixes_fetch_region reply")?;
+        let rects = reply
+            .rectangles
+            .into_iter()
+            .filter_map(|r| DamageRect::from_x_rect(r, self.width, self.height))
+            .collect();
+        Ok(rects)
+    }
+
+    /// Discard any pending damage without capturing (used to reset state after a
+    /// full frame so we don't immediately re-send already-covered regions).
+    fn clear_damage(&self) -> anyhow::Result<()> {
+        let _ = self.drain_damage_events()?;
+        let _ = self.subtract_into_rects()?;
+        Ok(())
+    }
+}
+
+impl Capturer for X11Capturer {
+    fn desktop_size(&self) -> (u16, u16) {
+        (self.width, self.height)
+    }
+
+    fn capture(&mut self) -> anyhow::Result<Frame> {
+        self.grab_rect(0, 0, self.width, self.height)
+    }
+
+    fn is_event_driven(&self) -> bool {
+        self.damage.is_some()
+    }
+
+    fn next_updates(&mut self, first: bool) -> anyhow::Result<Vec<Frame>> {
+        // Polling fallback (no DAMAGE): one full frame; the display layer adds
+        // its own interval + dedup.
+        if self.damage.is_none() {
+            return Ok(vec![self.capture()?]);
+        }
+
+        // First frame of a connection MUST be full so the encoder seeds its
+        // framebuffer before any cropped region is diffed against it. Clear any
+        // damage accumulated before the client connected so we don't immediately
+        // re-send a region that's already covered by this full frame.
+        if first {
+            self.conn.flush().context("flush")?;
+            self.clear_damage()?;
+            self.conn.flush().context("flush")?;
+            let frame = self.capture()?;
+            if let Some(d) = self.damage.as_mut() {
+                d.last_capture = Some(Instant::now());
+            }
+            return Ok(vec![frame]);
+        }
+
+        // Wait (sleeping, no readback) until the X server reports damage or the
+        // budget elapses. Idle ⇒ we return an empty vec so the caller can check
+        // for shutdown.
+        let deadline = Instant::now() + DAMAGE_WAIT_BUDGET;
+        loop {
+            self.conn.flush().context("flush")?;
+            if self.drain_damage_events()? {
+                break;
+            }
+            if Instant::now() >= deadline {
+                return Ok(vec![]);
+            }
+            std::thread::sleep(DAMAGE_POLL_STEP);
+        }
+
+        // Enforce a max capture rate under continuous damage: if we captured
+        // very recently, sleep the remainder and let more damage accumulate
+        // server-side (free coalescing — it folds into the one subtract below).
+        if let Some(last) = self.damage.as_ref().and_then(|d| d.last_capture) {
+            if let Some(rem) = MIN_FRAME_INTERVAL.checked_sub(last.elapsed()) {
+                std::thread::sleep(rem);
+                self.conn.flush().context("flush")?;
+                let _ = self.drain_damage_events()?;
+            }
+        }
+
+        // Atomically consume + read back the exact changed rectangles, then grab
+        // only those regions. Many tiny scattered rects (e.g. text carets) would
+        // mean many small readbacks; cap the count by falling back to a single
+        // bounding box when the server reports a lot of fragments.
+        let rects = self.subtract_into_rects()?;
+        self.conn.flush().context("flush")?;
+        if rects.is_empty() {
+            return Ok(vec![]);
+        }
+
+        const MAX_RECTS: usize = 8;
+        let regions: Vec<DamageRect> = if rects.len() > MAX_RECTS {
+            // Coalesce everything into one bounding box: cheaper than dozens of
+            // round-trips, and the encoder still tile-diffs it.
+            let mut bbox = rects[0];
+            for r in &rects[1..] {
+                bbox = bbox.union(*r);
+            }
+            vec![bbox]
+        } else {
+            rects
+        };
+
+        let mut frames = Vec::with_capacity(regions.len());
+        for r in regions {
+            frames.push(self.grab_rect(r.x, r.y, r.w, r.h)?);
+        }
+        if let Some(d) = self.damage.as_mut() {
+            d.last_capture = Some(Instant::now());
+        }
+        Ok(frames)
     }
 }
 
@@ -355,6 +674,7 @@ mod tests {
             height: screen.height_in_pixels,
             depth: screen.root_depth,
             backend: Backend::Plain,
+            damage: None,
             conn,
         };
         let frame = cap.capture().expect("plain GetImage capture");
@@ -366,6 +686,143 @@ mod tests {
             "BGRA frame length matches geometry"
         );
         assert_eq!(frame.stride, usize::from(frame.width) * 4);
+    }
+
+    /// Build a capturer without a `LogEmitter` (which needs a Tauri AppHandle),
+    /// wiring up SHM-or-plain and DAMAGE exactly like `new()` does. Returns
+    /// `None` (test skips) when no X11 display is reachable.
+    fn connect_capturer() -> Option<X11Capturer> {
+        if std::env::var_os("DISPLAY").is_none() {
+            eprintln!("skipping: no DISPLAY");
+            return None;
+        }
+        let (conn, screen_num) = match x11rb::connect(None) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skipping: cannot connect to X11: {e}");
+                return None;
+            }
+        };
+        let screen = &conn.setup().roots[screen_num];
+        let root = screen.root;
+        let width = screen.width_in_pixels;
+        let height = screen.height_in_pixels;
+        let depth = screen.root_depth;
+        let backend = match X11Capturer::try_init_shm(&conn, width, height) {
+            Ok(shm) => Backend::Shm(shm),
+            Err(_) => Backend::Plain,
+        };
+        let damage = X11Capturer::try_init_damage(&conn, root).ok();
+        Some(X11Capturer {
+            conn,
+            root,
+            width,
+            height,
+            depth,
+            backend,
+            damage,
+        })
+    }
+
+    /// End-to-end check of the event-driven path on a live X11 box: DAMAGE must
+    /// initialize, the first `next_updates` must return one full-screen frame
+    /// (so the encoder framebuffer is seeded), and an idle tick afterwards must
+    /// return promptly (empty or a small region — never the whole screen by
+    /// default). Skips cleanly when DISPLAY/DAMAGE are unavailable.
+    #[test]
+    fn damage_first_update_is_full_then_idle_is_bounded() {
+        let Some(mut cap) = connect_capturer() else {
+            return;
+        };
+        if !cap.is_event_driven() {
+            eprintln!("skipping: DAMAGE not available on this server");
+            return;
+        }
+        let (w, h) = cap.desktop_size();
+
+        // First update: exactly one full-screen frame at origin (0,0).
+        let first = cap.next_updates(true).expect("first next_updates");
+        assert_eq!(first.len(), 1, "first update should be a single full frame");
+        let f = &first[0];
+        assert_eq!((f.x, f.y, f.width, f.height), (0, 0, w, h));
+        assert_eq!(f.data.len(), usize::from(w) * usize::from(h) * 4);
+        assert_eq!(f.stride, usize::from(w) * 4);
+
+        // A subsequent update returns within ~2x the wait budget. On an idle
+        // desktop it's empty; if the desktop happens to change (clock, cursor
+        // caret) it's a region that fits within the screen and is tightly
+        // packed. Either way it must NOT block indefinitely or exceed bounds.
+        let start = Instant::now();
+        let next = cap.next_updates(false).expect("second next_updates");
+        assert!(
+            start.elapsed() < DAMAGE_WAIT_BUDGET * 3,
+            "next_updates should return within the wait budget"
+        );
+        for f in &next {
+            assert!(f.x + f.width <= w && f.y + f.height <= h, "region in bounds");
+            assert_eq!(f.stride, usize::from(f.width) * 4, "tightly packed");
+            assert_eq!(
+                f.data.len(),
+                usize::from(f.width) * usize::from(f.height) * 4
+            );
+        }
+    }
+
+    #[test]
+    fn damage_rect_clamps_into_screen() {
+        // A rect partly off the right/bottom edge is clipped to the screen.
+        let r = xproto::Rectangle {
+            x: 1900,
+            y: 1060,
+            width: 200,
+            height: 200,
+        };
+        let d = DamageRect::from_x_rect(r, 1920, 1080).expect("in-bounds after clamp");
+        assert_eq!((d.x, d.y, d.w, d.h), (1900, 1060, 20, 20));
+    }
+
+    #[test]
+    fn damage_rect_negative_origin_clamped() {
+        // Negative origins (i16) clamp to 0 and the extent shrinks accordingly.
+        let r = xproto::Rectangle {
+            x: -10,
+            y: -5,
+            width: 50,
+            height: 50,
+        };
+        let d = DamageRect::from_x_rect(r, 1920, 1080).expect("in-bounds");
+        assert_eq!((d.x, d.y, d.w, d.h), (0, 0, 40, 45));
+    }
+
+    #[test]
+    fn damage_rect_fully_offscreen_is_none() {
+        let r = xproto::Rectangle {
+            x: 2000,
+            y: 0,
+            width: 10,
+            height: 10,
+        };
+        assert!(DamageRect::from_x_rect(r, 1920, 1080).is_none());
+    }
+
+    #[test]
+    fn damage_rect_union_is_bounding_box() {
+        let a = DamageRect {
+            x: 10,
+            y: 10,
+            w: 20,
+            h: 20,
+        };
+        let b = DamageRect {
+            x: 100,
+            y: 5,
+            w: 10,
+            h: 10,
+        };
+        // Union spans x:[10,110), y:[5,30) → (10,5,100,25).
+        assert_eq!(a.union(b), DamageRect { x: 10, y: 5, w: 100, h: 25 });
+        // Union is commutative.
+        assert_eq!(a.union(b), b.union(a));
     }
 }
 

--- a/src-tauri/src/servers/rdp/display.rs
+++ b/src-tauri/src/servers/rdp/display.rs
@@ -21,7 +21,7 @@ use ironrdp::server::{
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};
 
-use super::capture::{create_capturer, Frame};
+use super::capture::{create_capturer, Capturer, Frame};
 use crate::servers::engine::LogEmitter;
 
 /// Display handler handed to the IronRDP builder. Probes the capture backend to
@@ -122,14 +122,17 @@ impl DisplayUpdatesImpl {
         }
     }
 
-    /// Wrap a captured BGRA frame into a full-screen [`BitmapUpdate`].
+    /// Wrap a captured BGRA frame (full screen or a cropped damage region) into
+    /// a [`BitmapUpdate`] placed at the region's origin. The IronRDP encoder
+    /// diffs it against its framebuffer at that offset and encodes only the
+    /// changed tiles, so a small region costs O(region), not O(screen).
     fn frame_to_bitmap(frame: Frame) -> Option<BitmapUpdate> {
         let width = NonZeroU16::new(frame.width)?;
         let height = NonZeroU16::new(frame.height)?;
         let stride = NonZeroUsize::new(frame.stride)?;
         Some(BitmapUpdate {
-            x: 0,
-            y: 0,
+            x: frame.x,
+            y: frame.y,
             width,
             height,
             format: PixelFormat::BgrA32,
@@ -195,14 +198,21 @@ impl RdpServerDisplayUpdates for DisplayUpdatesImpl {
     }
 }
 
-/// Capture-thread body: create the backend on this thread, then loop capturing
-/// frames and sending them to the display task. Exits when the receiver is
+/// Capture-thread body: create the backend on this thread, then loop producing
+/// updates and sending them to the display task. Exits when the receiver is
 /// dropped (client disconnected) or capture errors out.
 ///
-/// Phase 3 frame-suppression: an unchanged frame (same FNV-1a hash as the last
-/// one sent) is dropped here rather than forwarded, so a static desktop costs
-/// nothing downstream. The ironrdp-server encoder still diffs the frames we DO
-/// send and only encodes changed rectangles, so we don't crop here.
+/// Two regimes, chosen by the backend:
+///
+/// - **Event-driven** (X11 XDamage): the backend blocks until the screen
+///   actually changes and returns only the changed regions (the first frame is
+///   full, to seed the encoder framebuffer). No interval, no hashing — idle
+///   costs nothing and a small change sends a small region.
+/// - **Polling fallback** (synthetic, or X11 without DAMAGE, or other
+///   platforms): capture a full frame on a ~30 fps interval and suppress
+///   byte-identical frames with a cheap FNV-1a hash so a static desktop still
+///   costs near-zero downstream. The IronRDP encoder diffs the frames we DO
+///   send and only encodes changed rectangles.
 fn capture_loop(log: LogEmitter, tx: mpsc::Sender<Frame>) {
     let mut capturer = match create_capturer(&log) {
         Ok(c) => c,
@@ -212,8 +222,51 @@ fn capture_loop(log: LogEmitter, tx: mpsc::Sender<Frame>) {
         }
     };
 
-    // ~30 fps ceiling. The idle case is cheap because identical frames are
-    // suppressed below; only changed frames traverse the channel and encoder.
+    if capturer.is_event_driven() {
+        capture_loop_event_driven(capturer.as_mut(), &tx);
+    } else {
+        capture_loop_polling(capturer.as_mut(), &tx);
+    }
+    log.line("capture thread stopped");
+}
+
+/// Damage-driven loop: forward whatever regions the backend reports. The
+/// backend internally blocks on change notifications and caps the frame rate,
+/// so this loop adds no interval of its own. An empty result is an idle tick;
+/// we use it to notice a disconnected client (closed channel) promptly.
+fn capture_loop_event_driven(capturer: &mut dyn Capturer, tx: &mpsc::Sender<Frame>) {
+    let mut first = true;
+    loop {
+        match capturer.next_updates(first) {
+            Ok(frames) => {
+                first = false;
+                if frames.is_empty() {
+                    // Idle tick: nothing changed within the wait budget. Bail
+                    // out if the client went away, otherwise keep waiting.
+                    if tx.is_closed() {
+                        break;
+                    }
+                    continue;
+                }
+                for frame in frames {
+                    if tx.blocking_send(frame).is_err() {
+                        return;
+                    }
+                }
+            }
+            Err(e) => {
+                let _ = tx; // nothing to send; surface and stop
+                tracing::warn!("RDP capture (damage): {}", e);
+                break;
+            }
+        }
+    }
+}
+
+/// Fixed-interval full-frame loop with FNV-1a dedup (used when the backend is
+/// not event-driven). ~30 fps ceiling; identical frames are suppressed so a
+/// static desktop costs nothing downstream.
+fn capture_loop_polling(capturer: &mut dyn Capturer, tx: &mpsc::Sender<Frame>) {
     let frame_interval = std::time::Duration::from_millis(33);
     let mut last_hash: Option<u64> = None;
     let mut first = true;
@@ -233,7 +286,7 @@ fn capture_loop(log: LogEmitter, tx: mpsc::Sender<Frame>) {
                 }
             }
             Err(e) => {
-                log.line(format!("capture error: {}", e));
+                tracing::warn!("RDP capture (polling): {}", e);
                 break;
             }
         }
@@ -241,5 +294,4 @@ fn capture_loop(log: LogEmitter, tx: mpsc::Sender<Frame>) {
             std::thread::sleep(rem);
         }
     }
-    log.line("capture thread stopped");
 }


### PR DESCRIPTION
The X11 RDP-server capture polled the full 1920x1080 root window every 33ms and ran an 8MB FNV-1a hash on every frame just to decide whether anything changed — a fixed ~143ms/frame floor (debug, ~95ms readback + ~49ms hash) regardless of activity. Even a one-pixel change went through a full-frame readback, copy, hash, and library-side full-frame diff.

Rework the X11 backend to the RustDesk/NoMachine model: event-driven and region-based.

- XDamage (NON_EMPTY) replaces interval polling: idle means no events, so zero readback / zero hashing / zero CPU. Needs x11rb `damage` feature (transitively pulls `xfixes`).
- Damage is consumed race-free via `damage_subtract` into an XFixes region
  + `xfixes_fetch_region`, yielding the exact changed rectangles (no lost-update window between notify and clear).
- Only the changed bounding box(es) are read back and handed to the encoder (>8 fragments coalesce to one box). The IronRDP encoder then 64-tile diffs and RemoteFX-encodes just that sub-region. First frame per connection stays full to seed the encoder framebuffer.
- 60fps cap under continuous motion; graceful fallback to the legacy interval+FNV-dedup path when DAMAGE/XFIXES are unavailable.

Measured on a live X11 box (debug, 1920x1080): idle 0ms, 100x40 region readback ~0.25ms vs ~95ms full-screen — change cost now scales with the changed area, not the screen.

Trait/type changes: `Frame` gains `x,y` region origin; `Capturer` gains `is_event_driven()` + `next_updates(first)` (default = full-frame poll, so synthetic/Windows/macOS backends are unchanged). `display.rs::capture_loop` splits into event-driven vs polling regimes.

Tests: DamageRect union/clamp unit tests + a live end-to-end XDamage runtime test (first-frame-full, bounded idle, in-bounds tightly-packed regions); all 19 RDP tests pass. Updates dev-plan phase 3 to reflect this.