### PR TITLE
feat(updater): non-intrusive update indicator + 6-hour periodic check

### DIFF
--- a/claudedocs/auto-update-plan.md
+++ b/claudedocs/auto-update-plan.md
@@ -27,8 +27,9 @@
 ## 3. 更新链路总览
 
 ```
-客户端启动(延迟 3-5s) → 静默 check()(原生架构)拉取 latest.json(GitHub Release)
-  → 比对 version → 有新版则【仅提示】(更新对话框:新版本号 + 更新说明),不自动下载
+客户端启动(延迟 3-5s)+ 之后每 6 小时 → 静默 check()(原生架构)拉取 latest.json(GitHub Release)
+  → 比对 version → 有新版则【非干扰提示】:仅点亮标题栏角标(不弹窗、不下载)
+  → 用户点角标(或 About 内「检查更新」)→ 打开更新对话框(新版本号 + 更新说明)
   → 用户在对话框内选择安装包架构(默认 = 当前运行架构;macOS 另可选 arm64/x86_64)
   → 用户点「下载并安装」(✅ 确认门 #1) → check({ target }) 取所选架构产物
   → 下载更新包(minisign 验签)→ 安装
@@ -36,7 +37,8 @@
 （未点确认 ⇒ 不下载;已安装未重启 ⇒ 下次启动生效）
 ```
 
-> **两道确认门**:① 下载/安装前必须用户点击,启动检测只"提示"不"动手";② 安装完成后不自动重启,由用户决定何时重启。
+> **非干扰式提示**:启动与每 6 小时的静默检查**只点亮标题栏角标**(`TitleBarTrayControls` 内,有新版/已就绪时显示带红点的下载图标),绝不自动弹窗。更新窗仅在用户点角标或 About「检查更新」时打开。检查在对话框打开、或正在检查/下载/已就绪时自动跳过,避免打断用户。
+> **两道确认门**:① 下载/安装前必须用户点击;② 安装完成后不自动重启,由用户决定何时重启。
 > **架构选择**:`check({ target })` 的 `target` 即 `latest.json` `platforms` 的 key(如 `darwin-x86_64`)。已核实 Tauri v2 updater JS `CheckOptions.target?: string` 支持按调用覆盖目标平台,因此无需自建下载器,仍由插件完成下载/验签/安装。
 
 `latest.json`(Tauri v2 格式)示例:
@@ -168,11 +170,12 @@ target key 规则:`{os}-{arch}`,`os ∈ {darwin, windows, linux}`,`arch` 取 `st
   `candidates / nativeTarget / recommendedTarget / isRosetta / selectedTarget`,和"所选架构在此版本是否可用"的校验态(`targetStatus: unknown | checking | ok | unavailable`)。
   - `selectedTarget` 默认 = `recommendedTarget`。
   - 切换 `selectedTarget` 时调 `check({ target })`:返回 null ⇒ `targetStatus = unavailable`(该架构无此版本),否则 `ok`。
-- 启动检查:`MainLayout` mount 后延迟 3-5s,先 `getPlatform()` 再静默 `check()`(原生架构),仅在有新版时把状态置 `available`(只提示、不下载)。
+- 启动检查:`MainLayout` mount 后延迟 3-5s,先 `getPlatform()` 再静默 `check()`(原生架构);**之后每 6 小时**用 `setInterval` 再查一次。两者都是**非干扰**:仅把状态置 `available` 点亮标题栏角标,不弹窗。守卫:对话框打开 / 正在 `checking|downloading|ready` 时跳过本次检查,避免打断用户。
 
 ### 4.8 前端 UI
 
 - 改 `src/components/AboutDialog.tsx`:加"检查更新"按钮 + 当前状态文案。
+- 改 `src/components/window/TitleBarTrayControls.tsx`:加**非干扰式更新角标**(状态 `available`/`ready` 时显示带红点的下载图标,点击 `openDialog()` 打开更新窗;两种标题栏布局——`AppTitleBar` 与 `CompactTitleBar`——都渲染该 tray,故各平台/各布局通用)。
 - 新增 `src/components/UpdateDialog.tsx`,自上而下:
   1. 新版本号 + 更新说明(`notes`)。
   2. **安装包/架构选择器**(仅 `candidates.length > 1` 时显示,默认选中 `recommendedTarget`):
@@ -230,7 +233,7 @@ target key 规则:`{os}-{arch}`,`os ∈ {darwin, windows, linux}`,`arch` 取 `st
 
 ## 9. 涉及文件清单
 
-**修改:** `src-tauri/Cargo.toml`、`package.json`、`src-tauri/tauri.conf.json`、`src-tauri/capabilities/default.json`、`src-tauri/src/lib.rs`、`.github/workflows/release.yml`、`src/components/AboutDialog.tsx`、`src/layouts/MainLayout.tsx`、`src/lib/i18n/locales/en.ts`、`src/lib/i18n/locales/zh-CN.ts`
+**修改:** `src-tauri/Cargo.toml`、`package.json`、`src-tauri/tauri.conf.json`、`src-tauri/capabilities/default.json`、`src-tauri/src/lib.rs`、`.github/workflows/release.yml`、`src/components/AboutDialog.tsx`、`src/components/window/TitleBarTrayControls.tsx`、`src/layouts/MainLayout.tsx`、`src/stubs/tauri-core.ts`、`src/lib/i18n/locales/en.ts`、`src/lib/i18n/locales/zh-CN.ts`
 
 **新增:** `src-tauri/src/update.rs`(架构探测命令)、`src/lib/updateService.ts`、`src/stores/updateStore.ts`、`src/components/UpdateDialog.tsx`、`src/stores/updateStore.test.ts`
 

--- a/src/components/window/TitleBarTrayControls.tsx
+++ b/src/components/window/TitleBarTrayControls.tsx
@@ -1,8 +1,9 @@
-import { Monitor, Moon, Sun, PanelTopClose, PanelTopOpen, SplitSquareVertical, Users, Bot } from "lucide-react";
+import { Monitor, Moon, Sun, PanelTopClose, PanelTopOpen, SplitSquareVertical, Users, Bot, Download } from "lucide-react";
 import { useAppTheme, type AppThemeMode } from "../../lib/appTheme";
 import { useAppStore } from "../../stores/appStore";
 import { useChatStore } from "../../stores/chatStore";
 import { useAiStore } from "../../stores/aiStore";
+import { useUpdateStore } from "../../stores/updateStore";
 import { getAppPlatform } from "../../lib/runtime";
 import { useT } from "../../lib/i18n";
 import { useAppThemeI18nLabel } from "../../lib/i18n/labels";
@@ -27,6 +28,9 @@ export function TitleBarTrayControls() {
   const drawerScope = useChatStore((s) => s.drawerScope);
   const toggleGlobalChat = useChatStore((s) => s.toggleGlobalChat);
   const aiFullyDisabled = useAiStore((s) => s.config?.fully_disabled === true);
+  const updateStatus = useUpdateStore((s) => s.status);
+  const updateVersion = useUpdateStore((s) => s.availableVersion);
+  const openUpdateDialog = useUpdateStore((s) => s.openDialog);
   const t = useT();
   const themeLabel = useAppThemeI18nLabel();
 
@@ -45,8 +49,37 @@ export function TitleBarTrayControls() {
   const chatTitle = chatOpenForGlobal ? t("titlebar.closeGlobalChat") : t("titlebar.openGlobalChat");
   const chatAria = chatOpenForGlobal ? t("titlebar.closeGlobalChatAria") : t("titlebar.openGlobalChatAria");
 
+  // Non-intrusive update hint: a small badge that appears only once a new
+  // version is available (or staged). Clicking it opens the update window —
+  // checks never pop it up on their own.
+  const updatePending = updateStatus === "available" || updateStatus === "ready";
+  const updateTitle = t("titlebar.updateAvailable", { version: updateVersion ?? "" });
+
   return (
     <div className="taomni-titlebar-tray flex items-stretch self-stretch shrink-0" data-testid="titlebar-tray">
+      {updatePending && (
+        <>
+          <div className="taomni-titlebar-tray-group flex items-stretch self-stretch">
+            <TrayButton
+              testId="titlebar-update-available"
+              title={updateTitle}
+              ariaLabel={updateTitle}
+              onClick={openUpdateDialog}
+            >
+              <span className="relative inline-flex">
+                <Download className="w-[16px] h-[16px]" />
+                <span
+                  aria-hidden="true"
+                  className="absolute -top-0.5 -right-0.5 w-[7px] h-[7px] rounded-full"
+                  style={{ background: "#e5534b", boxShadow: "0 0 0 1.5px var(--taomni-chrome-bg)" }}
+                />
+              </span>
+            </TrayButton>
+          </div>
+          <TrayGroupSeparator />
+        </>
+      )}
+
       {/* Voice group */}
       <div className="taomni-titlebar-tray-group flex items-stretch self-stretch">
         <PttButton />

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -362,16 +362,27 @@ export function MainLayout() {
     void refreshVault().catch(() => undefined);
   }, [refreshVault]);
 
-  // Auto-update: silently check shortly after launch (delayed so it doesn't
-  // compete with first render). This only *surfaces* an update — nothing is
-  // downloaded or installed without the user's explicit confirmation. No-op
-  // outside the desktop app.
+  // Auto-update: silently check shortly after launch and then every 6 hours.
+  // Checks are non-intrusive — they only flip the store to "available" so the
+  // title-bar indicator lights up; the update window opens when the user clicks
+  // it (or "Check for updates" in About), never on its own. No-op outside the
+  // desktop app.
   useEffect(() => {
     if (!isTauriRuntime()) return;
-    const handle = window.setTimeout(() => {
-      void useUpdateStore.getState().check();
-    }, 4000);
-    return () => window.clearTimeout(handle);
+    const runCheck = () => {
+      const st = useUpdateStore.getState();
+      // Don't disturb the user mid-flow: skip while the window is open or a
+      // check/download/staged-install is in progress.
+      if (st.dialogOpen) return;
+      if (st.status === "checking" || st.status === "downloading" || st.status === "ready") return;
+      void st.check();
+    };
+    const initial = window.setTimeout(runCheck, 4000);
+    const interval = window.setInterval(runCheck, 6 * 60 * 60 * 1000);
+    return () => {
+      window.clearTimeout(initial);
+      window.clearInterval(interval);
+    };
   }, []);
 
   // Listen for VAULT_LOCKED events emitted by ipc helpers (e.g. when an

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -56,6 +56,7 @@ const dict = {
     cycleTheme: "Theme: {mode} ({resolved}). Click for {next}.",
     cycleThemeAria: "Cycle application theme",
     appThemeAria: "Application theme",
+    updateAvailable: "Update available: {version}. Click to view.",
     enterCompact: "Enter compact mode",
     exitCompact: "Exit compact mode",
     enableSplit: "Enable terminal split view",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -55,6 +55,7 @@ export const zhCN: DeepPartial<typeof en> = {
     cycleTheme: "主题：{mode}（{resolved}）。点击切换到 {next}。",
     cycleThemeAria: "切换应用主题",
     appThemeAria: "应用主题",
+    updateAvailable: "发现新版本：{version}，点击查看。",
     enterCompact: "进入紧凑模式",
     exitCompact: "退出紧凑模式",
     enableSplit: "启用终端分屏视图",

--- a/src/stores/updateStore.test.ts
+++ b/src/stores/updateStore.test.ts
@@ -69,7 +69,7 @@ describe("updateStore.check", () => {
     expect(get().dialogOpen).toBe(true);
   });
 
-  it("surfaces an available update and defaults to the native target", async () => {
+  it("surfaces an available update without auto-opening the window (startup)", async () => {
     mocked.getUpdaterPlatform.mockResolvedValue(platform());
     mocked.checkForUpdate.mockResolvedValue(update());
     await get().check();
@@ -79,9 +79,18 @@ describe("updateStore.check", () => {
     expect(s.notes).toBe("Notes");
     expect(s.selectedTarget).toBe("darwin-aarch64");
     expect(s.targetStatus).toBe("ok");
-    expect(s.dialogOpen).toBe(true);
+    expect(s.dialogOpen).toBe(false); // non-intrusive: indicator only
     expect(mocked.checkForUpdate).toHaveBeenCalledTimes(1);
     expect(mocked.checkForUpdate).toHaveBeenCalledWith("darwin-aarch64");
+  });
+
+  it("opens the window for an available update on a manual check", async () => {
+    mocked.getUpdaterPlatform.mockResolvedValue(platform());
+    mocked.checkForUpdate.mockResolvedValue(update());
+    await get().check({ manual: true });
+    const s = get();
+    expect(s.status).toBe("available");
+    expect(s.dialogOpen).toBe(true);
   });
 
   it("under Rosetta, recommends and validates the native arm64 build", async () => {

--- a/src/stores/updateStore.ts
+++ b/src/stores/updateStore.ts
@@ -105,7 +105,10 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
         availableVersion: found.version,
         currentVersion: found.currentVersion,
         notes: found.notes,
-        dialogOpen: true,
+        // Non-intrusive: startup/periodic checks only light up the title-bar
+        // indicator. Only a manual check (About button) opens the window here;
+        // otherwise the user opens it by clicking the indicator.
+        dialogOpen: manual,
         targetStatus: nativeIsRecommended ? "ok" : "unknown",
       });
       // When we steer the user to a different arch (e.g. Rosetta → native


### PR DESCRIPTION
Startup and periodic checks no longer pop the update window open. They only set the store to "available", which lights up a small red-dotted indicator in the title-bar tray (TitleBarTrayControls, shown in both the normal and compact title bars). Clicking it — or "Check for updates" in About — opens the window. A manual check still opens the window directly (incl. the up-to-date result).

Also add a guarded 6-hour periodic check alongside the ~4s startup check in MainLayout: it skips while the window is open or a check/download/staged install is in progress, so it never disrupts the user.

- store: available status now opens the dialog only on a manual check
- titlebar: update indicator (Download icon + dot) -> openDialog()
- MainLayout: setInterval(6h) + guard next to the startup setTimeout
- i18n: titlebar.updateAvailable (en + zh-CN)
- tests: startup available no longer auto-opens; manual available does