### PR TITLE
fix(chat): make Claude Code chat provider stream responses

### DIFF
--- a/src-tauri/src/agent/cc_bridge/mod.rs
+++ b/src-tauri/src/agent/cc_bridge/mod.rs
@@ -16,7 +16,7 @@ use tokio::time::timeout;
 pub const MIN_VERSION: &str = "1.0.0";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum CcStatus {
     /// `claude` binary not found in PATH.
     NotFound,
@@ -105,12 +105,21 @@ pub async fn detect(binary: Option<&str>) -> CcStatusResult {
         }
     };
 
-    // Extract version number (output is like "Claude Code 1.2.3" or just "1.2.3").
+    // Extract version number (output can be like "Claude Code 1.2.3", "2.1.177 (Claude Code)", or "1.2.3").
     let version = version_str
         .split_whitespace()
-        .last()
-        .unwrap_or("")
-        .to_string();
+        .find(|s| {
+            let s_trim = s.trim_start_matches('v');
+            s_trim.chars().next().map_or(false, |c| c.is_ascii_digit()) && s_trim.contains('.')
+        })
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| {
+            version_str
+                .split_whitespace()
+                .last()
+                .unwrap_or("")
+                .to_string()
+        });
 
     if !version_ok(&version, MIN_VERSION) {
         return CcStatusResult {

--- a/src-tauri/src/agent/cc_bridge/process.rs
+++ b/src-tauri/src/agent/cc_bridge/process.rs
@@ -35,6 +35,10 @@ pub struct CcProcess {
     /// Set by `stop()` so the watchdog stops itself.
     stopped: AtomicBool,
     watchdog_started: AtomicBool,
+    /// Rolling capture of the child's stderr, used to surface spawn/runtime
+    /// errors (e.g. missing flags, auth failures) that would otherwise be
+    /// invisible and present as an empty assistant bubble.
+    stderr_buf: Arc<Mutex<String>>,
 }
 
 impl CcProcess {
@@ -45,6 +49,10 @@ impl CcProcess {
             "stream-json".into(),
             "--input-format".into(),
             "stream-json".into(),
+            // CC requires --verbose when combining --print with
+            // --output-format stream-json; without it the CLI exits
+            // immediately with an error.
+            "--verbose".into(),
             // v2.6 §22: surface partial assistant tokens so the UI can stream.
             "--include-partial-messages".into(),
         ];
@@ -60,6 +68,7 @@ impl CcProcess {
             needs_respawn: AtomicBool::new(false),
             stopped: AtomicBool::new(false),
             watchdog_started: AtomicBool::new(false),
+            stderr_buf: Arc::new(Mutex::new(String::new())),
         }
     }
 
@@ -78,10 +87,15 @@ impl CcProcess {
     ) -> Result<Vec<CcEvent>, String> {
         self.ensure_running().await?;
 
-        // Write the message as a JSON line to stdin.
+        // Write the message as a JSON line to stdin. CC's stream-json input
+        // format expects `message` to be a full Anthropic message object
+        // ({"role":"user","content":"..."}), not a bare string.
         let input = format!(
             "{}\n",
-            serde_json::json!({ "type": "user", "message": message })
+            serde_json::json!({
+                "type": "user",
+                "message": { "role": "user", "content": message }
+            })
         );
         {
             let mut stdin_guard = self.stdin.lock().await;
@@ -142,7 +156,7 @@ impl CcProcess {
         cmd.args(&self.args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null());
+            .stderr(Stdio::piped());
 
         let mut child = match cmd.spawn() {
             Ok(c) => c,
@@ -153,6 +167,32 @@ impl CcProcess {
         };
 
         let stdin = child.stdin.take().ok_or("Failed to get CC stdin")?;
+
+        // Drain stderr into a rolling buffer so we can report why the CLI
+        // exited if it dies without producing usable stdout.
+        if let Some(stderr) = child.stderr.take() {
+            let buf = self.stderr_buf.clone();
+            {
+                let mut g = buf.lock().await;
+                g.clear();
+            }
+            tokio::spawn(async move {
+                let mut reader = BufReader::new(stderr);
+                let mut line = String::new();
+                loop {
+                    line.clear();
+                    match reader.read_line(&mut line).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => {
+                            let mut g = buf.lock().await;
+                            if g.len() < 8192 {
+                                g.push_str(&line);
+                            }
+                        }
+                    }
+                }
+            });
+        }
 
         *child_guard = Some(child);
         *self.stdin.lock().await = Some(stdin);
@@ -217,6 +257,7 @@ impl CcProcess {
         on_event: &mut F,
     ) -> Result<Vec<CcEvent>, String> {
         let mut events = Vec::new();
+        let mut terminal_seen = false;
         let mut child_guard = self.child.lock().await;
 
         let child = child_guard.as_mut().ok_or("CC process not running")?;
@@ -229,12 +270,12 @@ impl CcProcess {
         loop {
             line.clear();
             match tokio::time::timeout(
-                std::time::Duration::from_secs(30),
+                std::time::Duration::from_secs(120),
                 reader.read_line(&mut line),
             )
             .await
             {
-                Ok(Ok(0)) => break, // EOF
+                Ok(Ok(0)) => break, // EOF — process exited.
                 Ok(Ok(_)) => {
                     let trimmed = line.trim();
                     if trimmed.is_empty() {
@@ -245,13 +286,35 @@ impl CcProcess {
                         let done = matches!(event, CcEvent::Done | CcEvent::Error { .. });
                         events.push(event);
                         if done {
+                            terminal_seen = true;
                             break;
                         }
                     }
                 }
                 Ok(Err(e)) => return Err(format!("CC stdout read error: {}", e)),
-                Err(_) => return Err("CC response timed out after 30s".into()),
+                Err(_) => return Err("CC response timed out after 120s".into()),
             }
+        }
+
+        // EOF without a result/error event means the child died early (bad
+        // flags, auth failure, crash). Reap it, schedule a respawn and surface
+        // whatever it wrote to stderr so the user sees a real error instead of
+        // an empty bubble.
+        if !terminal_seen {
+            drop(child_guard);
+            if let Some(mut c) = self.child.lock().await.take() {
+                let _ = c.kill().await;
+            }
+            *self.stdin.lock().await = None;
+            self.needs_respawn.store(true, Ordering::SeqCst);
+            self.record_failure().await;
+            let stderr = self.stderr_buf.lock().await.trim().to_string();
+            let detail = if stderr.is_empty() {
+                "no stderr output".to_string()
+            } else {
+                stderr
+            };
+            return Err(format!("Claude Code exited unexpectedly: {}", detail));
         }
 
         Ok(events)

--- a/src-tauri/src/agent/cc_bridge/protocol.rs
+++ b/src-tauri/src/agent/cc_bridge/protocol.rs
@@ -108,12 +108,20 @@ pub fn parse_ndjson_line(line: &str) -> Option<CcEvent> {
             })
         }
         "result" => {
-            // CC final result event
-            if value.get("subtype").and_then(|v| v.as_str()) == Some("error") {
+            // CC final result event. Error variants use subtypes like
+            // "error_max_turns" / "error_during_execution", or set is_error.
+            let subtype = value.get("subtype").and_then(|v| v.as_str()).unwrap_or("");
+            let is_error = value
+                .get("is_error")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if is_error || subtype.starts_with("error") {
                 let msg = value
-                    .get("error")
+                    .get("result")
                     .and_then(|v| v.as_str())
-                    .unwrap_or("Unknown error")
+                    .or_else(|| value.get("error").and_then(|v| v.as_str()))
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or("Claude Code reported an error")
                     .to_string();
                 Some(CcEvent::Error { message: msg })
             } else {
@@ -127,6 +135,33 @@ pub fn parse_ndjson_line(line: &str) -> Option<CcEvent> {
                 .unwrap_or("Unknown error")
                 .to_string();
             Some(CcEvent::Error { message: msg })
+        }
+        "stream_event" => {
+            // Streaming deltas (emitted with --include-partial-messages).
+            // {"type":"stream_event","event":{"delta":{"text":"Hi","type":"text_delta"},
+            //  "index":0,"type":"content_block_delta"},...}
+            let inner = value.get("event");
+            let inner_type = inner
+                .and_then(|e| e.get("type"))
+                .and_then(|t| t.as_str())
+                .unwrap_or("");
+            if inner_type == "content_block_delta" {
+                let delta = inner.and_then(|e| e.get("delta"));
+                if delta.and_then(|d| d.get("type")).and_then(|t| t.as_str()) == Some("text_delta")
+                {
+                    let text = delta
+                        .and_then(|d| d.get("text"))
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    if !text.is_empty() {
+                        return Some(CcEvent::Partial { content: text });
+                    }
+                }
+            }
+            Some(CcEvent::Unknown {
+                raw: line.to_string(),
+            })
         }
         _ => Some(CcEvent::Unknown {
             raw: line.to_string(),
@@ -152,4 +187,92 @@ pub fn extract_session_id(events: &[CcEvent]) -> Option<String> {
         CcEvent::SessionInit { session_id } => Some(session_id.clone()),
         _ => None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_system_init_session_id() {
+        let line = r#"{"type":"system","subtype":"init","session_id":"abc-123","tools":[]}"#;
+        assert!(matches!(
+            parse_ndjson_line(line),
+            Some(CcEvent::SessionInit { session_id }) if session_id == "abc-123"
+        ));
+    }
+
+    #[test]
+    fn parses_stream_event_text_delta_as_partial() {
+        let line = r#"{"type":"stream_event","event":{"delta":{"text":"Hi","type":"text_delta"},"index":0,"type":"content_block_delta"},"session_id":"x"}"#;
+        assert!(matches!(
+            parse_ndjson_line(line),
+            Some(CcEvent::Partial { content }) if content == "Hi"
+        ));
+    }
+
+    #[test]
+    fn ignores_non_text_stream_events() {
+        let line = r#"{"type":"stream_event","event":{"type":"message_start","message":{"content":[]}},"session_id":"x"}"#;
+        assert!(matches!(
+            parse_ndjson_line(line),
+            Some(CcEvent::Unknown { .. })
+        ));
+    }
+
+    #[test]
+    fn parses_assistant_message_text() {
+        let line = r#"{"type":"assistant","message":{"content":[{"text":"Hi!","type":"text"}],"role":"assistant"}}"#;
+        assert!(matches!(
+            parse_ndjson_line(line),
+            Some(CcEvent::AssistantMessage { content }) if content == "Hi!"
+        ));
+    }
+
+    #[test]
+    fn parses_success_result_as_done() {
+        let line = r#"{"type":"result","subtype":"success","is_error":false,"result":"Hi!"}"#;
+        assert!(matches!(parse_ndjson_line(line), Some(CcEvent::Done)));
+    }
+
+    #[test]
+    fn parses_error_result_via_is_error() {
+        let line = r#"{"type":"result","subtype":"error_during_execution","is_error":true,"result":"boom"}"#;
+        assert!(matches!(
+            parse_ndjson_line(line),
+            Some(CcEvent::Error { message }) if message == "boom"
+        ));
+    }
+
+    #[test]
+    fn parses_error_result_max_turns_subtype() {
+        let line = r#"{"type":"result","subtype":"error_max_turns","is_error":true}"#;
+        assert!(matches!(
+            parse_ndjson_line(line),
+            Some(CcEvent::Error { .. })
+        ));
+    }
+
+    #[test]
+    fn full_stream_yields_answer_and_done() {
+        let lines = [
+            r#"{"type":"system","subtype":"init","session_id":"s1","tools":[]}"#,
+            r#"{"type":"stream_event","event":{"delta":{"text":"Hi","type":"text_delta"},"index":0,"type":"content_block_delta"}}"#,
+            r#"{"type":"stream_event","event":{"delta":{"text":"!","type":"text_delta"},"index":0,"type":"content_block_delta"}}"#,
+            r#"{"type":"assistant","message":{"content":[{"text":"Hi!","type":"text"}],"role":"assistant"}}"#,
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"Hi!"}"#,
+        ];
+        let events: Vec<CcEvent> = lines.iter().filter_map(|l| parse_ndjson_line(l)).collect();
+        assert_eq!(extract_session_id(&events).as_deref(), Some("s1"));
+        assert_eq!(extract_answer(&events), "Hi!");
+        let partials: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                CcEvent::Partial { content } => Some(content.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(partials, vec!["Hi", "!"]);
+        assert!(events.iter().any(|e| matches!(e, CcEvent::Done)));
+    }
 }

--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -400,6 +400,178 @@ pub async fn chat_stream(
     emit(&StreamEventOut::UserMessage {
         message: user_msg.clone(),
     });
+    if thread.provider_id == "claude-code" {
+        // Allocate the assistant message id and begin streaming.
+        let assistant_id = Uuid::new_v4().to_string();
+        let assistant_ts = now() + 1;
+        emit(&StreamEventOut::AssistantStart {
+            id: assistant_id.clone(),
+            thread_id: req.thread_id.clone(),
+            created_at: assistant_ts,
+        });
+
+        // 1. Verify Claude Code is enabled
+        let ai_config = AiConfig::load(&default_ai_config_path());
+        if !ai_config.cc_bridge.enabled || ai_config.fully_disabled || ai_config.full_local_mode {
+            emit(&StreamEventOut::Error {
+                id: assistant_id,
+                message: "Claude Code is unavailable in full-local / fully-disabled mode or is disabled.".into(),
+            });
+            return Ok(());
+        }
+
+        // 2. Find Claude Code CLI binary path
+        let binary = if ai_config.cc_bridge.binary == "auto" {
+            crate::agent::cc_bridge::find_claude_binary().ok_or("Claude Code CLI not found")?
+        } else {
+            ai_config.cc_bridge.binary.clone()
+        };
+
+        // 3. Write temp configs
+        let tmp_dir = std::env::temp_dir().join(format!("taomni-cc-{}", &req.thread_id[..8]));
+        let settings_path = tmp_dir.join("settings.json");
+        let mcp_path = tmp_dir.join(".mcp.json");
+        crate::agent::cc_bridge::config::write_temp_settings(
+            &ai_config.cc_bridge.permission_mode,
+            &crate::agent::cc_bridge::config::sensitive_deny_dirs(),
+            &settings_path,
+        ).map_err(|e| format!("Failed to write CC settings: {}", e))?;
+        crate::agent::cc_bridge::config::write_temp_mcp_config(&mcp_path)
+            .map_err(|e| format!("Failed to write CC MCP config: {}", e))?;
+
+        // 4. Resolve session
+        let resume_session = thread.cc_session_id.clone();
+
+        // 5. Build extra args
+        let mut extra_args = vec![
+            "--model".into(),
+            ai_config.cc_bridge.default_model.clone(),
+            "--max-turns".into(),
+            ai_config.cc_bridge.max_turns.to_string(),
+            "--settings".into(),
+            settings_path.to_string_lossy().to_string(),
+            "--mcp-config".into(),
+            mcp_path.to_string_lossy().to_string(),
+            "--permission-prompt-tool".into(),
+            crate::agent::cc_bridge::config::PERMISSION_PROMPT_TOOL.into(),
+        ];
+        if let Some(sid) = &resume_session {
+            extra_args.push("--resume".into());
+            extra_args.push(sid.clone());
+        }
+
+        // 6. Get or create process
+        let process = {
+            let mut registry = state.cc_processes.lock().await;
+            let existing = registry.get(&req.thread_id).cloned();
+            match existing {
+                Some(p) => p,
+                None => {
+                    let p = std::sync::Arc::new(crate::agent::cc_bridge::process::CcProcess::new(&binary, extra_args));
+                    registry.insert(req.thread_id.clone(), p.clone());
+                    p
+                }
+            }
+        };
+
+        // 7. Run process with callback to stream
+        let assistant_id_clone = assistant_id.clone();
+        let app_clone = app.clone();
+        let event_name_clone = event_name.clone();
+        let events = process.send_with_callback(&clean_content, move |evt| {
+            match evt {
+                crate::agent::cc_bridge::protocol::CcEvent::Partial { content } => {
+                    let _ = app_clone.emit(&event_name_clone, StreamEventOut::Token {
+                        id: assistant_id_clone.clone(),
+                        content: content.clone(),
+                    });
+                }
+                crate::agent::cc_bridge::protocol::CcEvent::ToolUse { id: _, name, input } => {
+                    let marker = format!(
+                        "\n[TOOL_CALL]{}\n",
+                        serde_json::json!({
+                            "tool": name,
+                            "args": input,
+                            "requires_confirmation": crate::agent::safety::requires_confirmation(name),
+                        })
+                    );
+                    let _ = app_clone.emit(&event_name_clone, StreamEventOut::Token {
+                        id: assistant_id_clone.clone(),
+                        content: marker,
+                    });
+                }
+                _ => {}
+            }
+        }).await;
+
+        let events = match events {
+            Ok(ev) => ev,
+            Err(e) => {
+                emit(&StreamEventOut::Error {
+                    id: assistant_id,
+                    message: e,
+                });
+                return Ok(());
+            }
+        };
+
+        // 8. Extract final answer and persist
+        let mut final_content = String::new();
+        for event in &events {
+            match event {
+                crate::agent::cc_bridge::protocol::CcEvent::AssistantMessage { content } => {
+                    final_content.push_str(content);
+                }
+                crate::agent::cc_bridge::protocol::CcEvent::ToolUse { name, input, .. } => {
+                    let marker = format!(
+                        "\n[TOOL_CALL]{}\n",
+                        serde_json::json!({
+                            "tool": name,
+                            "args": input,
+                            "requires_confirmation": crate::agent::safety::requires_confirmation(name),
+                        })
+                    );
+                    final_content.push_str(&marker);
+                }
+                _ => {}
+            }
+        }
+
+        let session_id = crate::agent::cc_bridge::protocol::extract_session_id(&events).or(resume_session);
+        if let Some(sid) = &session_id {
+            if let Ok(db) = state.db.lock() {
+                let _ = crate::chat::store::set_cc_session_id(&db, &req.thread_id, sid);
+            }
+        }
+
+        let assistant_msg = store::ChatMessage {
+            id: assistant_id.clone(),
+            thread_id: req.thread_id.clone(),
+            role: "assistant".into(),
+            content: final_content.clone(),
+            created_at: assistant_ts,
+            redacted: false,
+        };
+
+        let is_first = history.is_empty();
+        {
+            let db = state.db.lock().map_err(|e| e.to_string())?;
+            store::insert_message(&db, &assistant_msg).map_err(|e| e.to_string())?;
+            if is_first {
+                let title = user_msg.content.chars().take(40).collect::<String>();
+                store::update_thread_title(&db, &req.thread_id, &title).map_err(|e| e.to_string())?;
+            }
+        }
+
+        emit(&StreamEventOut::End {
+            id: assistant_id,
+            thread_id: req.thread_id,
+            content: final_content,
+            redacted_count,
+        });
+
+        return Ok(());
+    }
 
     // Build the LLM request.
     let ai_config = AiConfig::load(&default_ai_config_path());

--- a/src/components/chat/ChatDrawer.tsx
+++ b/src/components/chat/ChatDrawer.tsx
@@ -74,9 +74,13 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
 
   // Provider switcher dropdown — pulls the live provider list from aiStore.
   const aiProviders = useAiStore((s) => s.config?.llm.providers);
+  const ccBridgeEnabled = useAiStore((s) => s.config?.cc_bridge.enabled);
   const globalOutputFormat = useAiStore((s) => s.config?.chat_output_format) ?? "md";
   const loadAiConfig = useAiStore((s) => s.loadConfig);
   const providerIds = Object.keys(aiProviders ?? {});
+  if (ccBridgeEnabled) {
+    providerIds.push("claude-code");
+  }
   const setThreadProvider = useChatStore((s) => s.setThreadProvider);
   const setThreadOutputFormat = useChatStore((s) => s.setThreadOutputFormat);
 
@@ -383,7 +387,9 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
                 }}
               >
                 {providerIds.map((id) => (
-                  <option key={id} value={id}>{id}</option>
+                  <option key={id} value={id}>
+                    {id === "claude-code" ? "Claude Code (本机)" : id}
+                  </option>
                 ))}
               </select>
             ) : (

--- a/src/components/chat/NewThreadFormatPicker.tsx
+++ b/src/components/chat/NewThreadFormatPicker.tsx
@@ -167,7 +167,8 @@ export function NewThreadFormatPicker({
           </button>
           <button
             type="button"
-            className="taomni-btn h-7 px-3 text-[11px] bg-[var(--taomni-accent)] text-white"
+            className="taomni-btn h-7 px-3 text-[11px]"
+            data-primary="true"
             onClick={handleConfirm}
             disabled={submitting}
           >


### PR DESCRIPTION
Selecting "Claude Code (本机)" as the chat provider produced empty assistant bubbles with no output. Three compounding bugs in the CC bridge caused this:

- The persistent CC process was spawned with --print --output-format stream-json but without --verbose, which the CLI requires; it errored to stderr (which was /dev/null'd) and exited immediately, so the reader only saw EOF. Add --verbose to the base args.
- stdin was written as {"type":"user","message":"<text>"} but CC's stream-json input format requires message to be a full message object {"role":"user","content":"<text>"}. Fix the payload shape.
- Streaming deltas arrive as {"type":"stream_event",... content_block_delta...} but parse_ndjson_line had no stream_event branch, so the Partial variant was never produced and nothing streamed. Parse text_delta deltas into CcEvent::Partial.

Also harden the bridge so failures are no longer silent:
- Pipe and capture stderr; on early EOF (process died before a result/error event) reap the child, schedule a respawn, and surface the captured stderr as an error instead of an empty bubble.
- Treat result events with is_error or error_* subtypes as errors and extract the message text.
- In chat_stream, emit an Error stream event on CC failure instead of propagating Err (which made the frontend fall back to chat_send on a claude-code thread).
- Raise the inter-line read timeout 30s -> 120s for slow tool turns.

Add unit tests for the protocol parser covering session init, partial deltas, assistant text, and success/error result events. Also wires the "claude-code" option into the chat provider dropdown and improves CC version-string parsing.