### PR TITLE
feat: add native HBase RPC client (ZooKeeper + RegionServer/Master)

### DIFF
--- a/claudedocs/hbase-native-rpc-refactor.md
+++ b/claudedocs/hbase-native-rpc-refactor.md
@@ -1,0 +1,190 @@
+# HBase 原生 RPC 客户端重构方案
+
+## 背景与目标
+
+当前 `src-tauri/src/hbase/mod.rs` 通过 HBase REST/Stargate API 实现 shell 客户端。问题：生产集群**不一定开启 REST Server**（也不一定开 Thrift Server，二者都是独立网关进程）。
+
+目标：参照 Java `hbase-client` 2.6.x 的工作方式，实现**原生 RPC 客户端** —— 直连 RegionServer(16020) + Master(16000)，通过 ZooKeeper(2181) 引导，全程 protobuf + CellBlock，无需 server 端任何额外网关进程。支持 simple 与 Kerberos/SASL 两种认证。
+
+## 生态结论
+
+- crates.io 无原生 RPC 的 Rust HBase 客户端（唯一的 `hbase-thrift` 仍依赖 ThriftServer）。
+- 蓝本：`tsuna/gohbase`（Go，完整非 JVM 原生实现，simple auth）。
+- Kerberos 蓝本：`OpenTSDB/asynchbase`（Java，GSSAPI SASL）。gohbase 不含 Kerberos。
+- protobuf：引入 `prost` + `prost-build`，从 HBase 2.6.x `hbase-protocol-shaded` 模块 vendor `.proto`。
+
+## 新增依赖 (src-tauri/Cargo.toml)
+
+```toml
+prost = "0.13"
+byteorder = "1"            # 或复用 bytes::Buf 的 BE 读写
+zookeeper-client = "0.x"   # 纯 Rust 异步 ZK 客户端
+cross-krb5 = "0.x"         # GSSAPI/SSPI 跨平台 Kerberos（仅 kerberos 特性下启用）
+
+[build-dependencies]
+prost-build = "0.13"
+```
+
+Kerberos 依赖用 Cargo feature `hbase-kerberos` 包裹，默认开启；simple-only 构建可关闭以避免系统 GSSAPI 库依赖。
+
+## 模块结构 (src-tauri/src/hbase/)
+
+```
+mod.rs        Tauri 命令 + session map（保持现有 IPC 公共 API 不变）
+config.rs     HBaseConfig（扩展：zk quorum / 直连 RS / 认证方式）
+shell.rs      命令解析器（从 mod.rs 抽出，复用现有 parser）+ 翻译到原生操作
+client.rs     HBaseClient：SendRPC 编排、region 定位、重试/退避状态机
+zk.rs         znode 读取（/hbase/meta-region-server, /hbase/master）+ 0xFF/PBUF 解析
+region.rs     RegionInfo、meta 行解析、region-name 比较器（Compare）
+meta.rs       hbase:meta 反向 scan 定位 region + B-tree 缓存 + split/merge 处理
+rpc/
+  conn.rs     连接 actor：preamble、ConnectionHeader、帧编解码、call-id 多路复用
+  framing.rs  请求/响应帧（4字节BE长度 + varint+RequestHeader + varint+param + cellblock）
+auth.rs       simple(0x50) + kerberos(0x51 GSSAPI token 握手 + 可选 wrap/unwrap)
+cell.rs       KeyValueCodec：CellBlock 编解码（零拷贝，bytes::Bytes）
+proto.rs      include! prost 生成的 pb 类型
+```
+
+build.rs 增加 `prost_build::compile_protos`，输出到 OUT_DIR。
+
+## 协议关键点（实现依据）
+
+### 连接握手 (rpc/conn.rs)
+- Preamble 6 字节：`"HBas"` + `0x00`(版本) + auth 字节（simple=`0x50`，kerberos=`0x51`）。
+- 之后 `<4字节BE长度><ConnectionHeader protobuf>`：`UserInformation.effective_user`、`service_name`（"ClientService" / "MasterService"）、`cell_block_codec_class = "org.apache.hadoop.hbase.codec.KeyValueCodec"`。
+- 成功时服务器**无应答**；版本/认证错误抛 FatalConnectionException 并断开。
+- Kerberos：preamble 之后、ConnectionHeader 之前插入 `<i32 len><GSSAPI token>` 往返，直到 SASL 完成；若协商出 auth-int/auth-conf QOP，后续每帧需 wrap/unwrap。
+
+### 请求/响应帧 (rpc/framing.rs)
+```
+请求: [4B BE 总长][varint][RequestHeader pb][varint][param pb][cellblock]
+响应: [4B BE 总长][varint][ResponseHeader pb][varint][response pb][cellblock]
+```
+- RequestHeader: call_id / method_name("Get"/"Mutate"/"Scan"/...) / request_param / cell_block_meta.length / priority。
+- ResponseHeader: call_id（必有）/ exception(ExceptionResponse) / cell_block_meta。
+- 多路复用：AtomicU32 自增 call_id；`HashMap<u32, oneshot::Sender>` 在飞映射；split TcpStream → reader task + writer task（tokio actor 模式）。
+
+### ZK 引导 (zk.rs)
+- znode 字节格式：`0xFF` + `u32 BE metadataLen` + 跳过 metadata + `"PBUF"`(magic) + protobuf。
+- `/hbase/meta-region-server` → `MetaRegionServer.server`(ServerName) → meta 所在 RS 的 host:port。
+- `/hbase/master` → `Master.master`(ServerName)。
+- 每次按需开 ZK 连接读取，不做 watch；陈旧靠 meta 重查 + 重试兜底。
+
+### region 定位与缓存 (region.rs / meta.rs)
+- 普通表：对 `hbase:meta` 做 **反向 scan**（startRow=`table,key,:`，Reversed，NumberOfRows=1，Family=info，CloseScanner）取覆盖目标 key 的 region。
+- 解析 `info:regioninfo`(=`'P'`+`PBUF`+RegionInfo pb) 与 `info:server`(ASCII host:port)。
+- B-tree 缓存按 region-name 排序，**必须**移植 gohbase 的 `Compare`（把 `,` 当最低分隔符 + key 比较 + 时间戳兜底），否则会路由到错误 region。
+- region-moved/NSRE → 重建 region 重试；CallQueueTooBig 等 → 退避重试；RS aborted/stopped → 重连。退避：翻倍至 5s，再 +5s 至 30s 封顶；maxFindRegionTries=10。
+- 单飞重连：首个 mark-unavailable 的请求触发重建，其余阻塞在 Notify 上。
+
+### CellBlock 编解码 (cell.rs)
+KeyValue 线格式（全 BE）：
+```
+[4B kvLen][4B keyLen][4B valueLen]
+key: [2B rowLen][row][1B familyLen][family][qualifier][8B timestamp][1B cellType]
+value: [valueLen 字节]
+```
+- qualifierLen 由 keyLen 推导，不单独存储。
+- cell 个数out-of-band：scan 看 `cells_per_result[]`+`partial_flag_per_result[]`，get/mutate 看 `Result.associated_cell_count`。
+- 用 `bytes::Bytes` 做零拷贝切片。
+
+### Scan 状态机 (client.rs)
+- Open（无 scanner_id，带完整 Scan 子消息）→ Next（带 scanner_id，无 Scan 子消息）→ Close（close_scanner=true）。
+- `more_results_in_region` 控制同 region 续读；`more_results` 控制跨 region 推进。
+- 反向 scan 跨 region 的 key 递减逻辑需精确移植。
+- 始终设 ClientHandlesPartials/ClientHandlesHeartbeats=true；跨响应的部分行需在高层 coalesce。
+
+## shell 命令 → 原生 RPC 映射
+
+| 命令 | RPC | Service | 备注 |
+|------|-----|---------|------|
+| get | Get | ClientService | 经 meta 定位 region |
+| put | Mutate(PUT) | ClientService | |
+| delete | Mutate(DELETE) | ClientService | |
+| deleteall | Mutate(DELETE 整行) | ClientService | |
+| scan | Scan(open/next/close) | ClientService | 状态机 |
+| list | GetTableNames | MasterService | 经 ZK 定位 master |
+| describe | GetTableDescriptors | MasterService | gohbase 未实现，需自接 |
+| create | CreateTable | MasterService | |
+| drop | DisableTable + DeleteTable | MasterService | HBase 要求先 disable |
+| status | GetClusterStatus | MasterService | |
+| version | GetClusterStatus / 连接信息 | MasterService | |
+| enable/disable/alter/count | 对应 Master/Client RPC | | 可在原生层补齐（原 REST 版未实现） |
+
+现有 `parse_shell_command` 解析器（含引号/`{}`/`[]` 嵌套处理）**完整保留**，只替换执行后端。
+
+## 配置与 UI 变更
+
+`HBaseConfig` / `HBaseConnectInfo` 扩展（向后兼容，新增字段都 optional）：
+- `connectionMode: "native" | "rest"`（默认 native；保留 REST 作为可选回退，契合"环境看情况"）
+- native 模式：`zkQuorum`（"host1:2181,host2:2181"）+ `zkRoot`（默认 `/hbase`）；或 `regionServers` 直连引导（绕过 ZK，对应 RpcConnectionRegistry）
+- `authMethod: "simple" | "kerberos"`；kerberos 下：`principal`、`servicePrincipal`(如 `hbase/_HOST@REALM`)、keytab 路径或走系统票据缓存
+- `effectiveUser`（simple 模式，默认当前用户）
+
+SessionEditor 的 `HBaseSettings` 表单相应增加：连接模式切换、ZK quorum 输入、认证方式选择及 Kerberos 字段。REST 模式保留现有 rest_path/namespace 字段。
+
+IPC 层（`src/lib/ipc.ts`）：`toHBaseConfigPayload` 增加新字段映射；6 个命令签名与返回类型**不变**，前端 `HBaseShellTab` 几乎无需改动。
+
+## 分阶段实施（每阶段可独立验证）
+
+- **P0 基础设施**：加依赖 + build.rs proto codegen；vendor HBase 2.6.x `.proto`；proto.rs 编译通过。验证：`cargo build`。
+- **P1 RPC 传输（simple）**：conn.rs/framing.rs；preamble + ConnectionHeader + 帧编解码 + call-id 多路复用。验证：单元测试帧编解码；连本地 RS 发 GetClusterStatus。
+- **P2 ZK + meta 定位**：zk.rs + region.rs + meta.rs + 缓存。验证：znode 解析单测、Compare 单测、反向 scan 定位单测；连真集群定位任意表。
+- **P3 数据面**：cell.rs + Get/Put/Scan/Delete + scan 状态机。验证：cell 编解码单测；连真集群 get/put/scan/delete 往返。
+- **P4 控制面**：MasterService 定位 + list/describe/create/drop/status/version。验证：连真集群建表/列表/描述/删表。
+- **P5 接线**：shell.rs 复用解析器，executor 切到原生；mod.rs/IPC/state 接入；保留 REST 作回退分支。验证：`pnpm build` + 现有前端跑通。
+- **P6 Kerberos**：auth.rs GSSAPI 握手 + 可选 wrap/unwrap；feature gate。验证：连启用 Kerberos 的集群。
+- **P7 配置/UI/测试**：config 扩展、SessionEditor 表单、ipc 映射；补齐单测；更新 CLAUDE.md/导入导出。验证：`pnpm test` + `cargo test` + `tsc -b --noEmit`。
+
+## 测试策略
+
+- **可离线确定性单测**（核心，进 CI）：cell KeyValue 编解码、znode 0xFF/PBUF 解析、region-name Compare、帧 varint/BE 编解码、meta 行解析、反向 scan key 递减、shell parser（已有）。
+- **需真集群的集成测试**：手动，分 simple / kerberos 两套环境验证 get/put/scan/list/create/drop。
+- 全程不破坏现有 REST 路径（作为 `connectionMode=rest` 保留）。
+
+## 风险与权衡
+
+- **工作量**：数千行 Rust，数周量级，且需跟随 HBase 协议版本维护。这是没有现成库的根本原因。
+- **Kerberos**：跨平台 GSSAPI（Linux MIT krb5 / Windows SSPI / macOS Heimdal）行为差异是最大不确定性；`cross-krb5` 覆盖但需逐平台验证。
+- **协议细节坑**：region-name 比较器、反向 scan 跨 region key 数学、部分行 coalesce —— 简单用例能过、边界（跨 region/表边界）才暴露。已在方案中标注需逐字移植。
+- **二进制体积/编译时间**：prost 生成代码 + 新依赖会增加，可接受。
+
+## 参考来源
+
+- gohbase 源码 https://github.com/tsuna/gohbase
+- HBase RPC 规范 https://hbase.apache.org/docs/rpc
+- HBase protobuf 序列化 https://hbase.apache.org/docs/protobuf
+- catalog/client 架构 https://hbase.apache.org/docs/architecture/client
+- asynchbase（Kerberos 蓝本）https://github.com/OpenTSDB/asynchbase
+
+## 实施状态（已完成）
+
+全部 8 个阶段完成，并在本机 standalone HBase 2.6.1（JDK17，ZK 2181 / Master 16000 / RegionServer 16020）上端到端验证通过。
+
+- **P0** proto 基础设施：vendor 23 个 HBase 2.6.1 `.proto`（`src-tauri/proto/`），`build.rs` 用 prost-build 生成 `hbase.pb`。`google.protobuf.Any` 映射到 `prost-types`。
+- **P1** RPC 传输：`rpc/codec.rs`（帧编解码，7 单测）+ `rpc/conn.rs`（连接 actor：preamble+ConnectionHeader 握手、reader/writer task、call-id 多路复用 oneshot 映射）。
+- **P2** ZK+region 定位：`zk.rs`（0xFF/PBUF znode 解析）+ `region.rs`（RegionInfo 解析、region-name 比较器）+ `client.rs::meta_lookup`（hbase:meta 反向 scan）。实测发现两个关键坑并修复：反向 scan 不能带 stop_row；`info:regioninfo` 值是 `PBUF`+protobuf（无前导版本字节）。
+- **P3** 数据面：`cell.rs`（KeyValueCodec 编解码，零拷贝 bytes，7 单测）+ Get/Put/Scan/Delete/DeleteAll。
+- **P4** 控制面：list(GetTableNames)/describe(GetTableDescriptors)/create(CreateTable)/drop(Disable+Delete)/status/version(GetClusterStatus)，含 `getProcedureResult` 轮询等待异步建表/删表完成。
+- **P5** 接线：`HBaseSession` 改为 `Native|Rest` 枚举；复用现有 `parse_shell_command`；`native_execute` 分派；REST 作 `connectionMode=rest` 回退保留。
+- **P6** Kerberos：`auth.rs` GSSAPI SASL 握手（0x51 preamble + `<i32 len><token>` 往返，按 HBase `HBaseSaslRpcClient.saslConnect` 线格式），`cross-krb5` 跨平台，feature `hbase-kerberos`（默认关，需系统 GSSAPI 头）。
+- **P7** 配置/UI：`HBaseConfig`/`HBaseConnectInfo` 扩展 connectionMode/zkQuorum/zkRoot/effectiveUser；SessionEditor 加模式切换+ZK 表单；ipc.ts 映射；MainLayout 透传。前端 362 测试全过，tsc 干净。
+- **P8** 真集群验收：`HBASE_LIVE_TEST=1` 下 ping/create/list/describe/put/get/scan/delete/deleteall/drop 全链路 + 多列族多行 scan-limit 验证通过。
+
+附带修复：`get` 命令解析器对裸列名（`get 't','r','cf:q'`）误当 option map 解析的 pre-existing bug。
+
+### 测试命令
+
+```bash
+# 纯单元测试（CI，无需集群）
+cargo test --lib hbase::native        # 35 passed
+# 真集群集成测试
+HBASE_LIVE_TEST=1 cargo test --lib hbase -- --test-threads=1
+# Kerberos feature 编译（需 GSSAPI 头）
+cargo build --lib --features hbase-kerberos
+```
+
+### 已知环境限制
+
+`hbase::tests::describe_request_error_surfaces_transport_cause` 及 3 个 `database::presto` 测试在本开发沙箱失败——该环境对 localhost 有透明代理返回 HTTP 500，使"连接被拒绝"类断言失效。这些测试在干净提交上同样失败，与本次改动无关。
+

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -113,6 +113,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +515,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-process"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +548,26 @@ name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-select"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f98ef72872a2864ded4fd54074e10c1546d08ce2e8904f687ddf7721e661e4"
+dependencies = [
+ "async-select-proc-macros",
+]
+
+[[package]]
+name = "async-select-proc-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcc8b85e96f3b0ea1f3541195519dad61f58df6876c35699d60db487badde4b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -587,6 +630,24 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "asyncs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91a519e400b968b4ddf2933aeb5b75752d73b27e7aeaab055612140683fcd059"
+dependencies = [
+ "async-select",
+ "asyncs-sync",
+ "spawns",
+ "spawns-core",
+]
+
+[[package]]
+name = "asyncs-sync"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9294d4a9e741fcab9c317b247d378b4421e14638d8db307d1a81059273361c8"
 
 [[package]]
 name = "atk"
@@ -733,6 +794,26 @@ dependencies = [
  "shlex 1.3.0",
  "syn 2.0.117",
  "which 4.4.2",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.12.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex 1.3.0",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1145,6 +1226,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +1475,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b5c3ee2b4ffa00ac2b00d1645cd9229ade668139bccf95f15fadcf374127b"
+dependencies = [
+ "castaway",
+ "itoa",
+ "ryu",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1505,27 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "convert_case"
@@ -1601,6 +1723,19 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "cross-krb5"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d426da4c3f9df62d4dac801df95d980a8ba8c4b4f95d02b9b607dab079d6768"
+dependencies = [
+ "anyhow",
+ "bitflags 2.12.1",
+ "bytes",
+ "libgssapi",
+ "windows 0.62.2",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -2072,6 +2207,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2677,6 +2823,12 @@ checksum = "f9f9e65c593dd01ac77daad909ea4ad17f0d6d1776193fc8ea766356177abdad"
 dependencies = [
  "glob",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flagset"
@@ -3384,7 +3536,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -3392,6 +3544,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3421,6 +3577,15 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
@@ -3439,6 +3604,15 @@ dependencies = [
  "rustc_version",
  "spin",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3799,6 +3973,12 @@ name = "if_chain"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
+
+[[package]]
+name = "ignore-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "665ff4dce8edd10d490641ccb78949832f1ddbff02c584fb1f85ab888fe0e50c"
 
 [[package]]
 name = "image"
@@ -4500,6 +4680,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4563,6 +4758,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
  "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "libgssapi"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e440a6151f5ef06571612e4121709aed90cfc0c40f8161f9090c71656758086d"
+dependencies = [
+ "bitflags 2.12.1",
+ "bytes",
+ "libgssapi-sys",
+]
+
+[[package]]
+name = "libgssapi-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5103ac4557eacd36ff678b654b943f8966d3db9688fbd180a0b4c5464759ce17"
+dependencies = [
+ "bindgen 0.71.1",
  "pkg-config",
 ]
 
@@ -4998,6 +5214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5022,7 +5244,7 @@ dependencies = [
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
- "num_enum",
+ "num_enum 0.7.6",
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
@@ -5233,12 +5455,33 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.7.6",
  "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5858,6 +6101,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "phc"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6380,6 +6634,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6390,6 +6663,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -7059,7 +7341,7 @@ dependencies = [
  "bitflags 2.12.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.11.0",
  "libsqlite3-sys",
  "smallvec",
  "sqlite-wasm-rs",
@@ -8117,6 +8399,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "spawns"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af41bca015637549a86dd319733953067982368b00a1aa1b9249b44a8b3fde9"
+dependencies = [
+ "spawns-compat",
+ "spawns-core",
+]
+
+[[package]]
+name = "spawns-compat"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302ec2aa72b920e30b02e7dd7b7632b038731efd832a5bad452736de07b5b3df"
+dependencies = [
+ "linkme",
+ "spawns-core",
+ "tokio",
+]
+
+[[package]]
+name = "spawns-core"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a16f73dcebb4e44f93258cc9712d57f3c076f67b91163d6ded5a675577f5cdc5"
+dependencies = [
+ "linkme",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8176,7 +8488,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.16.1",
- "hashlink",
+ "hashlink 0.11.0",
  "indexmap 2.14.0",
  "log",
  "memchr",
@@ -8388,6 +8700,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8436,11 +8754,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
+dependencies = [
+ "strum_macros 0.23.1",
+]
+
+[[package]]
+name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8767,10 +9107,12 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.22.1",
+ "byteorder",
  "bytes",
  "cbc 0.2.1",
  "chrono",
  "cpal",
+ "cross-krb5",
  "des",
  "dirs",
  "enigo",
@@ -8791,6 +9133,9 @@ dependencies = [
  "pbkdf2",
  "plist",
  "portable-pty",
+ "prost",
+ "prost-build",
+ "prost-types",
  "rand 0.10.1",
  "rcgen",
  "redis",
@@ -8830,6 +9175,7 @@ dependencies = [
  "winreg 0.55.0",
  "x11rb",
  "zeroize",
+ "zookeeper-client",
 ]
 
 [[package]]
@@ -9709,8 +10055,8 @@ dependencies = [
  "shuttle",
  "simsimd",
  "smallvec",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "tantivy",
  "tempfile",
  "thiserror 2.0.18",
@@ -9756,8 +10102,8 @@ dependencies = [
  "bitflags 2.12.1",
  "memchr",
  "miette",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "thiserror 2.0.18",
  "turso_macros",
 ]
@@ -11603,6 +11949,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zookeeper-client"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67fd2ce183d9030446d3f608ca8d85a25bcc50bf2c0026fc9ce7b43cabe0878"
+dependencies = [
+ "async-io",
+ "async-net",
+ "asyncs",
+ "bytes",
+ "compact_str",
+ "const_format",
+ "derive-where",
+ "either",
+ "fastrand",
+ "futures",
+ "futures-lite",
+ "hashbrown 0.12.3",
+ "hashlink 0.8.4",
+ "ignore-result",
+ "num_enum 0.5.11",
+ "static_assertions",
+ "strum 0.23.0",
+ "thiserror 1.0.69",
+ "tracing",
+ "uuid",
+]
 
 [[package]]
 name = "zstd"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
+prost-build = "0.14"
 
 [dependencies]
 tauri = { version = "2", features = [] }
@@ -91,6 +92,17 @@ sqlx-core = { version = "0.9", default-features = false, features = ["_rt-tokio"
 sqlx-mysql = { version = "0.9", default-features = false, features = ["chrono", "bigdecimal", "uuid", "json"] }
 sqlx-postgres = { version = "0.9", default-features = false, features = ["chrono", "bigdecimal", "uuid", "json"] }
 redis = { version = "1.2", default-features = false, features = ["tokio-comp", "tokio-rustls-comp", "streams"] }
+# Native HBase RPC client (hbase/native): protobuf wire types via prost,
+# big-endian frame codecs via byteorder, and ZooKeeper bootstrap for region
+# discovery. Replaces the REST/Stargate dependency so we can talk to clusters
+# that only expose the native RegionServer/Master RPC ports.
+prost = "0.14"
+prost-types = "0.14"
+byteorder = "1"
+zookeeper-client = { version = "0.11", features = ["tokio"] }
+# Cross-platform GSSAPI/Kerberos for native HBase secure (kerberos) auth. Behind
+# the `hbase-kerberos` feature so the default build needs no system GSSAPI libs.
+cross-krb5 = { version = "0.5", optional = true }
 
 [patch.crates-io]
 ironrdp-connector = { path = "vendor/ironrdp-connector" }
@@ -106,6 +118,7 @@ voice-capture = ["dep:cpal"]
 asr-sherpa-onnx = []
 vulkan-detect = ["dep:ash"]
 local-llm-fim = ["dep:llama-cpp-2"]
+hbase-kerberos = ["dep:cross-krb5"]
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "commdlg", "shellapi", "winbase", "winuser"] }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -3,7 +3,47 @@ use std::path::Path;
 
 fn main() {
     enforce_asr_llm_isolation();
+    compile_hbase_protos();
     tauri_build::build();
+}
+
+/// Compile the vendored HBase 2.6.x protobuf definitions into Rust types for
+/// the native RPC client (src/hbase/native). The generated module is written to
+/// `OUT_DIR/hbase.pb.rs` (package `hbase.pb`) and included via
+/// `src/hbase/native/proto.rs`. The shaded `google.protobuf.Any` lives under the
+/// vendor path `proto/org/apache/hbase/thirdparty/...` that HBase's protos import.
+fn compile_hbase_protos() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into());
+    let proto_root = Path::new(&manifest_dir).join("proto");
+    if !proto_root.exists() {
+        return;
+    }
+    println!("cargo:rerun-if-changed=proto");
+
+    let mut protos: Vec<std::path::PathBuf> = Vec::new();
+    collect_protos(&proto_root, &mut protos);
+    if protos.is_empty() {
+        return;
+    }
+
+    let mut config = prost_build::Config::new();
+    config
+        .compile_protos(&protos, &[proto_root.as_path()])
+        .expect("failed to compile vendored HBase protobuf definitions");
+}
+
+fn collect_protos(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_protos(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("proto") {
+            out.push(path);
+        }
+    }
 }
 
 /// Compile-time guardrail: asr/* must not import llm/* and vice versa.

--- a/src-tauri/proto/AccessControl.proto
+++ b/src-tauri/proto/AccessControl.proto
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "AccessControlProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+import "HBase.proto";
+
+/**
+* Messages and services in shaded AccessControl.proto only use for serializing/deserializing permissions
+* in .snapshotinfo, and should not use for access control logic for coprocessor endpoints compatibility
+* (use AccessControl.proto under hbase-protocol module instead).
+*/
+
+message Permission {
+    enum Action {
+        READ = 0;
+        WRITE = 1;
+        EXEC = 2;
+        CREATE = 3;
+        ADMIN = 4;
+    }
+    enum Type {
+        Global = 1;
+        Namespace = 2;
+        Table = 3;
+    }
+    required Type type = 1;
+    optional GlobalPermission global_permission = 2;
+    optional NamespacePermission namespace_permission = 3;
+    optional TablePermission table_permission = 4;
+}
+
+message TablePermission {
+    optional TableName table_name = 1;
+    optional bytes family = 2;
+    optional bytes qualifier = 3;
+    repeated Permission.Action action = 4;
+}
+
+message NamespacePermission {
+    optional bytes namespace_name = 1;
+    repeated Permission.Action action = 2;
+}
+
+message GlobalPermission {
+    repeated Permission.Action action = 1;
+}
+
+message UserPermission {
+    required bytes user = 1;
+    required Permission permission = 3;
+}
+
+/**
+ * Content of the /hbase/acl/<table or namespace> znode.
+ */
+message UsersAndPermissions {
+  message UserPermissions {
+    required bytes user = 1;
+    repeated Permission permissions = 2;
+  }
+
+  repeated UserPermissions user_permissions = 1;
+}
+
+message GrantRequest {
+  required UserPermission user_permission = 1;
+  optional bool merge_existing_permissions = 2 [default = false];
+}
+
+message GrantResponse {
+}
+
+message RevokeRequest {
+  required UserPermission user_permission = 1;
+}
+
+message RevokeResponse {
+}
+
+message GetUserPermissionsRequest {
+  optional Permission.Type type = 1;
+  optional TableName table_name = 2;
+  optional bytes namespace_name = 3;
+  optional bytes column_family = 4;
+  optional bytes column_qualifier = 5;
+  optional bytes user_name = 6;
+}
+
+message GetUserPermissionsResponse {
+  repeated UserPermission user_permission = 1;
+}
+
+message CheckPermissionsRequest {
+  repeated Permission permission = 1;
+}
+
+message CheckPermissionsResponse {
+}
+
+message HasUserPermissionsRequest {
+  optional bytes user_name = 1;
+  repeated Permission permission = 2;
+}
+
+message HasUserPermissionsResponse {
+  repeated bool has_user_permission = 1;
+}
+
+service AccessControlService {
+    rpc Grant(GrantRequest)
+      returns (GrantResponse);
+
+    rpc Revoke(RevokeRequest)
+      returns (RevokeResponse);
+
+    rpc GetUserPermissions(GetUserPermissionsRequest)
+      returns (GetUserPermissionsResponse);
+
+    rpc CheckPermissions(CheckPermissionsRequest)
+      returns (CheckPermissionsResponse);
+}

--- a/src-tauri/proto/Cell.proto
+++ b/src-tauri/proto/Cell.proto
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+// Cell and KeyValue protos
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "CellProtos";
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+/**
+ * The type of the key in a Cell
+ */
+enum CellType {
+    MINIMUM = 0;
+    PUT = 4;
+
+    DELETE = 8;
+    DELETE_FAMILY_VERSION = 10;
+    DELETE_COLUMN = 12;
+    DELETE_FAMILY = 14;
+
+    // MAXIMUM is used when searching; you look from maximum on down.
+    MAXIMUM = 255;
+}
+
+/**
+ * Protocol buffer version of Cell.
+ */
+message Cell {
+  optional bytes row = 1;
+  optional bytes family = 2;
+  optional bytes qualifier = 3;
+  optional uint64 timestamp = 4;
+  optional CellType cell_type = 5;
+  optional bytes value = 6;
+  optional bytes tags = 7;
+}
+
+/**
+ * Protocol buffer version of KeyValue.
+ * It doesn't have those transient parameters
+ */
+message KeyValue {
+  required bytes row = 1;
+  required bytes family = 2;
+  required bytes qualifier = 3;
+  optional uint64 timestamp = 4;
+  optional CellType key_type = 5;
+  optional bytes value = 6;
+  optional bytes tags = 7;
+}

--- a/src-tauri/proto/Client.proto
+++ b/src-tauri/proto/Client.proto
@@ -1,0 +1,557 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+// This file contains protocol buffers that are used for Client service.
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "ClientProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+import "HBase.proto";
+import "Filter.proto";
+import "Cell.proto";
+import "Comparator.proto";
+import "MapReduce.proto";
+
+/**
+ * The protocol buffer version of Authorizations.
+ */
+message Authorizations {
+  repeated string label = 1;
+}
+
+/**
+ * The protocol buffer version of CellVisibility.
+ */
+message CellVisibility {
+  required string expression = 1;
+}
+
+/**
+ * Container for a list of column qualifier names of a family.
+ */
+message Column {
+  required bytes family = 1;
+  repeated bytes qualifier = 2;
+}
+
+/**
+ * Consistency defines the expected consistency level for an operation.
+ */
+enum Consistency {
+  STRONG   = 0;
+  TIMELINE = 1;
+}
+
+/**
+ * The protocol buffer version of Get.
+ * Unless existence_only is specified, return all the requested data
+ * for the row that matches exactly.
+ */
+message Get {
+  required bytes row = 1;
+  repeated Column column = 2;
+  repeated NameBytesPair attribute = 3;
+  optional Filter filter = 4;
+  optional TimeRange time_range = 5;
+  optional uint32 max_versions = 6 [default = 1];
+  optional bool cache_blocks = 7 [default = true];
+  optional uint32 store_limit = 8;
+  optional uint32 store_offset = 9;
+
+  // The result isn't asked for, just check for
+  // the existence.
+  optional bool existence_only = 10 [default = false];
+
+  // If the row to get doesn't exist, return the
+  // closest row before. Deprecated. No longer used!
+  // Since hbase-2.0.0 but left in place so can test
+  // for Gets with this set and throw Exception.
+  optional bool closest_row_before = 11 [default = false];
+
+  optional Consistency consistency = 12 [default = STRONG];
+  repeated ColumnFamilyTimeRange cf_time_range = 13;
+  optional bool load_column_families_on_demand = 14; /* DO NOT add defaults to load_column_families_on_demand. */
+}
+
+message Result {
+  // Result includes the Cells or else it just has a count of Cells
+  // that are carried otherwise.
+  repeated Cell cell = 1;
+  // The below count is set when the associated cells are
+  // not part of this protobuf message; they are passed alongside
+  // and then this Message is just a placeholder with metadata.
+  // The count is needed to know how many to peel off the block of Cells as
+  // ours.  NOTE: This is different from the pb managed cell_count of the
+  // 'cell' field above which is non-null when the cells are pb'd.
+  optional int32 associated_cell_count = 2;
+
+  // used for Get to check existence only. Not set if existence_only was not set to true
+  //  in the query.
+  optional bool exists = 3;
+
+  // Whether or not the results are coming from possibly stale data
+  optional bool stale = 4 [default = false];
+
+  // Whether or not the entire result could be returned. Results will be split when
+  // the RPC chunk size limit is reached. Partial results contain only a subset of the
+  // cells for a row and must be combined with a result containing the remaining cells
+  // to form a complete result. The equivalent flag in o.a.h.h.client.Result is
+  // mayHaveMoreCellsInRow.
+  optional bool partial = 5 [default = false];
+}
+
+/**
+ * The get request. Perform a single Get operation.
+ */
+message GetRequest {
+  required RegionSpecifier region = 1;
+  required Get get = 2;
+}
+
+message GetResponse {
+  optional Result result = 1;
+}
+
+/**
+ * Condition to check if the value of a given cell (row, family, qualifier) matches a value via a
+ * given comparator or the value of a given cell matches a given filter.
+ *
+ * Condition is used in check and mutate operations.
+ */
+message Condition {
+  required bytes row = 1;
+  optional bytes family = 2;
+  optional bytes qualifier = 3;
+  optional CompareType compare_type = 4;
+  optional Comparator comparator = 5;
+  optional TimeRange time_range = 6;
+  optional Filter filter = 7;
+}
+
+
+/**
+ * A specific mutation inside a mutate request.
+ * It can be an append, increment, put or delete based
+ * on the mutation type.  It can be fully filled in or
+ * only metadata present because data is being carried
+ * elsewhere outside of pb.
+ */
+message MutationProto {
+  optional bytes row = 1;
+  optional MutationType mutate_type = 2;
+  repeated ColumnValue column_value = 3;
+  optional uint64 timestamp = 4;
+  repeated NameBytesPair attribute = 5;
+  optional Durability durability = 6 [default = USE_DEFAULT];
+
+  // For some mutations, a result may be returned, in which case,
+  // time range can be specified for potential performance gain
+  optional TimeRange time_range = 7;
+  // The below count is set when the associated cells are NOT
+  // part of this protobuf message; they are passed alongside
+  // and then this Message is a placeholder with metadata.  The
+  // count is needed to know how many to peel off the block of Cells as
+  // ours.  NOTE: This is different from the pb managed cell_count of the
+  // 'cell' field above which is non-null when the cells are pb'd.
+  optional int32 associated_cell_count = 8;
+
+  optional uint64 nonce = 9;
+
+  enum Durability {
+    USE_DEFAULT  = 0;
+    SKIP_WAL     = 1;
+    ASYNC_WAL    = 2;
+    SYNC_WAL     = 3;
+    FSYNC_WAL    = 4;
+  }
+
+  enum MutationType {
+    APPEND = 0;
+    INCREMENT = 1;
+    PUT = 2;
+    DELETE = 3;
+  }
+
+  enum DeleteType {
+    DELETE_ONE_VERSION = 0;
+    DELETE_MULTIPLE_VERSIONS = 1;
+    DELETE_FAMILY = 2;
+    DELETE_FAMILY_VERSION = 3;
+  }
+
+  message ColumnValue {
+    required bytes family = 1;
+    repeated QualifierValue qualifier_value = 2;
+
+    message QualifierValue {
+      optional bytes qualifier = 1;
+      optional bytes value = 2;
+      optional uint64 timestamp = 3;
+      optional DeleteType delete_type = 4;
+      optional bytes tags = 5;
+    }
+  }
+}
+
+/**
+ * The mutate request. Perform a single Mutate operation.
+ *
+ * Optionally, you can specify a condition. The mutate
+ * will take place only if the condition is met.  Otherwise,
+ * the mutate will be ignored.  In the response result,
+ * parameter processed is used to indicate if the mutate
+ * actually happened.
+ */
+message MutateRequest {
+  required RegionSpecifier region = 1;
+  required MutationProto mutation = 2;
+  optional Condition condition = 3;
+  optional uint64 nonce_group = 4;
+}
+
+message MutateResponse {
+  optional Result result = 1;
+
+  // used for mutate to indicate processed only
+  optional bool processed = 2;
+}
+
+/**
+ * Instead of get from a table, you can scan it with optional filters.
+ * You can specify the row key range, time range, the columns/families
+ * to scan and so on.
+ *
+ * This scan is used the first time in a scan request. The response of
+ * the initial scan will return a scanner id, which should be used to
+ * fetch result batches later on before it is closed.
+ */
+message Scan {
+  repeated Column column = 1;
+  repeated NameBytesPair attribute = 2;
+  optional bytes start_row = 3;
+  optional bytes stop_row = 4;
+  optional Filter filter = 5;
+  optional TimeRange time_range = 6;
+  optional uint32 max_versions = 7 [default = 1];
+  optional bool cache_blocks = 8 [default = true];
+  optional uint32 batch_size = 9;
+  optional uint64 max_result_size = 10;
+  optional uint32 store_limit = 11;
+  optional uint32 store_offset = 12;
+  optional bool load_column_families_on_demand = 13; /* DO NOT add defaults to load_column_families_on_demand. */
+  optional bool small = 14 [deprecated = true];
+  optional bool reversed = 15 [default = false];
+  optional Consistency consistency = 16 [default = STRONG];
+  optional uint32 caching = 17;
+  optional bool allow_partial_results = 18;
+  repeated ColumnFamilyTimeRange cf_time_range = 19;
+  optional uint64 mvcc_read_point = 20 [default = 0];
+  optional bool include_start_row = 21 [default = true];
+  optional bool include_stop_row = 22 [default = false];
+  enum ReadType {
+    DEFAULT = 0;
+    STREAM = 1;
+    PREAD = 2;
+  }
+  optional ReadType readType = 23 [default = DEFAULT];
+  optional bool need_cursor_result = 24 [default = false];
+}
+
+/**
+ * A scan request. Initially, it should specify a scan. Later on, you
+ * can use the scanner id returned to fetch result batches with a different
+ * scan request.
+ *
+ * The scanner will remain open if there are more results, and it's not
+ * asked to be closed explicitly.
+ *
+ * You can fetch the results and ask the scanner to be closed to save
+ * a trip if you are not interested in remaining results.
+ */
+message ScanRequest {
+  optional RegionSpecifier region = 1;
+  optional Scan scan = 2;
+  optional uint64 scanner_id = 3;
+  optional uint32 number_of_rows = 4;
+  optional bool close_scanner = 5;
+  optional uint64 next_call_seq = 6;
+  optional bool client_handles_partials = 7;
+  optional bool client_handles_heartbeats = 8;
+  optional bool track_scan_metrics = 9;
+  optional bool renew = 10 [default = false];
+  // if we have returned limit_of_rows rows to client, then close the scanner.
+  optional uint32 limit_of_rows = 11 [default = 0];
+}
+
+/**
+* Scan cursor to tell client where we are scanning.
+*
+ */
+message Cursor {
+  optional bytes row = 1;
+}
+
+/**
+ * The scan response. If there are no more results, more_results will
+ * be false.  If it is not specified, it means there are more.
+ */
+message ScanResponse {
+  // This field is filled in if we are doing cellblocks.  A cellblock is made up
+  // of all Cells serialized out as one cellblock BUT responses from a server
+  // have their Cells grouped by Result.  So we can reconstitute the
+  // Results on the client-side, this field is a list of counts of Cells
+  // in each Result that makes up the response.  For example, if this field
+  // has 3, 3, 3 in it, then we know that on the client, we are to make
+  // three Results each of three Cells each.
+  repeated uint32 cells_per_result = 1;
+
+  optional uint64 scanner_id = 2;
+  optional bool more_results = 3;
+  optional uint32 ttl = 4;
+  // If cells are not carried in an accompanying cellblock, then they are pb'd here.
+  // This field is mutually exclusive with cells_per_result (since the Cells will
+  // be inside the pb'd Result)
+  repeated Result results = 5;
+  optional bool stale = 6;
+
+  // This field is filled in if we are doing cellblocks. In the event that a row
+  // could not fit all of its cells into a single RPC chunk, the results will be
+  // returned as partials, and reconstructed into a complete result on the client
+  // side. This field is a list of flags indicating whether or not the result
+  // that the cells belong to is a partial result. For example, if this field
+  // has false, false, true in it, then we know that on the client side, we need to
+  // make another RPC request since the last result was only a partial.
+  repeated bool partial_flag_per_result = 7;
+
+  // A server may choose to limit the number of results returned to the client for
+  // reasons such as the size in bytes or quantity of results accumulated. This field
+  // will true when more results exist in the current region.
+  optional bool more_results_in_region = 8;
+
+  // This field is filled in if the server is sending back a heartbeat message.
+  // Heartbeat messages are sent back to the client to prevent the scanner from
+  // timing out. Seeing a heartbeat message communicates to the Client that the
+  // server would have continued to scan had the time limit not been reached.
+  optional bool heartbeat_message = 9;
+
+  // This field is filled in if the client has requested that scan metrics be tracked.
+  // The metrics tracked here are sent back to the client to be tracked together with
+  // the existing client side metrics.
+  optional ScanMetrics scan_metrics = 10;
+
+  // The mvcc read point which is used to open the scanner at server side. Client can
+  // make use of this mvcc_read_point when restarting a scanner to get a consistent view
+  // of a row.
+  optional uint64 mvcc_read_point = 11 [default = 0];
+
+  // If the Scan need cursor, return the row key we are scanning in heartbeat message.
+  // If the Scan doesn't need a cursor, don't set this field to reduce network IO.
+  optional Cursor cursor = 12;
+}
+
+/**
+ * Atomically bulk load multiple HFiles (say from different column families)
+ * into an open region.
+ */
+message BulkLoadHFileRequest {
+  required RegionSpecifier region = 1;
+  repeated FamilyPath family_path = 2;
+  optional bool assign_seq_num = 3;
+  optional DelegationToken fs_token = 4;
+  optional string bulk_token = 5;
+  optional bool copy_file = 6 [default = false];
+  repeated string cluster_ids = 7;
+  optional bool replicate = 8 [default = true];
+
+  message FamilyPath {
+    required bytes family = 1;
+    required string path = 2;
+  }
+}
+
+message BulkLoadHFileResponse {
+  required bool loaded = 1;
+}
+
+message DelegationToken {
+  optional bytes identifier = 1;
+  optional bytes password = 2;
+  optional string kind = 3;
+  optional string service = 4;
+}
+
+message PrepareBulkLoadRequest {
+  required TableName table_name = 1;
+  optional RegionSpecifier region = 2;
+}
+
+message PrepareBulkLoadResponse {
+  required string bulk_token = 1;
+}
+
+message CleanupBulkLoadRequest {
+  required string bulk_token = 1;
+  optional RegionSpecifier region = 2;
+}
+
+message CleanupBulkLoadResponse {
+}
+
+message CoprocessorServiceCall {
+  required bytes row = 1;
+  required string service_name = 2;
+  required string method_name = 3;
+  required bytes request = 4;
+}
+
+message CoprocessorServiceResult {
+  optional NameBytesPair value = 1;
+}
+
+message CoprocessorServiceRequest {
+  required RegionSpecifier region = 1;
+  required CoprocessorServiceCall call = 2;
+}
+
+message CoprocessorServiceResponse {
+  required RegionSpecifier region = 1;
+  required NameBytesPair value = 2;
+}
+
+// Either a Get or a Mutation
+message Action {
+  // If part of a multi action, useful aligning
+  // result with what was originally submitted.
+  optional uint32 index = 1;
+  optional MutationProto mutation = 2;
+  optional Get get = 3;
+  optional CoprocessorServiceCall service_call = 4;
+}
+
+/**
+ * Actions to run against a Region.
+ */
+message RegionAction {
+  required RegionSpecifier region = 1;
+  // When set, run mutations as atomic unit.
+  optional bool atomic = 2;
+  repeated Action action = 3;
+  optional Condition condition = 4;
+}
+
+/*
+* Statistics about the current load on the region
+*/
+message RegionLoadStats {
+  // Percent load on the memstore. Guaranteed to be positive, between 0 and 100.
+  optional int32 memStoreLoad = 1 [default = 0];
+  // Percent JVM heap occupancy. Guaranteed to be positive, between 0 and 100.
+  // We can move this to "ServerLoadStats" should we develop them.
+  optional int32 heapOccupancy = 2 [default = 0];
+  // Compaction pressure. Guaranteed to be positive, between 0 and 100.
+  optional int32 compactionPressure = 3 [default = 0];
+}
+
+message MultiRegionLoadStats{
+  repeated RegionSpecifier region = 1;
+  repeated RegionLoadStats stat = 2;
+}
+
+/**
+ * Either a Result or an Exception NameBytesPair (keyed by
+ * exception name whose value is the exception stringified)
+ * or maybe empty if no result and no exception.
+ */
+message ResultOrException {
+  // If part of a multi call, save original index of the list of all
+  // passed so can align this response w/ original request.
+  optional uint32 index = 1;
+  optional Result result = 2;
+  optional NameBytesPair exception = 3;
+  // result if this was a coprocessor service call
+  optional CoprocessorServiceResult service_result = 4;
+  // current load on the region
+  optional RegionLoadStats loadStats = 5 [deprecated=true];
+}
+
+/**
+ * The result of a RegionAction.
+ */
+message RegionActionResult {
+  repeated ResultOrException resultOrException = 1;
+  // If the operation failed globally for this region, this exception is set
+  optional NameBytesPair exception = 2;
+  optional bool processed = 3;
+}
+
+/**
+ * Execute a list of actions on a given region in order.
+ * Nothing prevents a request to contains a set of RegionAction on the same region.
+ * For this reason, the matching between the MultiRequest and the MultiResponse is not
+ *  done by the region specifier but by keeping the order of the RegionActionResult vs.
+ *  the order of the RegionAction.
+ */
+message MultiRequest {
+  repeated RegionAction regionAction = 1;
+  optional uint64 nonceGroup = 2;
+  // Moved this to RegionAction in HBASE-8458. Keep it for backward compatibility. Need to remove
+  // it in the future.
+  optional Condition condition = 3 [deprecated=true];
+}
+
+message MultiResponse {
+  repeated RegionActionResult regionActionResult = 1;
+  // Moved this to RegionActionResult in HBASE-8458. Keep it for backward compatibility. Need to
+  // remove it in the future.
+  optional bool processed = 2 [deprecated=true];
+  optional MultiRegionLoadStats regionStatistics = 3;
+}
+
+
+service ClientService {
+  rpc Get(GetRequest)
+    returns(GetResponse);
+
+  rpc Mutate(MutateRequest)
+    returns(MutateResponse);
+
+  rpc Scan(ScanRequest)
+    returns(ScanResponse);
+
+  rpc BulkLoadHFile(BulkLoadHFileRequest)
+    returns(BulkLoadHFileResponse);
+
+  rpc PrepareBulkLoad(PrepareBulkLoadRequest)
+    returns (PrepareBulkLoadResponse);
+
+  rpc CleanupBulkLoad(CleanupBulkLoadRequest)
+    returns (CleanupBulkLoadResponse);
+
+  rpc ExecService(CoprocessorServiceRequest)
+    returns(CoprocessorServiceResponse);
+
+  rpc ExecRegionServerService(CoprocessorServiceRequest)
+    returns(CoprocessorServiceResponse);
+
+  rpc Multi(MultiRequest)
+    returns(MultiResponse);
+}

--- a/src-tauri/proto/ClusterId.proto
+++ b/src-tauri/proto/ClusterId.proto
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+// This file contains protocol buffers that are shared throughout HBase
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "ClusterIdProtos";
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+/**
+ * Content of the '/hbase/hbaseid', cluster id, znode.
+ * Also cluster of the ${HBASE_ROOTDIR}/hbase.id file.
+ */
+message ClusterId {
+  // This is the cluster id, a uuid as a String
+  required string cluster_id = 1;
+}

--- a/src-tauri/proto/ClusterStatus.proto
+++ b/src-tauri/proto/ClusterStatus.proto
@@ -1,0 +1,371 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+// This file contains protocol buffers that are used for ClustStatus
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "ClusterStatusProtos";
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+import "HBase.proto";
+import "ClusterId.proto";
+import "FS.proto";
+
+message RegionState {
+  required RegionInfo region_info = 1;
+  required State state = 2;
+  optional uint64 stamp = 3;
+  enum State {
+    OFFLINE = 0;       // region is in an offline state
+    PENDING_OPEN = 1;  // sent rpc to server to open but has not begun
+    OPENING = 2;       // server has begun to open but not yet done
+    OPEN = 3;          // server opened region and updated meta
+    PENDING_CLOSE = 4; // sent rpc to server to close but has not begun
+    CLOSING = 5;       // server has begun to close but not yet done
+    CLOSED = 6;        // server closed region and updated meta
+    SPLITTING = 7;     // server started split of a region
+    SPLIT = 8;         // server completed split of a region
+    FAILED_OPEN = 9;   // failed to open, and won't retry any more
+    FAILED_CLOSE = 10; // failed to close, and won't retry any more
+    MERGING = 11;      // server started merge a region
+    MERGED = 12;       // server completed merge of a region
+    SPLITTING_NEW = 13;  // new region to be created when RS splits a parent
+                       // region but hasn't be created yet, or master doesn't
+                       // know it's already created
+    MERGING_NEW = 14;  // new region to be created when RS merges two
+                       // daughter regions but hasn't be created yet, or
+                       // master doesn't know it's already created
+    ABNORMALLY_CLOSED = 15;// the region is CLOSED because of a RS crash. Usually it is the same
+                       // with CLOSED, but for some operations such as merge/split, we can not
+                       // apply it to a region in this state, as it may lead to data loss as we
+                       // may have some data in recovered edits.
+  }
+}
+
+message RegionInTransition {
+  required RegionSpecifier spec = 1;
+  required RegionState region_state = 2;
+}
+
+/**
+ * sequence Id of a store
+ */
+message StoreSequenceId {
+  required bytes family_name = 1;
+  required uint64 sequence_id = 2;
+}
+
+/**
+ * contains a sequence id of a region which should be the minimum of its store sequence ids and
+ * list of sequence ids of the region's stores
+ */
+message RegionStoreSequenceIds {
+  required uint64 last_flushed_sequence_id = 1;
+  repeated StoreSequenceId store_sequence_id = 2;
+}
+
+message RegionLoad {
+  /** the region specifier */
+  required RegionSpecifier region_specifier = 1;
+
+  /** the number of stores for the region */
+  optional uint32 stores = 2;
+
+  /** the number of storefiles for the region */
+  optional uint32 storefiles = 3;
+
+  /** the total size of the store files for the region, uncompressed, in MB */
+  optional uint32 store_uncompressed_size_MB = 4;
+
+  /** the current total size of the store files for the region, in MB */
+  optional uint32 storefile_size_MB = 5;
+
+  /** the current size of the memstore for the region, in MB */
+  optional uint32 mem_store_size_MB = 6;
+
+  /**
+   * The current total size of root-level store file indexes for the region,
+   * in KB. The same as {@link #rootIndexSizeKB}.
+   */
+  optional uint64 storefile_index_size_KB = 7;
+
+  /** the current total read requests made to region */
+  optional uint64 read_requests_count = 8;
+
+  /** the current total write requests made to region */
+  optional uint64 write_requests_count = 9;
+
+  /** the total compacting key values in currently running compaction */
+  optional uint64 total_compacting_KVs = 10;
+
+  /** the completed count of key values in currently running compaction */
+  optional uint64 current_compacted_KVs = 11;
+
+   /** The current total size of root-level indexes for the region, in KB. */
+  optional uint32 root_index_size_KB = 12;
+
+  /** The total size of all index blocks, not just the root level, in KB. */
+  optional uint32 total_static_index_size_KB = 13;
+
+  /**
+   * The total size of all Bloom filter blocks, not just loaded into the
+   * block cache, in KB.
+   */
+  optional uint32 total_static_bloom_size_KB = 14;
+
+  /** the most recent sequence Id from cache flush */
+  optional uint64 complete_sequence_id = 15;
+
+  /** The current data locality for region in the regionserver */
+  optional float data_locality = 16;
+
+  optional uint64 last_major_compaction_ts = 17 [default = 0];
+
+  /** the most recent sequence Id of store from cache flush */
+  repeated StoreSequenceId store_complete_sequence_id = 18;
+
+  /** the current total filtered read requests made to region */
+  optional uint64 filtered_read_requests_count = 19;
+
+  /** master defines cp_requests_count = 20, the current total coprocessor
+      requests made to region */
+
+  /** the number of references active on the store */
+  optional int32 store_ref_count = 21 [default = 0];
+
+  /**
+   *  The max number of references active on single store file among all compacted store files
+   *  that belong to given region
+   */
+  optional int32 max_compacted_store_file_ref_count = 22 [default = 0];
+
+  /** The current data locality for ssd for region in the regionserver */
+  optional float data_locality_for_ssd = 23;
+
+  /** The current blocks local weight for region in the regionserver */
+  optional uint64 blocks_local_weight = 24;
+
+  /** The current blocks local weight with ssd for region in the regionserver */
+  optional uint64 blocks_local_with_ssd_weight = 25;
+
+  /** The current blocks total weight for region in the regionserver */
+  optional uint64 blocks_total_weight = 26;
+
+  /** The compaction state for region */
+  optional CompactionState compaction_state = 27;
+
+  enum CompactionState {
+    NONE = 0;
+    MINOR = 1;
+    MAJOR = 2;
+    MAJOR_AND_MINOR = 3;
+  }
+
+  /** Total region size in MB */
+  optional uint32 region_size_MB = 28;
+
+  /** Current region cache ratio on this server */
+  optional float current_region_cached_ratio = 29;
+}
+
+message UserLoad {
+
+  /** short user name */
+  required string userName = 1;
+
+  /** Metrics for all clients of a user */
+  repeated ClientMetrics clientMetrics = 2;
+}
+
+message ClientMetrics {
+  /** client host name */
+  required string hostName = 1;
+
+  /** the current total read requests made from a client */
+  optional uint64 read_requests_count = 2;
+
+  /** the current total write requests made from a client */
+  optional uint64 write_requests_count = 3;
+
+  /** the current total filtered requests made from a client */
+  optional uint64 filtered_requests_count = 4;
+}
+
+/* Server-level protobufs */
+
+message ReplicationLoadSink {
+  required uint64 ageOfLastAppliedOp = 1;
+  required uint64 timeStampsOfLastAppliedOp = 2;
+  // The below two were added after hbase-2.0.0 went out. They have to be added as 'optional' else
+  // we break upgrades; old RegionServers reporting in w/ old forms of this message will fail to
+  // deserialize on the new Master. See HBASE-25234
+  optional uint64 timestampStarted = 3;
+  optional uint64 totalOpsProcessed = 4;
+}
+
+message ReplicationLoadSource {
+  required string peerID = 1;
+  required uint64 ageOfLastShippedOp = 2;
+  required uint32 sizeOfLogQueue = 3;
+  required uint64 timeStampOfLastShippedOp = 4;
+  required uint64 replicationLag = 5;
+  optional uint64 timeStampOfNextToReplicate=6;
+  optional string queueId = 7;
+  optional bool recovered = 8;
+  optional bool running = 9;
+  optional bool editsSinceRestart = 10;
+  optional uint64 editsRead = 11;
+  optional uint64 oPsShipped = 12;
+}
+
+message ServerTask {
+  required string description = 1;
+  required string status = 2;
+  required State state = 3;
+  optional uint64 startTime = 4;
+  optional uint64 completionTime = 5;
+
+  enum State {
+    RUNNING = 0;
+    WAITING = 1;
+    COMPLETE = 2;
+    ABORTED = 3;
+  }
+}
+
+message ServerLoad {
+  /** Number of requests since last report. */
+  optional uint64 number_of_requests = 1;
+
+  /** Total Number of requests from the start of the region server. */
+  optional uint64 total_number_of_requests = 2;
+
+  /** the amount of used heap, in MB. */
+  optional uint32 used_heap_MB = 3;
+
+  /** the maximum allowable size of the heap, in MB. */
+  optional uint32 max_heap_MB = 4;
+
+  /** Information on the load of individual regions. */
+  repeated RegionLoad region_loads = 5;
+
+  /**
+   * Regionserver-level coprocessors, e.g., WALObserver implementations.
+   * Region-level coprocessors, on the other hand, are stored inside RegionLoad
+   * objects.
+   */
+  repeated Coprocessor coprocessors = 6;
+
+  /**
+   * Time when incremental (non-total) counts began being calculated (e.g. number_of_requests)
+   * time is measured as the difference, measured in milliseconds, between the current time
+   * and midnight, January 1, 1970 UTC.
+   */
+  optional uint64 report_start_time = 7;
+
+  /**
+   * Time when report was generated.
+   * time is measured as the difference, measured in milliseconds, between the current time
+   * and midnight, January 1, 1970 UTC.
+   */
+  optional uint64 report_end_time = 8;
+
+  /**
+   * The port number that this region server is hosing an info server on.
+   */
+  optional uint32 info_server_port = 9;
+
+  /**
+   * The replicationLoadSource for the replication Source status of this region server.
+   */
+  repeated ReplicationLoadSource replLoadSource = 10;
+
+  /**
+   * The replicationLoadSink for the replication Sink status of this region server.
+   */
+  optional ReplicationLoadSink replLoadSink = 11;
+
+  /**
+   * The metrics for each user on this region server
+   */
+  repeated UserLoad userLoads = 12;
+
+  /**
+   * The metrics for region cached on this region server
+   */
+  map<string, uint32> regionCachedInfo = 13;
+
+  /**
+   * The active monitored tasks
+   */
+  repeated ServerTask tasks = 15; /* 15 here to stay in sync with master branch */
+}
+
+message LiveServerInfo {
+  required ServerName server = 1;
+  required ServerLoad server_load = 2;
+}
+
+message RegionStatesCount {
+  required uint32 open_regions = 1;
+  required uint32 split_regions = 2;
+  required uint32 closed_regions = 3;
+  required uint32 regions_in_transition = 4;
+  required uint32 total_regions = 5;
+}
+
+message TableRegionStatesCount {
+  required TableName table_name = 1;
+  required RegionStatesCount region_states_count = 2;
+}
+
+message ClusterStatus {
+  optional HBaseVersionFileContent hbase_version = 1;
+  repeated LiveServerInfo live_servers = 2;
+  repeated ServerName dead_servers = 3;
+  repeated RegionInTransition regions_in_transition = 4;
+  optional ClusterId cluster_id = 5;
+  repeated Coprocessor master_coprocessors = 6;
+  optional ServerName master = 7;
+  repeated ServerName backup_masters = 8;
+  optional bool balancer_on = 9;
+  optional int32 master_info_port = 10 [default = -1];
+  repeated ServerName servers_name = 11;
+  repeated TableRegionStatesCount table_region_states_count = 12;
+  repeated ServerTask master_tasks = 13;
+  repeated ServerName unknown_servers = 14;
+}
+
+enum Option {
+  HBASE_VERSION = 0;
+  CLUSTER_ID = 1;
+  LIVE_SERVERS = 2;
+  DEAD_SERVERS = 3;
+  MASTER = 4;
+  BACKUP_MASTERS = 5;
+  MASTER_COPROCESSORS = 6;
+  REGIONS_IN_TRANSITION = 7;
+  BALANCER_ON = 8;
+  MASTER_INFO_PORT = 9;
+  SERVERS_NAME = 10;
+  TABLE_TO_REGIONS_COUNT = 11;
+  TASKS = 12;
+  UNKNOWN_SERVERS = 13;
+}

--- a/src-tauri/proto/Comparator.proto
+++ b/src-tauri/proto/Comparator.proto
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+// This file contains protocol buffers that are used for filters
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "ComparatorProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+// This file contains protocol buffers that are used for comparators (e.g. in filters)
+
+message Comparator {
+  required string name = 1;
+  optional bytes serialized_comparator = 2;
+}
+
+message ByteArrayComparable {
+  optional bytes value = 1;
+}
+
+message BinaryComparator {
+  required ByteArrayComparable comparable = 1;
+}
+
+message LongComparator {
+  required ByteArrayComparable comparable = 1;
+}
+
+message BinaryPrefixComparator {
+  required ByteArrayComparable comparable = 1;
+}
+
+message BitComparator {
+  required ByteArrayComparable comparable = 1;
+  required BitwiseOp bitwise_op = 2;
+
+  enum BitwiseOp {
+    AND = 1;
+    OR = 2;
+    XOR = 3;
+  }
+}
+
+message NullComparator {
+}
+
+message RegexStringComparator {
+  required string pattern = 1;
+  required int32 pattern_flags = 2;
+  required string charset = 3;
+  optional string engine = 4;
+}
+
+message SubstringComparator {
+  required string substr = 1;
+}
+
+message BigDecimalComparator {
+  required ByteArrayComparable comparable = 1;
+}
+
+message BinaryComponentComparator {
+  required bytes  value = 1;
+  required uint32 offset = 2;
+}

--- a/src-tauri/proto/Encryption.proto
+++ b/src-tauri/proto/Encryption.proto
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+// This file contains protocol buffers used for encryption
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "EncryptionProtos";
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+message WrappedKey {
+  required string algorithm = 1;
+  required uint32 length = 2;
+  required bytes data = 3;
+  optional bytes iv = 4;
+  optional bytes hash = 5;
+  optional string hash_algorithm = 6 [default = "MD5"];
+}

--- a/src-tauri/proto/ErrorHandling.proto
+++ b/src-tauri/proto/ErrorHandling.proto
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+// This file contains protocol buffers that are used for error handling
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "ErrorHandlingProtos";
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+/**
+ * Protobuf version of a java.lang.StackTraceElement
+ * so we can serialize exceptions.
+ */
+message StackTraceElementMessage {
+  optional string declaring_class = 1;
+  optional string method_name = 2;
+  optional string file_name = 3;
+  optional int32 line_number = 4;
+}
+
+/**
+ * Cause of a remote failure for a generic exception. Contains
+ * all the information for a generic exception as well as
+ * optional info about the error for generic info passing
+ * (which should be another protobuffed class).
+ */
+message GenericExceptionMessage {
+  optional string class_name = 1;
+  optional string message = 2;
+  optional bytes error_info = 3;
+  repeated StackTraceElementMessage trace = 4;
+}
+
+/**
+ * Exception sent across the wire when a remote task needs
+ * to notify other tasks that it failed and why
+ */
+message ForeignExceptionMessage {
+  optional string source = 1;
+  optional GenericExceptionMessage generic_exception = 2;
+}

--- a/src-tauri/proto/FS.proto
+++ b/src-tauri/proto/FS.proto
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+// This file contains protocol buffers that are written into the filesystem
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "FSProtos";
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+/**
+ * The ${HBASE_ROOTDIR}/hbase.version file content
+ */
+message HBaseVersionFileContent {
+  required string version = 1;
+}
+
+/**
+ * Reference file content used when we split an hfile under a region.
+ */
+message Reference {
+  required bytes splitkey = 1;
+  enum Range {
+    TOP = 0;
+    BOTTOM = 1;
+  }
+  required Range range = 2;
+}
+

--- a/src-tauri/proto/Filter.proto
+++ b/src-tauri/proto/Filter.proto
@@ -1,0 +1,180 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+// This file contains protocol buffers that are used for filters
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "FilterProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+import "HBase.proto";
+import "Comparator.proto";
+
+message Filter {
+  required string name = 1;
+  optional bytes serialized_filter = 2;
+}
+
+message ColumnCountGetFilter {
+  required int32 limit = 1;
+}
+
+message ColumnPaginationFilter {
+  required int32 limit = 1;
+  optional int32 offset = 2;
+  optional bytes column_offset = 3;
+}
+
+message ColumnPrefixFilter {
+  required bytes prefix = 1;
+}
+
+message ColumnRangeFilter {
+  optional bytes min_column = 1;
+  optional bool min_column_inclusive = 2;
+  optional bytes max_column = 3;
+  optional bool max_column_inclusive = 4;
+}
+
+message CompareFilter {
+  required CompareType compare_op = 1;
+  optional Comparator comparator = 2;
+}
+
+message DependentColumnFilter {
+  required CompareFilter compare_filter = 1;
+  optional bytes column_family = 2;
+  optional bytes column_qualifier = 3;
+  optional bool drop_dependent_column = 4;
+}
+
+message FamilyFilter {
+  required CompareFilter compare_filter = 1;
+}
+
+message FilterList {
+  required Operator operator = 1;
+  repeated Filter filters = 2;
+
+  enum Operator {
+    MUST_PASS_ALL = 1;
+    MUST_PASS_ONE = 2;
+  }
+}
+
+message FilterWrapper {
+  required Filter filter = 1;
+}
+
+message FirstKeyOnlyFilter {
+}
+
+message FirstKeyValueMatchingQualifiersFilter {
+  repeated bytes qualifiers = 1;
+}
+
+message FuzzyRowFilter {
+  repeated BytesBytesPair fuzzy_keys_data = 1;
+  optional bool is_mask_v2 = 2;
+}
+
+message InclusiveStopFilter {
+  optional bytes stop_row_key = 1;
+}
+
+message KeyOnlyFilter {
+  required bool len_as_val = 1;
+}
+
+message MultipleColumnPrefixFilter {
+  repeated bytes sorted_prefixes = 1;
+}
+
+message PageFilter {
+  required int64 page_size = 1;
+}
+
+message PrefixFilter {
+  optional bytes prefix = 1;
+}
+
+message QualifierFilter {
+  required CompareFilter compare_filter = 1;
+}
+
+message RandomRowFilter {
+  required float chance = 1;
+}
+
+message RowFilter {
+  required CompareFilter compare_filter = 1;
+}
+
+message SingleColumnValueExcludeFilter {
+  required SingleColumnValueFilter single_column_value_filter = 1;
+}
+
+message SingleColumnValueFilter {
+  optional bytes column_family = 1;
+  optional bytes column_qualifier = 2;
+  required CompareType compare_op = 3;
+  required Comparator comparator = 4;
+  optional bool filter_if_missing = 5;
+  optional bool latest_version_only = 6;
+}
+
+message SkipFilter {
+  required Filter filter = 1;
+}
+
+message TimestampsFilter {
+  repeated int64 timestamps = 1 [packed=true];
+  optional bool can_hint = 2;
+}
+
+message ValueFilter {
+  required CompareFilter compare_filter = 1;
+}
+
+message WhileMatchFilter {
+  required Filter filter = 1;
+}
+message FilterAllFilter {
+}
+
+message RowRange {
+  optional bytes start_row = 1;
+  optional bool start_row_inclusive = 2;
+  optional bytes stop_row = 3;
+  optional bool stop_row_inclusive =4;
+}
+
+message MultiRowRangeFilter {
+  repeated RowRange row_range_list = 1;
+}
+
+message ColumnValueFilter {
+  required bytes family = 1;
+  required bytes qualifier = 2;
+  required CompareType compare_op = 3;
+  required Comparator comparator = 4;
+}

--- a/src-tauri/proto/HBase.proto
+++ b/src-tauri/proto/HBase.proto
@@ -1,0 +1,276 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+// This file contains protocol buffers that are shared throughout HBase
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "HBaseProtos";
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+
+/**
+ * Table Name
+ */
+message TableName {
+  required bytes namespace = 1;
+  required bytes qualifier = 2;
+}
+
+/**
+ * Table Schema
+ * Inspired by the rest TableSchema
+ */
+message TableSchema {
+  optional TableName table_name = 1;
+  repeated BytesBytesPair attributes = 2;
+  repeated ColumnFamilySchema column_families = 3;
+  repeated NameStringPair configuration = 4;
+}
+
+/** Denotes state of the table */
+message TableState {
+  // Table's current state
+  enum State {
+    ENABLED = 0;
+    DISABLED = 1;
+    DISABLING = 2;
+    ENABLING = 3;
+  }
+  // This is the table's state.
+  required State state = 1;
+}
+
+/**
+ * Column Family Schema
+ * Inspired by the rest ColumSchemaMessage
+ */
+message ColumnFamilySchema {
+  required bytes name = 1;
+  repeated BytesBytesPair attributes = 2;
+  repeated NameStringPair configuration = 3;
+}
+
+/**
+ * Protocol buffer version of RegionInfo.
+ */
+message RegionInfo {
+  required uint64 region_id = 1;
+  required TableName table_name = 2;
+  optional bytes start_key = 3;
+  optional bytes end_key = 4;
+  optional bool offline = 5;
+  optional bool split = 6;
+  optional int32 replica_id = 7 [default = 0];
+}
+
+/**
+ * Protocol buffer for favored nodes
+ */
+message FavoredNodes {
+  repeated ServerName favored_node = 1;
+}
+
+/**
+ * Container protocol buffer to specify a region.
+ * You can specify region by region name, or the hash
+ * of the region name, which is known as encoded
+ * region name.
+ */
+message RegionSpecifier {
+  required RegionSpecifierType type = 1;
+  required bytes value = 2;
+
+  enum RegionSpecifierType {
+    // <tablename>,<startkey>,<regionId>.<encodedName>
+    REGION_NAME = 1;
+
+    // hash of <tablename>,<startkey>,<regionId>
+    ENCODED_REGION_NAME = 2;
+  }
+}
+
+/**
+ * A range of time. Both from and to are Java time
+ * stamp in milliseconds. If you don't specify a time
+ * range, it means all time.  By default, if not
+ * specified, from = 0, and to = Long.MAX_VALUE
+ */
+message TimeRange {
+  optional uint64 from = 1;
+  optional uint64 to = 2;
+}
+
+message TimeRangeTracker {
+  optional uint64 from = 1;
+  optional uint64 to = 2;
+}
+
+/* ColumnFamily Specific TimeRange */
+message ColumnFamilyTimeRange {
+  required bytes column_family = 1;
+  required TimeRange time_range = 2;
+}
+
+/* Comparison operators */
+enum CompareType {
+  LESS = 0;
+  LESS_OR_EQUAL = 1;
+  EQUAL = 2;
+  NOT_EQUAL = 3;
+  GREATER_OR_EQUAL = 4;
+  GREATER = 5;
+  NO_OP = 6;
+}
+
+/**
+ * Protocol buffer version of ServerName
+ */
+message ServerName {
+  required string host_name = 1;
+  optional uint32 port = 2;
+  optional uint64 start_code = 3;
+}
+
+// Comment data structures
+
+message Coprocessor {
+  required string name = 1;
+}
+
+message NameStringPair {
+  required string name = 1;
+  required string value = 2;
+}
+
+message NameBytesPair {
+  required string name = 1;
+  optional bytes value = 2;
+}
+
+message BytesBytesPair {
+  required bytes first = 1;
+  required bytes second = 2;
+}
+
+message NameInt64Pair {
+  optional string name = 1;
+  optional int64 value = 2;
+}
+
+
+
+/**
+ * Description of the distributed procedure to take
+ */
+message ProcedureDescription {
+  required string signature = 1; // the unique signature of the procedure
+  optional string instance = 2; // the procedure instance name
+  optional int64 creation_time = 3 [default = 0];
+  repeated NameStringPair configuration = 4;
+}
+
+message EmptyMsg {
+}
+
+enum TimeUnit {
+  NANOSECONDS = 1;
+  MICROSECONDS = 2;
+  MILLISECONDS = 3;
+  SECONDS = 4;
+  MINUTES = 5;
+  HOURS = 6;
+  DAYS = 7;
+}
+
+message LongMsg {
+  required int64 long_msg = 1;
+}
+
+message DoubleMsg {
+  required double double_msg = 1;
+}
+
+message BigDecimalMsg {
+  required bytes bigdecimal_msg = 1;
+}
+
+message UUID {
+  required uint64 least_sig_bits = 1;
+  required uint64 most_sig_bits = 2;
+}
+
+message NamespaceDescriptor {
+  required bytes name = 1;
+  repeated NameStringPair configuration = 2;
+}
+
+// Rpc client version info proto. Included in ConnectionHeader on connection setup
+message VersionInfo {
+  required string version = 1;
+  required string url = 2;
+  required string revision = 3;
+  required string user = 4;
+  required string date = 5;
+  required string src_checksum = 6;
+  optional uint32 version_major = 7;
+  optional uint32 version_minor = 8;
+}
+
+/**
+ * Description of the region server info
+ */
+message RegionServerInfo {
+  optional int32 infoPort = 1;
+  optional VersionInfo version_info = 2;
+}
+
+message RegionExceptionMessage {
+  required RegionSpecifier region = 1;
+  required NameBytesPair exception = 2;
+}
+
+message CacheEvictionStats {
+  optional int64 evicted_blocks = 1;
+  optional int64 bytes_evicted = 2;
+  optional int64 max_cache_size = 3;
+  repeated RegionExceptionMessage exception = 4;
+}
+
+message RegionLocation {
+  required RegionInfo region_info = 1;
+  optional ServerName server_name = 2;
+  required int64 seq_num = 3;
+}
+
+message LogRequest {
+  required string log_class_name = 1;
+  required bytes log_message = 2;
+}
+
+message LogEntry {
+  required string log_class_name = 1;
+  required bytes log_message = 2;
+}
+
+message RotateFileData {
+  required int64 timestamp = 1;
+  required bytes data = 2;
+}

--- a/src-tauri/proto/LockService.proto
+++ b/src-tauri/proto/LockService.proto
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "LockServiceProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+import "HBase.proto";
+import "Procedure.proto";
+
+enum LockType {
+  EXCLUSIVE = 1;
+  SHARED = 2;
+}
+
+message LockRequest {
+  required LockType lock_type = 1;
+  optional string namespace = 2;
+  optional TableName table_name = 3;
+  repeated RegionInfo region_info = 4;
+  optional string description = 5;
+  optional uint64 nonce_group = 6 [default = 0];
+  optional uint64 nonce = 7 [default = 0];
+}
+
+message LockResponse {
+  required uint64 proc_id = 1;
+}
+
+message LockHeartbeatRequest {
+  required uint64 proc_id = 1;
+  optional bool keep_alive = 2 [default = true];
+}
+
+message LockHeartbeatResponse {
+  enum LockStatus {
+    UNLOCKED = 1;
+    LOCKED = 2;
+  }
+
+  required LockStatus lock_status = 1;
+  // Timeout of lock (if locked).
+  optional uint32 timeout_ms = 2;
+}
+
+message LockProcedureData {
+  required LockType lock_type = 1;
+  optional string namespace = 2;
+  optional TableName table_name = 3;
+  repeated RegionInfo region_info = 4;
+  optional string description = 5;
+  optional bool is_master_lock = 6 [default = false];
+}
+
+enum LockedResourceType {
+  SERVER = 1;
+  NAMESPACE = 2;
+  TABLE = 3;
+  REGION = 4;
+  PEER = 5;
+}
+
+message LockedResource {
+  required LockedResourceType resource_type = 1;
+  optional string resource_name = 2;
+  required LockType lock_type = 3;
+  optional Procedure exclusive_lock_owner_procedure = 4;
+  optional int32 shared_lock_count = 5;
+  repeated Procedure waitingProcedures = 6;
+}
+
+service LockService {
+  /** Acquire lock on namespace/table/region */
+  rpc RequestLock(LockRequest) returns(LockResponse);
+
+  /** Keep alive (or not) a previously acquired lock */
+  rpc LockHeartbeat(LockHeartbeatRequest) returns(LockHeartbeatResponse);
+}

--- a/src-tauri/proto/MapReduce.proto
+++ b/src-tauri/proto/MapReduce.proto
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+ //This file includes protocol buffers used in MapReduce only.
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "MapReduceProtos";
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+import "HBase.proto";
+
+message ScanMetrics {
+  repeated NameInt64Pair metrics = 1;
+}
+
+message TableSnapshotRegionSplit {
+  repeated string locations = 2;
+  optional TableSchema table = 3;
+  optional RegionInfo region = 4;
+}

--- a/src-tauri/proto/Master.proto
+++ b/src-tauri/proto/Master.proto
@@ -1,0 +1,1364 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+// All to do with the Master.  Includes schema management since these
+// changes are run by the Master process.
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "MasterProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+import "HBase.proto";
+import "Client.proto";
+import "ClusterStatus.proto";
+import "ErrorHandling.proto";
+import "LockService.proto";
+import "Procedure.proto";
+import "Quota.proto";
+import "Replication.proto";
+import "Snapshot.proto";
+import "AccessControl.proto";
+import "RecentLogs.proto";
+
+/* Column-level protobufs */
+
+message AddColumnRequest {
+  required TableName table_name = 1;
+  required ColumnFamilySchema column_families = 2;
+  optional uint64 nonce_group = 3 [default = 0];
+  optional uint64 nonce = 4 [default = 0];
+}
+
+message AddColumnResponse {
+  optional uint64 proc_id = 1;
+}
+
+message DeleteColumnRequest {
+  required TableName table_name = 1;
+  required bytes column_name = 2;
+  optional uint64 nonce_group = 3 [default = 0];
+  optional uint64 nonce = 4 [default = 0];
+}
+
+message DeleteColumnResponse {
+  optional uint64 proc_id = 1;
+}
+
+message ModifyColumnRequest {
+  required TableName table_name = 1;
+  required ColumnFamilySchema column_families = 2;
+  optional uint64 nonce_group = 3 [default = 0];
+  optional uint64 nonce = 4 [default = 0];
+}
+
+message ModifyColumnResponse {
+  optional uint64 proc_id = 1;
+}
+
+/* Region-level Protos */
+
+message MoveRegionRequest {
+  required RegionSpecifier region = 1;
+  optional ServerName dest_server_name = 2;
+}
+
+message MoveRegionResponse {
+}
+
+
+/**
+ * Merging the specified regions in a table.
+ */
+message MergeTableRegionsRequest {
+  repeated RegionSpecifier region = 1;
+  optional bool forcible = 3 [default = false];
+  optional uint64 nonce_group = 4 [default = 0];
+  optional uint64 nonce = 5 [default = 0];
+}
+
+message MergeTableRegionsResponse {
+  optional uint64 proc_id = 1;
+}
+
+message AssignRegionRequest {
+  required RegionSpecifier region = 1;
+  optional bool override = 2 [default = false];
+}
+
+message AssignRegionResponse {
+}
+
+message UnassignRegionRequest {
+  required RegionSpecifier region = 1;
+  // This parameter is ignored
+  optional bool force = 2 [default = false];
+}
+
+message UnassignRegionResponse {
+}
+
+message OfflineRegionRequest {
+  required RegionSpecifier region = 1;
+}
+
+message OfflineRegionResponse {
+}
+
+/* Table-level protobufs */
+
+message SplitTableRegionRequest {
+  required RegionInfo region_info = 1;
+  optional bytes split_row = 2;
+  optional uint64 nonce_group = 3 [default = 0];
+  optional uint64 nonce = 4 [default = 0];
+}
+
+message SplitTableRegionResponse {
+  optional uint64 proc_id = 1;
+}
+
+message TruncateRegionRequest {
+  required RegionInfo region_info = 1;
+  optional uint64 nonce_group = 2 [default = 0];
+  optional uint64 nonce = 3 [default = 0];
+}
+
+message TruncateRegionResponse {
+  optional uint64 proc_id = 1;
+}
+
+message CreateTableRequest {
+  required TableSchema table_schema = 1;
+  repeated bytes split_keys = 2;
+  optional uint64 nonce_group = 3 [default = 0];
+  optional uint64 nonce = 4 [default = 0];
+}
+
+message CreateTableResponse {
+  optional uint64 proc_id = 1;
+}
+
+message DeleteTableRequest {
+  required TableName table_name = 1;
+  optional uint64 nonce_group = 2 [default = 0];
+  optional uint64 nonce = 3 [default = 0];
+}
+
+message DeleteTableResponse {
+  optional uint64 proc_id = 1;
+}
+
+message TruncateTableRequest {
+  required TableName tableName = 1;
+  optional bool preserveSplits = 2 [default = false];
+  optional uint64 nonce_group = 3 [default = 0];
+  optional uint64 nonce = 4 [default = 0];
+}
+
+message TruncateTableResponse {
+  optional uint64 proc_id = 1;
+}
+
+message EnableTableRequest {
+  required TableName table_name = 1;
+  optional uint64 nonce_group = 2 [default = 0];
+  optional uint64 nonce = 3 [default = 0];
+}
+
+message EnableTableResponse {
+  optional uint64 proc_id = 1;
+}
+
+message DisableTableRequest {
+  required TableName table_name = 1;
+  optional uint64 nonce_group = 2 [default = 0];
+  optional uint64 nonce = 3 [default = 0];
+}
+
+message DisableTableResponse {
+  optional uint64 proc_id = 1;
+}
+
+message ModifyTableRequest {
+  required TableName table_name = 1;
+  required TableSchema table_schema = 2;
+  optional uint64 nonce_group = 3 [default = 0];
+  optional uint64 nonce = 4 [default = 0];
+  optional bool reopen_regions = 5 [default = true];
+}
+
+message ModifyTableResponse {
+  optional uint64 proc_id = 1;
+}
+
+message FlushTableRequest {
+  required TableName table_name = 1;
+  repeated bytes column_family = 2;
+  optional uint64 nonce_group = 3 [default = 0];
+  optional uint64 nonce = 4 [default = 0];
+}
+
+message FlushTableResponse {
+  optional uint64 proc_id = 1;
+}
+
+/* Namespace-level protobufs */
+
+message CreateNamespaceRequest {
+  required NamespaceDescriptor namespaceDescriptor = 1;
+  optional uint64 nonce_group = 2 [default = 0];
+  optional uint64 nonce = 3 [default = 0];
+}
+
+message CreateNamespaceResponse {
+  optional uint64 proc_id = 1;
+}
+
+message DeleteNamespaceRequest {
+  required string namespaceName = 1;
+  optional uint64 nonce_group = 2 [default = 0];
+  optional uint64 nonce = 3 [default = 0];
+}
+
+message DeleteNamespaceResponse {
+  optional uint64 proc_id = 1;
+}
+
+message ModifyNamespaceRequest {
+  required NamespaceDescriptor namespaceDescriptor = 1;
+  optional uint64 nonce_group = 2 [default = 0];
+  optional uint64 nonce = 3 [default = 0];
+}
+
+message ModifyNamespaceResponse {
+  optional uint64 proc_id = 1;
+}
+
+message GetNamespaceDescriptorRequest {
+  required string namespaceName = 1;
+}
+
+message GetNamespaceDescriptorResponse {
+  required NamespaceDescriptor namespaceDescriptor = 1;
+}
+
+message ListNamespacesRequest {
+}
+
+message ListNamespacesResponse {
+  repeated string namespaceName = 1;
+}
+
+message ListNamespaceDescriptorsRequest {
+}
+
+message ListNamespaceDescriptorsResponse {
+  repeated NamespaceDescriptor namespaceDescriptor = 1;
+}
+
+message ListTableDescriptorsByNamespaceRequest {
+  required string namespaceName = 1;
+}
+
+message ListTableDescriptorsByNamespaceResponse {
+  repeated TableSchema tableSchema = 1;
+}
+
+message ListTableNamesByNamespaceRequest {
+  required string namespaceName = 1;
+}
+
+message ListTableNamesByNamespaceResponse {
+  repeated TableName tableName = 1;
+}
+
+/* Cluster-level protobufs */
+
+
+message ShutdownRequest {
+}
+
+message ShutdownResponse {
+}
+
+message StopMasterRequest {
+}
+
+message StopMasterResponse {
+}
+
+message IsInMaintenanceModeRequest {
+}
+
+message IsInMaintenanceModeResponse {
+  required bool inMaintenanceMode = 1;
+}
+
+message BalanceRequest {
+  optional bool ignore_rit = 1;
+  optional bool dry_run = 2;
+}
+
+message BalanceResponse {
+  required bool balancer_ran = 1;
+  optional uint32 moves_calculated = 2;
+  optional uint32 moves_executed = 3;
+}
+
+message SetBalancerRunningRequest {
+  required bool on = 1;
+  optional bool synchronous = 2;
+}
+
+message SetBalancerRunningResponse {
+  optional bool prev_balance_value = 1;
+}
+
+message IsBalancerEnabledRequest {
+}
+
+message IsBalancerEnabledResponse {
+  required bool enabled = 1;
+}
+
+enum MasterSwitchType {
+  SPLIT = 0;
+  MERGE = 1;
+}
+
+message SetSnapshotCleanupRequest {
+  required bool enabled = 1;
+  optional bool synchronous = 2;
+}
+
+message SetSnapshotCleanupResponse {
+  required bool prev_snapshot_cleanup = 1;
+}
+
+message IsSnapshotCleanupEnabledRequest {
+}
+
+message IsSnapshotCleanupEnabledResponse {
+  required bool enabled = 1;
+}
+
+message SetSplitOrMergeEnabledRequest {
+  required bool enabled = 1;
+  optional bool synchronous = 2;
+  repeated MasterSwitchType switch_types = 3;
+}
+
+message SetSplitOrMergeEnabledResponse {
+  repeated bool prev_value = 1;
+}
+
+message IsSplitOrMergeEnabledRequest {
+  required MasterSwitchType switch_type = 1;
+}
+
+message IsSplitOrMergeEnabledResponse {
+  required bool enabled = 1;
+}
+
+message NormalizeRequest {
+  repeated TableName table_names = 1;
+  optional string regex = 2;
+  optional string namespace = 3;
+}
+
+message NormalizeResponse {
+  required bool normalizer_ran = 1;
+}
+
+message SetNormalizerRunningRequest {
+  required bool on = 1;
+}
+
+message SetNormalizerRunningResponse {
+  optional bool prev_normalizer_value = 1;
+}
+
+message IsNormalizerEnabledRequest {
+}
+
+message IsNormalizerEnabledResponse {
+  required bool enabled = 1;
+}
+
+message RunHbckChoreRequest {
+}
+
+message RunHbckChoreResponse {
+  required bool ran = 1;
+}
+
+message RunCatalogScanRequest {
+}
+
+message RunCatalogScanResponse {
+  // This is how many archiving tasks we started as a result of this scan.
+  optional int32 scan_result = 1;
+}
+
+message EnableCatalogJanitorRequest {
+  required bool enable = 1;
+}
+
+message EnableCatalogJanitorResponse {
+  optional bool prev_value = 1;
+}
+
+message IsCatalogJanitorEnabledRequest {
+}
+
+message IsCatalogJanitorEnabledResponse {
+  required bool value = 1;
+}
+
+message RunCleanerChoreRequest {
+}
+
+message RunCleanerChoreResponse {
+  required bool cleaner_chore_ran = 1;
+}
+
+message SetCleanerChoreRunningRequest {
+  required bool on = 1;
+}
+
+message SetCleanerChoreRunningResponse {
+  optional bool prev_value = 1;
+}
+
+message IsCleanerChoreEnabledRequest {
+}
+
+message IsCleanerChoreEnabledResponse {
+  required bool value = 1;
+}
+
+message SnapshotRequest {
+  required SnapshotDescription snapshot = 1;
+  optional uint64 nonce_group = 2 [default = 0];
+  optional uint64 nonce = 3 [default = 0];
+}
+
+message SnapshotResponse {
+  required int64 expected_timeout = 1;
+  optional int64 proc_id = 2;
+}
+
+message GetCompletedSnapshotsRequest {
+}
+
+message GetCompletedSnapshotsResponse {
+  repeated SnapshotDescription snapshots = 1;
+}
+
+message DeleteSnapshotRequest {
+  required SnapshotDescription snapshot = 1;
+}
+
+message DeleteSnapshotResponse {
+}
+
+message RestoreSnapshotRequest {
+  required SnapshotDescription snapshot = 1;
+  optional uint64 nonce_group = 2 [default = 0];
+  optional uint64 nonce = 3 [default = 0];
+  optional bool restoreACL = 4 [default = false];
+  optional string customSFT = 5;
+}
+
+message RestoreSnapshotResponse {
+  required uint64 proc_id = 1;
+}
+
+/* if you don't send the snapshot, then you will get it back
+ * in the response (if the snapshot is done) so you can check the snapshot
+ */
+message IsSnapshotDoneRequest {
+  optional SnapshotDescription snapshot = 1;
+}
+
+message IsSnapshotDoneResponse {
+  optional bool done = 1 [default = false];
+  optional SnapshotDescription snapshot = 2;
+}
+
+message IsRestoreSnapshotDoneRequest {
+  optional SnapshotDescription snapshot = 1;
+}
+
+message IsRestoreSnapshotDoneResponse {
+  optional bool done = 1 [default = false];
+}
+
+message GetSchemaAlterStatusRequest {
+  required TableName table_name = 1;
+}
+
+message GetSchemaAlterStatusResponse {
+  optional uint32 yet_to_update_regions = 1;
+  optional uint32 total_regions = 2;
+}
+
+message GetTableDescriptorsRequest {
+  repeated TableName table_names = 1;
+  optional string regex = 2;
+  optional bool include_sys_tables = 3 [default=false];
+  optional string namespace = 4;
+}
+
+message GetTableDescriptorsResponse {
+  repeated TableSchema table_schema = 1;
+}
+
+message ListTableDescriptorsByStateRequest {
+  required bool is_enabled = 1;
+}
+
+message ListTableDescriptorsByStateResponse {
+  repeated TableSchema table_schema = 1;
+}
+
+message GetTableNamesRequest {
+  optional string regex = 1;
+  optional bool include_sys_tables = 2 [default=false];
+  optional string namespace = 3;
+}
+
+message GetTableNamesResponse {
+  repeated TableName table_names = 1;
+}
+
+message ListTableNamesByStateRequest {
+  required bool is_enabled = 1;
+}
+
+message ListTableNamesByStateResponse {
+  repeated TableName table_names = 1;
+}
+
+message GetTableStateRequest {
+  required TableName table_name = 1;
+}
+
+message GetTableStateResponse {
+  required TableState table_state = 1;
+}
+
+message GetClusterStatusRequest {
+  repeated Option options = 1;
+}
+
+message GetClusterStatusResponse {
+  required ClusterStatus cluster_status = 1;
+}
+
+message IsMasterRunningRequest {
+}
+
+message IsMasterRunningResponse {
+  required bool is_master_running = 1;
+}
+
+message ExecProcedureRequest {
+  required ProcedureDescription procedure = 1;
+}
+
+message ExecProcedureResponse {
+  optional int64 expected_timeout = 1;
+  optional bytes return_data = 2;
+}
+
+message IsProcedureDoneRequest {
+  optional ProcedureDescription procedure = 1;
+}
+
+message IsProcedureDoneResponse {
+  optional bool done = 1 [default = false];
+  optional ProcedureDescription snapshot = 2;
+}
+
+message GetProcedureResultRequest {
+  required uint64 proc_id = 1;
+}
+
+message GetProcedureResultResponse {
+  enum State {
+    NOT_FOUND = 0;
+    RUNNING = 1;
+    FINISHED = 2;
+  }
+
+  required State state = 1;
+  optional uint64 submitted_time = 2;
+  optional uint64 last_update = 3;
+  optional bytes result = 4;
+  optional ForeignExceptionMessage exception = 5;
+}
+
+message AbortProcedureRequest {
+  required uint64 proc_id = 1;
+  optional bool mayInterruptIfRunning = 2 [default = true];
+}
+
+message AbortProcedureResponse {
+  required bool is_procedure_aborted = 1;
+}
+
+message GetProceduresRequest {
+}
+
+message GetProceduresResponse {
+  repeated Procedure procedure = 1;
+}
+
+message GetLocksRequest {
+}
+
+message GetLocksResponse {
+  repeated LockedResource lock = 1;
+}
+
+message SetQuotaRequest {
+  optional string user_name = 1;
+  optional string user_group = 2;
+  optional string namespace = 3;
+  optional TableName table_name = 4;
+
+  optional bool remove_all = 5;
+  optional bool bypass_globals = 6;
+  optional ThrottleRequest throttle = 7;
+
+  optional SpaceLimitRequest space_limit = 8;
+  optional string region_server = 9;
+}
+
+message SetQuotaResponse {
+}
+
+message MajorCompactionTimestampRequest {
+  required TableName table_name = 1;
+}
+
+message MajorCompactionTimestampForRegionRequest {
+  required RegionSpecifier region = 1;
+}
+
+message MajorCompactionTimestampResponse {
+  required int64 compaction_timestamp = 1;
+}
+
+message SecurityCapabilitiesRequest {
+}
+
+message SecurityCapabilitiesResponse {
+  enum Capability {
+    SIMPLE_AUTHENTICATION = 0;
+    SECURE_AUTHENTICATION = 1;
+    AUTHORIZATION = 2;
+    CELL_AUTHORIZATION = 3;
+    CELL_VISIBILITY = 4;
+  }
+
+  repeated Capability capabilities = 1;
+}
+
+message ListDecommissionedRegionServersRequest {
+}
+
+message ListDecommissionedRegionServersResponse {
+  repeated ServerName server_name = 1;
+}
+
+message DecommissionRegionServersRequest {
+  repeated ServerName server_name = 1;
+  required bool offload = 2;
+}
+
+message DecommissionRegionServersResponse {
+}
+
+message RecommissionRegionServerRequest {
+  required ServerName server_name = 1;
+  repeated RegionSpecifier region = 2;
+}
+
+message RecommissionRegionServerResponse {
+}
+
+message ClearDeadServersRequest {
+  repeated ServerName server_name = 1;
+}
+
+message ClearDeadServersResponse {
+  repeated ServerName server_name = 1;
+}
+
+message SwitchRpcThrottleRequest {
+  required bool rpc_throttle_enabled = 1;
+}
+
+message SwitchRpcThrottleResponse {
+  required bool previous_rpc_throttle_enabled = 1;
+}
+
+message IsRpcThrottleEnabledRequest {
+}
+
+message IsRpcThrottleEnabledResponse {
+  required bool rpc_throttle_enabled = 1;
+}
+
+message SwitchExceedThrottleQuotaRequest {
+  required bool exceed_throttle_quota_enabled = 1;
+}
+
+message SwitchExceedThrottleQuotaResponse {
+  required bool previous_exceed_throttle_quota_enabled = 1;
+}
+
+/**
+ * BalancerDecision (LogRequest) use-case specific RPC request. This request payload will be
+ * converted in bytes and sent to generic RPC API: GetLogEntries
+ * LogRequest message has two params:
+ * 1. log_class_name: BalancerDecisionsRequest (for BalancerDecision use-case)
+ * 2. log_message: BalancerDecisionsRequest converted in bytes (for BalancerDecision use-case)
+ */
+message BalancerDecisionsRequest {
+  optional uint32 limit = 1;
+}
+
+/**
+ * Same as BalancerDecision but used for BalancerRejection
+ */
+message BalancerRejectionsRequest {
+  optional uint32 limit = 1;
+}
+
+/**
+ * BalancerDecision (LogEntry) use-case specific RPC response. This response payload will be
+ * converted in bytes by servers and sent as response to generic RPC API: GetLogEntries
+ * LogEntry message has two params:
+ * 1. log_class_name: BalancerDecisionsResponse (for BalancerDecision use-case)
+ * 2. log_message: BalancerDecisionsResponse converted in bytes (for BalancerDecision use-case)
+ */
+message BalancerDecisionsResponse {
+  repeated BalancerDecision balancer_decision = 1;
+}
+
+message BalancerRejectionsResponse {
+  repeated BalancerRejection balancer_rejection = 1;
+}
+
+message ModifyTableStoreFileTrackerRequest {
+  required TableName table_Name = 1;
+  required string dst_sft = 2;
+  optional uint64 nonce_group = 3 [default = 0];
+  optional uint64 nonce = 4 [default = 0];
+}
+
+message ModifyTableStoreFileTrackerResponse {
+  optional uint64 proc_id = 1;
+}
+
+message ModifyColumnStoreFileTrackerRequest {
+  required TableName table_Name = 1;
+  required bytes family = 2;
+  required string dst_sft = 3;
+  optional uint64 nonce_group = 4 [default = 0];
+  optional uint64 nonce = 5 [default = 0];
+}
+
+message ModifyColumnStoreFileTrackerResponse {
+  optional uint64 proc_id = 1;
+}
+
+message FlushMasterStoreRequest {}
+message FlushMasterStoreResponse {}
+
+service MasterService {
+  /** Used by the client to get the number of regions that have received the updated schema */
+  rpc GetSchemaAlterStatus(GetSchemaAlterStatusRequest)
+    returns(GetSchemaAlterStatusResponse);
+
+  /** Get list of TableDescriptors for requested tables. */
+  rpc GetTableDescriptors(GetTableDescriptorsRequest)
+    returns(GetTableDescriptorsResponse);
+
+  /** List all enabled or disabled table descriptors. */
+  rpc ListTableDescriptorsByState(ListTableDescriptorsByStateRequest)
+    returns(ListTableDescriptorsByStateResponse);
+
+  /** Get the list of table names. */
+  rpc GetTableNames(GetTableNamesRequest)
+    returns(GetTableNamesResponse);
+
+  /** List all enabled or disabled table names. */
+  rpc ListTableNamesByState(ListTableNamesByStateRequest)
+    returns(ListTableNamesByStateResponse);
+
+  /** Return cluster status. */
+  rpc GetClusterStatus(GetClusterStatusRequest)
+    returns(GetClusterStatusResponse);
+
+  /** return true if master is available */
+  rpc IsMasterRunning(IsMasterRunningRequest) returns(IsMasterRunningResponse);
+
+  /** Adds a column to the specified table. */
+  rpc AddColumn(AddColumnRequest)
+    returns(AddColumnResponse);
+
+  /** Deletes a column from the specified table. Table must be disabled. */
+  rpc DeleteColumn(DeleteColumnRequest)
+    returns(DeleteColumnResponse);
+
+  /** Modifies an existing column on the specified table. */
+  rpc ModifyColumn(ModifyColumnRequest)
+    returns(ModifyColumnResponse);
+
+  /** Move the region region to the destination server. */
+  rpc MoveRegion(MoveRegionRequest)
+    returns(MoveRegionResponse);
+
+ /** Master merge the regions */
+  rpc MergeTableRegions(MergeTableRegionsRequest)
+    returns(MergeTableRegionsResponse);
+
+  /** Assign a region to a server chosen at random. */
+  rpc AssignRegion(AssignRegionRequest)
+    returns(AssignRegionResponse);
+
+  /**
+   * Unassign a region from current hosting regionserver.  Region will then be
+   * assigned to a regionserver chosen at random.  Region could be reassigned
+   * back to the same server.  Use MoveRegion if you want
+   * to control the region movement.
+   */
+  rpc UnassignRegion(UnassignRegionRequest)
+    returns(UnassignRegionResponse);
+
+  /**
+   * Offline a region from the assignment manager's in-memory state.  The
+   * region should be in a closed state and there will be no attempt to
+   * automatically reassign the region as in unassign.   This is a special
+   * method, and should only be used by experts or hbck.
+   */
+  rpc OfflineRegion(OfflineRegionRequest)
+    returns(OfflineRegionResponse);
+
+  /**
+   * Split region
+   */
+  rpc SplitRegion(SplitTableRegionRequest)
+    returns(SplitTableRegionResponse);
+
+  /**
+   * Truncate region
+   */
+  rpc TruncateRegion(TruncateRegionRequest)
+    returns(TruncateRegionResponse);
+
+  /** Deletes a table */
+  rpc DeleteTable(DeleteTableRequest)
+    returns(DeleteTableResponse);
+
+  /** Truncate a table */
+  rpc truncateTable(TruncateTableRequest)
+    returns(TruncateTableResponse);
+
+  /** Puts the table on-line (only needed if table has been previously taken offline) */
+  rpc EnableTable(EnableTableRequest)
+    returns(EnableTableResponse);
+
+  /** Take table offline */
+  rpc DisableTable(DisableTableRequest)
+    returns(DisableTableResponse);
+
+  /** Modify a table's metadata */
+  rpc ModifyTable(ModifyTableRequest)
+    returns(ModifyTableResponse);
+
+  /** Flush a table's memstore */
+  rpc FlushTable(FlushTableRequest)
+    returns(FlushTableResponse);
+
+  /** Creates a new table asynchronously */
+  rpc CreateTable(CreateTableRequest)
+    returns(CreateTableResponse);
+
+    /** Shutdown an HBase cluster. */
+  rpc Shutdown(ShutdownRequest)
+    returns(ShutdownResponse);
+
+  /** Stop HBase Master only.  Does not shutdown the cluster. */
+  rpc StopMaster(StopMasterRequest)
+    returns(StopMasterResponse);
+
+  /**
+   * Query whether the Master is in maintenance mode.
+   */
+  rpc IsMasterInMaintenanceMode(IsInMaintenanceModeRequest)
+    returns(IsInMaintenanceModeResponse);
+
+  /**
+   * Run the balancer.  Will run the balancer and if regions to move, it will
+   * go ahead and do the reassignments.  Can NOT run for various reasons.
+   * Check logs.
+   */
+  rpc Balance(BalanceRequest)
+    returns(BalanceResponse);
+
+  /**
+   * Turn the load balancer on or off.
+   * If synchronous is true, it waits until current balance() call, if outstanding, to return.
+   */
+  rpc SetBalancerRunning(SetBalancerRunningRequest)
+    returns(SetBalancerRunningResponse);
+
+  /**
+   * Query whether the Region Balancer is running.
+   */
+  rpc IsBalancerEnabled(IsBalancerEnabledRequest)
+    returns(IsBalancerEnabledResponse);
+
+  /**
+   * Turn the split or merge switch on or off.
+   * If synchronous is true, it waits until current operation call, if outstanding, to return.
+   */
+  rpc SetSplitOrMergeEnabled(SetSplitOrMergeEnabledRequest)
+    returns(SetSplitOrMergeEnabledResponse);
+
+  /**
+   * Query whether the split or merge switch is on/off.
+   */
+  rpc IsSplitOrMergeEnabled(IsSplitOrMergeEnabledRequest)
+    returns(IsSplitOrMergeEnabledResponse);
+
+  /**
+   * Run region normalizer. Can NOT run for various reasons. Check logs.
+   */
+  rpc Normalize(NormalizeRequest)
+    returns(NormalizeResponse);
+
+  /**
+   * Turn region normalizer on or off.
+   */
+  rpc SetNormalizerRunning(SetNormalizerRunningRequest)
+    returns(SetNormalizerRunningResponse);
+
+  /**
+   * Query whether region normalizer is enabled.
+   */
+  rpc IsNormalizerEnabled(IsNormalizerEnabledRequest)
+    returns(IsNormalizerEnabledResponse);
+
+  /** Get a run of the catalog janitor */
+  rpc RunCatalogScan(RunCatalogScanRequest)
+     returns(RunCatalogScanResponse);
+
+  /**
+   * Enable the catalog janitor on or off.
+   */
+  rpc EnableCatalogJanitor(EnableCatalogJanitorRequest)
+     returns(EnableCatalogJanitorResponse);
+
+  /**
+   * Query whether the catalog janitor is enabled.
+   */
+  rpc IsCatalogJanitorEnabled(IsCatalogJanitorEnabledRequest)
+     returns(IsCatalogJanitorEnabledResponse);
+
+  /** Get a run of the CleanerChore */
+  rpc RunCleanerChore(RunCleanerChoreRequest)
+     returns(RunCleanerChoreResponse);
+
+  /**
+   * Enable the CleanerChore on or off.
+   */
+  rpc SetCleanerChoreRunning(SetCleanerChoreRunningRequest)
+     returns(SetCleanerChoreRunningResponse);
+
+  /**
+   * Query whether the CleanerChore is enabled.
+   */
+  rpc IsCleanerChoreEnabled(IsCleanerChoreEnabledRequest)
+     returns(IsCleanerChoreEnabledResponse);
+
+  /**
+   * Call a master coprocessor endpoint
+   */
+  rpc ExecMasterService(CoprocessorServiceRequest)
+    returns(CoprocessorServiceResponse);
+
+  /**
+   * Create a snapshot for the given table.
+   */
+  rpc Snapshot(SnapshotRequest) returns(SnapshotResponse);
+
+  /**
+   * Get completed snapshots.
+   * Returns a list of snapshot descriptors for completed snapshots
+   */
+  rpc GetCompletedSnapshots(GetCompletedSnapshotsRequest) returns(GetCompletedSnapshotsResponse);
+
+  /**
+   * Delete an existing snapshot. This method can also be used to clean up an aborted snapshot.
+   */
+  rpc DeleteSnapshot(DeleteSnapshotRequest) returns(DeleteSnapshotResponse);
+
+  /**
+   * Determine if the snapshot is done yet.
+   */
+  rpc IsSnapshotDone(IsSnapshotDoneRequest) returns(IsSnapshotDoneResponse);
+
+  /**
+   * Restore a snapshot
+   */
+  rpc RestoreSnapshot(RestoreSnapshotRequest) returns(RestoreSnapshotResponse);
+
+  /**
+   * Turn on/off snapshot auto-cleanup based on TTL expiration
+   */
+  rpc SwitchSnapshotCleanup (SetSnapshotCleanupRequest)
+    returns (SetSnapshotCleanupResponse);
+
+  /**
+   * Determine if snapshot auto-cleanup based on TTL expiration is turned on
+   */
+  rpc IsSnapshotCleanupEnabled (IsSnapshotCleanupEnabledRequest)
+    returns (IsSnapshotCleanupEnabledResponse);
+
+  /**
+   * Execute a distributed procedure.
+   */
+  rpc ExecProcedure(ExecProcedureRequest) returns(ExecProcedureResponse);
+
+  /**
+   * Execute a distributed procedure with return data.
+   */
+  rpc ExecProcedureWithRet(ExecProcedureRequest) returns(ExecProcedureResponse);
+
+  /**
+   * Determine if the procedure is done yet.
+   */
+  rpc IsProcedureDone(IsProcedureDoneRequest) returns(IsProcedureDoneResponse);
+
+  /** return true if master is available */
+  /** rpc IsMasterRunning(IsMasterRunningRequest) returns(IsMasterRunningResponse); */
+
+  /** Modify a namespace's metadata */
+  rpc ModifyNamespace(ModifyNamespaceRequest)
+    returns(ModifyNamespaceResponse);
+
+  /** Creates a new namespace synchronously */
+  rpc CreateNamespace(CreateNamespaceRequest)
+    returns(CreateNamespaceResponse);
+
+  /** Deletes namespace synchronously */
+  rpc DeleteNamespace(DeleteNamespaceRequest)
+    returns(DeleteNamespaceResponse);
+
+  /** Get a namespace descriptor by name */
+  rpc GetNamespaceDescriptor(GetNamespaceDescriptorRequest)
+    returns(GetNamespaceDescriptorResponse);
+
+  /** returns a list of namespace descriptors */
+  rpc ListNamespaceDescriptors(ListNamespaceDescriptorsRequest)
+    returns(ListNamespaceDescriptorsResponse);
+
+  /** returns a list of tables for a given namespace*/
+  rpc ListTableDescriptorsByNamespace(ListTableDescriptorsByNamespaceRequest)
+    returns(ListTableDescriptorsByNamespaceResponse);
+
+  /** returns a list of tables for a given namespace*/
+  rpc ListTableNamesByNamespace(ListTableNamesByNamespaceRequest)
+    returns(ListTableNamesByNamespaceResponse);
+
+  /** returns table state */
+  rpc GetTableState(GetTableStateRequest)
+    returns(GetTableStateResponse);
+
+  /** Apply the new quota settings */
+  rpc SetQuota(SetQuotaRequest) returns(SetQuotaResponse);
+
+  /** Returns the timestamp of the last major compaction */
+  rpc getLastMajorCompactionTimestamp(MajorCompactionTimestampRequest)
+    returns(MajorCompactionTimestampResponse);
+
+  /** Returns the timestamp of the last major compaction */
+  rpc getLastMajorCompactionTimestampForRegion(MajorCompactionTimestampForRegionRequest)
+    returns(MajorCompactionTimestampResponse);
+
+  rpc getProcedureResult(GetProcedureResultRequest)
+    returns(GetProcedureResultResponse);
+
+  /** Returns the security capabilities in effect on the cluster */
+  rpc getSecurityCapabilities(SecurityCapabilitiesRequest)
+    returns(SecurityCapabilitiesResponse);
+
+  /** Abort a procedure */
+  rpc AbortProcedure(AbortProcedureRequest)
+    returns(AbortProcedureResponse);
+
+  /** returns a list of procedures */
+  rpc GetProcedures(GetProceduresRequest)
+    returns(GetProceduresResponse);
+
+  rpc GetLocks(GetLocksRequest)
+    returns(GetLocksResponse);
+
+  /** Add a replication peer */
+  rpc AddReplicationPeer(AddReplicationPeerRequest)
+    returns(AddReplicationPeerResponse);
+
+  /** Remove a replication peer */
+  rpc RemoveReplicationPeer(RemoveReplicationPeerRequest)
+    returns(RemoveReplicationPeerResponse);
+
+  /** Enable a replication peer */
+  rpc EnableReplicationPeer(EnableReplicationPeerRequest)
+    returns(EnableReplicationPeerResponse);
+
+  /** Disable a replication peer */
+  rpc DisableReplicationPeer(DisableReplicationPeerRequest)
+    returns(DisableReplicationPeerResponse);
+
+  /** Return peer config for a replication peer */
+  rpc GetReplicationPeerConfig(GetReplicationPeerConfigRequest)
+    returns(GetReplicationPeerConfigResponse);
+
+  /** Update peer config for a replication peer */
+  rpc UpdateReplicationPeerConfig(UpdateReplicationPeerConfigRequest)
+    returns(UpdateReplicationPeerConfigResponse);
+
+  /** Returns a list of replication peers */
+  rpc ListReplicationPeers(ListReplicationPeersRequest)
+    returns(ListReplicationPeersResponse);
+
+  /** Returns the stat of a replication peer */
+  rpc IsReplicationPeerEnabled(GetReplicationPeerStateRequest)
+    returns(GetReplicationPeerStateResponse);
+
+  rpc ReplicationPeerModificationSwitch(ReplicationPeerModificationSwitchRequest)
+    returns(ReplicationPeerModificationSwitchResponse);
+
+  rpc GetReplicationPeerModificationProcedures(GetReplicationPeerModificationProceduresRequest)
+    returns(GetReplicationPeerModificationProceduresResponse);
+
+  rpc IsReplicationPeerModificationEnabled(IsReplicationPeerModificationEnabledRequest)
+    returns(IsReplicationPeerModificationEnabledResponse);
+
+  /** Returns a list of ServerNames marked as decommissioned. */
+  rpc ListDecommissionedRegionServers(ListDecommissionedRegionServersRequest)
+    returns(ListDecommissionedRegionServersResponse);
+
+  /** Decommission region servers. */
+  rpc DecommissionRegionServers(DecommissionRegionServersRequest)
+    returns(DecommissionRegionServersResponse);
+
+  /** Re-commission region server. */
+  rpc RecommissionRegionServer(RecommissionRegionServerRequest)
+    returns(RecommissionRegionServerResponse);
+
+  /** Fetches the Master's view of space utilization */
+  rpc GetSpaceQuotaRegionSizes(GetSpaceQuotaRegionSizesRequest)
+    returns(GetSpaceQuotaRegionSizesResponse);
+
+  /** Fetches the Master's view of quotas */
+  rpc GetQuotaStates(GetQuotaStatesRequest)
+    returns(GetQuotaStatesResponse);
+
+  /** clear dead servers from master*/
+  rpc ClearDeadServers(ClearDeadServersRequest)
+    returns(ClearDeadServersResponse);
+
+  /** Turn the quota throttle on or off */
+  rpc SwitchRpcThrottle (SwitchRpcThrottleRequest) returns (SwitchRpcThrottleResponse);
+
+  /** Get if is rpc throttled enabled */
+  rpc IsRpcThrottleEnabled (IsRpcThrottleEnabledRequest)
+    returns (IsRpcThrottleEnabledResponse);
+
+  /** Turn the exceed throttle quota on or off */
+  rpc SwitchExceedThrottleQuota (SwitchExceedThrottleQuotaRequest)
+    returns (SwitchExceedThrottleQuotaResponse);
+
+  rpc Grant(GrantRequest) returns (GrantResponse);
+
+  rpc Revoke(RevokeRequest) returns (RevokeResponse);
+
+  rpc GetUserPermissions (GetUserPermissionsRequest) returns (GetUserPermissionsResponse);
+
+  rpc HasUserPermissions (HasUserPermissionsRequest) returns (HasUserPermissionsResponse);
+
+  /** returns a list of namespace names */
+  rpc ListNamespaces(ListNamespacesRequest)
+    returns(ListNamespacesResponse);
+
+  rpc GetLogEntries(LogRequest)
+    returns(LogEntry);
+
+  rpc ModifyTableStoreFileTracker(ModifyTableStoreFileTrackerRequest)
+    returns(ModifyTableStoreFileTrackerResponse);
+
+  rpc ModifyColumnStoreFileTracker(ModifyColumnStoreFileTrackerRequest)
+    returns(ModifyColumnStoreFileTrackerResponse);
+
+  rpc FlushMasterStore(FlushMasterStoreRequest)
+    returns(FlushMasterStoreResponse);
+}
+
+// HBCK Service definitions.
+
+message SetTableStateInMetaRequest {
+  required TableName table_name = 1;
+  required TableState table_state = 2;
+}
+
+message RegionSpecifierAndState {
+  required RegionSpecifier region_specifier = 1;
+  required RegionState.State state = 2;
+}
+
+message SetRegionStateInMetaRequest {
+  repeated RegionSpecifierAndState states = 1;
+}
+
+message SetRegionStateInMetaResponse {
+  repeated RegionSpecifierAndState states = 1;
+}
+
+/** Like Admin's AssignRegionRequest except it can
+ * take one or more Regions at a time.
+ */
+// NOTE: In hbck.proto, there is a define for
+// AssignRegionRequest -- singular 'Region'. This
+// is plural to convey it can carry more than one
+// Region at a time.
+message AssignsRequest {
+  repeated RegionSpecifier region = 1;
+  optional bool override = 2 [default = false];
+}
+
+/** Like Admin's AssignRegionResponse except it can
+ * return one or more pids as result -- one per assign.
+ */
+message AssignsResponse {
+  repeated uint64 pid = 1;
+}
+
+/** Like Admin's UnassignRegionRequest except it can
+ * take one or more Regions at a time.
+ */
+message UnassignsRequest {
+  repeated RegionSpecifier region = 1;
+  optional bool override = 2 [default = false];
+}
+
+/** Like Admin's UnassignRegionResponse except it can
+ * return one or more pids as result -- one per unassign.
+ */
+message UnassignsResponse {
+  repeated uint64 pid = 1;
+}
+
+message BypassProcedureRequest {
+  repeated uint64 proc_id = 1;
+  optional uint64 waitTime = 2; // wait time in ms to acquire lock on a procedure
+  optional bool override = 3 [default = false]; // if true, procedure is marked for bypass even if its executing
+  optional bool recursive = 4;
+}
+
+message BypassProcedureResponse {
+  repeated bool bypassed = 1;
+}
+
+message ScheduleServerCrashProcedureRequest {
+  repeated ServerName serverName = 1;
+}
+
+message ScheduleServerCrashProcedureResponse {
+  repeated uint64 pid = 1;
+}
+
+message ScheduleSCPsForUnknownServersRequest {}
+
+message ScheduleSCPsForUnknownServersResponse {
+  repeated uint64 pid = 1;
+}
+
+message FixMetaRequest {}
+
+message FixMetaResponse {}
+
+service HbckService {
+  /** Update state of the table in meta only*/
+  rpc SetTableStateInMeta(SetTableStateInMetaRequest)
+    returns(GetTableStateResponse);
+
+  /** Update state of the region in meta only*/
+  rpc SetRegionStateInMeta(SetRegionStateInMetaRequest)
+    returns(SetRegionStateInMetaResponse);
+
+  /**
+   * Assign regions.
+   * Like Admin's assign but works even if the
+   * Master is initializing. Also allows bulk'ing up
+   * assigns rather than one region at a time.
+   */
+  rpc Assigns(AssignsRequest)
+    returns(AssignsResponse);
+
+  /**
+   * Unassign regions
+   * Like Admin's unssign but works even if the
+   * Master is initializing. Also allows bulk'ing up
+   * assigns rather than one region at a time.
+   */
+  rpc Unassigns(UnassignsRequest)
+    returns(UnassignsResponse);
+
+  /** Bypass a procedure to completion, procedure is completed but no actual work is done*/
+  rpc BypassProcedure(BypassProcedureRequest)
+    returns(BypassProcedureResponse);
+
+  /** Schedule a ServerCrashProcedure to help recover a crash server */
+  rpc ScheduleServerCrashProcedure(ScheduleServerCrashProcedureRequest)
+    returns(ScheduleServerCrashProcedureResponse);
+
+  /** Schedule a ServerCrashProcedure for unknown servers */
+  rpc ScheduleSCPsForUnknownServers(ScheduleSCPsForUnknownServersRequest)
+    returns(ScheduleSCPsForUnknownServersResponse);
+
+  /**
+   * Request HBCK chore to run at master side.
+   */
+  rpc RunHbckChore(RunHbckChoreRequest)
+    returns(RunHbckChoreResponse);
+
+  /** Schedule a fix meta run. */
+  rpc FixMeta(FixMetaRequest)
+    returns(FixMetaResponse);
+}

--- a/src-tauri/proto/Procedure.proto
+++ b/src-tauri/proto/Procedure.proto
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "ProcedureProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+import "org/apache/hbase/thirdparty/google/protobuf/any.proto";
+import "ErrorHandling.proto";
+
+enum ProcedureState {
+  INITIALIZING = 1;         // Procedure in construction, not yet added to the executor
+  RUNNABLE = 2;             // Procedure added to the executor, and ready to be executed
+  WAITING = 3;              // The procedure is waiting on children to be completed
+  WAITING_TIMEOUT = 4;      // The procedure is waiting a timout or an external event
+  ROLLEDBACK = 5;           // The procedure failed and was rolledback
+  SUCCESS = 6;              // The procedure execution is completed successfully.
+  FAILED = 7;               // The procedure execution is failed, may need to rollback
+}
+
+/**
+ * Procedure metadata, serialized by the ProcedureStore to be able to recover the old state.
+ */
+message Procedure {
+  // internal "static" state
+  required string class_name = 1;        // full classname to be able to instantiate the procedure
+  optional uint64 parent_id = 2;         // parent if not a root-procedure otherwise not set
+  required uint64 proc_id = 3;
+  required uint64 submitted_time = 4;
+  optional string owner = 5;
+
+  // internal "runtime" state
+  required ProcedureState state = 6;
+  repeated uint32 stack_id = 7;          // stack indices in case the procedure was running
+  required uint64 last_update = 8;
+  optional uint32 timeout = 9;
+
+  // user state/results
+  optional ForeignExceptionMessage exception = 10;
+  optional bytes result = 11;           // opaque (user) result structure
+  optional bytes state_data = 12;       // opaque (user) procedure internal-state - OBSOLATE
+  repeated google.protobuf.Any state_message = 15; // opaque (user) procedure internal-state
+
+  // Nonce to prevent same procedure submit by multiple times
+  optional uint64 nonce_group = 13 [default = 0];
+  optional uint64 nonce = 14 [default = 0];
+
+  // whether the procedure has held the lock
+  optional bool locked = 16 [default = false];
+
+  // whether the procedure need to be bypassed
+  optional bool bypass = 17 [default = false];
+
+  // whether the procedure has been executed
+  // since we do not always maintain the stack_id now, we need a separated flag
+  optional bool executed = 18 [default = false];
+}
+
+/**
+ * SequentialProcedure data
+ */
+message SequentialProcedureData {
+  required bool executed = 1;
+}
+
+/**
+ * StateMachineProcedure data
+ */
+message StateMachineProcedureData {
+  repeated uint32 state = 1;
+}
+
+/**
+ * Procedure WAL header
+ */
+message ProcedureWALHeader {
+  required uint32 version = 1;
+  required uint32 type = 2;
+  required uint64 log_id = 3;
+  required uint64 min_proc_id = 4;
+}
+
+/**
+ * Procedure WAL trailer
+ */
+message ProcedureWALTrailer {
+  required uint32 version = 1;
+  required uint64 tracker_pos = 2;
+}
+
+message ProcedureStoreTracker {
+  message TrackerNode {
+    required uint64 start_id = 1;
+    repeated uint64 updated = 2;
+    repeated uint64 deleted = 3;
+  }
+
+  repeated TrackerNode node = 1;
+}
+
+message ProcedureWALEntry {
+  enum Type {
+    PROCEDURE_WAL_EOF     = 1;
+    PROCEDURE_WAL_INIT    = 2;
+    PROCEDURE_WAL_INSERT  = 3;
+    PROCEDURE_WAL_UPDATE  = 4;
+    PROCEDURE_WAL_DELETE  = 5;
+    PROCEDURE_WAL_COMPACT = 6;
+  }
+
+  required Type type = 1;
+  repeated Procedure procedure = 2;
+  optional uint64 proc_id = 3;
+  repeated uint64 child_id = 4;
+}

--- a/src-tauri/proto/Quota.proto
+++ b/src-tauri/proto/Quota.proto
@@ -1,0 +1,161 @@
+ /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "QuotaProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+import "HBase.proto";
+
+enum QuotaScope {
+  CLUSTER = 1;
+  MACHINE = 2;
+}
+
+message TimedQuota {
+  required TimeUnit time_unit = 1;
+  optional uint64 soft_limit  = 2;
+  optional float share = 3;
+  optional QuotaScope scope  = 4 [default = MACHINE];
+}
+
+enum ThrottleType {
+  REQUEST_NUMBER = 1;
+  REQUEST_SIZE   = 2;
+  WRITE_NUMBER   = 3;
+  WRITE_SIZE     = 4;
+  READ_NUMBER    = 5;
+  READ_SIZE      = 6;
+  REQUEST_CAPACITY_UNIT = 7;
+  WRITE_CAPACITY_UNIT   = 8;
+  READ_CAPACITY_UNIT    = 9;
+}
+
+message Throttle {
+  optional TimedQuota req_num  = 1;
+  optional TimedQuota req_size = 2;
+
+  optional TimedQuota write_num  = 3;
+  optional TimedQuota write_size = 4;
+
+  optional TimedQuota read_num  = 5;
+  optional TimedQuota read_size = 6;
+
+  optional TimedQuota req_capacity_unit   = 7;
+  optional TimedQuota write_capacity_unit = 8;
+  optional TimedQuota read_capacity_unit  = 9;
+}
+
+message ThrottleRequest {
+  optional ThrottleType type = 1;
+  optional TimedQuota timed_quota = 2;
+}
+
+enum QuotaType {
+  THROTTLE = 1;
+  SPACE = 2;
+}
+
+message Quotas {
+  optional bool bypass_globals = 1 [default = false];
+  optional Throttle throttle = 2;
+  optional SpaceQuota space = 3;
+}
+
+message QuotaUsage {
+}
+
+// Defines what action should be taken when the SpaceQuota is violated
+enum SpaceViolationPolicy {
+  DISABLE = 1; // Disable the table(s)
+  NO_WRITES_COMPACTIONS = 2; // No writes, bulk-loads, or compactions
+  NO_WRITES = 3; // No writes or bulk-loads
+  NO_INSERTS = 4; // No puts or bulk-loads, but deletes are allowed
+}
+
+// Defines a limit on the amount of filesystem space used by a table/namespace
+message SpaceQuota {
+  optional uint64 soft_limit = 1; // The limit of bytes for this quota
+  optional SpaceViolationPolicy violation_policy = 2; // The action to take when the quota is violated
+  optional bool remove = 3 [default = false]; // When true, remove the quota.
+}
+
+// The Request to limit space usage (to allow for schema evolution not tied to SpaceQuota).
+message SpaceLimitRequest {
+  optional SpaceQuota quota = 1;
+}
+
+// Represents the state of a quota on a table. Either the quota is not in violation
+// or it is in violation there is a violation policy which should be in effect.
+message SpaceQuotaStatus {
+  optional SpaceViolationPolicy violation_policy = 1;
+  optional bool in_violation = 2;
+}
+
+// Message stored in the value of hbase:quota table to denote the status of a table WRT
+// the quota applicable to it.
+message SpaceQuotaSnapshot {
+  optional SpaceQuotaStatus quota_status = 1;
+  optional uint64 quota_usage = 2;
+  optional uint64 quota_limit = 3;
+}
+
+message GetSpaceQuotaRegionSizesRequest {
+}
+
+message GetSpaceQuotaRegionSizesResponse {
+  message RegionSizes {
+    optional TableName table_name = 1;
+    optional uint64 size = 2;
+
+  }
+  repeated RegionSizes sizes = 1;
+}
+
+message GetSpaceQuotaSnapshotsRequest {
+}
+
+message GetSpaceQuotaSnapshotsResponse {
+  // Cannot use TableName as a map key, do the repeated nested message by hand.
+  message TableQuotaSnapshot {
+    optional TableName table_name = 1;
+    optional SpaceQuotaSnapshot snapshot = 2;
+  }
+  repeated TableQuotaSnapshot snapshots = 1;
+}
+
+message GetQuotaStatesRequest {
+}
+
+message GetQuotaStatesResponse {
+  message TableQuotaSnapshot {
+    optional TableName table_name = 1;
+    optional SpaceQuotaSnapshot snapshot = 2;
+  }
+  message NamespaceQuotaSnapshot {
+    optional string namespace = 1;
+    optional SpaceQuotaSnapshot snapshot = 2;
+  }
+  repeated TableQuotaSnapshot table_snapshots = 1;
+  repeated NamespaceQuotaSnapshot ns_snapshots = 2;
+}

--- a/src-tauri/proto/RPC.proto
+++ b/src-tauri/proto/RPC.proto
@@ -1,0 +1,165 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+package hbase.pb;
+
+import "Tracing.proto"; 
+import "HBase.proto";
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "RPCProtos";
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+// See https://issues.apache.org/jira/browse/HBASE-7898 for high-level
+// description of RPC specification.
+//
+// On connection setup, the client sends six bytes of preamble -- a four
+// byte magic, a byte of version, and a byte of authentication type.
+//
+// We then send a "ConnectionHeader" protobuf of user information and the
+// 'protocol' or 'service' that is to be run over this connection as well as
+// info such as codecs and compression to use when we send cell blocks(see below).
+// This connection header protobuf is prefaced by an int that holds the length
+// of this connection header (this is NOT a varint).  The pb connection header
+// is sent with Message#writeTo.  The server throws an exception if it doesn't
+// like what it was sent noting what it is objecting too.  Otherwise, the server
+// says nothing and is open for business.
+//
+// Hereafter the client makes requests and the server returns responses.
+//
+// Requests look like this:
+//
+// <An int with the total length of the request>
+// <RequestHeader Message written out using Message#writeDelimitedTo>
+// <Optionally a Request Parameter Message written out using Message#writeDelimitedTo>
+// <Optionally a Cell block>
+//
+// ...where the Request Parameter Message is whatever the method name stipulated
+// in the RequestHeader expects; e.g. if the method is a scan, then the pb
+// Request Message is a GetRequest, or a ScanRequest.  A block of Cells
+// optionally follows.  The presence of a Request param Message and/or a
+// block of Cells will be noted in the RequestHeader.
+//
+// Response is the mirror of the request:
+//
+// <An int with the total length of the response>
+// <ResponseHeader Message written out using Message#writeDelimitedTo>
+// <Optionally a Response Result Message written out using Message#writeDelimitedTo>
+// <Optionally a Cell block>
+//
+// ...where the Response Message is the response type that goes with the
+// method specified when making the request and the follow on Cell blocks may
+// or may not be there -- read the response header to find out if one following.
+// If an exception, it will be included inside the Response Header.
+//
+// Any time we write a pb, we do it with Message#writeDelimitedTo EXCEPT when
+// the connection header is sent; this is prefaced by an int with its length
+// and the pb connection header is then written with Message#writeTo.
+//
+
+// User Information proto.  Included in ConnectionHeader on connection setup
+message UserInformation {
+  required string effective_user = 1;
+  optional string real_user = 2;
+}
+
+// This is sent on connection setup after the connection preamble is sent.
+message ConnectionHeader {
+  optional UserInformation user_info = 1;
+  optional string service_name = 2;
+  // Cell block codec we will use sending over optional cell blocks.  Server throws exception
+  // if cannot deal.  Null means no codec'ing going on so we are pb all the time (SLOW!!!)
+  optional string cell_block_codec_class = 3;
+  // Compressor we will use if cell block is compressed.  Server will throw exception if not supported.
+  // Class must implement hadoop's CompressionCodec Interface.  Can't compress if no codec.
+  optional string cell_block_compressor_class = 4;
+  optional VersionInfo version_info = 5;
+  // the transformation for rpc AES encryption with Apache Commons Crypto
+  optional string rpc_crypto_cipher_transformation = 6;
+  repeated NameBytesPair attribute = 7;
+}
+
+// This is sent by rpc server to negotiate the data if necessary
+message ConnectionHeaderResponse {
+  // To use Apache Commons Crypto, negotiate the metadata
+  optional CryptoCipherMeta crypto_cipher_meta = 1;
+}
+
+// Optional Cell block Message.  Included in client RequestHeader
+message CellBlockMeta {
+  // Length of the following cell block.  Could calculate it but convenient having it too hand.
+  optional uint32 length = 1;
+}
+
+// At the RPC layer, this message is used to carry
+// the server side exception to the RPC client.
+message ExceptionResponse {
+  // Class name of the exception thrown from the server
+  optional string exception_class_name = 1;
+  // Exception stack trace from the server side
+  optional string stack_trace = 2;
+  // Optional hostname.  Filled in for some exceptions such as region moved
+  // where exception gives clue on where the region may have moved.
+  optional string hostname = 3;
+  optional int32 port = 4;
+  // Set if we are NOT to retry on receipt of this exception
+  optional bool do_not_retry = 5;
+  // Set true if the server was considered to be overloaded when exception was thrown
+  optional bool server_overloaded = 6;
+}
+
+/**
+ * Cipher meta for Crypto
+ */
+message CryptoCipherMeta {
+  required string transformation = 1;
+  optional bytes inKey = 2;
+  optional bytes inIv = 3;
+  optional bytes outKey = 4;
+  optional bytes outIv = 5;
+}
+
+// Header sent making a request.
+message RequestHeader {
+  // Monotonically increasing call_id to keep track of RPC requests and their response
+  optional uint32 call_id = 1;
+  optional RPCTInfo trace_info = 2;
+  optional string method_name = 3;
+  // If true, then a pb Message param follows.
+  optional bool request_param = 4;
+  // If present, then an encoded data block follows.
+  optional CellBlockMeta cell_block_meta = 5;
+  // 0 is NORMAL priority.  200 is HIGH.  If no priority, treat it as NORMAL.
+  // See HConstants.
+  optional uint32 priority = 6;
+  optional uint32 timeout = 7;
+  repeated NameBytesPair attribute = 8;
+}
+
+message ResponseHeader {
+  optional uint32 call_id = 1;
+  // If present, then request threw an exception and no response message (else we presume one)
+  optional ExceptionResponse exception = 2;
+  // If present, then an encoded data block follows.
+  optional CellBlockMeta cell_block_meta = 3;
+}
+
+message SecurityPreamableResponse {
+  required string server_principal = 1;
+}

--- a/src-tauri/proto/RecentLogs.proto
+++ b/src-tauri/proto/RecentLogs.proto
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+
+// This file contains protocol buffers that are used for Online BalancerDecision history
+// To be used as Ring Buffer payload
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "RecentLogs";
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+message BalancerDecision {
+
+  required string initial_function_costs = 1;
+  required string final_function_costs = 2;
+  required double init_total_cost = 3;
+  required double computed_total_cost = 4;
+  required uint64 computed_steps = 5;
+  repeated string region_plans = 6;
+
+}
+
+message BalancerRejection {
+  required string reason = 1;
+  repeated string cost_func_info = 2;
+}

--- a/src-tauri/proto/RegionServerStatus.proto
+++ b/src-tauri/proto/RegionServerStatus.proto
@@ -1,0 +1,238 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+// This file contains protocol buffers that are used for RegionServerStatusProtocol.
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "RegionServerStatusProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+import "HBase.proto";
+import "ClusterStatus.proto";
+import "ErrorHandling.proto";
+
+message RegionServerStartupRequest {
+  /** Port number this regionserver is up on */
+  required uint32 port = 1;
+
+  /** This servers' startcode */
+  required uint64 server_start_code = 2;
+
+  /** Current time of the region server in ms */
+  required uint64 server_current_time = 3;
+
+  /** hostname for region server, optional */
+  optional string use_this_hostname_instead = 4;
+}
+
+message RegionServerStartupResponse {
+  /**
+   * Configuration for the regionserver to use: e.g. filesystem,
+   * hbase rootdir, the hostname to use creating the RegionServer ServerName,
+   * etc
+   */
+  repeated NameStringPair map_entries = 1;
+}
+
+message RegionServerReportRequest {
+  required ServerName server = 1;
+
+  /** load the server is under */
+  optional ServerLoad load = 2;
+}
+
+message RegionServerReportResponse {
+}
+
+message ReportRSFatalErrorRequest {
+  /** name of the server experiencing the error */
+  required ServerName server = 1;
+
+  /** informative text to expose in the master logs and UI */
+  required string error_message = 2;
+}
+
+message ReportRSFatalErrorResponse {
+}
+
+message GetLastFlushedSequenceIdRequest {
+  /** region name */
+  required bytes region_name = 1;
+}
+
+message GetLastFlushedSequenceIdResponse {
+  /** the last WAL sequence id flushed from MemStore to HFile for the region */
+  required uint64 last_flushed_sequence_id = 1;
+
+  /** the last WAL sequence id flushed from MemStore to HFile for stores of the region */
+  repeated StoreSequenceId store_last_flushed_sequence_id = 2;
+}
+
+message RegionStateTransition {
+  required TransitionCode transition_code = 1;
+
+  /** Mutliple regions are involved during merging/splitting */
+  repeated RegionInfo region_info = 2;
+
+  /** For newly opened region, the open seq num is needed */
+  optional uint64 open_seq_num = 3;
+
+  repeated int64 proc_id = 4;
+
+  // Master active time as fencing token
+  optional int64 initiating_master_active_time = 5;
+  enum TransitionCode {
+    OPENED = 0;
+    FAILED_OPEN = 1;
+    /** No failed_close, in which case region server will abort */
+    CLOSED = 2;
+
+    /** Ask master for ok to split/merge region(s) */
+    READY_TO_SPLIT = 3;
+    READY_TO_MERGE = 4;
+
+
+    /** We used to have PONR enums for split and merge in here occupying
+     positions 5 and 6 but they have since been removed. Do not reuse these
+     indices */
+    SPLIT = 7;
+    MERGED = 8;
+
+    SPLIT_REVERTED = 9;
+    MERGE_REVERTED = 10;
+  }
+}
+
+message ReportRegionStateTransitionRequest {
+  /** This region server's server name */
+  required ServerName server = 1;
+
+  repeated RegionStateTransition transition = 2;
+}
+
+message ReportRegionStateTransitionResponse {
+  /** Error message if failed to update the region state */
+  optional string error_message = 1;
+}
+
+
+message RegionSpaceUse {
+  optional RegionInfo region_info = 1; // A region identifier
+  optional uint64 region_size = 2; // The size in bytes of the region
+}
+
+/**
+ * Reports filesystem usage for regions.
+ */
+message RegionSpaceUseReportRequest {
+  repeated RegionSpaceUse space_use = 1;
+}
+
+message RegionSpaceUseReportResponse {
+}
+
+message RemoteProcedureResult {
+  required uint64 proc_id = 1;
+  enum Status {
+    SUCCESS = 1;
+    ERROR = 2;
+  }
+  required Status status = 2;
+  optional ForeignExceptionMessage error = 3;
+  // Master active time as fencing token
+  optional int64 initiating_master_active_time = 4;
+}
+message ReportProcedureDoneRequest {
+  repeated RemoteProcedureResult result = 1;
+}
+
+message ReportProcedureDoneResponse {
+}
+
+message FileArchiveNotificationRequest {
+  message FileWithSize {
+    optional TableName table_name = 1;
+    optional string name = 2;
+    optional uint64 size = 3;
+  }
+  repeated FileWithSize archived_files = 1;
+}
+
+message FileArchiveNotificationResponse {
+}
+
+message GetLiveRegionServersRequest {
+  required uint32 count = 1;
+}
+
+message GetLiveRegionServersResponse {
+  repeated ServerName server = 1;
+  required uint32 total = 2;
+}
+
+service RegionServerStatusService {
+  /** Called when a region server first starts. */
+  rpc RegionServerStartup(RegionServerStartupRequest)
+    returns(RegionServerStartupResponse);
+
+  /** Called to report the load the RegionServer is under. */
+  rpc RegionServerReport(RegionServerReportRequest)
+    returns(RegionServerReportResponse);
+
+  /**
+   * Called by a region server to report a fatal error that is causing it to
+   * abort.
+   */
+  rpc ReportRSFatalError(ReportRSFatalErrorRequest)
+    returns(ReportRSFatalErrorResponse);
+
+  /** Called to get the sequence id of the last MemStore entry flushed to an
+   * HFile for a specified region. Used by the region server to speed up
+   * log splitting. */
+  rpc GetLastFlushedSequenceId(GetLastFlushedSequenceIdRequest)
+    returns(GetLastFlushedSequenceIdResponse);
+
+  /**
+   * Called by a region server to report the progress of a region
+   * transition. If the request fails, the transition should
+   * be aborted.
+   */
+  rpc ReportRegionStateTransition(ReportRegionStateTransitionRequest)
+    returns(ReportRegionStateTransitionResponse);
+
+  /**
+   * Reports Region filesystem space use
+   */
+  rpc ReportRegionSpaceUse(RegionSpaceUseReportRequest)
+    returns(RegionSpaceUseReportResponse);
+
+  rpc ReportProcedureDone(ReportProcedureDoneRequest)
+    returns(ReportProcedureDoneResponse);
+
+  /** Reports files that were moved to the archive directory for space quotas */
+  rpc ReportFileArchival(FileArchiveNotificationRequest)
+    returns(FileArchiveNotificationResponse);
+
+  /** Get some live region servers to be used as seed for bootstrap nodes */
+  rpc GetLiveRegionServers(GetLiveRegionServersRequest)
+    returns(GetLiveRegionServersResponse);
+}

--- a/src-tauri/proto/Replication.proto
+++ b/src-tauri/proto/Replication.proto
@@ -1,0 +1,174 @@
+ /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "ReplicationProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+import "HBase.proto";
+import "Procedure.proto";
+
+message TableCF {
+  optional TableName table_name = 1;
+  repeated bytes families = 2;
+}
+
+/**
+ * Used by replication. Holds a replication peer key.
+ */
+message ReplicationPeer {
+  // clusterkey is the concatenation of the slave cluster's
+  // hbase.zookeeper.quorum:hbase.zookeeper.property.clientPort:zookeeper.znode.parent
+  optional string clusterkey = 1;
+  optional string replicationEndpointImpl = 2;
+  repeated BytesBytesPair data = 3;
+  repeated NameStringPair configuration = 4;
+  repeated TableCF table_cfs = 5;
+  repeated bytes namespaces = 6;
+  optional int64 bandwidth = 7;
+  optional bool replicate_all = 8;
+  repeated TableCF exclude_table_cfs = 9;
+  repeated bytes exclude_namespaces = 10;
+  optional bool serial = 11;
+}
+
+/**
+ * Used by replication. Holds whether enabled or disabled
+ */
+message ReplicationState {
+  enum State {
+    ENABLED = 0;
+    DISABLED = 1;
+  }
+  required State state = 1;
+}
+
+/**
+ * Used by replication. Description of the replication peer.
+ */
+message ReplicationPeerDescription {
+  required string id = 1;
+  required ReplicationState state = 2;
+  required ReplicationPeer config = 3;
+}
+
+/**
+ * Used by replication. Holds the current position in an WAL file.
+ */
+message ReplicationHLogPosition {
+  required int64 position = 1;
+}
+
+message AddReplicationPeerRequest {
+  required string peer_id = 1;
+  required ReplicationPeer peer_config = 2;
+  required ReplicationState peer_state = 3;
+}
+
+message AddReplicationPeerResponse {
+  optional uint64 proc_id = 1;
+}
+
+message RemoveReplicationPeerRequest {
+  required string peer_id = 1;
+}
+
+message RemoveReplicationPeerResponse {
+  optional uint64 proc_id = 1;
+}
+
+message EnableReplicationPeerRequest {
+  required string peer_id = 1;
+}
+
+message EnableReplicationPeerResponse {
+  optional uint64 proc_id = 1;
+}
+
+message DisableReplicationPeerRequest {
+  required string peer_id = 1;
+}
+
+message DisableReplicationPeerResponse {
+  optional uint64 proc_id = 1;
+}
+
+message GetReplicationPeerConfigRequest {
+  required string peer_id = 1;
+}
+
+message GetReplicationPeerConfigResponse {
+  required string peer_id = 1;
+  required ReplicationPeer peer_config = 2;
+}
+
+message UpdateReplicationPeerConfigRequest {
+  required string peer_id = 1;
+  required ReplicationPeer peer_config = 2;
+}
+
+message UpdateReplicationPeerConfigResponse {
+  optional uint64 proc_id = 1;
+}
+
+message ListReplicationPeersRequest {
+  optional string regex = 1;
+}
+
+message ListReplicationPeersResponse {
+  repeated ReplicationPeerDescription peer_desc = 1;
+}
+
+message GetReplicationPeerStateRequest {
+  required string peer_id = 1;
+}
+
+message GetReplicationPeerStateResponse {
+  required bool is_enabled = 1;
+}
+
+message ReplicationPeerModificationSwitchRequest {
+  required bool on = 1;
+}
+
+message ReplicationPeerModificationSwitchResponse {
+  required bool previous_value = 1;
+}
+
+message ReplicationPeerModificationState {
+  required bool on = 1;
+}
+
+message GetReplicationPeerModificationProceduresRequest {
+}
+
+message GetReplicationPeerModificationProceduresResponse {
+  repeated Procedure procedure = 1;
+}
+
+message IsReplicationPeerModificationEnabledRequest {
+}
+
+message IsReplicationPeerModificationEnabledResponse {
+  required bool enabled = 1;
+}

--- a/src-tauri/proto/Snapshot.proto
+++ b/src-tauri/proto/Snapshot.proto
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "SnapshotProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+import "AccessControl.proto";
+import "FS.proto";
+import "HBase.proto";
+
+/**
+ * Description of the snapshot to take
+ */
+message SnapshotDescription {
+  required string name = 1;
+  optional string table = 2; // not needed for delete, but checked for in taking snapshot
+  optional int64 creation_time = 3 [default = 0];
+  enum Type {
+    DISABLED = 0;
+    FLUSH = 1;
+    SKIPFLUSH = 2;
+  }
+  optional Type type = 4 [default = FLUSH];
+  optional int32 version = 5;
+  optional string owner = 6;
+  optional UsersAndPermissions users_and_permissions = 7;
+  optional int64 ttl = 8 [default = 0];
+  optional int64 max_file_size = 9 [default = 0];
+}
+
+message SnapshotFileInfo {
+  enum Type {
+    HFILE = 1;
+    WAL = 2;
+  }
+
+  required Type type = 1;
+
+  optional string hfile = 3;
+
+  optional string wal_server = 4;
+  optional string wal_name = 5;
+}
+
+message SnapshotRegionManifest {
+  optional int32 version = 1;
+
+  required RegionInfo region_info = 2;
+  repeated FamilyFiles family_files = 3;
+
+  message StoreFile {
+    required string name = 1;
+    optional Reference reference = 2;
+
+    // TODO: Add checksums or other fields to verify the file
+    optional uint64 file_size = 3;
+  }
+
+  message FamilyFiles {
+    required bytes family_name = 1;
+    repeated StoreFile store_files = 2;
+  }
+}
+
+message SnapshotDataManifest {
+  required TableSchema table_schema = 1;
+  repeated SnapshotRegionManifest region_manifests = 2;
+}

--- a/src-tauri/proto/Tracing.proto
+++ b/src-tauri/proto/Tracing.proto
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "TracingProtos";
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+// OpenTelemetry propagates trace context through https://www.w3.org/TR/trace-context/, which
+// is a text-based approach that passes properties with http headers. Here we will also use this
+// approach so we just need a map to store the key value pair.
+
+message RPCTInfo {
+  optional int64 trace_id = 1 [deprecated = true];
+  optional int64 parent_id = 2 [deprecated = true];
+  map<string, string> headers = 3;
+}

--- a/src-tauri/proto/ZooKeeper.proto
+++ b/src-tauri/proto/ZooKeeper.proto
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+// ZNode data in hbase are serialized protobufs with a four byte
+// 'magic' 'PBUF' prefix.
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "ZooKeeperProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+import "HBase.proto";
+import "ClusterStatus.proto";
+
+/**
+ * Content of the meta-region-server znode.
+ */
+message MetaRegionServer {
+  // The ServerName hosting the meta region currently, or destination server,
+  // if meta region is in transition.
+  required ServerName server = 1;
+  // The major version of the rpc the server speaks.  This is used so that
+  // clients connecting to the cluster can have prior knowledge of what version
+  // to send to a RegionServer.  AsyncHBase will use this to detect versions.
+  optional uint32 rpc_version = 2;
+
+  // State of the region transition. OPEN means fully operational 'hbase:meta'
+  optional RegionState.State state = 3;
+}
+
+/**
+ * Content of the master znode.
+ */
+message Master {
+  // The ServerName of the current Master
+  required ServerName master = 1;
+  // Major RPC version so that clients can know what version the master can accept.
+  optional uint32 rpc_version = 2;
+  optional uint32 info_port = 3;
+}
+
+/**
+ * Content of the '/hbase/running', cluster state, znode.
+ */
+message ClusterUp {
+  // If this znode is present, cluster is up.  Currently
+  // the data is cluster start_date.
+  required string start_date = 1;
+}
+
+/**
+ * WAL SplitLog directory znodes have this for content.  Used doing distributed
+ * WAL splitting.  Holds current state and name of server that originated split.
+ */
+message SplitLogTask {
+  enum State {
+    UNASSIGNED = 0;
+    OWNED = 1;
+    RESIGNED = 2;
+    DONE = 3;
+    ERR = 4;
+  }
+  required State state = 1;
+  required ServerName server_name = 2;
+  // optional RecoveryMode DEPRECATED_mode = 3 [default = UNKNOWN];
+}
+
+/**
+ * The znode that holds state of table.
+ * Deprected, table state is stored in hbase:meta since 2.0.0.
+ */
+message DeprecatedTableState {
+  // Table's current state
+  enum State {
+    ENABLED = 0;
+    DISABLED = 1;
+    DISABLING = 2;
+    ENABLING = 3;
+  }
+  // This is the table's state.  If no znode for a table,
+  // its state is presumed enabled.  See o.a.h.h.zookeeper.ZKTable class
+  // for more.
+  required State state = 1 [default = ENABLED];
+}
+
+/**
+ * State of the switch.
+ */
+message SwitchState {
+  optional bool enabled = 1;
+}

--- a/src-tauri/proto/org/apache/hbase/thirdparty/google/protobuf/any.proto
+++ b/src-tauri/proto/org/apache/hbase/thirdparty/google/protobuf/any.proto
@@ -1,0 +1,12 @@
+// Vendored shaded Any definition. HBase 2.x relocates google.protobuf.Any
+// under org/apache/hbase/thirdparty/... at build time via hbase-thirdparty.
+// The repository does not ship this file, so we vendor the canonical
+// google.protobuf.Any here at the import path HBase's .proto files expect.
+syntax = "proto2";
+package google.protobuf;
+option java_package = "org.apache.hbase.thirdparty.google.protobuf";
+option java_outer_classname = "AnyProto";
+message Any {
+  optional string type_url = 1;
+  optional bytes value = 2;
+}

--- a/src-tauri/src/hbase/mod.rs
+++ b/src-tauri/src/hbase/mod.rs
@@ -4,6 +4,13 @@
 //! helper process. The frontend sends HBase-shell-like commands, we parse the
 //! small command language here, and each operation is translated into REST API
 //! calls against an HBase-compatible endpoint such as Stargate/Lindorm REST.
+//!
+//! The `native` submodule provides an alternative transport that speaks the
+//! native RegionServer/Master RPC protocol directly (bootstrapped via
+//! ZooKeeper), for clusters that do not expose a REST gateway.
+
+pub mod native;
+
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use reqwest::header::{HeaderMap, ACCEPT, CONTENT_TYPE, LOCATION};
@@ -36,15 +43,48 @@ pub struct HBaseConfig {
     /// Optional namespace automatically prefixed to unqualified table names.
     #[serde(default)]
     pub namespace: Option<String>,
+    /// Transport to use: `"native"` (RegionServer/Master RPC via ZooKeeper) or
+    /// `"rest"` (HBase REST/Stargate gateway). Defaults to native.
+    #[serde(default)]
+    pub connection_mode: Option<String>,
+    /// Comma-separated ZooKeeper quorum (`host:port,...`) for native mode. When
+    /// omitted, falls back to `host:port` (treating `port` as the ZK port).
+    #[serde(default)]
+    pub zk_quorum: Option<String>,
+    /// ZooKeeper root znode for native mode (default `/hbase`).
+    #[serde(default)]
+    pub zk_root: Option<String>,
+    /// Effective user for native simple auth (default `root`).
+    #[serde(default)]
+    pub effective_user: Option<String>,
 }
 
+impl HBaseConfig {
+    /// True when the native RPC transport should be used. Native is the
+    /// default; only an explicit `"rest"` selects the REST backend.
+    fn is_native(&self) -> bool {
+        !matches!(
+            self.connection_mode.as_deref().map(str::trim),
+            Some("rest") | Some("REST")
+        )
+    }
+}
+
+/// REST/Stargate transport session (legacy backend).
 #[derive(Debug, Clone)]
-pub struct HBaseSession {
+pub struct RestSession {
     client: Client,
     base_url: String,
     username: Option<String>,
     password: Option<String>,
     namespace: Option<String>,
+}
+
+/// A live HBase session, backed by either the native RPC client or the REST
+/// gateway. The map in `AppState` stores these behind an `Arc`.
+pub enum HBaseSession {
+    Native(native::client::NativeClient),
+    Rest(RestSession),
 }
 
 #[derive(Debug, Serialize)]
@@ -141,8 +181,8 @@ pub async fn hbase_connect(
     config: HBaseConfig,
 ) -> Result<HBaseConnectResult, String> {
     let password = resolve_secret(&state, config.password.as_deref())?;
-    let session = Arc::new(HBaseSession::new(&config, password)?);
-    ping_session(&session).await?;
+    let session = Arc::new(build_session(&config, password).await?);
+    ping_backend(&session).await?;
     let mut map = state.hbase_sessions.write().await;
     map.insert(session_id, session);
     Ok(HBaseConnectResult { ok: true })
@@ -151,7 +191,7 @@ pub async fn hbase_connect(
 #[tauri::command]
 pub async fn hbase_ping(state: State<'_, AppState>, session_id: String) -> Result<String, String> {
     let session = get_session(&state, &session_id).await?;
-    ping_session(&session).await
+    ping_backend(&session).await
 }
 
 #[tauri::command]
@@ -169,7 +209,10 @@ pub async fn hbase_list_tables(
     session_id: String,
 ) -> Result<Vec<HBaseTableInfo>, String> {
     let session = get_session(&state, &session_id).await?;
-    list_tables(&session).await
+    match session.as_ref() {
+        HBaseSession::Rest(rest) => list_tables(rest).await,
+        HBaseSession::Native(client) => native_list_tables(client).await,
+    }
 }
 
 #[tauri::command]
@@ -179,7 +222,10 @@ pub async fn hbase_describe_table(
     table: String,
 ) -> Result<HBaseTableSchema, String> {
     let session = get_session(&state, &session_id).await?;
-    describe_table(&session, &table).await
+    match session.as_ref() {
+        HBaseSession::Rest(rest) => describe_table(rest, &table).await,
+        HBaseSession::Native(client) => native_describe_table(client, &table).await,
+    }
 }
 
 #[tauri::command]
@@ -191,12 +237,75 @@ pub async fn hbase_execute(
     let session = get_session(&state, &session_id).await?;
     let parsed = parse_shell_command(&command)?;
     let started = Instant::now();
-    let mut result = execute_command(&session, parsed, command.trim().to_string()).await?;
+    let raw = command.trim().to_string();
+    let mut result = match session.as_ref() {
+        HBaseSession::Rest(rest) => execute_command(rest, parsed, raw).await?,
+        HBaseSession::Native(client) => native_execute(client, parsed, raw).await?,
+    };
     result.duration_ms = started.elapsed().as_millis() as u64;
     Ok(result)
 }
 
-impl HBaseSession {
+/// Build a session for the configured transport, resolving any secrets.
+async fn build_session(
+    config: &HBaseConfig,
+    password: Option<String>,
+) -> Result<HBaseSession, String> {
+    if config.is_native() {
+        Ok(HBaseSession::Native(build_native_client(config)?))
+    } else {
+        Ok(HBaseSession::Rest(RestSession::new(config, password)?))
+    }
+}
+
+/// Construct the native client from the connection config.
+fn build_native_client(
+    config: &HBaseConfig,
+) -> Result<native::client::NativeClient, String> {
+    let host = config.host.trim();
+    if host.is_empty() {
+        return Err("HBase host is required".into());
+    }
+    // ZK quorum: explicit field wins; otherwise treat host:port as the quorum.
+    let zk_quorum = match config.zk_quorum.as_deref().map(str::trim) {
+        Some(q) if !q.is_empty() => q.to_string(),
+        _ => format!("{host}:{}", config.port),
+    };
+    let cfg = native::client::NativeConfig {
+        zk_quorum,
+        zk_root: config
+            .zk_root
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("/hbase")
+            .to_string(),
+        effective_user: config
+            .effective_user
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("root")
+            .to_string(),
+        namespace: config
+            .namespace
+            .clone()
+            .filter(|s| !s.trim().is_empty()),
+        timeout: Duration::from_secs(config.timeout_secs.unwrap_or(15).clamp(1, 300)),
+        auth: native::auth::AuthMethod::Simple,
+    };
+    Ok(native::client::NativeClient::new(cfg))
+}
+
+/// Ping whichever backend the session uses.
+async fn ping_backend(session: &HBaseSession) -> Result<String, String> {
+    match session {
+        HBaseSession::Rest(rest) => ping_session(rest).await,
+        HBaseSession::Native(client) => client.ping().await.map_err(|e| e.to_string()),
+    }
+}
+
+impl RestSession {
     fn new(config: &HBaseConfig, password: Option<String>) -> Result<Self, String> {
         let host = config.host.trim();
         if host.is_empty() {
@@ -278,7 +387,7 @@ async fn get_session(
         .ok_or_else(|| format!("No active HBase shell session for {session_id}"))
 }
 
-async fn ping_session(session: &HBaseSession) -> Result<String, String> {
+async fn ping_session(session: &RestSession) -> Result<String, String> {
     let value = get_json(session, "/version/cluster?format=json").await?;
     if let Some(version) = value.get("Version").and_then(Value::as_str) {
         Ok(format!("HBase REST connection OK ({version})"))
@@ -289,12 +398,12 @@ async fn ping_session(session: &HBaseSession) -> Result<String, String> {
     }
 }
 
-async fn get_json(session: &HBaseSession, path: &str) -> Result<Value, String> {
+async fn get_json(session: &RestSession, path: &str) -> Result<Value, String> {
     send_json(session, Method::GET, path, None).await
 }
 
 async fn send_json(
-    session: &HBaseSession,
+    session: &RestSession,
     method: Method,
     path: &str,
     body: Option<Value>,
@@ -364,7 +473,7 @@ async fn response_json(resp: reqwest::Response) -> Result<Value, String> {
     }
 }
 
-async fn list_tables(session: &HBaseSession) -> Result<Vec<HBaseTableInfo>, String> {
+async fn list_tables(session: &RestSession) -> Result<Vec<HBaseTableInfo>, String> {
     let value = get_json(session, "/?format=json").await?;
     Ok(extract_table_names(&value)
         .into_iter()
@@ -404,7 +513,7 @@ fn extract_table_names(value: &Value) -> Vec<String> {
         .unwrap_or_default()
 }
 
-async fn describe_table(session: &HBaseSession, table: &str) -> Result<HBaseTableSchema, String> {
+async fn describe_table(session: &RestSession, table: &str) -> Result<HBaseTableSchema, String> {
     let table = session.table_name(table);
     let path = format!("/{}/schema?format=json", enc(&table));
     let value = get_json(session, &path).await?;
@@ -448,7 +557,7 @@ fn parse_schema(fallback_name: &str, value: &Value) -> HBaseTableSchema {
 }
 
 async fn execute_command(
-    session: &HBaseSession,
+    session: &RestSession,
     command: ShellCommand,
     raw: String,
 ) -> Result<HBaseShellResult, String> {
@@ -586,7 +695,7 @@ async fn execute_command(
 }
 
 async fn scan_table(
-    session: &HBaseSession,
+    session: &RestSession,
     table: &str,
     limit: usize,
     start_row: Option<String>,
@@ -624,7 +733,7 @@ async fn scan_table(
     }
 }
 
-async fn create_scanner(session: &HBaseSession, path: &str, body: Value) -> Result<String, String> {
+async fn create_scanner(session: &RestSession, path: &str, body: Value) -> Result<String, String> {
     let resp = session
         .request(Method::PUT, session.url(path))
         .header(CONTENT_TYPE, "application/json")
@@ -646,7 +755,7 @@ async fn create_scanner(session: &HBaseSession, path: &str, body: Value) -> Resu
 }
 
 async fn read_scanner(
-    session: &HBaseSession,
+    session: &RestSession,
     location: &str,
     limit: usize,
 ) -> Result<Vec<Vec<String>>, String> {
@@ -696,7 +805,7 @@ fn scanner_location(base_url: &str, headers: &HeaderMap) -> Option<String> {
 }
 
 async fn scan_wildcard(
-    session: &HBaseSession,
+    session: &RestSession,
     table: &str,
     limit: usize,
 ) -> Result<Vec<Vec<String>>, String> {
@@ -741,20 +850,17 @@ fn parse_shell_command(input: &str) -> Result<ShellCommand, String> {
         "get" => {
             let table = required_arg(&args, 0, "get table")?;
             let row = required_arg(&args, 1, "get row")?;
-            let opts = args
-                .get(2)
-                .map(|s| parse_options(s))
-                .transpose()?
-                .unwrap_or_default();
-            let column = opts.get("COLUMN").cloned().or_else(|| {
-                args.get(2).and_then(|v| {
-                    if v.trim_start().starts_with('{') {
-                        None
-                    } else {
-                        Some(strip_quotes(v))
-                    }
-                })
-            });
+            // The third arg is either an option map (`{COLUMN=>'cf:q'}`) or a
+            // bare column literal (`'cf:q'`). Only parse it as a map when it
+            // actually looks like one, so a bare column doesn't error out.
+            let third = args.get(2).map(|s| s.trim());
+            let column = match third {
+                Some(s) if s.starts_with('{') => {
+                    parse_options(s)?.get("COLUMN").cloned()
+                }
+                Some(s) if !s.is_empty() => Some(strip_quotes(s)),
+                _ => None,
+            };
             Ok(ShellCommand::Get { table, row, column })
         }
         "scan" => {
@@ -1116,9 +1222,214 @@ fn deb64(value: &str) -> String {
         .unwrap_or_else(|_| value.to_string())
 }
 
+// ---- native backend dispatch -----------------------------------------------
+
+use native::client::{NativeClient, ResultRow};
+
+async fn native_list_tables(client: &NativeClient) -> Result<Vec<HBaseTableInfo>, String> {
+    client
+        .list_tables()
+        .await
+        .map(|names| names.into_iter().map(|name| HBaseTableInfo { name }).collect())
+        .map_err(|e| e.to_string())
+}
+
+async fn native_describe_table(
+    client: &NativeClient,
+    table: &str,
+) -> Result<HBaseTableSchema, String> {
+    let (name, families) = client.describe_table(table).await.map_err(|e| e.to_string())?;
+    Ok(HBaseTableSchema {
+        name,
+        column_families: families
+            .into_iter()
+            .map(|f| HBaseColumnFamily {
+                name: f.name,
+                attributes: f.attributes,
+            })
+            .collect(),
+    })
+}
+
+/// Render result-row cells into the shell's ROW/COLUMN/TIMESTAMP/VALUE table.
+fn rows_to_cell_table(raw: String, rows: Vec<ResultRow>) -> HBaseShellResult {
+    let body: Vec<Vec<String>> = rows
+        .into_iter()
+        .map(|r| {
+            vec![
+                String::from_utf8_lossy(&r.row).into_owned(),
+                String::from_utf8_lossy(&r.column).into_owned(),
+                r.timestamp.to_string(),
+                String::from_utf8_lossy(&r.value).into_owned(),
+            ]
+        })
+        .collect();
+    table_result(
+        raw,
+        format!("{} cell(s)", body.len()),
+        vec!["ROW", "COLUMN", "TIMESTAMP", "VALUE"],
+        body,
+    )
+}
+
+/// Execute a parsed shell command against the native client.
+async fn native_execute(
+    client: &NativeClient,
+    command: ShellCommand,
+    raw: String,
+) -> Result<HBaseShellResult, String> {
+    match command {
+        ShellCommand::Help => Ok(help_result(raw)),
+        ShellCommand::List => {
+            let tables = client.list_tables().await.map_err(|e| e.to_string())?;
+            Ok(table_result(
+                raw,
+                format!("{} table(s)", tables.len()),
+                vec!["TABLE"],
+                tables.into_iter().map(|name| vec![name]).collect(),
+            ))
+        }
+        ShellCommand::Status => {
+            let pairs = client.cluster_status().await.map_err(|e| e.to_string())?;
+            Ok(table_result(
+                raw,
+                "Cluster status".into(),
+                vec!["KEY", "VALUE"],
+                pairs.into_iter().map(|(k, v)| vec![k, v]).collect(),
+            ))
+        }
+        ShellCommand::Version => {
+            let msg = client.ping().await.map_err(|e| e.to_string())?;
+            Ok(message_result(raw, msg))
+        }
+        ShellCommand::Describe { table } => {
+            let schema = native_describe_table(client, &table).await?;
+            let rows = schema
+                .column_families
+                .into_iter()
+                .map(|family| {
+                    vec![
+                        family.name,
+                        family
+                            .attributes
+                            .into_iter()
+                            .map(|(k, v)| format!("{k}={v}"))
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                    ]
+                })
+                .collect::<Vec<_>>();
+            Ok(table_result(
+                raw,
+                format!("Schema for {}", schema.name),
+                vec!["COLUMN FAMILY", "ATTRIBUTES"],
+                rows,
+            ))
+        }
+        ShellCommand::Create { table, families } => {
+            let specs: Vec<(String, BTreeMap<String, String>)> = families
+                .into_iter()
+                .map(|f| (f.name, f.attributes))
+                .collect();
+            client
+                .create_table(&table, &specs)
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(message_result(raw, format!("Created table {table}")))
+        }
+        ShellCommand::Drop { table } => {
+            client.drop_table(&table).await.map_err(|e| e.to_string())?;
+            Ok(message_result(raw, format!("Dropped table {table}")))
+        }
+        ShellCommand::Get { table, row, column } => {
+            let rows = client
+                .get(&table, row.as_bytes(), column.as_deref())
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(rows_to_cell_table(raw, rows))
+        }
+        ShellCommand::Scan {
+            table,
+            limit,
+            start_row,
+            stop_row,
+            columns,
+        } => {
+            let rows = client
+                .scan(
+                    &table,
+                    limit,
+                    start_row.as_deref().map(str::as_bytes),
+                    stop_row.as_deref().map(str::as_bytes),
+                    &columns,
+                )
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(rows_to_cell_table(raw, rows))
+        }
+        ShellCommand::Put {
+            table,
+            row,
+            column,
+            value,
+        } => {
+            client
+                .put(&table, row.as_bytes(), &column, value.as_bytes())
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(message_result(raw, "1 cell written".into()))
+        }
+        ShellCommand::Delete { table, row, column } => {
+            client
+                .delete(&table, row.as_bytes(), &column)
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(message_result(raw, "Cell deleted".into()))
+        }
+        ShellCommand::DeleteAll { table, row } => {
+            client
+                .delete_all(&table, row.as_bytes())
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(message_result(raw, "Row deleted".into()))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_get_with_bare_column() {
+        // A bare quoted column must not be mistaken for an option map.
+        match parse_shell_command("get 't1', 'row2', 'cf1:name'").unwrap() {
+            ShellCommand::Get { table, row, column } => {
+                assert_eq!(table, "t1");
+                assert_eq!(row, "row2");
+                assert_eq!(column.as_deref(), Some("cf1:name"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_get_with_column_map() {
+        match parse_shell_command("get 't1', 'row2', {COLUMN=>'cf1:name'}").unwrap() {
+            ShellCommand::Get { column, .. } => {
+                assert_eq!(column.as_deref(), Some("cf1:name"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_get_without_column() {
+        match parse_shell_command("get 't1', 'row2'").unwrap() {
+            ShellCommand::Get { column, .. } => assert!(column.is_none()),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
 
     #[test]
     fn parses_scan_options() {
@@ -1215,3 +1526,77 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod native_shell_live_tests {
+    //! End-to-end test of the shell-command path (parse + native_execute)
+    //! against a live standalone HBase. Gated by HBASE_LIVE_TEST=1.
+    use super::*;
+
+    fn client() -> Option<NativeClient> {
+        if std::env::var("HBASE_LIVE_TEST").ok().as_deref() != Some("1") {
+            return None;
+        }
+        let zk = std::env::var("HBASE_ZK").unwrap_or_else(|_| "127.0.0.1:2181".into());
+        Some(NativeClient::new(native::client::NativeConfig {
+            zk_quorum: zk,
+            zk_root: "/hbase".into(),
+            effective_user: "test".into(),
+            namespace: None,
+            timeout: std::time::Duration::from_secs(20),
+            auth: native::auth::AuthMethod::Simple,
+        }))
+    }
+
+    async fn run(c: &NativeClient, cmd: &str) -> HBaseShellResult {
+        let parsed = parse_shell_command(cmd).expect("parse");
+        native_execute(c, parsed, cmd.to_string())
+            .await
+            .unwrap_or_else(|e| panic!("exec `{cmd}` failed: {e}"))
+    }
+
+    #[tokio::test]
+    async fn shell_path_lifecycle() {
+        let Some(c) = client() else { return };
+        let t = "taomni_shell_it";
+        // Best-effort cleanup; tolerate "table not found" if it's absent.
+        let _ = native_execute(
+            &c,
+            parse_shell_command(&format!("drop '{t}'")).unwrap(),
+            format!("drop '{t}'"),
+        )
+        .await;
+
+        let r = run(&c, &format!("create '{t}', {{NAME=>'cf', VERSIONS=>3}}")).await;
+        println!("create msg: {}", r.message);
+
+        let list = run(&c, "list").await;
+        assert!(list.rows.iter().any(|row| row[0] == t), "list missing {t}");
+
+        run(&c, &format!("put '{t}', 'r1', 'cf:a', 'v1'")).await;
+        run(&c, &format!("put '{t}', 'r2', 'cf:a', 'v2'")).await;
+
+        let got = run(&c, &format!("get '{t}', 'r1'")).await;
+        assert_eq!(got.rows.len(), 1);
+        assert_eq!(got.rows[0][3], "v1");
+
+        let scanned = run(&c, &format!("scan '{t}', {{LIMIT=>50}}")).await;
+        assert!(scanned.rows.len() >= 2, "scan rows: {}", scanned.rows.len());
+
+        let desc = run(&c, &format!("describe '{t}'")).await;
+        assert!(desc.rows.iter().any(|r| r[0] == "cf"));
+
+        run(&c, &format!("deleteall '{t}', 'r1'")).await;
+        let after = run(&c, &format!("get '{t}', 'r1'")).await;
+        assert_eq!(after.rows.len(), 0);
+
+        run(&c, &format!("drop '{t}'")).await;
+        let list2 = run(&c, "list").await;
+        assert!(!list2.rows.iter().any(|row| row[0] == t));
+        println!("shell-path lifecycle OK");
+    }
+}
+
+
+
+

--- a/src-tauri/src/hbase/native/auth.rs
+++ b/src-tauri/src/hbase/native/auth.rs
@@ -1,0 +1,170 @@
+//! HBase RPC authentication: simple (no negotiation) and Kerberos/GSSAPI.
+//!
+//! Simple auth (the default) writes the preamble with auth byte `0x50` and then
+//! the ConnectionHeader directly; the server stays silent on success.
+//!
+//! Kerberos (`0x51`) inserts a SASL/GSSAPI token negotiation between the
+//! preamble and the ConnectionHeader. The wire framing, transcribed from
+//! HBase's `HBaseSaslRpcClient.saslConnect` (rel/2.6.1):
+//! - client → server: `i32 BE token_len | token bytes` (initial response)
+//! - server → client: `i32 BE status` (0 = SUCCESS), then `i32 BE len | token`
+//!   where `len == -88` (`SWITCH_TO_SIMPLE_AUTH`) asks the client to downgrade.
+//! - repeat until the SASL client reports complete.
+//!
+//! The Kerberos path is compiled only with the `hbase-kerberos` feature so the
+//! default build pulls in no GSSAPI system libraries.
+
+/// SASL status sentinel: success.
+#[allow(dead_code)]
+pub const SASL_SUCCESS: i32 = 0;
+/// SASL length sentinel asking the client to fall back to simple auth.
+#[allow(dead_code)]
+pub const SWITCH_TO_SIMPLE_AUTH: i32 = -88;
+
+/// Selected authentication method for a connection.
+#[derive(Debug, Clone)]
+pub enum AuthMethod {
+    /// Simple auth (effective user only); preamble byte 0x50.
+    Simple,
+    /// Kerberos/GSSAPI; preamble byte 0x51. Carries the service principal name
+    /// (SPN), e.g. `hbase/host@REALM`.
+    Kerberos { service_principal: String },
+}
+
+impl AuthMethod {
+    /// The preamble auth byte for this method.
+    pub fn preamble_byte(&self) -> u8 {
+        match self {
+            AuthMethod::Simple => super::rpc::codec::AUTH_SIMPLE,
+            AuthMethod::Kerberos { .. } => super::rpc::codec::AUTH_KERBEROS,
+        }
+    }
+}
+
+#[cfg(feature = "hbase-kerberos")]
+pub mod kerberos {
+    //! GSSAPI SASL negotiation over a tokio TCP connection.
+    use cross_krb5::{ClientCtx, InitiateFlags, K5Ctx, Step};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Perform the HBase SASL/GSSAPI handshake on the raw socket halves, right
+    /// after the preamble and before the ConnectionHeader. Returns `Ok(true)`
+    /// when SASL completed, `Ok(false)` if the server asked to fall back to
+    /// simple auth.
+    ///
+    /// `service_principal` is the server SPN, e.g. `hbase/rs1.example.com@REALM`.
+    pub async fn sasl_connect<R, W>(
+        read: &mut R,
+        write: &mut W,
+        service_principal: &str,
+    ) -> Result<bool, String>
+    where
+        R: AsyncReadExt + Unpin,
+        W: AsyncWriteExt + Unpin,
+    {
+        // Initial token.
+        let (mut pending, token) =
+            ClientCtx::new(InitiateFlags::empty(), None, service_principal, None)
+                .map_err(|e| format!("GSSAPI init failed: {e}"))?;
+        write_token(write, &token).await?;
+
+        // First server reply: status + (challenge | switch-to-simple).
+        read_status(read).await?;
+        let len = read.read_i32().await.map_err(ioerr)?;
+        if len == super::SWITCH_TO_SIMPLE_AUTH {
+            return Ok(false);
+        }
+        let mut challenge = read_n(read, len).await?;
+
+        // Negotiation loop.
+        loop {
+            match pending.step(&challenge).map_err(|e| format!("GSSAPI step failed: {e}"))? {
+                Step::Finished((_ctx, last)) => {
+                    if let Some(tok) = last {
+                        write_token(write, &tok).await?;
+                    }
+                    return Ok(true);
+                }
+                Step::Continue((next, tok)) => {
+                    write_token(write, &tok).await?;
+                    read_status(read).await?;
+                    let len = read.read_i32().await.map_err(ioerr)?;
+                    challenge = read_n(read, len).await?;
+                    pending = next;
+                }
+            }
+        }
+    }
+
+    async fn write_token<W: AsyncWriteExt + Unpin>(
+        write: &mut W,
+        token: &[u8],
+    ) -> Result<(), String> {
+        write.write_i32(token.len() as i32).await.map_err(ioerr)?;
+        write.write_all(token).await.map_err(ioerr)?;
+        write.flush().await.map_err(ioerr)?;
+        Ok(())
+    }
+
+    async fn read_status<R: AsyncReadExt + Unpin>(read: &mut R) -> Result<(), String> {
+        let status = read.read_i32().await.map_err(ioerr)?;
+        if status != super::SASL_SUCCESS {
+            // On error the server sends two writable strings (class, message).
+            let class = read_writable_string(read).await.unwrap_or_default();
+            let msg = read_writable_string(read).await.unwrap_or_default();
+            return Err(format!("SASL negotiation failed: {class}: {msg}"));
+        }
+        Ok(())
+    }
+
+    async fn read_n<R: AsyncReadExt + Unpin>(read: &mut R, len: i32) -> Result<Vec<u8>, String> {
+        if len < 0 {
+            return Err(format!("negative SASL token length {len}"));
+        }
+        let mut buf = vec![0u8; len as usize];
+        read.read_exact(&mut buf).await.map_err(ioerr)?;
+        Ok(buf)
+    }
+
+    /// Hadoop `WritableUtils.readString`: a vint length prefix + UTF-8 bytes.
+    /// We approximate with a 4-byte length (sufficient for error text framing
+    /// in practice; on parse trouble we just return what we read).
+    async fn read_writable_string<R: AsyncReadExt + Unpin>(
+        read: &mut R,
+    ) -> Result<String, String> {
+        let len = read.read_i32().await.map_err(ioerr)?;
+        if !(0..=1_000_000).contains(&len) {
+            return Ok(String::new());
+        }
+        let mut buf = vec![0u8; len as usize];
+        read.read_exact(&mut buf).await.map_err(ioerr)?;
+        Ok(String::from_utf8_lossy(&buf).into_owned())
+    }
+
+    fn ioerr(e: std::io::Error) -> String {
+        format!("SASL io error: {e}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preamble_bytes() {
+        assert_eq!(AuthMethod::Simple.preamble_byte(), 0x50);
+        assert_eq!(
+            AuthMethod::Kerberos {
+                service_principal: "hbase/h@R".into()
+            }
+            .preamble_byte(),
+            0x51
+        );
+    }
+
+    #[test]
+    fn sasl_constants() {
+        assert_eq!(SASL_SUCCESS, 0);
+        assert_eq!(SWITCH_TO_SIMPLE_AUTH, -88);
+    }
+}

--- a/src-tauri/src/hbase/native/cell.rs
+++ b/src-tauri/src/hbase/native/cell.rs
@@ -1,0 +1,312 @@
+//! KeyValueCodec CellBlock encoding/decoding.
+//!
+//! HBase ferries the bulk of cell data outside protobuf, in a "cell block": a
+//! length-prefixed concatenation of KeyValue cells appended after the protobuf
+//! portion of a frame. The codec class advertised in the ConnectionHeader is
+//! `org.apache.hadoop.hbase.codec.KeyValueCodec`. The number of cells is carried
+//! out-of-band (ScanResponse.cells_per_result / Result.associated_cell_count),
+//! not in the block itself.
+//!
+//! One cell on the wire (all integers big-endian):
+//! ```text
+//! u32 kv_len      // length of everything after this field
+//! u32 key_len     // length of the Key section
+//! u32 value_len   // length of the value
+//! ── Key section (key_len bytes) ──
+//! u16 row_len | row | u8 family_len | family | qualifier
+//!   | u64 timestamp | u8 cell_type
+//! ── Value (value_len bytes) ──
+//! ```
+//! `qualifier_len` is derived: key_len - (2 + row_len + 1 + family_len + 8 + 1).
+
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+
+/// KeyValue.Type byte codes (HBase `KeyValue.Type`); see Cell.proto CellType.
+pub mod cell_type {
+    pub const MINIMUM: u8 = 0;
+    pub const PUT: u8 = 4;
+    pub const DELETE: u8 = 8;
+    pub const DELETE_FAMILY_VERSION: u8 = 10;
+    pub const DELETE_COLUMN: u8 = 12;
+    pub const DELETE_FAMILY: u8 = 14;
+    pub const MAXIMUM: u8 = 255;
+}
+
+/// HBase's "latest timestamp" sentinel (`HConstants.LATEST_TIMESTAMP`): the
+/// server stamps the current time when it sees `i64::MAX`.
+pub const LATEST_TIMESTAMP: u64 = i64::MAX as u64;
+
+/// A decoded cell. Backed by a single `Bytes` buffer with the four variable
+/// fields exposed as zero-copy slices.
+#[derive(Clone)]
+pub struct Cell {
+    pub row: Bytes,
+    pub family: Bytes,
+    pub qualifier: Bytes,
+    pub timestamp: u64,
+    pub cell_type: u8,
+    pub value: Bytes,
+}
+
+impl std::fmt::Debug for Cell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Cell")
+            .field("row", &String::from_utf8_lossy(&self.row))
+            .field("family", &String::from_utf8_lossy(&self.family))
+            .field("qualifier", &String::from_utf8_lossy(&self.qualifier))
+            .field("timestamp", &self.timestamp)
+            .field("cell_type", &self.cell_type)
+            .field("value", &String::from_utf8_lossy(&self.value))
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub enum CellError {
+    Truncated(String),
+    Invalid(String),
+}
+
+impl std::fmt::Display for CellError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CellError::Truncated(s) => write!(f, "truncated cell block: {s}"),
+            CellError::Invalid(s) => write!(f, "invalid cell: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for CellError {}
+
+impl Cell {
+    /// Encode this cell into a fresh `Bytes` (`u32 kv_len | ... | value`).
+    pub fn encode(&self) -> Bytes {
+        let row_len = self.row.len();
+        let family_len = self.family.len();
+        let qualifier_len = self.qualifier.len();
+        let value_len = self.value.len();
+        // Key = 2 + row + 1 + family + qualifier + 8 (ts) + 1 (type)
+        let key_len = 2 + row_len + 1 + family_len + qualifier_len + 8 + 1;
+        // kv_len = key_len field + value_len field + key + value
+        let kv_len = 4 + 4 + key_len + value_len;
+
+        let mut buf = BytesMut::with_capacity(4 + kv_len);
+        buf.put_u32(kv_len as u32);
+        buf.put_u32(key_len as u32);
+        buf.put_u32(value_len as u32);
+        buf.put_u16(row_len as u16);
+        buf.extend_from_slice(&self.row);
+        buf.put_u8(family_len as u8);
+        buf.extend_from_slice(&self.family);
+        buf.extend_from_slice(&self.qualifier);
+        buf.put_u64(self.timestamp);
+        buf.put_u8(self.cell_type);
+        buf.extend_from_slice(&self.value);
+        buf.freeze()
+    }
+
+    /// Decode exactly one cell from the front of `buf`, advancing it past the
+    /// consumed bytes. The buffer must own its memory as `Bytes` so slices are
+    /// zero-copy; we take `&mut Bytes`.
+    pub fn decode(buf: &mut Bytes) -> Result<Cell, CellError> {
+        if buf.len() < 4 {
+            return Err(CellError::Truncated("missing kv_len".into()));
+        }
+        let kv_len = buf.get_u32() as usize; // advances 4
+        if buf.len() < kv_len {
+            return Err(CellError::Truncated(format!(
+                "kv_len {kv_len} exceeds remaining {}",
+                buf.len()
+            )));
+        }
+        // Work within exactly kv_len bytes.
+        let mut body = buf.split_to(kv_len);
+        if body.len() < 8 {
+            return Err(CellError::Truncated("missing key/value lengths".into()));
+        }
+        let key_len = body.get_u32() as usize;
+        let value_len = body.get_u32() as usize;
+        if body.len() != key_len + value_len {
+            return Err(CellError::Invalid(format!(
+                "key_len {key_len} + value_len {value_len} != body {}",
+                body.len()
+            )));
+        }
+        let mut key = body.split_to(key_len);
+        let value = body; // remaining value_len bytes
+
+        // Parse the key section.
+        if key.len() < 2 {
+            return Err(CellError::Truncated("missing row_len".into()));
+        }
+        let row_len = key.get_u16() as usize;
+        if key.len() < row_len + 1 {
+            return Err(CellError::Truncated("row/family_len".into()));
+        }
+        let row = key.split_to(row_len);
+        let family_len = key.get_u8() as usize;
+        // Remaining must hold: family + qualifier + 8 (ts) + 1 (type)
+        if key.len() < family_len + 9 {
+            return Err(CellError::Truncated("family/qualifier/ts/type".into()));
+        }
+        let family = key.split_to(family_len);
+        let qualifier_len = key.len() - 9; // 8 ts + 1 type
+        let qualifier = key.split_to(qualifier_len);
+        let timestamp = key.get_u64();
+        let cell_type = key.get_u8();
+        debug_assert!(key.is_empty(), "key section fully consumed");
+
+        Ok(Cell {
+            row,
+            family,
+            qualifier,
+            timestamp,
+            cell_type,
+            value,
+        })
+    }
+}
+
+/// Encode a sequence of cells into one cell block.
+pub fn encode_cell_block(cells: &[Cell]) -> Bytes {
+    let mut out = BytesMut::new();
+    for cell in cells {
+        out.extend_from_slice(&cell.encode());
+    }
+    out.freeze()
+}
+
+/// Decode `count` cells from `block`. Stops early if the block is exhausted
+/// (returning what was parsed) only when `count` is `None`; when `count` is
+/// given, it is an error to run short.
+pub fn decode_cell_block(block: Bytes, count: Option<usize>) -> Result<Vec<Cell>, CellError> {
+    let mut buf = block;
+    let mut cells = Vec::new();
+    match count {
+        Some(n) => {
+            for _ in 0..n {
+                cells.push(Cell::decode(&mut buf)?);
+            }
+        }
+        None => {
+            while !buf.is_empty() {
+                cells.push(Cell::decode(&mut buf)?);
+            }
+        }
+    }
+    Ok(cells)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Cell {
+        Cell {
+            row: Bytes::from_static(b"row-key-1"),
+            family: Bytes::from_static(b"cf"),
+            qualifier: Bytes::from_static(b"q1"),
+            timestamp: 1234567890,
+            cell_type: cell_type::PUT,
+            value: Bytes::from_static(b"the-value"),
+        }
+    }
+
+    #[test]
+    fn cell_roundtrip() {
+        let c = sample();
+        let mut encoded = c.encode();
+        let decoded = Cell::decode(&mut encoded).unwrap();
+        assert_eq!(&decoded.row[..], b"row-key-1");
+        assert_eq!(&decoded.family[..], b"cf");
+        assert_eq!(&decoded.qualifier[..], b"q1");
+        assert_eq!(decoded.timestamp, 1234567890);
+        assert_eq!(decoded.cell_type, cell_type::PUT);
+        assert_eq!(&decoded.value[..], b"the-value");
+        assert!(encoded.is_empty(), "decode consumes exactly one cell");
+    }
+
+    #[test]
+    fn empty_qualifier_and_value() {
+        let c = Cell {
+            row: Bytes::from_static(b"r"),
+            family: Bytes::from_static(b"f"),
+            qualifier: Bytes::new(),
+            timestamp: LATEST_TIMESTAMP,
+            cell_type: cell_type::DELETE_FAMILY,
+            value: Bytes::new(),
+        };
+        let mut e = c.encode();
+        let d = Cell::decode(&mut e).unwrap();
+        assert!(d.qualifier.is_empty());
+        assert!(d.value.is_empty());
+        assert_eq!(d.timestamp, LATEST_TIMESTAMP);
+        assert_eq!(d.cell_type, cell_type::DELETE_FAMILY);
+    }
+
+    #[test]
+    fn multi_cell_block_with_count() {
+        let cells = vec![sample(), sample(), sample()];
+        let block = encode_cell_block(&cells);
+        let decoded = decode_cell_block(block, Some(3)).unwrap();
+        assert_eq!(decoded.len(), 3);
+        for d in &decoded {
+            assert_eq!(&d.value[..], b"the-value");
+        }
+    }
+
+    #[test]
+    fn multi_cell_block_no_count() {
+        let cells = vec![sample(), sample()];
+        let block = encode_cell_block(&cells);
+        let decoded = decode_cell_block(block, None).unwrap();
+        assert_eq!(decoded.len(), 2);
+    }
+
+    #[test]
+    fn truncated_block_errors() {
+        let mut e = sample().encode();
+        // Lop off the last byte to truncate the value.
+        let truncated = e.split_to(e.len() - 1);
+        let mut b = truncated;
+        assert!(matches!(Cell::decode(&mut b), Err(CellError::Truncated(_))));
+    }
+
+    #[test]
+    fn count_short_errors() {
+        let block = encode_cell_block(&[sample()]);
+        // Ask for 2 when only 1 is present.
+        assert!(decode_cell_block(block, Some(2)).is_err());
+    }
+
+    #[test]
+    fn known_byte_layout() {
+        // Verify exact wire bytes for a tiny cell so we catch layout drift.
+        let c = Cell {
+            row: Bytes::from_static(b"r"),     // row_len=1
+            family: Bytes::from_static(b"f"),  // family_len=1
+            qualifier: Bytes::from_static(b"q"), // qualifier_len=1
+            timestamp: 0x0102030405060708,
+            cell_type: cell_type::PUT,
+            value: Bytes::from_static(b"v"), // value_len=1
+        };
+        let e = c.encode();
+        // key_len = 2 + 1 + 1 + 1 + 1 + 8 + 1 = 15
+        // kv_len  = 4 + 4 + 15 + 1 = 24
+        let expected: Vec<u8> = [
+            &[0, 0, 0, 24][..],        // kv_len
+            &[0, 0, 0, 15][..],        // key_len
+            &[0, 0, 0, 1][..],         // value_len
+            &[0, 1][..],               // row_len = 1
+            b"r",
+            &[1][..],                  // family_len = 1
+            b"f",
+            b"q",                      // qualifier (len derived)
+            &[1, 2, 3, 4, 5, 6, 7, 8][..], // timestamp BE
+            &[cell_type::PUT][..],
+            b"v",
+        ]
+        .concat();
+        assert_eq!(&e[..], &expected[..]);
+    }
+}

--- a/src-tauri/src/hbase/native/client.rs
+++ b/src-tauri/src/hbase/native/client.rs
@@ -1,0 +1,1115 @@
+//! High-level native HBase client: connection management, ZooKeeper bootstrap,
+//! `hbase:meta` region location with caching, and the data/control plane
+//! operations (get/put/delete/scan + list/describe/create/drop/status).
+//!
+//! This is the orchestration layer. It is deliberately synchronous-per-call
+//! (locate region → RPC → parse) with a region-location cache; it does not yet
+//! implement the full single-flight reconnect dance — on a NotServingRegion /
+//! stale-cache error it invalidates the cached location and retries with a
+//! bounded budget.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use prost::Message;
+use tokio::sync::RwLock;
+
+use super::cell::{self, Cell};
+use super::proto::pb;
+use super::region::{self, RegionLocation};
+use super::rpc::codec::{CLIENT_SERVICE, MASTER_SERVICE};
+use super::rpc::conn::{RpcConnection, RpcError};
+use super::zk::{self, ServerEndpoint};
+
+const META_TABLE: &str = "hbase:meta";
+const MAX_RETRIES: usize = 6;
+const BACKOFF_START_MS: u64 = 50;
+
+/// Connection / bootstrap configuration for the native client.
+#[derive(Debug, Clone)]
+pub struct NativeConfig {
+    /// Comma-separated `host:port` ZooKeeper quorum.
+    pub zk_quorum: String,
+    /// ZK root znode (default `/hbase`).
+    pub zk_root: String,
+    /// Effective user for simple auth.
+    pub effective_user: String,
+    /// Default namespace prefixed to unqualified table names.
+    pub namespace: Option<String>,
+    /// Connect/operation timeout.
+    pub timeout: Duration,
+    /// Authentication method (simple or Kerberos).
+    pub auth: super::auth::AuthMethod,
+}
+
+impl Default for NativeConfig {
+    fn default() -> Self {
+        Self {
+            zk_quorum: "localhost:2181".into(),
+            zk_root: zk::DEFAULT_ZK_ROOT.into(),
+            effective_user: "root".into(),
+            namespace: None,
+            timeout: Duration::from_secs(15),
+            auth: super::auth::AuthMethod::Simple,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ClientError {
+    Zk(String),
+    Rpc(String),
+    Region(String),
+    Decode(String),
+    Unsupported(String),
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClientError::Zk(e) => write!(f, "{e}"),
+            ClientError::Rpc(e) => write!(f, "{e}"),
+            ClientError::Region(e) => write!(f, "{e}"),
+            ClientError::Decode(e) => write!(f, "HBase decode error: {e}"),
+            ClientError::Unsupported(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for ClientError {}
+
+impl From<RpcError> for ClientError {
+    fn from(e: RpcError) -> Self {
+        ClientError::Rpc(e.to_string())
+    }
+}
+
+/// A get/scan cell row, flattened for the shell result table.
+#[derive(Debug, Clone)]
+pub struct ResultRow {
+    pub row: Vec<u8>,
+    pub column: Vec<u8>,
+    pub timestamp: u64,
+    pub value: Vec<u8>,
+}
+
+/// The native HBase client. Cheap to clone (shared connection pool + caches).
+#[derive(Clone)]
+pub struct NativeClient {
+    cfg: Arc<NativeConfig>,
+    /// addr -> connection to a RegionServer (ClientService).
+    region_conns: Arc<RwLock<HashMap<String, RpcConnection>>>,
+    /// Active master connection (MasterService), lazily established.
+    master_conn: Arc<RwLock<Option<RpcConnection>>>,
+    /// Cached meta RegionServer connection.
+    meta_conn: Arc<RwLock<Option<RpcConnection>>>,
+    /// table+row -> located region (simple cache, invalidated on NSRE).
+    region_cache: Arc<RwLock<HashMap<String, RegionLocation>>>,
+}
+
+impl NativeClient {
+    pub fn new(cfg: NativeConfig) -> Self {
+        Self {
+            cfg: Arc::new(cfg),
+            region_conns: Arc::new(RwLock::new(HashMap::new())),
+            master_conn: Arc::new(RwLock::new(None)),
+            meta_conn: Arc::new(RwLock::new(None)),
+            region_cache: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Resolve a table name to its fully-qualified (namespace:qualifier) form.
+    pub fn qualify(&self, table: &str) -> String {
+        let t = table.trim();
+        if t.contains(':') {
+            return t.to_string();
+        }
+        match self.cfg.namespace.as_deref() {
+            Some(ns) if !ns.is_empty() => format!("{ns}:{t}"),
+            _ => t.to_string(),
+        }
+    }
+
+    /// Split a qualified table name into (namespace, qualifier) byte vectors.
+    fn split_table(qualified: &str) -> (Vec<u8>, Vec<u8>) {
+        match qualified.split_once(':') {
+            Some((ns, q)) => (ns.as_bytes().to_vec(), q.as_bytes().to_vec()),
+            None => (b"default".to_vec(), qualified.as_bytes().to_vec()),
+        }
+    }
+
+    fn table_name_pb(qualified: &str) -> pb::TableName {
+        let (ns, q) = Self::split_table(qualified);
+        pb::TableName {
+            namespace: ns,
+            qualifier: q,
+        }
+    }
+
+    /// Ping the cluster: resolve the master via ZK and call GetClusterStatus.
+    pub async fn ping(&self) -> Result<String, ClientError> {
+        let master = self.master().await?;
+        let req = pb::GetClusterStatusRequest::default();
+        let (resp, _) = master
+            .call_pb::<_, pb::GetClusterStatusResponse>("GetClusterStatus", &req, None)
+            .await?;
+        let version = resp
+            .cluster_status
+            .hbase_version
+            .map(|v| v.version)
+            .unwrap_or_else(|| "unknown".into());
+        Ok(format!("HBase native RPC connection OK ({version})"))
+    }
+
+    // ---- connection helpers ------------------------------------------------
+
+    async fn region_connection(
+        &self,
+        ep: &ServerEndpoint,
+    ) -> Result<RpcConnection, ClientError> {
+        let addr = ep.addr();
+        if let Some(conn) = self.region_conns.read().await.get(&addr).cloned() {
+            return Ok(conn);
+        }
+        let conn = RpcConnection::connect_with_auth(
+            &addr,
+            CLIENT_SERVICE,
+            &self.cfg.effective_user,
+            &self.cfg.auth,
+            self.cfg.timeout,
+        )
+        .await?;
+        self.region_conns
+            .write()
+            .await
+            .insert(addr, conn.clone());
+        Ok(conn)
+    }
+
+    async fn master(&self) -> Result<RpcConnection, ClientError> {
+        if let Some(conn) = self.master_conn.read().await.clone() {
+            return Ok(conn);
+        }
+        let ep = zk::locate_master(&self.cfg.zk_quorum, &self.cfg.zk_root, self.cfg.timeout)
+            .await
+            .map_err(|e| ClientError::Zk(e.to_string()))?;
+        let conn = RpcConnection::connect_with_auth(
+            &ep.addr(),
+            MASTER_SERVICE,
+            &self.cfg.effective_user,
+            &self.cfg.auth,
+            self.cfg.timeout,
+        )
+        .await?;
+        *self.master_conn.write().await = Some(conn.clone());
+        Ok(conn)
+    }
+
+    async fn meta_connection(&self) -> Result<RpcConnection, ClientError> {
+        if let Some(conn) = self.meta_conn.read().await.clone() {
+            return Ok(conn);
+        }
+        let ep = zk::locate_meta(&self.cfg.zk_quorum, &self.cfg.zk_root, self.cfg.timeout)
+            .await
+            .map_err(|e| ClientError::Zk(e.to_string()))?;
+        let conn = RpcConnection::connect_with_auth(
+            &ep.addr(),
+            CLIENT_SERVICE,
+            &self.cfg.effective_user,
+            &self.cfg.auth,
+            self.cfg.timeout,
+        )
+        .await?;
+        *self.meta_conn.write().await = Some(conn.clone());
+        Ok(conn)
+    }
+
+    // ---- region location ---------------------------------------------------
+
+    /// Locate the region serving `(table, row)`, using the cache when possible.
+    async fn locate_region(
+        &self,
+        qualified_table: &str,
+        row: &[u8],
+    ) -> Result<RegionLocation, ClientError> {
+        let cache_key = format!("{qualified_table}\x00{}", String::from_utf8_lossy(row));
+        if let Some(loc) = self.region_cache.read().await.get(&cache_key).cloned() {
+            if loc.contains(row) {
+                return Ok(loc);
+            }
+        }
+        let loc = self.meta_lookup(qualified_table, row).await?;
+        self.region_cache
+            .write()
+            .await
+            .insert(cache_key, loc.clone());
+        Ok(loc)
+    }
+
+    /// Invalidate any cached region location for `(table, row)`.
+    async fn invalidate_region(&self, qualified_table: &str, row: &[u8]) {
+        let cache_key = format!("{qualified_table}\x00{}", String::from_utf8_lossy(row));
+        self.region_cache.write().await.remove(&cache_key);
+    }
+
+    /// Reverse-scan `hbase:meta` for the single region covering `(table, row)`.
+    async fn meta_lookup(
+        &self,
+        qualified_table: &str,
+        row: &[u8],
+    ) -> Result<RegionLocation, ClientError> {
+        let meta = self.meta_connection().await?;
+        let search_key = region::meta_search_key(qualified_table, row);
+
+        // A reversed scan from `table,row,:` returns the greatest meta row <=
+        // the search key — i.e. the region whose range contains `row`. We fetch
+        // a single row, so no stop_row is needed; supplying one with reversed
+        // semantics risks excluding the very region we are looking for.
+        let scan = pb::Scan {
+            column: vec![pb::Column {
+                family: b"info".to_vec(),
+                qualifier: vec![],
+            }],
+            start_row: Some(search_key),
+            reversed: Some(true),
+            max_versions: Some(1),
+            ..Default::default()
+        };
+
+        let region_spec = meta_region_specifier();
+        let rows = scan_once(&meta, region_spec, scan, 1).await?;
+        let (row_key, cells) = rows
+            .into_iter()
+            .next()
+            .ok_or_else(|| ClientError::Region(format!("no meta entry for {qualified_table}")))?;
+        // Guard against landing on a different table's region (e.g. when the
+        // target table has no regions yet): verify the row key's table prefix.
+        let prefix = region::meta_table_start_key(qualified_table);
+        if !row_key.starts_with(&prefix) {
+            return Err(ClientError::Region(format!(
+                "no meta entry for {qualified_table}"
+            )));
+        }
+        region::region_from_meta_cells(&row_key, &cells)
+            .map_err(|e| ClientError::Region(e.to_string()))
+    }
+
+    // ---- data plane --------------------------------------------------------
+
+    /// Get a single row, optionally restricted to one `family:qualifier`.
+    pub async fn get(
+        &self,
+        table: &str,
+        row: &[u8],
+        column: Option<&str>,
+    ) -> Result<Vec<ResultRow>, ClientError> {
+        let qualified = self.qualify(table);
+        let columns = column
+            .map(|c| vec![parse_column(c)])
+            .unwrap_or_default();
+        let get = pb::Get {
+            row: row.to_vec(),
+            column: columns,
+            max_versions: Some(1),
+            ..Default::default()
+        };
+
+        self.with_region_retry(&qualified, row, |loc, conn| {
+            let get = get.clone();
+            async move {
+                let req = pb::GetRequest {
+                    region: region_specifier(&loc),
+                    get,
+                };
+                let resp = conn
+                    .call("Get", Some(req.encode_to_vec()), None)
+                    .await?;
+                let get_resp = pb::GetResponse::decode(resp.param)
+                    .map_err(|e| ClientError::Decode(e.to_string()))?;
+                let cells = result_to_cells(get_resp.result.as_ref(), &resp.cell_block)?;
+                Ok(cells_to_rows(&cells))
+            }
+        })
+        .await
+    }
+
+    /// Put a single cell.
+    pub async fn put(
+        &self,
+        table: &str,
+        row: &[u8],
+        column: &str,
+        value: &[u8],
+    ) -> Result<(), ClientError> {
+        let qualified = self.qualify(table);
+        let (family, qualifier) = split_column(column);
+        let cell = Cell {
+            row: Bytes::copy_from_slice(row),
+            family: Bytes::copy_from_slice(&family),
+            qualifier: Bytes::copy_from_slice(&qualifier),
+            timestamp: cell::LATEST_TIMESTAMP,
+            cell_type: cell::cell_type::PUT,
+            value: Bytes::copy_from_slice(value),
+        };
+        let mutation = pb::MutationProto {
+            row: Some(row.to_vec()),
+            mutate_type: Some(pb::mutation_proto::MutationType::Put as i32),
+            associated_cell_count: Some(1),
+            ..Default::default()
+        };
+        let cell_block = cell::encode_cell_block(&[cell]).to_vec();
+
+        self.with_region_retry(&qualified, row, |loc, conn| {
+            let mutation = mutation.clone();
+            let cell_block = cell_block.clone();
+            async move {
+                let req = pb::MutateRequest {
+                    region: region_specifier(&loc),
+                    mutation,
+                    condition: None,
+                    nonce_group: None,
+                };
+                conn.call("Mutate", Some(req.encode_to_vec()), Some(cell_block))
+                    .await?;
+                Ok(())
+            }
+        })
+        .await
+    }
+
+    /// Delete a single column (all versions) of a row.
+    pub async fn delete(
+        &self,
+        table: &str,
+        row: &[u8],
+        column: &str,
+    ) -> Result<(), ClientError> {
+        let qualified = self.qualify(table);
+        let (family, qualifier) = split_column(column);
+        let mutation = pb::MutationProto {
+            row: Some(row.to_vec()),
+            mutate_type: Some(pb::mutation_proto::MutationType::Delete as i32),
+            column_value: vec![pb::mutation_proto::ColumnValue {
+                family: family.clone(),
+                qualifier_value: vec![pb::mutation_proto::column_value::QualifierValue {
+                    qualifier: Some(qualifier.clone()),
+                    value: None,
+                    timestamp: Some(cell::LATEST_TIMESTAMP),
+                    delete_type: Some(
+                        pb::mutation_proto::DeleteType::DeleteMultipleVersions as i32,
+                    ),
+                    tags: None,
+                }],
+            }],
+            ..Default::default()
+        };
+
+        self.with_region_retry(&qualified, row, |loc, conn| {
+            let mutation = mutation.clone();
+            async move {
+                let req = pb::MutateRequest {
+                    region: region_specifier(&loc),
+                    mutation,
+                    condition: None,
+                    nonce_group: None,
+                };
+                conn.call("Mutate", Some(req.encode_to_vec()), None).await?;
+                Ok(())
+            }
+        })
+        .await
+    }
+
+    /// Delete an entire row (all families/columns).
+    pub async fn delete_all(&self, table: &str, row: &[u8]) -> Result<(), ClientError> {
+        let qualified = self.qualify(table);
+        let mutation = pb::MutationProto {
+            row: Some(row.to_vec()),
+            mutate_type: Some(pb::mutation_proto::MutationType::Delete as i32),
+            ..Default::default()
+        };
+        self.with_region_retry(&qualified, row, |loc, conn| {
+            let mutation = mutation.clone();
+            async move {
+                let req = pb::MutateRequest {
+                    region: region_specifier(&loc),
+                    mutation,
+                    condition: None,
+                    nonce_group: None,
+                };
+                conn.call("Mutate", Some(req.encode_to_vec()), None).await?;
+                Ok(())
+            }
+        })
+        .await
+    }
+
+    /// Scan a table, returning up to `limit` cells, walking across regions.
+    pub async fn scan(
+        &self,
+        table: &str,
+        limit: usize,
+        start_row: Option<&[u8]>,
+        stop_row: Option<&[u8]>,
+        columns: &[String],
+    ) -> Result<Vec<ResultRow>, ClientError> {
+        let qualified = self.qualify(table);
+        let mut out: Vec<ResultRow> = Vec::new();
+        let mut next_row: Vec<u8> = start_row.map(|r| r.to_vec()).unwrap_or_default();
+        let column_specs: Vec<pb::Column> = columns.iter().map(|c| parse_column(c)).collect();
+
+        for _ in 0..10_000 {
+            if out.len() >= limit {
+                break;
+            }
+            let loc = self.locate_region(&qualified, &next_row).await?;
+            let conn = self.region_connection(&loc.server).await?;
+
+            let scan = pb::Scan {
+                column: column_specs.clone(),
+                start_row: Some(next_row.clone()),
+                stop_row: stop_row.map(|s| s.to_vec()),
+                max_versions: Some(1),
+                ..Default::default()
+            };
+            let remaining = limit - out.len();
+            let rows = scan_once(
+                &conn,
+                region_specifier(&loc),
+                scan,
+                remaining.min(1000) as u32,
+            )
+            .await?;
+            for (row_key, cells) in &rows {
+                for c in cells {
+                    out.push(cell_to_row(row_key, c));
+                    if out.len() >= limit {
+                        break;
+                    }
+                }
+            }
+
+            let end = loc.end_key().to_vec();
+            if end.is_empty() {
+                break;
+            }
+            if let Some(stop) = stop_row {
+                if end.as_slice() >= stop {
+                    break;
+                }
+            }
+            next_row = end;
+        }
+        Ok(out)
+    }
+
+    /// Run `op` against the region serving `(table, row)`, invalidating the
+    /// cache and retrying on NotServingRegion / connection errors.
+    async fn with_region_retry<F, Fut, T>(
+        &self,
+        qualified_table: &str,
+        row: &[u8],
+        op: F,
+    ) -> Result<T, ClientError>
+    where
+        F: Fn(RegionLocation, RpcConnection) -> Fut,
+        Fut: std::future::Future<Output = Result<T, ClientError>>,
+    {
+        let mut backoff = BACKOFF_START_MS;
+        let mut last_err: Option<ClientError> = None;
+        for attempt in 0..MAX_RETRIES {
+            let loc = match self.locate_region(qualified_table, row).await {
+                Ok(l) => l,
+                Err(e) => {
+                    last_err = Some(e);
+                    self.invalidate_region(qualified_table, row).await;
+                    tokio::time::sleep(Duration::from_millis(backoff)).await;
+                    backoff = (backoff * 2).min(5000);
+                    continue;
+                }
+            };
+            let conn = match self.region_connection(&loc.server).await {
+                Ok(c) => c,
+                Err(e) => {
+                    last_err = Some(e);
+                    self.drop_region_connection(&loc.server).await;
+                    self.invalidate_region(qualified_table, row).await;
+                    tokio::time::sleep(Duration::from_millis(backoff)).await;
+                    backoff = (backoff * 2).min(5000);
+                    continue;
+                }
+            };
+            match op(loc.clone(), conn).await {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    if is_retryable(&e) && attempt + 1 < MAX_RETRIES {
+                        self.invalidate_region(qualified_table, row).await;
+                        self.drop_region_connection(&loc.server).await;
+                        tokio::time::sleep(Duration::from_millis(backoff)).await;
+                        backoff = (backoff * 2).min(5000);
+                        last_err = Some(e);
+                        continue;
+                    }
+                    return Err(e);
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| ClientError::Region("region retries exhausted".into())))
+    }
+
+    async fn drop_region_connection(&self, ep: &ServerEndpoint) {
+        self.region_conns.write().await.remove(&ep.addr());
+    }
+}
+
+// ---- control plane (MasterService) -----------------------------------------
+
+/// A column family descriptor for `describe`.
+#[derive(Debug, Clone)]
+pub struct FamilyDesc {
+    pub name: String,
+    pub attributes: std::collections::BTreeMap<String, String>,
+}
+
+impl NativeClient {
+    /// List user table names.
+    pub async fn list_tables(&self) -> Result<Vec<String>, ClientError> {
+        let master = self.master().await?;
+        let req = pb::GetTableNamesRequest::default();
+        let (resp, _) = master
+            .call_pb::<_, pb::GetTableNamesResponse>("GetTableNames", &req, None)
+            .await?;
+        Ok(resp
+            .table_names
+            .into_iter()
+            .map(|tn| qualify_table_name(&tn))
+            .collect())
+    }
+
+    /// Describe a table's column families.
+    pub async fn describe_table(
+        &self,
+        table: &str,
+    ) -> Result<(String, Vec<FamilyDesc>), ClientError> {
+        let qualified = self.qualify(table);
+        let master = self.master().await?;
+        let req = pb::GetTableDescriptorsRequest {
+            table_names: vec![Self::table_name_pb(&qualified)],
+            ..Default::default()
+        };
+        let (resp, _) = master
+            .call_pb::<_, pb::GetTableDescriptorsResponse>("GetTableDescriptors", &req, None)
+            .await?;
+        let schema = resp
+            .table_schema
+            .into_iter()
+            .next()
+            .ok_or_else(|| ClientError::Region(format!("table not found: {qualified}")))?;
+        let name = schema
+            .table_name
+            .as_ref()
+            .map(qualify_table_name)
+            .unwrap_or_else(|| qualified.clone());
+        let families = schema
+            .column_families
+            .into_iter()
+            .map(|cf| {
+                let mut attributes = std::collections::BTreeMap::new();
+                for attr in &cf.attributes {
+                    attributes.insert(
+                        String::from_utf8_lossy(&attr.first).into_owned(),
+                        String::from_utf8_lossy(&attr.second).into_owned(),
+                    );
+                }
+                for conf in &cf.configuration {
+                    attributes.insert(conf.name.clone(), conf.value.clone());
+                }
+                FamilyDesc {
+                    name: String::from_utf8_lossy(&cf.name).into_owned(),
+                    attributes,
+                }
+            })
+            .collect();
+        Ok((name, families))
+    }
+
+    /// Create a table with the given column families.
+    pub async fn create_table(
+        &self,
+        table: &str,
+        families: &[(String, std::collections::BTreeMap<String, String>)],
+    ) -> Result<(), ClientError> {
+        let qualified = self.qualify(table);
+        let master = self.master().await?;
+        let column_families = families
+            .iter()
+            .map(|(name, attrs)| pb::ColumnFamilySchema {
+                name: name.as_bytes().to_vec(),
+                attributes: attrs
+                    .iter()
+                    .map(|(k, v)| pb::BytesBytesPair {
+                        first: k.as_bytes().to_vec(),
+                        second: v.as_bytes().to_vec(),
+                    })
+                    .collect(),
+                configuration: Vec::new(),
+            })
+            .collect();
+        let req = pb::CreateTableRequest {
+            table_schema: pb::TableSchema {
+                table_name: Some(Self::table_name_pb(&qualified)),
+                attributes: Vec::new(),
+                column_families,
+                configuration: Vec::new(),
+            },
+            split_keys: Vec::new(),
+            nonce_group: None,
+            nonce: None,
+        };
+        let (resp, _) = master
+            .call_pb::<_, pb::CreateTableResponse>("CreateTable", &req, None)
+            .await?;
+        if let Some(proc_id) = resp.proc_id {
+            self.wait_for_procedure(&master, proc_id).await?;
+        }
+        Ok(())
+    }
+
+    /// Poll `GetProcedureResult` until the master procedure `proc_id` finishes.
+    async fn wait_for_procedure(
+        &self,
+        master: &RpcConnection,
+        proc_id: u64,
+    ) -> Result<(), ClientError> {
+        let deadline = std::time::Instant::now() + self.cfg.timeout.max(Duration::from_secs(30));
+        loop {
+            let req = pb::GetProcedureResultRequest { proc_id };
+            let (resp, _) = master
+                .call_pb::<_, pb::GetProcedureResultResponse>("getProcedureResult", &req, None)
+                .await?;
+            use pb::get_procedure_result_response::State;
+            match State::try_from(resp.state).unwrap_or(State::Running) {
+                State::Finished => {
+                    if let Some(exc) = resp.exception {
+                        return Err(ClientError::Rpc(format!(
+                            "procedure {proc_id} failed: {}",
+                            exc.generic_exception
+                                .and_then(|g| g.message)
+                                .unwrap_or_else(|| "unknown".into())
+                        )));
+                    }
+                    return Ok(());
+                }
+                State::NotFound => return Ok(()), // already reaped = done
+                State::Running => {
+                    if std::time::Instant::now() >= deadline {
+                        return Err(ClientError::Rpc(format!(
+                            "timed out waiting for procedure {proc_id}"
+                        )));
+                    }
+                    tokio::time::sleep(Duration::from_millis(150)).await;
+                }
+            }
+        }
+    }
+
+    /// Disable then delete a table.
+    pub async fn drop_table(&self, table: &str) -> Result<(), ClientError> {
+        let qualified = self.qualify(table);
+        let master = self.master().await?;
+        let tn = Self::table_name_pb(&qualified);
+
+        // HBase requires a table to be disabled before deletion. Ignore "not
+        // enabled" errors so a second drop / already-disabled table still works.
+        let disable = pb::DisableTableRequest {
+            table_name: tn.clone(),
+            nonce_group: None,
+            nonce: None,
+        };
+        match master
+            .call_pb::<_, pb::DisableTableResponse>("DisableTable", &disable, None)
+            .await
+        {
+            Ok((resp, _)) => {
+                if let Some(proc_id) = resp.proc_id {
+                    self.wait_for_procedure(&master, proc_id).await?;
+                }
+            }
+            Err(e) => {
+                // Tolerate "table already disabled" style errors; surface others.
+                let msg = e.to_string();
+                if !msg.contains("TableNotEnabled") && !msg.contains("not enabled") {
+                    return Err(ClientError::Rpc(msg));
+                }
+            }
+        }
+
+        let del = pb::DeleteTableRequest {
+            table_name: tn,
+            nonce_group: None,
+            nonce: None,
+        };
+        let (resp, _) = master
+            .call_pb::<_, pb::DeleteTableResponse>("DeleteTable", &del, None)
+            .await?;
+        if let Some(proc_id) = resp.proc_id {
+            self.wait_for_procedure(&master, proc_id).await?;
+        }
+        Ok(())
+    }
+
+    /// Cluster status as key/value pairs.
+    pub async fn cluster_status(&self) -> Result<Vec<(String, String)>, ClientError> {
+        let master = self.master().await?;
+        let req = pb::GetClusterStatusRequest::default();
+        let (resp, _) = master
+            .call_pb::<_, pb::GetClusterStatusResponse>("GetClusterStatus", &req, None)
+            .await?;
+        let s = resp.cluster_status;
+        let mut out = Vec::new();
+        if let Some(v) = s.hbase_version {
+            out.push(("hbaseVersion".into(), v.version));
+        }
+        out.push(("liveServers".into(), s.live_servers.len().to_string()));
+        out.push(("deadServers".into(), s.dead_servers.len().to_string()));
+        out.push((
+            "regionsInTransition".into(),
+            s.regions_in_transition.len().to_string(),
+        ));
+        if let Some(b) = s.balancer_on {
+            out.push(("balancerOn".into(), b.to_string()));
+        }
+        if let Some(cid) = s.cluster_id {
+            out.push(("clusterId".into(), cid.cluster_id));
+        }
+        Ok(out)
+    }
+}
+
+// ---- free helpers ----------------------------------------------------------
+
+/// Build a RegionSpecifier (by region name) for a located region.
+fn region_specifier(loc: &RegionLocation) -> pb::RegionSpecifier {
+    pb::RegionSpecifier {
+        r#type: pb::region_specifier::RegionSpecifierType::RegionName as i32,
+        value: loc.region_name.clone(),
+    }
+}
+
+/// RegionSpecifier for the (single, well-known) `hbase:meta,,1` region.
+fn meta_region_specifier() -> pb::RegionSpecifier {
+    pb::RegionSpecifier {
+        r#type: pb::region_specifier::RegionSpecifierType::RegionName as i32,
+        value: b"hbase:meta,,1".to_vec(),
+    }
+}
+
+/// Open a scanner, read one batch of up to `number_of_rows`, then close it.
+/// Returns `(row_key, cells)` pairs. Used both for meta lookups and (per
+/// region) user scans.
+async fn scan_once(
+    conn: &RpcConnection,
+    region: pb::RegionSpecifier,
+    scan: pb::Scan,
+    number_of_rows: u32,
+) -> Result<Vec<(Vec<u8>, Vec<Cell>)>, ClientError> {
+    // Open: send the Scan, get a scanner_id + first batch.
+    let open = pb::ScanRequest {
+        region: Some(region),
+        scan: Some(scan),
+        number_of_rows: Some(number_of_rows),
+        client_handles_partials: Some(true),
+        client_handles_heartbeats: Some(true),
+        ..Default::default()
+    };
+    let resp = conn.call("Scan", Some(open.encode_to_vec()), None).await?;
+    let scan_resp = pb::ScanResponse::decode(resp.param)
+        .map_err(|e| ClientError::Decode(e.to_string()))?;
+    let scanner_id = scan_resp.scanner_id;
+
+    let mut rows = parse_scan_batch(&scan_resp, &resp.cell_block)?;
+
+    // Pull more batches from the same region while results remain and we are
+    // under the requested row count.
+    let mut more_in_region = scan_resp.more_results_in_region.unwrap_or(false);
+    if let Some(sid) = scanner_id {
+        let mut guard = 0;
+        while more_in_region && (rows.len() as u32) < number_of_rows && guard < 10_000 {
+            guard += 1;
+            let next = pb::ScanRequest {
+                scanner_id: Some(sid),
+                number_of_rows: Some(number_of_rows - rows.len() as u32),
+                client_handles_partials: Some(true),
+                client_handles_heartbeats: Some(true),
+                ..Default::default()
+            };
+            let resp = conn.call("Scan", Some(next.encode_to_vec()), None).await?;
+            let batch = pb::ScanResponse::decode(resp.param)
+                .map_err(|e| ClientError::Decode(e.to_string()))?;
+            let parsed = parse_scan_batch(&batch, &resp.cell_block)?;
+            if parsed.is_empty() && !batch.more_results_in_region.unwrap_or(false) {
+                break;
+            }
+            rows.extend(parsed);
+            more_in_region = batch.more_results_in_region.unwrap_or(false);
+        }
+
+        // Best-effort close.
+        let close = pb::ScanRequest {
+            scanner_id: Some(sid),
+            close_scanner: Some(true),
+            number_of_rows: Some(0),
+            ..Default::default()
+        };
+        let _ = conn.call("Scan", Some(close.encode_to_vec()), None).await;
+    }
+
+    Ok(rows)
+}
+
+/// Reconstruct `(row_key, cells)` from a ScanResponse + its cell block. Cells
+/// arrive either inline (`results`) or in the cell block split by
+/// `cells_per_result`.
+fn parse_scan_batch(
+    resp: &pb::ScanResponse,
+    cell_block: &Bytes,
+) -> Result<Vec<(Vec<u8>, Vec<Cell>)>, ClientError> {
+    let mut out = Vec::new();
+
+    if !resp.cells_per_result.is_empty() {
+        // Cells are in the cell block; split by the per-result counts.
+        let mut buf = cell_block.clone();
+        for &count in &resp.cells_per_result {
+            let mut cells = Vec::with_capacity(count as usize);
+            for _ in 0..count {
+                let c = Cell::decode(&mut buf)
+                    .map_err(|e| ClientError::Decode(e.to_string()))?;
+                cells.push(c);
+            }
+            let row_key = cells
+                .first()
+                .map(|c| c.row.to_vec())
+                .unwrap_or_default();
+            out.push((row_key, cells));
+        }
+    } else {
+        // Cells are pb'd inline in `results`.
+        for result in &resp.results {
+            let cells: Vec<Cell> = result
+                .cell
+                .iter()
+                .map(pb_cell_to_cell)
+                .collect();
+            let row_key = cells
+                .first()
+                .map(|c| c.row.to_vec())
+                .unwrap_or_default();
+            out.push((row_key, cells));
+        }
+    }
+    Ok(out)
+}
+
+/// Pull cells out of a Get/Mutate Result (inline or via the cell block).
+fn result_to_cells(
+    result: Option<&pb::Result>,
+    cell_block: &Bytes,
+) -> Result<Vec<Cell>, ClientError> {
+    let Some(result) = result else {
+        return Ok(Vec::new());
+    };
+    let assoc = result.associated_cell_count.unwrap_or(0);
+    if assoc > 0 {
+        let mut buf = cell_block.clone();
+        let mut cells = Vec::with_capacity(assoc as usize);
+        for _ in 0..assoc {
+            cells.push(
+                Cell::decode(&mut buf).map_err(|e| ClientError::Decode(e.to_string()))?,
+            );
+        }
+        Ok(cells)
+    } else {
+        Ok(result.cell.iter().map(pb_cell_to_cell).collect())
+    }
+}
+
+fn pb_cell_to_cell(c: &pb::Cell) -> Cell {
+    Cell {
+        row: Bytes::copy_from_slice(c.row.as_deref().unwrap_or(&[])),
+        family: Bytes::copy_from_slice(c.family.as_deref().unwrap_or(&[])),
+        qualifier: Bytes::copy_from_slice(c.qualifier.as_deref().unwrap_or(&[])),
+        timestamp: c.timestamp.unwrap_or(0),
+        cell_type: c.cell_type.unwrap_or(0) as u8,
+        value: Bytes::copy_from_slice(c.value.as_deref().unwrap_or(&[])),
+    }
+}
+
+fn cells_to_rows(cells: &[Cell]) -> Vec<ResultRow> {
+    cells.iter().map(|c| cell_to_row(&c.row, c)).collect()
+}
+
+fn cell_to_row(row_key: &[u8], c: &Cell) -> ResultRow {
+    // Column is "family:qualifier".
+    let mut column = Vec::with_capacity(c.family.len() + 1 + c.qualifier.len());
+    column.extend_from_slice(&c.family);
+    column.push(b':');
+    column.extend_from_slice(&c.qualifier);
+    ResultRow {
+        row: row_key.to_vec(),
+        column,
+        timestamp: c.timestamp,
+        value: c.value.to_vec(),
+    }
+}
+
+/// Parse a `family:qualifier` (or bare `family`) into a `Column` spec.
+fn parse_column(spec: &str) -> pb::Column {
+    let (family, qualifier) = split_column(spec);
+    pb::Column {
+        family,
+        qualifier: if qualifier.is_empty() {
+            Vec::new()
+        } else {
+            vec![qualifier]
+        },
+    }
+}
+
+/// Split `family:qualifier` into (family, qualifier) byte vectors. A bare
+/// `family` yields an empty qualifier.
+fn split_column(spec: &str) -> (Vec<u8>, Vec<u8>) {
+    match spec.split_once(':') {
+        Some((f, q)) => (f.as_bytes().to_vec(), q.as_bytes().to_vec()),
+        None => (spec.as_bytes().to_vec(), Vec::new()),
+    }
+}
+
+/// Render a `TableName` proto as `namespace:qualifier` (dropping `default:`).
+fn qualify_table_name(tn: &pb::TableName) -> String {
+    let ns = String::from_utf8_lossy(&tn.namespace);
+    let q = String::from_utf8_lossy(&tn.qualifier);
+    if ns == "default" || ns.is_empty() {
+        q.into_owned()
+    } else {
+        format!("{ns}:{q}")
+    }
+}
+
+/// Whether a client error warrants a region-relocate + retry.
+fn is_retryable(e: &ClientError) -> bool {
+    let msg = e.to_string();
+    msg.contains("NotServingRegion")
+        || msg.contains("RegionMoved")
+        || msg.contains("RegionOpening")
+        || msg.contains("connection closed")
+        || msg.contains("transport error")
+        || msg.contains("CallQueueTooBig")
+        || msg.contains("RegionTooBusy")
+}
+
+#[cfg(test)]
+mod live_tests {
+    //! Integration tests against a real HBase standalone cluster.
+    //!
+    //! These are gated behind `HBASE_LIVE_TEST=1` (and an optional
+    //! `HBASE_ZK=host:port`, default `127.0.0.1:2181`) so the normal unit-test
+    //! run stays hermetic. Run with:
+    //! `HBASE_LIVE_TEST=1 cargo test --lib hbase::native::client::live_tests -- --nocapture --test-threads=1`
+    use super::*;
+
+    fn live_client() -> Option<NativeClient> {
+        if std::env::var("HBASE_LIVE_TEST").ok().as_deref() != Some("1") {
+            return None;
+        }
+        let zk = std::env::var("HBASE_ZK").unwrap_or_else(|_| "127.0.0.1:2181".into());
+        Some(NativeClient::new(NativeConfig {
+            zk_quorum: zk,
+            zk_root: "/hbase".into(),
+            effective_user: "test".into(),
+            namespace: None,
+            timeout: Duration::from_secs(20),
+            auth: super::super::auth::AuthMethod::Simple,
+        }))
+    }
+
+    #[tokio::test]
+    async fn live_ping() {
+        let Some(c) = live_client() else { return };
+        let msg = c.ping().await.expect("ping failed");
+        println!("PING: {msg}");
+        assert!(msg.contains("OK"));
+    }
+
+    #[tokio::test]
+    async fn live_full_lifecycle() {
+        let Some(c) = live_client() else { return };
+        let table = "taomni_native_it";
+        let mut fam = std::collections::BTreeMap::new();
+        fam.insert("VERSIONS".to_string(), "1".to_string());
+
+        // Clean slate: drop if exists (ignore errors).
+        let _ = c.drop_table(table).await;
+
+        // create
+        c.create_table(table, &[("cf".to_string(), fam)])
+            .await
+            .expect("create_table");
+        println!("created {table}");
+
+        // list contains it
+        let tables = c.list_tables().await.expect("list_tables");
+        println!("tables: {tables:?}");
+        assert!(tables.iter().any(|t| t == table));
+
+        // describe
+        let (name, families) = c.describe_table(table).await.expect("describe");
+        println!("describe {name}: {families:?}");
+        assert!(families.iter().any(|f| f.name == "cf"));
+
+        // put
+        c.put(table, b"row1", "cf:q1", b"hello")
+            .await
+            .expect("put");
+        c.put(table, b"row2", "cf:q1", b"world")
+            .await
+            .expect("put2");
+        println!("put 2 rows");
+
+        // get
+        let got = c.get(table, b"row1", Some("cf:q1")).await.expect("get");
+        println!("get row1: {got:?}");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].value, b"hello");
+
+        // scan
+        let scanned = c
+            .scan(table, 100, None, None, &[])
+            .await
+            .expect("scan");
+        println!("scan: {} cells", scanned.len());
+        assert!(scanned.len() >= 2);
+
+        // delete one column
+        c.delete(table, b"row1", "cf:q1").await.expect("delete");
+        let after = c.get(table, b"row1", Some("cf:q1")).await.expect("get2");
+        println!("after delete row1: {after:?}");
+        assert!(after.is_empty());
+
+        // deleteall row2
+        c.delete_all(table, b"row2").await.expect("delete_all");
+
+        // drop
+        c.drop_table(table).await.expect("drop_table");
+        let tables = c.list_tables().await.expect("list2");
+        assert!(!tables.iter().any(|t| t == table), "table still present");
+        println!("dropped {table} — lifecycle OK");
+    }
+}
+
+
+
+
+
+

--- a/src-tauri/src/hbase/native/mod.rs
+++ b/src-tauri/src/hbase/native/mod.rs
@@ -1,0 +1,24 @@
+//! Native HBase RPC client.
+//!
+//! A JVM-free, REST-free HBase client that speaks the native RegionServer /
+//! Master RPC protocol directly, bootstrapped via ZooKeeper — the same wire
+//! protocol the Java `hbase-client` uses. This replaces the REST/Stargate
+//! transport so we can reach clusters that only expose the native RPC ports.
+//!
+//! Module layout mirrors the porting blueprint:
+//! - `proto`   — generated protobuf types (`hbase.pb`)
+//! - `rpc`     — connection actor, frame codecs, call-id multiplexing
+//! - `auth`    — simple (0x50) and Kerberos (0x51 / GSSAPI) handshakes
+//! - `cell`    — KeyValueCodec CellBlock encode/decode
+//! - `zk`      — ZooKeeper znode bootstrap (meta-region-server / master)
+//! - `region`  — RegionInfo, meta-row parsing, region-name comparator
+//! - `meta`    — hbase:meta region location + cache
+//! - `client`  — SendRPC orchestration, retries, scan state machine
+
+pub mod proto;
+pub mod rpc;
+pub mod cell;
+pub mod zk;
+pub mod region;
+pub mod auth;
+pub mod client;

--- a/src-tauri/src/hbase/native/proto.rs
+++ b/src-tauri/src/hbase/native/proto.rs
@@ -1,0 +1,14 @@
+//! Generated HBase protobuf types (package `hbase.pb`).
+//!
+//! The wire definitions are vendored under `src-tauri/proto/` and compiled by
+//! `build.rs` via prost-build. prost emits one file per proto package; HBase
+//! puts every message in `hbase.pb`, so the whole client surface lands in a
+//! single generated module that we re-export here as `pb`.
+//!
+//! `google.protobuf.Any` (used by Procedure.proto) is mapped by prost-build to
+//! `::prost_types::Any`, so there is no separate generated `google` module.
+#![allow(clippy::all)]
+
+pub mod pb {
+    include!(concat!(env!("OUT_DIR"), "/hbase.pb.rs"));
+}

--- a/src-tauri/src/hbase/native/region.rs
+++ b/src-tauri/src/hbase/native/region.rs
@@ -1,0 +1,411 @@
+//! Region model, `hbase:meta` row parsing, and the region-name comparator.
+//!
+//! A region is identified by its name: `table,start_key,region_id.encoded_md5.`
+//! Region locations are discovered by scanning `hbase:meta`, whose rows carry:
+//! - `info:regioninfo` → `'P' + "PBUF" + RegionInfo protobuf`
+//! - `info:server`     → ASCII `host:port` of the serving RegionServer
+//! - `info:serverstartcode`, `info:seqnumDuringOpen`, etc. (unused here)
+
+use prost::Message;
+
+use super::cell::Cell;
+use super::proto::pb;
+use super::zk::ServerEndpoint;
+
+const PBUF_MAGIC: &[u8; 4] = b"PBUF";
+
+/// A located region: its protobuf info plus the serving RegionServer.
+#[derive(Debug, Clone)]
+pub struct RegionLocation {
+    pub region: pb::RegionInfo,
+    pub server: ServerEndpoint,
+    /// The full region name bytes (`table,startkey,id.md5.`) as read from meta.
+    pub region_name: Vec<u8>,
+}
+
+impl RegionLocation {
+    /// Fully-qualified `namespace:table` of this region.
+    pub fn table_qualified(&self) -> String {
+        let tn = &self.region.table_name;
+        let ns = String::from_utf8_lossy(&tn.namespace);
+        let q = String::from_utf8_lossy(&tn.qualifier);
+        if ns == "default" || ns.is_empty() {
+            q.into_owned()
+        } else {
+            format!("{ns}:{q}")
+        }
+    }
+
+    pub fn start_key(&self) -> &[u8] {
+        self.region.start_key.as_deref().unwrap_or(&[])
+    }
+
+    pub fn end_key(&self) -> &[u8] {
+        self.region.end_key.as_deref().unwrap_or(&[])
+    }
+
+    /// True if `key` falls within this region's `[start_key, end_key)`.
+    /// Empty end_key means "last region" (unbounded above).
+    pub fn contains(&self, key: &[u8]) -> bool {
+        let after_start = self.start_key().is_empty() || key >= self.start_key();
+        let before_end = self.end_key().is_empty() || key < self.end_key();
+        after_start && before_end
+    }
+}
+
+#[derive(Debug)]
+pub enum RegionError {
+    Parse(String),
+    Offline,
+    NotFound(String),
+}
+
+impl std::fmt::Display for RegionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RegionError::Parse(e) => write!(f, "meta row parse failed: {e}"),
+            RegionError::Offline => write!(f, "region is offline"),
+            RegionError::NotFound(e) => write!(f, "region not found: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for RegionError {}
+
+/// Decode the `info:regioninfo` cell value.
+///
+/// The value is the `PBUF` magic (4 bytes) directly followed by the
+/// `RegionInfo` protobuf. (Some references describe a leading version byte
+/// before the magic; HBase 2.x writes the magic at offset 0, where its first
+/// byte `0x50` is the ASCII `'P'`. We accept both: magic at offset 0, or a
+/// single version byte followed by the magic.)
+pub fn parse_region_info(value: &[u8]) -> Result<pb::RegionInfo, RegionError> {
+    if value.len() < 4 {
+        return Err(RegionError::Parse("regioninfo too short".into()));
+    }
+    let body = if &value[0..4] == PBUF_MAGIC {
+        &value[4..]
+    } else if value.len() >= 5 && &value[1..5] == PBUF_MAGIC {
+        // Tolerate a leading version byte before the magic.
+        &value[5..]
+    } else {
+        return Err(RegionError::Parse("missing PBUF magic in regioninfo".into()));
+    };
+    pb::RegionInfo::decode(body).map_err(|e| RegionError::Parse(e.to_string()))
+}
+
+/// Build a `RegionLocation` from the cells of a single `hbase:meta` row.
+/// `row_key` is the meta row key (== the region name).
+pub fn region_from_meta_cells(
+    row_key: &[u8],
+    cells: &[Cell],
+) -> Result<RegionLocation, RegionError> {
+    let mut region_info: Option<pb::RegionInfo> = None;
+    let mut server: Option<ServerEndpoint> = None;
+
+    for cell in cells {
+        if &cell.family[..] != b"info" {
+            continue;
+        }
+        match &cell.qualifier[..] {
+            b"regioninfo" => {
+                region_info = Some(parse_region_info(&cell.value)?);
+            }
+            b"server" => {
+                // Value is the literal ASCII "host:port"; empty during NSRE.
+                if !cell.value.is_empty() {
+                    let s = String::from_utf8_lossy(&cell.value);
+                    server = parse_host_port(&s);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let region = region_info
+        .ok_or_else(|| RegionError::NotFound("no info:regioninfo in row".into()))?;
+    if region.offline.unwrap_or(false) {
+        return Err(RegionError::Offline);
+    }
+    let server = server.ok_or_else(|| {
+        RegionError::NotFound("no info:server (region in transition)".into())
+    })?;
+
+    Ok(RegionLocation {
+        region,
+        server,
+        region_name: row_key.to_vec(),
+    })
+}
+
+fn parse_host_port(s: &str) -> Option<ServerEndpoint> {
+    let (host, port) = s.rsplit_once(':')?;
+    let port: u16 = port.trim().parse().ok()?;
+    Some(ServerEndpoint {
+        host: host.to_string(),
+        port,
+    })
+}
+
+/// Build the meta search key for locating the region containing `(table, key)`.
+/// HBase meta rows sort by region name; appending `,:` exploits that `:` is the
+/// first byte greater than `9`, so a reversed scan from this key lands on the
+/// region whose name is the greatest one <= the target.
+pub fn meta_search_key(table: &str, row: &[u8]) -> Vec<u8> {
+    let mut k = Vec::with_capacity(table.len() + row.len() + 3);
+    k.extend_from_slice(table.as_bytes());
+    k.push(b',');
+    k.extend_from_slice(row);
+    k.extend_from_slice(b",:");
+    k
+}
+
+/// Build the meta key that stops a forward scan of all regions of `table`:
+/// `table,,` is the smallest possible; `table .` (table + first byte > ',') is
+/// the smallest key after the table's region range.
+pub fn meta_table_start_key(table: &str) -> Vec<u8> {
+    let mut k = Vec::with_capacity(table.len() + 1);
+    k.extend_from_slice(table.as_bytes());
+    k.push(b',');
+    k
+}
+
+pub fn meta_table_stop_key(table: &str) -> Vec<u8> {
+    let mut k = Vec::with_capacity(table.len() + 1);
+    k.extend_from_slice(table.as_bytes());
+    // ',' + 1 = '-'? No: the convention uses the table name followed by a byte
+    // strictly greater than ',' (0x2c). The next byte value 0x2d works for the
+    // standard "all regions of a table" stop key.
+    k.push(b',' + 1);
+    k
+}
+
+/// Compare two region names the way HBase orders them in `hbase:meta`.
+///
+/// Region name = `table,start_key,timestamp[.encoded.]`. A naive byte compare
+/// is wrong because (a) the table delimiter `,` must sort before any real key
+/// byte, and (b) within the same table a shorter start key sorts before a
+/// longer one with the same prefix. This mirrors gohbase's `region.Compare`.
+pub fn compare_region_names(a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+
+    // Split each name into (table, rest) on the first comma.
+    let (a_table, a_rest) = split_first_comma(a);
+    let (b_table, b_rest) = split_first_comma(b);
+
+    match a_table.cmp(b_table) {
+        Ordering::Equal => {}
+        non_eq => return non_eq,
+    }
+
+    // Within the same table, compare the start key, which runs from the first
+    // comma up to the last comma (the trailing field is the region id/ts).
+    let a_key = key_between_commas(a_rest);
+    let b_key = key_between_commas(b_rest);
+
+    // The empty start key (first region) must sort before any non-empty key.
+    match (a_key.is_empty(), b_key.is_empty()) {
+        (true, true) => return tiebreak(a_rest, b_rest),
+        (true, false) => return Ordering::Less,
+        (false, true) => return Ordering::Greater,
+        (false, false) => {}
+    }
+
+    match a_key.cmp(b_key) {
+        Ordering::Equal => tiebreak(a_rest, b_rest),
+        non_eq => non_eq,
+    }
+}
+
+fn split_first_comma(name: &[u8]) -> (&[u8], &[u8]) {
+    match name.iter().position(|&c| c == b',') {
+        Some(i) => (&name[..i], &name[i + 1..]),
+        None => (name, &[]),
+    }
+}
+
+/// Given the bytes after the first comma (`start_key,timestamp.md5.`), return
+/// the start key (everything up to the last comma).
+fn key_between_commas(rest: &[u8]) -> &[u8] {
+    match rest.iter().rposition(|&c| c == b',') {
+        Some(i) => &rest[..i],
+        None => rest,
+    }
+}
+
+/// Tiebreaker for equal table+startkey: compare the trailing region-id/ts
+/// component lexically (newer regions have larger timestamps).
+fn tiebreak(a_rest: &[u8], b_rest: &[u8]) -> std::cmp::Ordering {
+    let a_tail = a_rest
+        .iter()
+        .rposition(|&c| c == b',')
+        .map(|i| &a_rest[i + 1..])
+        .unwrap_or(a_rest);
+    let b_tail = b_rest
+        .iter()
+        .rposition(|&c| c == b',')
+        .map(|i| &b_rest[i + 1..])
+        .unwrap_or(b_rest);
+    a_tail.cmp(b_tail)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use std::cmp::Ordering;
+
+    fn region_info_value(table: &str, start: &[u8], end: &[u8]) -> Vec<u8> {
+        let ri = pb::RegionInfo {
+            region_id: 1,
+            table_name: pb::TableName {
+                namespace: b"default".to_vec(),
+                qualifier: table.as_bytes().to_vec(),
+            },
+            start_key: Some(start.to_vec()),
+            end_key: Some(end.to_vec()),
+            offline: None,
+            split: None,
+            replica_id: Some(0),
+        };
+        let mut v = vec![b'P'];
+        v.extend_from_slice(PBUF_MAGIC);
+        v.extend_from_slice(&ri.encode_to_vec());
+        v
+    }
+
+    fn cell(family: &str, qualifier: &str, value: &[u8]) -> Cell {
+        Cell {
+            row: Bytes::from_static(b"meta-row"),
+            family: Bytes::copy_from_slice(family.as_bytes()),
+            qualifier: Bytes::copy_from_slice(qualifier.as_bytes()),
+            timestamp: 1,
+            cell_type: super::super::cell::cell_type::PUT,
+            value: Bytes::copy_from_slice(value),
+        }
+    }
+
+    #[test]
+    fn parse_region_info_roundtrip() {
+        let v = region_info_value("t1", b"a", b"z");
+        let ri = parse_region_info(&v).unwrap();
+        assert_eq!(ri.table_name.qualifier, b"t1");
+        assert_eq!(ri.start_key.as_deref(), Some(&b"a"[..]));
+        assert_eq!(ri.end_key.as_deref(), Some(&b"z"[..]));
+    }
+
+    #[test]
+    fn region_info_missing_magic() {
+        // No PBUF magic at offset 0 or 1 → reject.
+        let bad = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+        assert!(parse_region_info(&bad).is_err());
+    }
+
+    #[test]
+    fn region_info_magic_at_offset_zero() {
+        // HBase 2.x layout: PBUF directly at offset 0.
+        let ri = pb::RegionInfo {
+            region_id: 9,
+            table_name: pb::TableName {
+                namespace: b"default".to_vec(),
+                qualifier: b"t1".to_vec(),
+            },
+            start_key: Some(b"a".to_vec()),
+            end_key: Some(b"z".to_vec()),
+            offline: None,
+            split: None,
+            replica_id: Some(0),
+        };
+        let mut v = PBUF_MAGIC.to_vec();
+        v.extend_from_slice(&ri.encode_to_vec());
+        let parsed = parse_region_info(&v).unwrap();
+        assert_eq!(parsed.region_id, 9);
+    }
+
+    #[test]
+    fn region_from_meta_cells_ok() {
+        let cells = vec![
+            cell("info", "regioninfo", &region_info_value("t1", b"", b"m")),
+            cell("info", "server", b"rs1.example.com:16020"),
+        ];
+        let loc = region_from_meta_cells(b"t1,,1.abc.", &cells).unwrap();
+        assert_eq!(loc.server.host, "rs1.example.com");
+        assert_eq!(loc.server.port, 16020);
+        assert_eq!(loc.table_qualified(), "t1");
+        assert!(loc.contains(b"a"));
+        assert!(loc.contains(b"l"));
+        assert!(!loc.contains(b"m")); // end exclusive
+    }
+
+    #[test]
+    fn region_in_transition_has_no_server() {
+        let cells = vec![
+            cell("info", "regioninfo", &region_info_value("t1", b"", b"")),
+            cell("info", "server", b""),
+        ];
+        assert!(region_from_meta_cells(b"t1,,1.abc.", &cells).is_err());
+    }
+
+    #[test]
+    fn contains_first_and_last_region() {
+        let cells_first = vec![
+            cell("info", "regioninfo", &region_info_value("t1", b"", b"m")),
+            cell("info", "server", b"h:1"),
+        ];
+        let first = region_from_meta_cells(b"t1,,1.a.", &cells_first).unwrap();
+        assert!(first.contains(b"")); // empty start key
+        assert!(first.contains(b"a"));
+
+        let cells_last = vec![
+            cell("info", "regioninfo", &region_info_value("t1", b"m", b"")),
+            cell("info", "server", b"h:1"),
+        ];
+        let last = region_from_meta_cells(b"t1,m,1.b.", &cells_last).unwrap();
+        assert!(last.contains(b"z")); // empty end key = unbounded
+        assert!(!last.contains(b"a"));
+    }
+
+    #[test]
+    fn meta_search_key_format() {
+        assert_eq!(meta_search_key("t1", b"row5"), b"t1,row5,:");
+        assert_eq!(meta_search_key("ns:t", b""), b"ns:t,,:");
+    }
+
+    #[test]
+    fn compare_empty_start_key_sorts_first() {
+        // First region of a table (empty start key) must precede any other.
+        let first = b"t1,,1.aaa.";
+        let second = b"t1,m,2.bbb.";
+        assert_eq!(compare_region_names(first, second), Ordering::Less);
+        assert_eq!(compare_region_names(second, first), Ordering::Greater);
+    }
+
+    #[test]
+    fn compare_by_table_first() {
+        assert_eq!(
+            compare_region_names(b"aaa,,1.x.", b"bbb,,1.x."),
+            Ordering::Less
+        );
+    }
+
+    #[test]
+    fn compare_by_start_key_within_table() {
+        assert_eq!(
+            compare_region_names(b"t1,a,1.x.", b"t1,b,1.x."),
+            Ordering::Less
+        );
+        // Shorter key with same prefix sorts first.
+        assert_eq!(
+            compare_region_names(b"t1,a,1.x.", b"t1,aa,1.x."),
+            Ordering::Less
+        );
+    }
+
+    #[test]
+    fn compare_equal_names() {
+        assert_eq!(
+            compare_region_names(b"t1,a,1.x.", b"t1,a,1.x."),
+            Ordering::Equal
+        );
+    }
+}

--- a/src-tauri/src/hbase/native/rpc/codec.rs
+++ b/src-tauri/src/hbase/native/rpc/codec.rs
@@ -1,0 +1,374 @@
+//! HBase RPC frame encoding/decoding.
+//!
+//! Wire layout (HBase 0.95+, all integer prefixes big-endian; see
+//! <https://hbase.apache.org/docs/rpc>):
+//!
+//! Connection preamble (once per TCP connection):
+//! ```text
+//! "HBas" (4B magic) | 0x00 (RPC version) | auth byte (0x50 simple / 0x51 kerberos)
+//! | u32 BE len | ConnectionHeader protobuf
+//! ```
+//! The server sends no reply on success.
+//!
+//! Request frame:
+//! ```text
+//! u32 BE total_len | varint+RequestHeader | [varint+param] | [cell_block]
+//! ```
+//! Response frame:
+//! ```text
+//! u32 BE total_len | varint+ResponseHeader | [varint+response] | [cell_block]
+//! ```
+//! where `total_len` covers everything after the 4-byte length field, and the
+//! trailing cell block length (when present) is carried in
+//! `*.cell_block_meta.length`.
+
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use prost::Message;
+
+use super::super::proto::pb;
+
+/// 6-byte connection preamble magic + RPC format version (auth byte appended).
+pub const RPC_MAGIC: &[u8; 4] = b"HBas";
+pub const RPC_VERSION: u8 = 0;
+pub const AUTH_SIMPLE: u8 = 80; // 0x50
+pub const AUTH_KERBEROS: u8 = 81; // 0x51
+
+pub const KEYVALUE_CODEC_CLASS: &str = "org.apache.hadoop.hbase.codec.KeyValueCodec";
+pub const CLIENT_SERVICE: &str = "ClientService";
+pub const MASTER_SERVICE: &str = "MasterService";
+
+/// Errors surfaced by the frame codec.
+#[derive(Debug)]
+pub enum CodecError {
+    /// The buffer does not yet hold a full frame; caller should read more.
+    Incomplete,
+    /// A protobuf message failed to decode.
+    Decode(String),
+    /// The frame was structurally invalid (bad varint, truncated, oversized).
+    Malformed(String),
+}
+
+impl std::fmt::Display for CodecError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CodecError::Incomplete => write!(f, "incomplete frame"),
+            CodecError::Decode(e) => write!(f, "protobuf decode failed: {e}"),
+            CodecError::Malformed(e) => write!(f, "malformed frame: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for CodecError {}
+
+/// Build the 6-byte connection preamble for the given auth method.
+pub fn connection_preamble(auth: u8) -> [u8; 6] {
+    [
+        RPC_MAGIC[0],
+        RPC_MAGIC[1],
+        RPC_MAGIC[2],
+        RPC_MAGIC[3],
+        RPC_VERSION,
+        auth,
+    ]
+}
+
+/// Serialize a `ConnectionHeader` as `u32 BE len | bytes`, ready to write right
+/// after the preamble.
+pub fn encode_connection_header(header: &pb::ConnectionHeader) -> Bytes {
+    let body = header.encode_to_vec();
+    let mut out = BytesMut::with_capacity(4 + body.len());
+    out.put_u32(body.len() as u32);
+    out.extend_from_slice(&body);
+    out.freeze()
+}
+
+/// Construct the standard client `ConnectionHeader`.
+pub fn make_connection_header(effective_user: &str, service_name: &str) -> pb::ConnectionHeader {
+    pb::ConnectionHeader {
+        user_info: Some(pb::UserInformation {
+            effective_user: effective_user.to_string(),
+            real_user: None,
+        }),
+        service_name: Some(service_name.to_string()),
+        cell_block_codec_class: Some(KEYVALUE_CODEC_CLASS.to_string()),
+        cell_block_compressor_class: None,
+        version_info: None,
+        rpc_crypto_cipher_transformation: None,
+        attribute: Vec::new(),
+    }
+}
+
+/// Encode one request frame. `param` is the already-serialized request protobuf
+/// (e.g. a `GetRequest`); pass `None` for parameterless calls. `cell_block` is
+/// the raw KeyValueCodec bytes (already built), appended verbatim.
+pub fn encode_request(
+    header: &pb::RequestHeader,
+    param: Option<&[u8]>,
+    cell_block: Option<&[u8]>,
+) -> Bytes {
+    let header_bytes = header.encode_to_vec();
+
+    // Compute the body length: delimited(header) + delimited(param) + cellblock.
+    let mut body = BytesMut::new();
+    put_delimited(&mut body, &header_bytes);
+    if let Some(p) = param {
+        put_delimited(&mut body, p);
+    }
+    if let Some(cb) = cell_block {
+        body.extend_from_slice(cb);
+    }
+
+    let mut out = BytesMut::with_capacity(4 + body.len());
+    out.put_u32(body.len() as u32);
+    out.extend_from_slice(&body);
+    out.freeze()
+}
+
+/// A decoded response frame: the header plus the still-undecoded response
+/// param bytes and trailing cell block (sliced out by length).
+#[derive(Debug)]
+pub struct ResponseFrame {
+    pub header: pb::ResponseHeader,
+    /// Serialized response protobuf (decode into the expected type by caller).
+    pub param: Bytes,
+    /// Raw cell block bytes (KeyValueCodec), empty when none present.
+    pub cell_block: Bytes,
+}
+
+/// Try to decode a single response frame from `buf`. On success the consumed
+/// bytes are removed from `buf` and the frame returned. Returns
+/// `Err(CodecError::Incomplete)` (leaving `buf` untouched) when more bytes are
+/// needed.
+pub fn try_decode_response(buf: &mut BytesMut) -> Result<ResponseFrame, CodecError> {
+    if buf.len() < 4 {
+        return Err(CodecError::Incomplete);
+    }
+    // Peek total length without consuming, so an incomplete frame is retryable.
+    let total_len = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+    if buf.len() < 4 + total_len {
+        return Err(CodecError::Incomplete);
+    }
+    buf.advance(4);
+    let mut frame = buf.split_to(total_len);
+
+    // ResponseHeader (length-delimited).
+    let header_bytes = take_delimited(&mut frame)?;
+    let header = pb::ResponseHeader::decode(header_bytes)
+        .map_err(|e| CodecError::Decode(e.to_string()))?;
+
+    // The cell block length lives in the header; whatever is not header/param.
+    let cell_len = header
+        .cell_block_meta
+        .as_ref()
+        .and_then(|m| m.length)
+        .unwrap_or(0) as usize;
+
+    // If the server threw, there is no response param — only the header.
+    let (param, cell_block) = if header.exception.is_some() {
+        (Bytes::new(), Bytes::new())
+    } else if frame.is_empty() {
+        (Bytes::new(), Bytes::new())
+    } else {
+        // Remaining = delimited(param) + cell_block(cell_len).
+        if frame.len() < cell_len {
+            return Err(CodecError::Malformed(format!(
+                "cell block length {cell_len} exceeds remaining {} bytes",
+                frame.len()
+            )));
+        }
+        let param_region_len = frame.len() - cell_len;
+        let mut param_region = frame.split_to(param_region_len);
+        let cell_block = frame.split_to(cell_len).freeze();
+        let param = if param_region.is_empty() {
+            Bytes::new()
+        } else {
+            take_delimited(&mut param_region)?
+        };
+        (param, cell_block)
+    };
+
+    Ok(ResponseFrame {
+        header,
+        param,
+        cell_block,
+    })
+}
+
+/// Append `bytes` to `out` as a protobuf length-delimited field (varint len +
+/// payload), matching Java's `writeDelimitedTo`.
+fn put_delimited(out: &mut BytesMut, bytes: &[u8]) {
+    let mut tmp = [0u8; 10];
+    let n = encode_varint(bytes.len() as u64, &mut tmp);
+    out.extend_from_slice(&tmp[..n]);
+    out.extend_from_slice(bytes);
+}
+
+/// Read one length-delimited chunk (varint len + payload) from the front of
+/// `buf`, advancing it past the chunk and returning the payload.
+fn take_delimited(buf: &mut BytesMut) -> Result<Bytes, CodecError> {
+    let (len, consumed) = decode_varint(buf)?;
+    let len = len as usize;
+    if buf.len() < consumed + len {
+        return Err(CodecError::Malformed(format!(
+            "delimited chunk wants {len} bytes, only {} available",
+            buf.len().saturating_sub(consumed)
+        )));
+    }
+    buf.advance(consumed);
+    Ok(buf.split_to(len).freeze())
+}
+
+/// Encode a u64 as a protobuf base-128 varint into `out`, returning byte count.
+fn encode_varint(mut value: u64, out: &mut [u8; 10]) -> usize {
+    let mut i = 0;
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        out[i] = byte;
+        i += 1;
+        if value == 0 {
+            break;
+        }
+    }
+    i
+}
+
+/// Decode a base-128 varint from the front of `buf` (without consuming).
+/// Returns `(value, bytes_consumed)`.
+fn decode_varint(buf: &[u8]) -> Result<(u64, usize), CodecError> {
+    let mut result: u64 = 0;
+    let mut shift = 0u32;
+    for (i, &byte) in buf.iter().enumerate() {
+        if shift >= 64 {
+            return Err(CodecError::Malformed("varint overflow".into()));
+        }
+        result |= ((byte & 0x7f) as u64) << shift;
+        if byte & 0x80 == 0 {
+            return Ok((result, i + 1));
+        }
+        shift += 7;
+    }
+    Err(CodecError::Incomplete)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preamble_simple_and_kerberos() {
+        assert_eq!(connection_preamble(AUTH_SIMPLE), *b"HBas\x00\x50");
+        assert_eq!(connection_preamble(AUTH_KERBEROS), *b"HBas\x00\x51");
+    }
+
+    #[test]
+    fn varint_roundtrip() {
+        for v in [0u64, 1, 127, 128, 300, 16384, u32::MAX as u64, u64::MAX] {
+            let mut buf = [0u8; 10];
+            let n = encode_varint(v, &mut buf);
+            let (decoded, consumed) = decode_varint(&buf[..n]).unwrap();
+            assert_eq!(decoded, v);
+            assert_eq!(consumed, n);
+        }
+    }
+
+    #[test]
+    fn decode_varint_incomplete() {
+        // 0x80 means "more bytes follow" but none do.
+        assert!(matches!(decode_varint(&[0x80]), Err(CodecError::Incomplete)));
+    }
+
+    #[test]
+    fn connection_header_has_codec_and_user() {
+        let h = make_connection_header("alice", CLIENT_SERVICE);
+        assert_eq!(h.user_info.as_ref().unwrap().effective_user, "alice");
+        assert_eq!(h.service_name.as_deref(), Some(CLIENT_SERVICE));
+        assert_eq!(
+            h.cell_block_codec_class.as_deref(),
+            Some(KEYVALUE_CODEC_CLASS)
+        );
+        let framed = encode_connection_header(&h);
+        // First 4 bytes are the BE length of the remainder.
+        let len = u32::from_be_bytes([framed[0], framed[1], framed[2], framed[3]]) as usize;
+        assert_eq!(len, framed.len() - 4);
+    }
+
+    #[test]
+    fn request_response_frame_roundtrip() {
+        // Build a request frame, then feed an analogous response back through
+        // the decoder to verify framing/delimiting are symmetric.
+        let header = pb::RequestHeader {
+            call_id: Some(7),
+            trace_info: None,
+            method_name: Some("Get".to_string()),
+            request_param: Some(true),
+            cell_block_meta: None,
+            priority: None,
+            timeout: None,
+            attribute: Vec::new(),
+        };
+        let param = b"hello-param";
+        let frame = encode_request(&header, Some(param), None);
+        // total_len prefix is correct.
+        let total = u32::from_be_bytes([frame[0], frame[1], frame[2], frame[3]]) as usize;
+        assert_eq!(total, frame.len() - 4);
+
+        // Now craft a response with the same shape and decode it.
+        let resp_header = pb::ResponseHeader {
+            call_id: Some(7),
+            exception: None,
+            cell_block_meta: None,
+        };
+        let rh_bytes = resp_header.encode_to_vec();
+        let mut body = BytesMut::new();
+        put_delimited(&mut body, &rh_bytes);
+        put_delimited(&mut body, param);
+        let mut full = BytesMut::new();
+        full.put_u32(body.len() as u32);
+        full.extend_from_slice(&body);
+
+        let decoded = try_decode_response(&mut full).unwrap();
+        assert_eq!(decoded.header.call_id, Some(7));
+        assert_eq!(&decoded.param[..], param);
+        assert!(decoded.cell_block.is_empty());
+        assert!(full.is_empty(), "decoder must consume the whole frame");
+    }
+
+    #[test]
+    fn try_decode_incomplete_is_retryable() {
+        let mut buf = BytesMut::new();
+        buf.put_u32(100); // claims 100 bytes follow, but none do
+        assert!(matches!(
+            try_decode_response(&mut buf),
+            Err(CodecError::Incomplete)
+        ));
+        // Buffer must be left intact for a retry.
+        assert_eq!(buf.len(), 4);
+    }
+
+    #[test]
+    fn response_with_cell_block_splits_correctly() {
+        let resp_header = pb::ResponseHeader {
+            call_id: Some(1),
+            exception: None,
+            cell_block_meta: Some(pb::CellBlockMeta { length: Some(5) }),
+        };
+        let rh = resp_header.encode_to_vec();
+        let param = b"P";
+        let cells = b"CELLS";
+        let mut body = BytesMut::new();
+        put_delimited(&mut body, &rh);
+        put_delimited(&mut body, param);
+        body.extend_from_slice(cells);
+        let mut full = BytesMut::new();
+        full.put_u32(body.len() as u32);
+        full.extend_from_slice(&body);
+
+        let decoded = try_decode_response(&mut full).unwrap();
+        assert_eq!(&decoded.param[..], param);
+        assert_eq!(&decoded.cell_block[..], cells);
+    }
+}

--- a/src-tauri/src/hbase/native/rpc/conn.rs
+++ b/src-tauri/src/hbase/native/rpc/conn.rs
@@ -1,0 +1,391 @@
+//! Single-connection RPC actor.
+//!
+//! Owns one TCP connection to a RegionServer or Master. After the preamble +
+//! ConnectionHeader handshake, a writer task drains a request channel and a
+//! reader task decodes response frames, matching them back to callers by
+//! `call_id` via an in-flight `oneshot` map. This is the classic tokio actor
+//! pattern: callers hold an `RpcConnection` handle (clonable) and `await` a
+//! `oneshot` per call.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::BytesMut;
+use prost::Message;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::sync::{mpsc, oneshot, Mutex};
+
+use super::super::auth::AuthMethod;
+use super::super::proto::pb;
+use super::codec::{
+    self, connection_preamble, encode_connection_header, encode_request, make_connection_header,
+    try_decode_response, CodecError, ResponseFrame,
+};
+
+/// An error from an RPC call.
+#[derive(Debug, Clone)]
+pub enum RpcError {
+    /// Transport-level failure (connect/IO/handshake); the connection is dead.
+    Transport(String),
+    /// The server returned an ExceptionResponse for this call.
+    Remote {
+        class: String,
+        stack: String,
+        do_not_retry: bool,
+    },
+    /// The connection was closed before this call completed.
+    Closed,
+    /// Frame/protobuf decode failure.
+    Decode(String),
+}
+
+impl std::fmt::Display for RpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RpcError::Transport(e) => write!(f, "HBase RPC transport error: {e}"),
+            RpcError::Remote { class, stack, .. } => {
+                // Surface the simple class name + first line of the trace.
+                let short = class.rsplit('.').next().unwrap_or(class);
+                let first_line = stack.lines().next().unwrap_or("").trim();
+                if first_line.is_empty() {
+                    write!(f, "{short}")
+                } else {
+                    write!(f, "{short}: {first_line}")
+                }
+            }
+            RpcError::Closed => write!(f, "HBase RPC connection closed"),
+            RpcError::Decode(e) => write!(f, "HBase RPC decode error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for RpcError {}
+
+impl RpcError {
+    /// Java exception class name, if this is a remote exception.
+    pub fn exception_class(&self) -> Option<&str> {
+        match self {
+            RpcError::Remote { class, .. } => Some(class),
+            _ => None,
+        }
+    }
+}
+
+/// A successfully decoded RPC response: the response param bytes (decode into
+/// the expected protobuf) and the trailing cell block.
+#[derive(Debug)]
+pub struct RpcResponse {
+    pub param: bytes::Bytes,
+    pub cell_block: bytes::Bytes,
+}
+
+/// An outgoing request queued to the writer task.
+struct Outbound {
+    call_id: u32,
+    method: String,
+    param: Option<Vec<u8>>,
+    cell_block: Option<Vec<u8>>,
+    reply: oneshot::Sender<Result<RpcResponse, RpcError>>,
+}
+
+type InFlight = Arc<Mutex<HashMap<u32, oneshot::Sender<Result<RpcResponse, RpcError>>>>>;
+
+/// A handle to a live RPC connection. Cheap to clone; all clones share the
+/// underlying socket and writer task.
+#[derive(Clone)]
+pub struct RpcConnection {
+    tx: mpsc::Sender<Outbound>,
+    next_call_id: Arc<AtomicU32>,
+    service: String,
+    addr: String,
+}
+
+impl RpcConnection {
+    /// Establish a connection with simple auth (the common case).
+    pub async fn connect(
+        addr: &str,
+        service: &str,
+        effective_user: &str,
+        connect_timeout: Duration,
+    ) -> Result<Self, RpcError> {
+        Self::connect_with_auth(addr, service, effective_user, &AuthMethod::Simple, connect_timeout)
+            .await
+    }
+
+    /// Establish a connection to `addr` (`host:port`), perform the preamble +
+    /// (optional SASL) + ConnectionHeader handshake for `service`
+    /// ("ClientService" / "MasterService") as `effective_user`, and spawn the
+    /// reader/writer tasks.
+    pub async fn connect_with_auth(
+        addr: &str,
+        service: &str,
+        effective_user: &str,
+        auth: &AuthMethod,
+        connect_timeout: Duration,
+    ) -> Result<Self, RpcError> {
+        let stream = tokio::time::timeout(connect_timeout, TcpStream::connect(addr))
+            .await
+            .map_err(|_| RpcError::Transport(format!("connect to {addr} timed out")))?
+            .map_err(|e| RpcError::Transport(format!("connect to {addr}: {e}")))?;
+        stream
+            .set_nodelay(true)
+            .map_err(|e| RpcError::Transport(e.to_string()))?;
+
+        let (mut read_half, mut write_half) = stream.into_split();
+
+        // Handshake: preamble + (SASL for Kerberos) + length-delimited
+        // ConnectionHeader. No reply on success — the server stays silent until
+        // it rejects us.
+        let preamble = connection_preamble(auth.preamble_byte());
+        write_half
+            .write_all(&preamble)
+            .await
+            .map_err(|e| RpcError::Transport(format!("write preamble: {e}")))?;
+        write_half
+            .flush()
+            .await
+            .map_err(|e| RpcError::Transport(format!("flush preamble: {e}")))?;
+
+        // Kerberos: negotiate SASL/GSSAPI before the ConnectionHeader.
+        match auth {
+            AuthMethod::Simple => {}
+            AuthMethod::Kerberos { service_principal } => {
+                run_sasl(&mut read_half, &mut write_half, service_principal).await?;
+            }
+        }
+
+        let header = make_connection_header(effective_user, service);
+        let header_framed = encode_connection_header(&header);
+        write_half
+            .write_all(&header_framed)
+            .await
+            .map_err(|e| RpcError::Transport(format!("write ConnectionHeader: {e}")))?;
+        write_half
+            .flush()
+            .await
+            .map_err(|e| RpcError::Transport(format!("flush handshake: {e}")))?;
+
+        let in_flight: InFlight = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, mut rx) = mpsc::channel::<Outbound>(256);
+
+        // Writer task: drain the request channel, register each call, frame &
+        // send it. Registration happens here (before send) so the reader can
+        // never see a response for an unregistered call.
+        {
+            let in_flight = in_flight.clone();
+            let addr_w = addr.to_string();
+            tokio::spawn(async move {
+                while let Some(out) = rx.recv().await {
+                    let Outbound {
+                        call_id,
+                        method,
+                        param,
+                        cell_block,
+                        reply,
+                    } = out;
+
+                    let cell_len = cell_block.as_ref().map(|c| c.len()).unwrap_or(0);
+                    let req_header = pb::RequestHeader {
+                        call_id: Some(call_id),
+                        trace_info: None,
+                        method_name: Some(method),
+                        request_param: Some(param.is_some()),
+                        cell_block_meta: if cell_len > 0 {
+                            Some(pb::CellBlockMeta {
+                                length: Some(cell_len as u32),
+                            })
+                        } else {
+                            None
+                        },
+                        priority: None,
+                        timeout: None,
+                        attribute: Vec::new(),
+                    };
+                    let frame = encode_request(
+                        &req_header,
+                        param.as_deref(),
+                        cell_block.as_deref(),
+                    );
+
+                    in_flight.lock().await.insert(call_id, reply);
+
+                    if let Err(e) = write_half.write_all(&frame).await {
+                        // Send failed: fail this call and stop the writer.
+                        if let Some(reply) = in_flight.lock().await.remove(&call_id) {
+                            let _ = reply.send(Err(RpcError::Transport(format!(
+                                "write to {addr_w}: {e}"
+                            ))));
+                        }
+                        break;
+                    }
+                    if let Err(e) = write_half.flush().await {
+                        if let Some(reply) = in_flight.lock().await.remove(&call_id) {
+                            let _ = reply
+                                .send(Err(RpcError::Transport(format!("flush to {addr_w}: {e}"))));
+                        }
+                        break;
+                    }
+                }
+                // Channel closed or write failed: drop write_half (closes the
+                // socket write side), which makes the reader see EOF.
+            });
+        }
+
+        // Reader task: decode frames, match by call_id, deliver to waiters.
+        {
+            let in_flight = in_flight.clone();
+            tokio::spawn(async move {
+                let mut buf = BytesMut::with_capacity(8192);
+                let mut chunk = [0u8; 8192];
+                loop {
+                    // Drain any complete frames already buffered.
+                    loop {
+                        match try_decode_response(&mut buf) {
+                            Ok(frame) => deliver(&in_flight, frame).await,
+                            Err(CodecError::Incomplete) => break,
+                            Err(e) => {
+                                // Malformed stream: fail everyone and stop.
+                                fail_all(&in_flight, RpcError::Decode(e.to_string())).await;
+                                return;
+                            }
+                        }
+                    }
+                    match read_half.read(&mut chunk).await {
+                        Ok(0) => {
+                            fail_all(&in_flight, RpcError::Closed).await;
+                            return;
+                        }
+                        Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                        Err(e) => {
+                            fail_all(&in_flight, RpcError::Transport(e.to_string())).await;
+                            return;
+                        }
+                    }
+                }
+            });
+        }
+
+        Ok(RpcConnection {
+            tx,
+            next_call_id: Arc::new(AtomicU32::new(0)),
+            service: service.to_string(),
+            addr: addr.to_string(),
+        })
+    }
+
+    pub fn service(&self) -> &str {
+        &self.service
+    }
+
+    pub fn addr(&self) -> &str {
+        &self.addr
+    }
+
+    /// Issue an RPC and await the response. `param` is the serialized request
+    /// protobuf; `cell_block` is raw KeyValueCodec bytes (for Put/Mutate).
+    pub async fn call(
+        &self,
+        method: &str,
+        param: Option<Vec<u8>>,
+        cell_block: Option<Vec<u8>>,
+    ) -> Result<RpcResponse, RpcError> {
+        let call_id = self.next_call_id.fetch_add(1, Ordering::SeqCst);
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let out = Outbound {
+            call_id,
+            method: method.to_string(),
+            param,
+            cell_block,
+            reply: reply_tx,
+        };
+        self.tx
+            .send(out)
+            .await
+            .map_err(|_| RpcError::Closed)?;
+        reply_rx.await.map_err(|_| RpcError::Closed)?
+    }
+
+    /// Convenience: issue an RPC whose param is a prost message and decode the
+    /// response into `T`.
+    pub async fn call_pb<Req: Message, T: Message + Default>(
+        &self,
+        method: &str,
+        req: &Req,
+        cell_block: Option<Vec<u8>>,
+    ) -> Result<(T, bytes::Bytes), RpcError> {
+        let resp = self
+            .call(method, Some(req.encode_to_vec()), cell_block)
+            .await?;
+        let decoded = T::decode(resp.param.clone())
+            .map_err(|e| RpcError::Decode(e.to_string()))?;
+        Ok((decoded, resp.cell_block))
+    }
+}
+
+/// Deliver one decoded response frame to its waiting caller.
+async fn deliver(in_flight: &InFlight, frame: ResponseFrame) {
+    let Some(call_id) = frame.header.call_id else {
+        return; // can't route without a call id
+    };
+    let reply = in_flight.lock().await.remove(&call_id);
+    let Some(reply) = reply else {
+        return; // no waiter (already failed/timed out)
+    };
+    let result = if let Some(exc) = frame.header.exception {
+        Err(RpcError::Remote {
+            class: exc.exception_class_name.unwrap_or_default(),
+            stack: exc.stack_trace.unwrap_or_default(),
+            do_not_retry: exc.do_not_retry.unwrap_or(false),
+        })
+    } else {
+        Ok(RpcResponse {
+            param: frame.param,
+            cell_block: frame.cell_block,
+        })
+    };
+    let _ = reply.send(result);
+}
+
+/// Fail every in-flight call with `err` (connection died).
+async fn fail_all(in_flight: &InFlight, err: RpcError) {
+    let mut map = in_flight.lock().await;
+    for (_, reply) in map.drain() {
+        let _ = reply.send(Err(err.clone()));
+    }
+}
+
+// Keep codec helper referenced even if higher layers haven't wired it yet.
+#[allow(unused_imports)]
+use codec as _codec;
+
+/// Run the SASL/GSSAPI negotiation. Requires the `hbase-kerberos` feature.
+#[cfg(feature = "hbase-kerberos")]
+async fn run_sasl(
+    read: &mut tokio::net::tcp::OwnedReadHalf,
+    write: &mut tokio::net::tcp::OwnedWriteHalf,
+    service_principal: &str,
+) -> Result<(), RpcError> {
+    let ok = super::super::auth::kerberos::sasl_connect(read, write, service_principal)
+        .await
+        .map_err(RpcError::Transport)?;
+    if !ok {
+        return Err(RpcError::Transport(
+            "server requested fallback to simple auth, but Kerberos was configured".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "hbase-kerberos"))]
+async fn run_sasl(
+    _read: &mut tokio::net::tcp::OwnedReadHalf,
+    _write: &mut tokio::net::tcp::OwnedWriteHalf,
+    _service_principal: &str,
+) -> Result<(), RpcError> {
+    Err(RpcError::Transport(
+        "Kerberos auth requires building taomni with the `hbase-kerberos` feature".into(),
+    ))
+}

--- a/src-tauri/src/hbase/native/rpc/mod.rs
+++ b/src-tauri/src/hbase/native/rpc/mod.rs
@@ -1,0 +1,5 @@
+//! HBase RPC transport: connection preamble, ConnectionHeader, request/response
+//! framing, and call-id multiplexing over a single TCP connection.
+
+pub mod codec;
+pub mod conn;

--- a/src-tauri/src/hbase/native/zk.rs
+++ b/src-tauri/src/hbase/native/zk.rs
@@ -1,0 +1,243 @@
+//! ZooKeeper bootstrap for the native HBase client.
+//!
+//! HBase publishes the location of the meta region and the active master as
+//! znodes under the configured root (default `/hbase`). The client reads
+//! `/hbase/meta-region-server` to find the RegionServer hosting `hbase:meta`,
+//! and `/hbase/master` to find the active Master.
+//!
+//! znode payload format (the "protobuf-with-magic" serialization):
+//! ```text
+//! 0xFF | u32 BE metadata_len | <metadata_len bytes, skipped> | "PBUF" | protobuf
+//! ```
+
+use prost::Message;
+use std::time::Duration;
+
+use super::proto::pb;
+
+/// znode paths relative to the HBase ZK root.
+pub const META_REGION_SERVER: &str = "/meta-region-server";
+pub const MASTER: &str = "/master";
+pub const DEFAULT_ZK_ROOT: &str = "/hbase";
+
+/// `PBUF` magic delimiting the protobuf payload.
+const PBUF_MAGIC: &[u8; 4] = b"PBUF";
+
+#[derive(Debug)]
+pub enum ZkError {
+    Connect(String),
+    Read(String),
+    Parse(String),
+}
+
+impl std::fmt::Display for ZkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ZkError::Connect(e) => write!(f, "ZooKeeper connect failed: {e}"),
+            ZkError::Read(e) => write!(f, "ZooKeeper read failed: {e}"),
+            ZkError::Parse(e) => write!(f, "ZooKeeper znode parse failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ZkError {}
+
+/// A resolved server endpoint (`host:port`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerEndpoint {
+    pub host: String,
+    pub port: u16,
+}
+
+impl ServerEndpoint {
+    pub fn addr(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+fn server_name_to_endpoint(server: &pb::ServerName) -> ServerEndpoint {
+    ServerEndpoint {
+        host: server.host_name.clone(),
+        // RegionServers always carry a port; default is informational only.
+        port: server.port.unwrap_or(16020) as u16,
+    }
+}
+
+/// Strip the `0xFF + metadata + PBUF` envelope from a znode payload, returning
+/// the inner protobuf bytes.
+fn strip_znode_envelope(data: &[u8]) -> Result<&[u8], ZkError> {
+    if data.is_empty() {
+        return Err(ZkError::Parse("empty znode".into()));
+    }
+    if data[0] != 0xFF {
+        return Err(ZkError::Parse(format!(
+            "first byte was 0x{:02x}, not 0xFF",
+            data[0]
+        )));
+    }
+    if data.len() < 5 {
+        return Err(ZkError::Parse("missing metadata length".into()));
+    }
+    let metadata_len = u32::from_be_bytes([data[1], data[2], data[3], data[4]]) as usize;
+    if metadata_len < 1 || metadata_len > 65000 {
+        return Err(ZkError::Parse(format!(
+            "implausible metadata length {metadata_len}"
+        )));
+    }
+    // Layout: [0xFF][4B len][metadata_len bytes][PBUF][protobuf]
+    let magic_start = 1 + 4 + metadata_len;
+    let magic_end = magic_start + 4;
+    if data.len() < magic_end {
+        return Err(ZkError::Parse("truncated before PBUF magic".into()));
+    }
+    if &data[magic_start..magic_end] != PBUF_MAGIC {
+        return Err(ZkError::Parse("missing PBUF magic".into()));
+    }
+    Ok(&data[magic_end..])
+}
+
+/// Parse a `/hbase/meta-region-server` payload into the meta RegionServer addr.
+pub fn parse_meta_region_server(data: &[u8]) -> Result<ServerEndpoint, ZkError> {
+    let pbuf = strip_znode_envelope(data)?;
+    let msg = pb::MetaRegionServer::decode(pbuf).map_err(|e| ZkError::Parse(e.to_string()))?;
+    Ok(server_name_to_endpoint(&msg.server))
+}
+
+/// Parse a `/hbase/master` payload into the active Master addr.
+pub fn parse_master(data: &[u8]) -> Result<ServerEndpoint, ZkError> {
+    let pbuf = strip_znode_envelope(data)?;
+    let msg = pb::Master::decode(pbuf).map_err(|e| ZkError::Parse(e.to_string()))?;
+    let mut ep = server_name_to_endpoint(&msg.master);
+    // Master default port differs from RS; only override if proto omitted it.
+    if msg.master.port.is_none() {
+        ep.port = 16000;
+    }
+    Ok(ep)
+}
+
+/// Connect to the ZooKeeper quorum, read a znode, and return its raw bytes.
+/// `quorum` is a comma-separated `host:port` list; `path` is the full znode
+/// path (root already prepended).
+pub async fn read_znode(
+    quorum: &str,
+    path: &str,
+    timeout: Duration,
+) -> Result<Vec<u8>, ZkError> {
+    // A fresh, short-lived session per lookup (no watches): matches gohbase.
+    let mut connector = zookeeper_client::Client::connector();
+    connector.session_timeout(timeout);
+    let client = connector
+        .connect(quorum)
+        .await
+        .map_err(|e| ZkError::Connect(e.to_string()))?;
+    let (data, _stat) = client
+        .get_data(path)
+        .await
+        .map_err(|e| ZkError::Read(e.to_string()))?;
+    Ok(data)
+}
+
+/// Resolve the meta RegionServer via ZooKeeper.
+pub async fn locate_meta(
+    quorum: &str,
+    zk_root: &str,
+    timeout: Duration,
+) -> Result<ServerEndpoint, ZkError> {
+    let path = format!("{}{}", zk_root, META_REGION_SERVER);
+    let data = read_znode(quorum, &path, timeout).await?;
+    parse_meta_region_server(&data)
+}
+
+/// Resolve the active Master via ZooKeeper.
+pub async fn locate_master(
+    quorum: &str,
+    zk_root: &str,
+    timeout: Duration,
+) -> Result<ServerEndpoint, ZkError> {
+    let path = format!("{}{}", zk_root, MASTER);
+    let data = read_znode(quorum, &path, timeout).await?;
+    parse_master(&data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic znode payload wrapping `proto_bytes`.
+    fn wrap_znode(proto_bytes: &[u8]) -> Vec<u8> {
+        let metadata = b"\x00metadata-magic-skipped"; // arbitrary, skipped
+        let mut out = Vec::new();
+        out.push(0xFF);
+        out.extend_from_slice(&(metadata.len() as u32).to_be_bytes());
+        out.extend_from_slice(metadata);
+        out.extend_from_slice(PBUF_MAGIC);
+        out.extend_from_slice(proto_bytes);
+        out
+    }
+
+    #[test]
+    fn parse_meta_region_server_ok() {
+        let msg = pb::MetaRegionServer {
+            server: pb::ServerName {
+                host_name: "rs1.example.com".into(),
+                port: Some(16020),
+                start_code: Some(123456),
+            },
+            rpc_version: Some(1),
+            state: None,
+        };
+        let payload = wrap_znode(&msg.encode_to_vec());
+        let ep = parse_meta_region_server(&payload).unwrap();
+        assert_eq!(ep.host, "rs1.example.com");
+        assert_eq!(ep.port, 16020);
+        assert_eq!(ep.addr(), "rs1.example.com:16020");
+    }
+
+    #[test]
+    fn parse_master_ok() {
+        let msg = pb::Master {
+            master: pb::ServerName {
+                host_name: "master.example.com".into(),
+                port: Some(16000),
+                start_code: Some(999),
+            },
+            rpc_version: Some(1),
+            info_port: Some(16010),
+        };
+        let payload = wrap_znode(&msg.encode_to_vec());
+        let ep = parse_master(&payload).unwrap();
+        assert_eq!(ep.host, "master.example.com");
+        assert_eq!(ep.port, 16000);
+    }
+
+    #[test]
+    fn rejects_bad_first_byte() {
+        let mut payload = wrap_znode(b"whatever");
+        payload[0] = 0x00;
+        assert!(matches!(
+            strip_znode_envelope(&payload),
+            Err(ZkError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_pbuf_magic() {
+        let metadata = b"meta";
+        let mut out = Vec::new();
+        out.push(0xFF);
+        out.extend_from_slice(&(metadata.len() as u32).to_be_bytes());
+        out.extend_from_slice(metadata);
+        out.extend_from_slice(b"XXXX"); // wrong magic
+        out.extend_from_slice(b"body");
+        assert!(matches!(strip_znode_envelope(&out), Err(ZkError::Parse(_))));
+    }
+
+    #[test]
+    fn rejects_implausible_metadata_len() {
+        let mut out = Vec::new();
+        out.push(0xFF);
+        out.extend_from_slice(&70000u32.to_be_bytes()); // > 65000
+        out.extend_from_slice(b"PBUF");
+        assert!(matches!(strip_znode_envelope(&out), Err(ZkError::Parse(_))));
+    }
+}

--- a/src/components/session/SessionEditor.test.tsx
+++ b/src/components/session/SessionEditor.test.tsx
@@ -451,6 +451,8 @@ describe("SessionEditor SSH settings tabs", () => {
 
     await waitFor(() => expect(screen.getByTestId("session-hbase-section")).toBeInTheDocument());
     await user.type(screen.getByLabelText("Remote host"), "hbase-rest.example.com");
+    // Switch to REST mode so the REST-only fields render.
+    await user.selectOptions(screen.getByTestId("hbase-connection-mode"), "rest");
     await user.type(screen.getByLabelText("HBase username"), "root");
     await user.type(screen.getByLabelText("HBase namespace"), "prod");
     await user.type(screen.getByLabelText("HBase REST path"), "/gateway/hbase");
@@ -469,7 +471,35 @@ describe("SessionEditor SSH settings tabs", () => {
     expect(savedOptions).toMatchObject({
       hbaseNamespace: "prod",
       hbaseRestPath: "/gateway/hbase",
+      hbaseConnectionMode: "rest",
       dbTimeout: "15",
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists HBase native RPC settings (ZooKeeper quorum) through the save path", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderEditor(undefined, { initialProto: "HBaseShell" });
+
+    await waitFor(() => expect(screen.getByTestId("session-hbase-section")).toBeInTheDocument());
+    await user.type(screen.getByLabelText("Remote host"), "hbase.example.com");
+    // Native is the default mode; the ZK quorum field should be present.
+    await user.type(screen.getByLabelText("HBase ZooKeeper quorum"), "zk1:2181,zk2:2181");
+    await user.type(screen.getByLabelText("HBase namespace"), "prod");
+
+    await user.click(screen.getByRole("button", { name: "OK" }));
+
+    expect(ipcMocks.saveSession).toHaveBeenCalledTimes(1);
+    const savedConfig = ipcMocks.saveSession.mock.calls[0][0];
+    const savedOptions = JSON.parse(savedConfig.options_json);
+    expect(savedConfig).toMatchObject({
+      session_type: "HBaseShell",
+      host: "hbase.example.com",
+    });
+    expect(savedOptions).toMatchObject({
+      hbaseConnectionMode: "native",
+      hbaseZkQuorum: "zk1:2181,zk2:2181",
+      hbaseNamespace: "prod",
     });
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/src/components/session/SessionEditor.tsx
+++ b/src/components/session/SessionEditor.tsx
@@ -1154,6 +1154,10 @@ function HBaseSettings({
   vaultState,
   namespace, setNamespace,
   restPath, setRestPath,
+  connectionMode, setConnectionMode,
+  zkQuorum, setZkQuorum,
+  zkRoot, setZkRoot,
+  effectiveUser, setEffectiveUser,
   ssl, setSsl,
   timeoutSecs, setTimeoutSecs,
 }: {
@@ -1165,11 +1169,64 @@ function HBaseSettings({
   vaultState: "empty" | "locked" | "unlocked";
   namespace: string; setNamespace: (v: string) => void;
   restPath: string; setRestPath: (v: string) => void;
+  connectionMode: string; setConnectionMode: (v: string) => void;
+  zkQuorum: string; setZkQuorum: (v: string) => void;
+  zkRoot: string; setZkRoot: (v: string) => void;
+  effectiveUser: string; setEffectiveUser: (v: string) => void;
   ssl: boolean; setSsl: (v: boolean) => void;
   timeoutSecs: string; setTimeoutSecs: (v: string) => void;
 }) {
+  const isNative = connectionMode !== "rest";
   return (
     <div data-testid="hbase-settings" className="grid grid-cols-12 gap-x-3 gap-y-2.5 text-[12px]">
+      <Field label="Mode">
+        <select
+          className="taomni-input w-64"
+          data-testid="hbase-connection-mode"
+          aria-label="HBase connection mode"
+          value={isNative ? "native" : "rest"}
+          onChange={(e) => setConnectionMode(e.target.value)}
+        >
+          <option value="native">Native RPC (ZooKeeper + RegionServer)</option>
+          <option value="rest">REST / Stargate gateway</option>
+        </select>
+        <span className="ml-2 text-[var(--taomni-text-muted)]">
+          {isNative ? "No gateway needed; talks the native protocol." : "Requires an HBase REST server."}
+        </span>
+      </Field>
+
+      {isNative && (
+        <>
+          <Field label="ZK quorum">
+            <input
+              className="taomni-input w-64"
+              value={zkQuorum}
+              aria-label="HBase ZooKeeper quorum"
+              placeholder="(optional) zk1:2181,zk2:2181 — defaults to host:port"
+              onChange={(e) => setZkQuorum(e.target.value)}
+            />
+          </Field>
+          <Field label="ZK root">
+            <input
+              className="taomni-input w-64"
+              value={zkRoot}
+              aria-label="HBase ZooKeeper root"
+              placeholder="(optional) /hbase"
+              onChange={(e) => setZkRoot(e.target.value)}
+            />
+          </Field>
+          <Field label="Effective user">
+            <input
+              className="taomni-input w-64"
+              value={effectiveUser}
+              aria-label="HBase effective user"
+              placeholder="(optional) defaults to root"
+              onChange={(e) => setEffectiveUser(e.target.value)}
+            />
+          </Field>
+        </>
+      )}
+
       <Field label="Username">
         <input
           className="taomni-input w-64"
@@ -1233,16 +1290,18 @@ function HBaseSettings({
         />
       </Field>
 
-      <Field label="REST path">
-        <input
-          className="taomni-input w-64"
-          value={restPath}
-          aria-label="HBase REST path"
-          placeholder="(optional) gateway prefix"
-          onChange={(e) => setRestPath(e.target.value)}
-        />
-        <span className="ml-2 text-[var(--taomni-text-muted)]">Leave empty for Stargate root.</span>
-      </Field>
+      {!isNative && (
+        <Field label="REST path">
+          <input
+            className="taomni-input w-64"
+            value={restPath}
+            aria-label="HBase REST path"
+            placeholder="(optional) gateway prefix"
+            onChange={(e) => setRestPath(e.target.value)}
+          />
+          <span className="ml-2 text-[var(--taomni-text-muted)]">Leave empty for Stargate root.</span>
+        </Field>
+      )}
 
       <Field label="SSL / TLS">
         <label className="flex items-center gap-1.5">
@@ -1369,6 +1428,10 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
   const [dbRedisIndex, setDbRedisIndex] = useState(() => optionString(initialOptions, "dbRedisIndex", "0"));
   const [hbaseNamespace, setHBaseNamespace] = useState(() => optionString(initialOptions, "hbaseNamespace", ""));
   const [hbaseRestPath, setHBaseRestPath] = useState(() => optionString(initialOptions, "hbaseRestPath", ""));
+  const [hbaseConnectionMode, setHBaseConnectionMode] = useState(() => optionString(initialOptions, "hbaseConnectionMode", "native"));
+  const [hbaseZkQuorum, setHBaseZkQuorum] = useState(() => optionString(initialOptions, "hbaseZkQuorum", ""));
+  const [hbaseZkRoot, setHBaseZkRoot] = useState(() => optionString(initialOptions, "hbaseZkRoot", ""));
+  const [hbaseEffectiveUser, setHBaseEffectiveUser] = useState(() => optionString(initialOptions, "hbaseEffectiveUser", ""));
 
   /* --- terminal profile --- */
   const [terminalProfile, setTerminalProfile] = useState<TerminalProfile>(() =>
@@ -1530,6 +1593,10 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
       ? {
           hbaseNamespace,
           hbaseRestPath,
+          hbaseConnectionMode,
+          hbaseZkQuorum,
+          hbaseZkRoot,
+          hbaseEffectiveUser,
           dbSsl,
           dbTimeout,
         }
@@ -1747,6 +1814,10 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
     setDbRedisIndex(optionString(nextOptions, "dbRedisIndex", "0"));
     setHBaseNamespace(optionString(nextOptions, "hbaseNamespace", ""));
     setHBaseRestPath(optionString(nextOptions, "hbaseRestPath", ""));
+    setHBaseConnectionMode(optionString(nextOptions, "hbaseConnectionMode", "native"));
+    setHBaseZkQuorum(optionString(nextOptions, "hbaseZkQuorum", ""));
+    setHBaseZkRoot(optionString(nextOptions, "hbaseZkRoot", ""));
+    setHBaseEffectiveUser(optionString(nextOptions, "hbaseEffectiveUser", ""));
     setTerminalProfile(getSessionTerminalProfile(session?.options_json) ?? loadGlobalTerminalProfile());
     setNetworkSettings(getSessionNetworkSettings(session?.options_json));
     setWslOptions(parseWslOptions(session?.options_json));
@@ -1885,6 +1956,10 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
     timeoutSecs: parseInt(dbTimeout) || null,
     restPath: hbaseRestPath || null,
     namespace: hbaseNamespace || null,
+    connectionMode: hbaseConnectionMode === "rest" ? "rest" : "native",
+    zkQuorum: hbaseZkQuorum || null,
+    zkRoot: hbaseZkRoot || null,
+    effectiveUser: hbaseEffectiveUser || null,
   });
 
   const handleTestDbConnection = async () => {
@@ -2312,6 +2387,10 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
                 vaultState={vaultState}
                 namespace={hbaseNamespace} setNamespace={setHBaseNamespace}
                 restPath={hbaseRestPath} setRestPath={setHBaseRestPath}
+                connectionMode={hbaseConnectionMode} setConnectionMode={setHBaseConnectionMode}
+                zkQuorum={hbaseZkQuorum} setZkQuorum={setHBaseZkQuorum}
+                zkRoot={hbaseZkRoot} setZkRoot={setHBaseZkRoot}
+                effectiveUser={hbaseEffectiveUser} setEffectiveUser={setHBaseEffectiveUser}
                 ssl={dbSsl} setSsl={setDbSsl}
                 timeoutSecs={dbTimeout} setTimeoutSecs={setDbTimeout}
               />

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -245,6 +245,10 @@ function sessionToHBaseConnectInfo(session: SessionConfig, password?: string): H
     timeoutSecs: num("dbTimeout"),
     restPath: str("hbaseRestPath") || null,
     namespace: str("hbaseNamespace") || null,
+    connectionMode: str("hbaseConnectionMode") === "rest" ? "rest" : "native",
+    zkQuorum: str("hbaseZkQuorum") || null,
+    zkRoot: str("hbaseZkRoot") || null,
+    effectiveUser: str("hbaseEffectiveUser") || null,
   };
 }
 

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -902,6 +902,10 @@ function toHBaseConfigPayload(info: HBaseConnectInfo): Record<string, unknown> {
     timeoutSecs: info.timeoutSecs ?? null,
     restPath: info.restPath ?? null,
     namespace: info.namespace ?? null,
+    connectionMode: info.connectionMode ?? null,
+    zkQuorum: info.zkQuorum ?? null,
+    zkRoot: info.zkRoot ?? null,
+    effectiveUser: info.effectiveUser ?? null,
   };
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,6 +54,14 @@ export interface HBaseConnectInfo {
   timeoutSecs?: number | null;
   restPath?: string | null;
   namespace?: string | null;
+  /** "native" (RegionServer/Master RPC via ZooKeeper) or "rest" (Stargate). */
+  connectionMode?: "native" | "rest" | null;
+  /** ZooKeeper quorum for native mode, e.g. "zk1:2181,zk2:2181". */
+  zkQuorum?: string | null;
+  /** ZooKeeper root znode for native mode (default "/hbase"). */
+  zkRoot?: string | null;
+  /** Effective user for native simple auth (default "root"). */
+  effectiveUser?: string | null;
 }
 
 export interface RdpConnectInfo {


### PR DESCRIPTION
Replace the REST-only HBase shell transport with a JVM-free native RPC client that speaks the RegionServer/Master protocol directly, bootstrapped via ZooKeeper — the same wire protocol the Java hbase-client uses — so clusters that expose no REST/Thrift gateway can be reached.

Backend (src-tauri/src/hbase/native/):
- proto: 23 vendored HBase 2.6.1 protobuf defs compiled by prost-build; google.protobuf.Any maps to prost-types.
- rpc/codec + rpc/conn: HBas preamble + ConnectionHeader handshake, BE frame codec, and a tokio connection actor with call-id multiplexing.
- zk: znode bootstrap (0xFF/metadata/PBUF) for meta-region-server/master.
- region + client::meta_lookup: hbase:meta reverse-scan region location, region-name comparator, and a region-location cache with retry/backoff.
- cell: zero-copy KeyValueCodec cell-block encode/decode.
- client: get/put/scan/delete + create/drop/list/describe/status, with getProcedureResult polling for async create/delete.
- auth: simple (0x50) and Kerberos/GSSAPI (0x51) SASL handshake, the latter behind the optional `hbase-kerberos` cargo feature (cross-krb5).

hbase/mod.rs: HBaseSession is now Native|Rest; the existing shell-command parser is reused and dispatched per backend. REST stays as the connectionMode="rest" fallback. Also fixes a pre-existing parser bug where a bare column in `get 't','r','cf:q'` was mistaken for an option map.

Frontend: HBaseConnectInfo/config gain connectionMode/zkQuorum/zkRoot/ effectiveUser; SessionEditor adds a transport toggle and ZooKeeper fields; ipc.ts and MainLayout thread the new fields through.

Verified end-to-end against a local standalone HBase 2.6.1: ping, create, list, describe, put, get, scan (with LIMIT and multi-family/multi-row), delete, deleteall, drop. 35 native unit tests pass; live integration tests are gated behind HBASE_LIVE_TEST=1.