### PR TITLE
fix(macos): bundle krb5 dylibs so the app is self-contained

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ tarpaulin-report.*
 flamegraph.svg
 perf.data*
 
+# krb5 dylibs staged by scripts/bundle-krb5-macos.sh (bundled into the macOS app)
+src-tauri/frameworks/
+
 # =============================================================================
 # Node
 # =============================================================================

--- a/scripts/bundle-krb5-macos.sh
+++ b/scripts/bundle-krb5-macos.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Make the macOS app self-contained w.r.t. MIT Kerberos (krb5).
+#
+# The default `hbase-kerberos` feature links cross-krb5 -> libgssapi, which on
+# macOS dynamically links Homebrew's keg-only krb5 at an ABSOLUTE path
+# (/usr/local/opt/krb5/... on Intel, /opt/homebrew/opt/krb5/... on Apple Silicon).
+# That path is baked into the binary with no @rpath fallback and the dylibs are
+# not shipped, so the app aborts at launch (dyld "Library missing" / SIGABRT) on
+# any machine lacking that exact Homebrew keg. This copies the krb5 dependency
+# closure into src-tauri/frameworks/ (bundled into Taomni.app/Contents/Frameworks
+# via bundle.macOS.frameworks), rewrites every install name / cross-reference to
+# @rpath, ad-hoc signs them (required on Apple Silicon), and rewrites the compiled
+# binary's krb5 load command to @rpath. With the @executable_path/../Frameworks
+# rpath added in build.rs, krb5 resolves from inside the bundle.
+#
+# Two phases, because tauri_build::build() validates bundle.macOS.frameworks at
+# COMPILE time (in build.rs), before the binary exists:
+#   stage  - copy + fix + sign the dylibs   (tauri.conf beforeBuildCommand, pre-compile)
+#   fixbin - rewrite + sign the executable  (tauri.conf beforeBundleCommand, post-compile)
+set -euo pipefail
+
+# macOS only; Linux/Windows bundles ignore bundle.macOS.frameworks.
+[ "$(uname -s)" = "Darwin" ] || exit 0
+
+MODE="${1:-all}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+TAURI_DIR="$ROOT_DIR/src-tauri"
+DEST_DIR="$TAURI_DIR/frameworks"
+
+# krb5 dependency closure of libgssapi_krb5 (verified: these 5 + only system libs).
+# Keep in sync with bundle.macOS.frameworks in tauri.conf.json.
+DYLIBS=(
+  libgssapi_krb5.2.2.dylib
+  libkrb5.3.3.dylib
+  libk5crypto.3.1.dylib
+  libcom_err.3.0.dylib
+  libkrb5support.1.1.dylib
+)
+
+is_known() { local b="$1" k; for k in "${DYLIBS[@]}"; do [ "$b" = "$k" ] && return 0; done; return 1; }
+
+# Rewrite any absolute load path whose basename is one of our dylibs to @rpath.
+retarget_to_rpath() {
+  local file="$1" dep base
+  while IFS= read -r dep; do
+    case "$dep" in
+      /*) base="$(basename "$dep")"; if is_known "$base"; then install_name_tool -change "$dep" "@rpath/$base" "$file"; fi ;;
+    esac
+  done < <(otool -L "$file" | tail -n +2 | awk '{print $1}')
+  return 0
+}
+
+stage_dylibs() {
+  local prefix="${LIBGSSAPI_PREFIX:-}" name src
+  [ -n "$prefix" ] || prefix="$(brew --prefix krb5 2>/dev/null || true)"
+  if [ -z "$prefix" ] || [ ! -d "$prefix/lib" ]; then
+    echo "bundle-krb5: cannot locate krb5 (set LIBGSSAPI_PREFIX or 'brew install krb5')." >&2
+    exit 1
+  fi
+  echo "bundle-krb5[stage]: $prefix/lib -> $DEST_DIR"
+  rm -rf "$DEST_DIR"; mkdir -p "$DEST_DIR"
+  for name in "${DYLIBS[@]}"; do
+    src="$prefix/lib/$name"
+    if [ ! -f "$src" ]; then
+      echo "bundle-krb5: expected dylib not found: $src" >&2
+      echo "bundle-krb5: krb5 soname versions likely changed; update DYLIBS here and bundle.macOS.frameworks in tauri.conf.json." >&2
+      exit 1
+    fi
+    cp -f "$src" "$DEST_DIR/$name"; chmod u+w "$DEST_DIR/$name"
+    install_name_tool -id "@rpath/$name" "$DEST_DIR/$name"
+  done
+  for name in "${DYLIBS[@]}"; do
+    retarget_to_rpath "$DEST_DIR/$name"
+    codesign --force --sign - "$DEST_DIR/$name"
+  done
+}
+
+fix_binary() {
+  local triple="${TAURI_ENV_TARGET_TRIPLE:-}" bin="" c
+  if [ -z "$triple" ]; then
+    case "${TAURI_ENV_ARCH:-}" in
+      x86_64) triple="x86_64-apple-darwin" ;;
+      aarch64|arm64) triple="aarch64-apple-darwin" ;;
+    esac
+  fi
+  for c in "${triple:+$TAURI_DIR/target/$triple/release/taomni}" "$TAURI_DIR/target/release/taomni"; do
+    [ -n "$c" ] && [ -f "$c" ] && { bin="$c"; break; }
+  done
+  if [ -z "$bin" ]; then
+    echo "bundle-krb5: could not locate compiled 'taomni' binary under src-tauri/target." >&2
+    exit 1
+  fi
+  echo "bundle-krb5[fixbin]: $bin"
+  retarget_to_rpath "$bin"
+  codesign --force --sign - "$bin"
+}
+
+case "$MODE" in
+  stage) stage_dylibs ;;
+  fixbin) fix_binary ;;
+  all) stage_dylibs; fix_binary ;;
+  *) echo "usage: $(basename "$0") [stage|fixbin|all]" >&2; exit 2 ;;
+esac
+echo "bundle-krb5: done ($MODE)."

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -4,7 +4,20 @@ use std::path::Path;
 fn main() {
     enforce_asr_llm_isolation();
     compile_hbase_protos();
+    configure_macos_rpath();
     tauri_build::build();
+}
+
+/// On macOS, add an `@executable_path/../Frameworks` rpath so the krb5 dylibs
+/// bundled into `Taomni.app/Contents/Frameworks` resolve at runtime. The default
+/// `hbase-kerberos` feature links libgssapi against Homebrew's keg-only krb5,
+/// whose absolute path is otherwise baked into the binary; scripts/bundle-krb5-macos.sh
+/// rewrites those load commands to `@rpath/...`, and this rpath is where dyld
+/// finds them inside the bundle.
+fn configure_macos_rpath() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-link-arg-bins=-Wl,-rpath,@executable_path/../Frameworks");
+    }
 }
 
 /// Compile the vendored HBase 2.6.x protobuf definitions into Rust types for

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,8 +6,9 @@
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
-    "beforeDevCommand": "pnpm dev",
-    "beforeBuildCommand": "pnpm build"
+    "beforeDevCommand": "bash scripts/bundle-krb5-macos.sh stage && pnpm dev",
+    "beforeBuildCommand": "pnpm build && bash scripts/bundle-krb5-macos.sh stage",
+    "beforeBundleCommand": "bash scripts/bundle-krb5-macos.sh fixbin"
   },
   "app": {
     "withGlobalTauri": true,
@@ -39,7 +40,16 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "frameworks": [
+        "frameworks/libgssapi_krb5.2.2.dylib",
+        "frameworks/libkrb5.3.3.dylib",
+        "frameworks/libk5crypto.3.1.dylib",
+        "frameworks/libcom_err.3.0.dylib",
+        "frameworks/libkrb5support.1.1.dylib"
+      ]
+    }
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
The default hbase-kerberos feature links cross-krb5 -> libgssapi against Homebrew's keg-only krb5 at an absolute path with no @rpath fallback, and the dylibs were not shipped. The app therefore aborted at launch (dyld "Library missing" / SIGABRT) on any Mac lacking that exact Homebrew keg.

Stage the krb5 dependency closure (libgssapi_krb5, libkrb5, libk5crypto, libcom_err, libkrb5support) into Taomni.app/Contents/Frameworks via bundle.macOS.frameworks, rewriting their install names and cross-references to @rpath and ad-hoc signing them, and rewrite the compiled binary's krb5 load command to @rpath (scripts/bundle-krb5-macos.sh). build.rs adds an @executable_path/../Frameworks rpath so dyld resolves them from inside the bundle.

Dylibs are staged in beforeBuildCommand because tauri_build validates bundle.macOS.frameworks at compile time; the binary load command is rewritten in beforeBundleCommand after compilation.