### PR TITLE
fix(ui): insert duplicated tab next to the original instead of appending

### DIFF
--- a/src/components/tabbar/TabBar.tsx
+++ b/src/components/tabbar/TabBar.tsx
@@ -83,7 +83,7 @@ export function TabBar({
     setActiveTab,
     removeTab,
     removeTabs,
-    addTab,
+    duplicateTab,
     moveTab,
     moveTabToIndex,
     updateTabTitle,
@@ -356,7 +356,7 @@ export function TabBar({
       { label: "", separator: true, onClick: () => {} },
       { label: t("tabs.rename"), icon: <Pencil className="w-3 h-3" />, onClick: () => startRename(tab), disabled: !tab.closable },
       { label: t("tabs.duplicate"), icon: <Copy className="w-3 h-3" />, onClick: () => {
-        addTab({ ...tab, id: `dup-${Date.now()}`, closable: true });
+        duplicateTab(tab.id);
       }, disabled: tab.type === "welcome" },
       { label: "", separator: true, onClick: () => {} },
       { label: t("tabs.moveToFirst"), icon: <ChevronFirst className="w-3 h-3" />, onClick: () => moveTabToIndex(tab.id, 0), disabled: isFirst },

--- a/src/stores/appStore.test.ts
+++ b/src/stores/appStore.test.ts
@@ -68,6 +68,63 @@ describe("appStore.moveTab", () => {
   });
 });
 
+describe("appStore.duplicateTab", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      tabs: [tab("a"), tab("b"), tab("c"), tab("d")],
+      activeTabId: "a",
+    });
+  });
+
+  it("inserts the copy immediately to the right of the original (issue #120)", () => {
+    useAppStore.getState().duplicateTab("b");
+    const ids = useAppStore.getState().tabs.map((t) => t.id);
+    expect(ids).toHaveLength(5);
+    // Copy sits at index 2, right after the source "b" — not at the end.
+    expect(ids.slice(0, 2)).toEqual(["a", "b"]);
+    expect(ids.slice(3)).toEqual(["c", "d"]);
+    expect(ids[2]).not.toBe("b");
+  });
+
+  it("activates the new copy", () => {
+    useAppStore.getState().duplicateTab("b");
+    const { tabs, activeTabId } = useAppStore.getState();
+    expect(activeTabId).toBe(tabs[2].id);
+  });
+
+  it("carries over the source tab fields with a fresh closable copy", () => {
+    useAppStore.setState({
+      tabs: [tab("a"), tab("locked", { closable: false, title: "Server", hasNewOutput: true })],
+      activeTabId: "a",
+    });
+    useAppStore.getState().duplicateTab("locked");
+    const copy = useAppStore.getState().tabs[2];
+    expect(copy.title).toBe("Server");
+    expect(copy.type).toBe("terminal");
+    expect(copy.closable).toBe(true);
+    expect(copy.hasNewOutput).toBe(false);
+  });
+
+  it("mints a unique id distinct from the source", () => {
+    useAppStore.getState().duplicateTab("a");
+    const ids = useAppStore.getState().tabs.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("is a no-op for an unknown id", () => {
+    const before = useAppStore.getState().tabs;
+    useAppStore.getState().duplicateTab("missing");
+    expect(useAppStore.getState().tabs).toBe(before);
+  });
+
+  it("duplicates the last tab adjacently, which is also the end", () => {
+    useAppStore.getState().duplicateTab("d");
+    const ids = useAppStore.getState().tabs.map((t) => t.id);
+    expect(ids.slice(0, 4)).toEqual(["a", "b", "c", "d"]);
+    expect(ids).toHaveLength(5);
+  });
+});
+
 describe("appStore.uiAppearance", () => {
   it("allows setting and persisting uiFontFamily", () => {
     const font = "Outfit, sans-serif";

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -45,6 +45,13 @@ interface AppState {
   tabMaximizedId: string | null;
 
   addTab: (tab: Tab) => void;
+  /**
+   * Duplicate an existing tab, inserting the copy immediately to the right of
+   * the original (not at the end of the strip) and activating it. See issue
+   * #120: a duplicated session should sit next to its source for quick
+   * switching/comparison.
+   */
+  duplicateTab: (id: string) => void;
   removeTab: (id: string) => void;
   removeTabs: (ids: string[]) => void;
   updateTabTitle: (id: string, title: string) => void;
@@ -198,6 +205,27 @@ export const useAppStore = create<AppState>((set) => ({
         activeTabId: tab.id,
         terminalSplitActive: tab.type === "terminal" ? s.terminalSplitActive : false,
         statusMessage: tr("status.openedTab", { title: tab.title }),
+      };
+    }),
+
+  duplicateTab: (id) =>
+    set((s) => {
+      const idx = s.tabs.findIndex((t) => t.id === id);
+      if (idx === -1) return s;
+      const source = s.tabs[idx];
+      const copy: Tab = {
+        ...source,
+        id: `dup-${crypto.randomUUID()}`,
+        closable: true,
+        hasNewOutput: false,
+      };
+      const next = s.tabs.slice();
+      next.splice(idx + 1, 0, copy);
+      return {
+        tabs: next,
+        activeTabId: copy.id,
+        terminalSplitActive: copy.type === "terminal" ? s.terminalSplitActive : false,
+        statusMessage: tr("status.openedTab", { title: copy.title }),
       };
     }),
 


### PR DESCRIPTION
Tab duplication routed through addTab, which appends unconditionally, so the copy jumped to the far end of the horizontal tab strip. Add a dedicated duplicateTab(id) store action that inserts the copy at index+1 (immediately right of the source) and activates it; repoint the TabBar menu item to it. addTab stays an append for the legitimate open-new-tab callers.

Closes #120