### PR TITLE
feat: object storage (S3 / OSS / Azure Blob) sessions and management

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4545,6 +4545,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6510,7 +6551,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -6587,6 +6628,21 @@ dependencies = [
  "cpubits",
  "cpufeatures 0.3.0",
  "universal-hash 0.6.1",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -6831,6 +6887,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -7795,6 +7862,25 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-s3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ec4851cde7bd44c6b1dbd7e68f70ac50f9dec29bb1f1ffd69426578af02d6b"
+dependencies = [
+ "base64 0.22.1",
+ "hmac 0.13.0",
+ "jiff",
+ "md-5 0.11.0",
+ "percent-encoding",
+ "quick-xml 0.39.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "url",
+ "zeroize",
+]
 
 [[package]]
 name = "ryu"
@@ -9263,9 +9349,11 @@ dependencies = [
  "generic-array 1.4.3",
  "heck 0.5.0",
  "hex",
+ "hmac 0.13.0",
  "ironrdp",
  "ironrdp-tls",
  "ironrdp-tokio",
+ "jiff",
  "keyring",
  "keyring-core",
  "libc",
@@ -9277,6 +9365,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "quick-xml 0.40.1",
  "rand 0.10.1",
  "rcgen",
  "redis",
@@ -9288,6 +9377,7 @@ dependencies = [
  "russh",
  "russh-sftp",
  "rustls",
+ "rusty-s3",
  "serde",
  "serde_json",
  "serde_yml",
@@ -10923,7 +11013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.4",
  "quote",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -108,6 +108,10 @@ zookeeper-client = { version = "0.11", features = ["tokio"] }
 # Cross-platform GSSAPI/Kerberos for native HBase secure (kerberos) auth. Behind
 # the `hbase-kerberos` feature so the default build needs no system GSSAPI libs.
 cross-krb5 = { version = "0.5", optional = true }
+rusty-s3 = "0.9.1"
+quick-xml = { version = "0.40.1", features = ["serialize"] }
+jiff = "0.2"
+hmac = "0.13.0"
 
 [patch.crates-io]
 ironrdp-connector = { path = "vendor/ironrdp-connector" }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ pub mod llm;
 mod migrate;
 pub mod models;
 mod nettools;
+mod objectstorage;
 pub mod perf;
 mod proxy;
 mod rdp;
@@ -235,6 +236,28 @@ pub fn run() {
             hbase::hbase_execute,
             hbase::hbase_parse_site_xml,
             hbase::hbase_parse_keytab_principal,
+            objectstorage::storage_attach,
+            objectstorage::storage_detach,
+            objectstorage::storage_ping,
+            objectstorage::storage_test_connection,
+            objectstorage::storage_list_buckets,
+            objectstorage::storage_list_objects,
+            objectstorage::storage_get_object_bytes,
+            objectstorage::storage_put_object_bytes,
+            objectstorage::storage_delete_object,
+            objectstorage::storage_create_folder,
+            objectstorage::storage_create_bucket,
+            objectstorage::storage_delete_bucket,
+            objectstorage::storage_delete_prefix,
+            objectstorage::storage_head_object,
+            objectstorage::storage_copy_object,
+            objectstorage::storage_move_object,
+            objectstorage::storage_share_url,
+            objectstorage::storage_download,
+            objectstorage::storage_upload,
+            objectstorage::storage_cancel_transfer,
+            objectstorage::storage_pause_transfer,
+            objectstorage::storage_resume_transfer,
             history::history_append,
             history::history_match_prefix,
             history::history_list_recent,

--- a/src-tauri/src/objectstorage/azure.rs
+++ b/src-tauri/src/objectstorage/azure.rs
@@ -1,0 +1,909 @@
+//! Azure Blob engine: raw HTTPS over the shared reqwest client + quick-xml,
+//! with a hand-written Shared Key signer (the official SDK only supports Entra
+//! ID natively). SAS auth appends the token to the URL instead of signing.
+//! Verified against Azurite. Mirrors the S3 client's operation surface so the
+//! command layer can dispatch on `OssHandle` uniformly.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+use base64::Engine as _;
+use hmac::{Hmac, KeyInit, Mac};
+use reqwest::Client;
+use serde::Deserialize;
+use sha2::Sha256;
+use tauri::{AppHandle, Runtime};
+use url::Url;
+
+use super::types::{BucketEntry, ObjectEntry, ObjectListPage, ObjectMetadata};
+use crate::filebrowser::transfer::TransferHandle;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const MS_VERSION: &str = "2021-12-02";
+
+/// How a request is authorized.
+pub enum AzureAuth {
+    /// Shared Key: the decoded (raw) account key, HMAC-signed per request.
+    SharedKey(Vec<u8>),
+    /// A SAS token (query string, without the leading '?') appended to the URL.
+    Sas(String),
+    /// An Entra ID (Azure AD) OAuth2 access token, sent as `Authorization:
+    /// Bearer`. Scoped to `https://storage.azure.com/`. Cannot mint a service
+    /// SAS (that needs the account key or a user-delegation key), so `share_url`
+    /// is unavailable under this auth.
+    Bearer(String),
+}
+
+pub struct AzureClient {
+    http: Client,
+    account: String,
+    /// Service base, e.g. `https://acct.blob.core.windows.net` (subdomain) or
+    /// `http://127.0.0.1:10000/devstoreaccount1` (Azurite path-style).
+    base: Url,
+    auth: AzureAuth,
+}
+
+/// Derive the blob service base URL from account + optional explicit endpoint /
+/// suffix. An explicit endpoint (e.g. Azurite's BlobEndpoint) wins.
+pub fn azure_base_url(
+    account: &str,
+    endpoint: Option<&str>,
+    endpoint_suffix: Option<&str>,
+) -> Result<Url, String> {
+    let raw = match endpoint.filter(|e| !e.is_empty()) {
+        Some(e) => e.to_string(),
+        None => {
+            let suffix = endpoint_suffix.filter(|s| !s.is_empty()).unwrap_or("core.windows.net");
+            format!("https://{account}.blob.{suffix}")
+        }
+    };
+    Url::parse(raw.trim_end_matches('/')).map_err(|e| format!("invalid azure endpoint: {e}"))
+}
+
+/// Parse an Azure storage connection string into (account, base_url, auth).
+pub fn parse_connection_string(cs: &str) -> Result<(String, Url, AzureAuth), String> {
+    let mut account = None;
+    let mut key = None;
+    let mut sas = None;
+    let mut blob_endpoint = None;
+    let mut suffix = None;
+    let mut protocol = "https";
+    for part in cs.split(';') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (k, v) = part.split_once('=').ok_or("malformed connection string")?;
+        match k.trim().to_ascii_lowercase().as_str() {
+            "accountname" => account = Some(v.trim().to_string()),
+            "accountkey" => key = Some(v.trim().to_string()),
+            "sharedaccesssignature" => sas = Some(v.trim().trim_start_matches('?').to_string()),
+            "blobendpoint" => blob_endpoint = Some(v.trim().to_string()),
+            "endpointsuffix" => suffix = Some(v.trim().to_string()),
+            "defaultendpointsprotocol" => protocol = if v.trim().eq_ignore_ascii_case("http") { "http" } else { "https" },
+            _ => {}
+        }
+    }
+    let account = account.ok_or("connection string missing AccountName")?;
+    let base = match blob_endpoint {
+        Some(e) => Url::parse(e.trim_end_matches('/')).map_err(|e| format!("invalid BlobEndpoint: {e}"))?,
+        None => {
+            let suffix = suffix.unwrap_or_else(|| "core.windows.net".into());
+            Url::parse(&format!("{protocol}://{account}.blob.{suffix}"))
+                .map_err(|e| format!("invalid derived endpoint: {e}"))?
+        }
+    };
+    let auth = if let Some(sas) = sas {
+        AzureAuth::Sas(sas)
+    } else if let Some(k) = key {
+        AzureAuth::SharedKey(decode_account_key(&k)?)
+    } else {
+        return Err("connection string needs AccountKey or SharedAccessSignature".into());
+    };
+    Ok((account, base, auth))
+}
+
+/// Base64-decode an account key into its raw bytes for HMAC signing.
+pub fn decode_account_key(key: &str) -> Result<Vec<u8>, String> {
+    base64::engine::general_purpose::STANDARD
+        .decode(key.trim())
+        .map_err(|e| format!("account key is not valid base64: {e}"))
+}
+
+/// Obtain an Entra ID (Azure AD) access token for the Blob service. A pasted
+/// token wins; otherwise we shell out to the Azure CLI
+/// (`az account get-access-token --resource https://storage.azure.com/`), which
+/// uses whatever identity the user is signed into (`az login`). Requires `az`
+/// on PATH. Dependency-free — no `azure_identity` SDK.
+pub async fn acquire_bearer_token(pasted: Option<&str>) -> Result<String, String> {
+    if let Some(t) = pasted.map(str::trim).filter(|t| !t.is_empty()) {
+        return Ok(t.to_string());
+    }
+    let output = tokio::process::Command::new("az")
+        .args([
+            "account",
+            "get-access-token",
+            "--resource",
+            "https://storage.azure.com/",
+            "--output",
+            "json",
+        ])
+        .output()
+        .await
+        .map_err(|e| {
+            format!(
+                "no access token provided and the Azure CLI (`az`) is not available to obtain \
+                 one: {e}"
+            )
+        })?;
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "`az account get-access-token` failed (run `az login` first?): {}",
+            err.trim()
+        ));
+    }
+    #[derive(Deserialize)]
+    struct Token {
+        #[serde(rename = "accessToken")]
+        access_token: String,
+    }
+    let token: Token = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("could not parse `az` token output: {e}"))?;
+    if token.access_token.is_empty() {
+        return Err("Azure CLI returned an empty access token".into());
+    }
+    Ok(token.access_token)
+}
+
+impl AzureClient {
+    pub fn new(http: Client, account: String, base: Url, auth: AzureAuth) -> Self {
+        Self { http, account, base, auth }
+    }
+
+    fn base_str(&self) -> &str {
+        self.base.as_str().trim_end_matches('/')
+    }
+
+    /// Build a request URL from a relative path (container or container/blob)
+    /// and query params, percent-encoding values correctly.
+    fn build(&self, rel_path: &str, query: &[(&str, &str)]) -> Url {
+        let mut s = String::from(self.base_str());
+        if !rel_path.is_empty() {
+            s.push('/');
+            s.push_str(rel_path);
+        }
+        let mut u = Url::parse(&s).expect("valid azure url");
+        if !query.is_empty() {
+            let mut qp = u.query_pairs_mut();
+            for (k, v) in query {
+                qp.append_pair(k, v);
+            }
+        }
+        u
+    }
+
+    /// Compute the `Authorization: SharedKey ...` header value for a request.
+    fn sign(
+        &self,
+        key: &[u8],
+        verb: &str,
+        url: &Url,
+        ms_headers: &[(String, String)],
+        content_length: usize,
+        content_type: &str,
+    ) -> String {
+        let mut ms: Vec<(String, String)> = ms_headers
+            .iter()
+            .filter(|(k, _)| k.starts_with("x-ms-"))
+            .map(|(k, v)| (k.to_ascii_lowercase(), v.trim().to_string()))
+            .collect();
+        ms.sort_by(|a, b| a.0.cmp(&b.0));
+        let canon_headers: String = ms.iter().map(|(k, v)| format!("{k}:{v}\n")).collect();
+
+        let mut canon_resource = format!("/{}{}", self.account, url.path());
+        let mut qp: Vec<(String, String)> = url
+            .query_pairs()
+            .map(|(k, v)| (k.to_ascii_lowercase(), v.into_owned()))
+            .collect();
+        qp.sort_by(|a, b| a.0.cmp(&b.0));
+        for (k, v) in &qp {
+            canon_resource.push_str(&format!("\n{k}:{v}"));
+        }
+
+        let cl = if content_length == 0 {
+            String::new()
+        } else {
+            content_length.to_string()
+        };
+        // VERB, Content-Encoding, Content-Language, Content-Length, Content-MD5,
+        // Content-Type, Date, If-Modified-Since, If-Match, If-None-Match,
+        // If-Unmodified-Since, Range — Date is empty because x-ms-date is used.
+        let head = [
+            verb, "", "", &cl, "", content_type, "", "", "", "", "", "",
+        ]
+        .join("\n");
+        let string_to_sign = format!("{head}\n{canon_headers}{canon_resource}");
+
+        let mut mac = HmacSha256::new_from_slice(key).expect("hmac accepts any key length");
+        mac.update(string_to_sign.as_bytes());
+        let sig = base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+        format!("SharedKey {}:{}", self.account, sig)
+    }
+
+    /// Execute a request with the configured auth (Shared Key signing, or SAS
+    /// appended to the URL).
+    async fn send(
+        &self,
+        verb: reqwest::Method,
+        url: Url,
+        body: Option<Vec<u8>>,
+        extra_ms_headers: &[(&str, &str)],
+        content_type: Option<&str>,
+    ) -> Result<reqwest::Response, String> {
+        let date = chrono::Utc::now()
+            .format("%a, %d %b %Y %H:%M:%S GMT")
+            .to_string();
+        let mut headers: Vec<(String, String)> = vec![
+            ("x-ms-date".to_string(), date),
+            ("x-ms-version".to_string(), MS_VERSION.to_string()),
+        ];
+        for (k, v) in extra_ms_headers {
+            headers.push((k.to_string(), v.to_string()));
+        }
+        let content_length = body.as_ref().map(|b| b.len()).unwrap_or(0);
+
+        let (final_url, sign) = match &self.auth {
+            AzureAuth::Sas(sas) => {
+                let sep = if url.query().is_some() { '&' } else { '?' };
+                let u = Url::parse(&format!("{url}{sep}{sas}"))
+                    .map_err(|e| format!("invalid SAS url: {e}"))?;
+                (u, None)
+            }
+            AzureAuth::SharedKey(key) => {
+                let auth = self.sign(
+                    key,
+                    verb.as_str(),
+                    &url,
+                    &headers,
+                    content_length,
+                    content_type.unwrap_or(""),
+                );
+                (url, Some(auth))
+            }
+            AzureAuth::Bearer(token) => (url, Some(format!("Bearer {token}"))),
+        };
+
+        let mut rb = self.http.request(verb, final_url);
+        for (k, v) in &headers {
+            rb = rb.header(k, v);
+        }
+        if let Some(ct) = content_type {
+            rb = rb.header("content-type", ct);
+        }
+        if let Some(auth) = sign {
+            rb = rb.header("authorization", auth);
+        }
+        // Azure's PutBlob requires an explicit Content-Length; reqwest omits it
+        // for an empty body, so set it ourselves for any body-bearing request.
+        if body.is_some() {
+            rb = rb.header(reqwest::header::CONTENT_LENGTH, content_length.to_string());
+        }
+        if let Some(b) = body {
+            rb = rb.body(b);
+        }
+        let resp = rb.send().await.map_err(net_err)?;
+        check(resp).await
+    }
+}
+
+fn net_err(e: reqwest::Error) -> String {
+    format!("request failed: {e}")
+}
+
+/// Build a fixed-width, base64-encoded block id (Azure requires all block ids
+/// in one blob to be the same length).
+fn block_id(index: u32) -> String {
+    base64::engine::general_purpose::STANDARD.encode(format!("{index:08}"))
+}
+
+async fn check(resp: reqwest::Response) -> Result<reqwest::Response, String> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+    let code = resp
+        .headers()
+        .get("x-ms-error-code")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    let body = resp.text().await.unwrap_or_default();
+    Err(format!(
+        "Azure error {} {}: {}",
+        status.as_u16(),
+        code,
+        body.chars().take(400).collect::<String>()
+    ))
+}
+
+fn parse_http_date(s: &str) -> Option<i64> {
+    chrono::NaiveDateTime::parse_from_str(s, "%a, %d %b %Y %H:%M:%S GMT")
+        .ok()
+        .map(|dt| dt.and_utc().timestamp())
+}
+
+impl AzureClient {
+    /// List containers (the bucket-level analog).
+    pub async fn list_buckets(&self) -> Result<Vec<BucketEntry>, String> {
+        let url = self.build("", &[("comp", "list")]);
+        let resp = self.send(reqwest::Method::GET, url, None, &[], None).await?;
+        let body = resp.text().await.map_err(net_err)?;
+        let parsed: EnumerationResults =
+            quick_xml::de::from_str(&body).map_err(|e| format!("parse containers: {e}"))?;
+        Ok(parsed
+            .containers
+            .map(|c| c.container)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|c| BucketEntry {
+                name: c.name,
+                created_at: c
+                    .properties
+                    .and_then(|p| p.last_modified)
+                    .as_deref()
+                    .and_then(parse_http_date),
+                region: None,
+            })
+            .collect())
+    }
+
+    pub async fn list_objects(
+        &self,
+        container: &str,
+        prefix: &str,
+        continuation: Option<&str>,
+        max_keys: usize,
+    ) -> Result<ObjectListPage, String> {
+        let max = max_keys.to_string();
+        let mut query: Vec<(&str, &str)> = vec![
+            ("restype", "container"),
+            ("comp", "list"),
+            ("delimiter", "/"),
+            ("maxresults", &max),
+        ];
+        if !prefix.is_empty() {
+            query.push(("prefix", prefix));
+        }
+        if let Some(m) = continuation {
+            query.push(("marker", m));
+        }
+        let url = self.build(container, &query);
+        let resp = self.send(reqwest::Method::GET, url, None, &[], None).await?;
+        let body = resp.text().await.map_err(net_err)?;
+        let parsed: EnumerationResults =
+            quick_xml::de::from_str(&body).map_err(|e| format!("parse blobs: {e}"))?;
+
+        let blobs = parsed.blobs.unwrap_or_default();
+        let mut entries = Vec::with_capacity(blobs.blob.len() + blobs.blob_prefix.len());
+        for bp in blobs.blob_prefix {
+            let trimmed = bp.name.trim_end_matches('/');
+            let name = trimmed.rsplit('/').next().unwrap_or(trimmed).to_string();
+            entries.push(ObjectEntry {
+                name,
+                key: bp.name,
+                is_dir: true,
+                size: 0,
+                last_modified: None,
+                etag: None,
+                storage_class: None,
+            });
+        }
+        for b in blobs.blob {
+            if b.name == prefix {
+                continue; // skip the folder-marker blob equal to the prefix
+            }
+            let name = b.name.strip_prefix(prefix).unwrap_or(&b.name).to_string();
+            let props = b.properties.unwrap_or_default();
+            entries.push(ObjectEntry {
+                name,
+                key: b.name,
+                is_dir: false,
+                size: props.content_length.unwrap_or(0),
+                last_modified: props.last_modified.as_deref().and_then(parse_http_date),
+                etag: props.etag.map(|e| e.trim_matches('"').to_string()),
+                storage_class: props.access_tier,
+            });
+        }
+        let next = parsed.next_marker.filter(|m| !m.is_empty());
+        Ok(ObjectListPage { entries, next_token: next })
+    }
+
+    pub async fn get_object_bytes(&self, container: &str, key: &str) -> Result<Vec<u8>, String> {
+        let url = self.build(&format!("{container}/{key}"), &[]);
+        let resp = self.send(reqwest::Method::GET, url, None, &[], None).await?;
+        Ok(resp.bytes().await.map_err(net_err)?.to_vec())
+    }
+
+    /// HEAD a blob and build its metadata from the response headers.
+    pub async fn head_object(&self, container: &str, key: &str) -> Result<ObjectMetadata, String> {
+        let url = self.build(&format!("{container}/{key}"), &[]);
+        let resp = self.send(reqwest::Method::HEAD, url, None, &[], None).await?;
+        let h = resp.headers();
+        let get = |name: &str| {
+            h.get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string())
+        };
+        let mut user_metadata = std::collections::BTreeMap::new();
+        for (name, value) in h.iter() {
+            if let Some(k) = name.as_str().strip_prefix("x-ms-meta-") {
+                if let Ok(v) = value.to_str() {
+                    user_metadata.insert(k.to_ascii_lowercase(), v.to_string());
+                }
+            }
+        }
+        Ok(ObjectMetadata {
+            key: key.to_string(),
+            size: get("content-length").and_then(|s| s.parse().ok()).unwrap_or(0),
+            content_type: get("content-type"),
+            etag: get("etag").map(|e| e.trim_matches('"').to_string()),
+            last_modified: get("last-modified").as_deref().and_then(parse_http_date),
+            storage_class: get("x-ms-access-tier"),
+            cache_control: get("cache-control"),
+            content_encoding: get("content-encoding"),
+            content_disposition: get("content-disposition"),
+            user_metadata,
+        })
+    }
+
+    pub async fn put_object_bytes(
+        &self,
+        container: &str,
+        key: &str,
+        body: Vec<u8>,
+    ) -> Result<(), String> {
+        let url = self.build(&format!("{container}/{key}"), &[]);
+        self.send(
+            reqwest::Method::PUT,
+            url,
+            Some(body),
+            &[("x-ms-blob-type", "BlockBlob")],
+            Some("application/octet-stream"),
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn delete_object(&self, container: &str, key: &str) -> Result<(), String> {
+        let url = self.build(&format!("{container}/{key}"), &[]);
+        self.send(reqwest::Method::DELETE, url, None, &[], None).await?;
+        Ok(())
+    }
+
+    /// Server-side Copy Blob, including across containers. With Shared Key the
+    /// source is authorized by the same account; with SAS the same token is
+    /// appended to the source URL.
+    pub async fn copy_object(
+        &self,
+        src_container: &str,
+        src_key: &str,
+        dst_container: &str,
+        dst_key: &str,
+    ) -> Result<(), String> {
+        let src_url = self.build(&format!("{src_container}/{src_key}"), &[]);
+        let copy_source = match &self.auth {
+            AzureAuth::Sas(sas) => format!("{src_url}?{sas}"),
+            AzureAuth::SharedKey(_) | AzureAuth::Bearer(_) => src_url.to_string(),
+        };
+        let dst_url = self.build(&format!("{dst_container}/{dst_key}"), &[]);
+        self.send(
+            reqwest::Method::PUT,
+            dst_url,
+            None,
+            &[("x-ms-copy-source", copy_source.as_str())],
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Recursively delete every blob under `prefix` with bounded concurrency.
+    pub async fn delete_prefix(&self, container: &str, prefix: &str) -> Result<(), String> {
+        use futures::stream::{self, StreamExt};
+        let keys = self.list_all_keys(container, prefix).await?;
+        let results: Vec<Result<(), String>> = stream::iter(keys.into_iter().map(|k| {
+            let container = container.to_string();
+            async move { self.delete_object(&container, &k).await }
+        }))
+        .buffer_unordered(16)
+        .collect()
+        .await;
+        for r in results {
+            r?;
+        }
+        Ok(())
+    }
+
+    /// Page through every blob name under `prefix` (no delimiter).
+    async fn list_all_keys(&self, container: &str, prefix: &str) -> Result<Vec<String>, String> {
+        let mut keys = Vec::new();
+        let mut marker: Option<String> = None;
+        loop {
+            let mut query: Vec<(&str, &str)> = vec![
+                ("restype", "container"),
+                ("comp", "list"),
+                ("maxresults", "5000"),
+            ];
+            if !prefix.is_empty() {
+                query.push(("prefix", prefix));
+            }
+            if let Some(m) = &marker {
+                query.push(("marker", m));
+            }
+            let url = self.build(container, &query);
+            let resp = self.send(reqwest::Method::GET, url, None, &[], None).await?;
+            let body = resp.text().await.map_err(net_err)?;
+            let parsed: EnumerationResults =
+                quick_xml::de::from_str(&body).map_err(|e| format!("parse blobs: {e}"))?;
+            if let Some(blobs) = parsed.blobs {
+                keys.extend(blobs.blob.into_iter().map(|b| b.name));
+            }
+            match parsed.next_marker.filter(|m| !m.is_empty()) {
+                Some(m) => marker = Some(m),
+                None => break,
+            }
+        }
+        Ok(keys)
+    }
+
+    pub async fn create_folder(&self, container: &str, prefix: &str) -> Result<(), String> {
+        let key = if prefix.ends_with('/') {
+            prefix.to_string()
+        } else {
+            format!("{prefix}/")
+        };
+        self.put_object_bytes(container, &key, Vec::new()).await
+    }
+
+    pub async fn create_bucket(&self, container: &str) -> Result<(), String> {
+        let url = self.build(container, &[("restype", "container")]);
+        self.send(reqwest::Method::PUT, url, None, &[], None).await?;
+        Ok(())
+    }
+
+    pub async fn delete_bucket(&self, container: &str) -> Result<(), String> {
+        let url = self.build(container, &[("restype", "container")]);
+        self.send(reqwest::Method::DELETE, url, None, &[], None).await?;
+        Ok(())
+    }
+
+    /// Build a shareable read-only URL for a blob, valid for `ttl_secs`. With
+    /// Shared Key we mint a service SAS (signed with the account key); with an
+    /// existing SAS token we just append it to the blob URL.
+    pub fn presign_get(&self, container: &str, key: &str, ttl_secs: u64) -> Result<String, String> {
+        let blob_url = self.build(&format!("{container}/{key}"), &[]);
+        match &self.auth {
+            AzureAuth::Sas(sas) => Ok(format!("{blob_url}?{sas}")),
+            AzureAuth::SharedKey(account_key) => {
+                let expiry = (chrono::Utc::now() + chrono::Duration::seconds(ttl_secs as i64))
+                    .format("%Y-%m-%dT%H:%M:%SZ")
+                    .to_string();
+                let protocol = if self.base.scheme() == "https" {
+                    "https"
+                } else {
+                    "https,http"
+                };
+                let permissions = "r";
+                let resource = "b";
+                let canonical = format!("/blob/{}/{}/{}", self.account, container, key);
+                // Service SAS string-to-sign for api-version 2020-12-06+ (16
+                // newline-joined fields). Empty fields: start, identifier, IP,
+                // snapshot, encryption scope, and the five response-override
+                // headers (rscc/rscd/rsce/rscl/rsct).
+                let fields = [
+                    permissions,
+                    "",
+                    expiry.as_str(),
+                    canonical.as_str(),
+                    "",
+                    "",
+                    protocol,
+                    MS_VERSION,
+                    resource,
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                ];
+                let string_to_sign = fields.join("\n");
+                let mut mac = HmacSha256::new_from_slice(account_key)
+                    .expect("hmac accepts any key length");
+                mac.update(string_to_sign.as_bytes());
+                let sig =
+                    base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+                let query = format!(
+                    "sv={}&sr={}&sp={}&se={}&spr={}&sig={}",
+                    MS_VERSION,
+                    resource,
+                    permissions,
+                    urlencoding::encode(&expiry),
+                    urlencoding::encode(protocol),
+                    urlencoding::encode(&sig),
+                );
+                Ok(format!("{blob_url}?{query}"))
+            }
+            AzureAuth::Bearer(_) => Err(
+                "share links require account-key or SAS auth; an Entra ID (bearer) connection \
+                 cannot mint a SAS"
+                    .into(),
+            ),
+        }
+    }
+
+    /// Stream a blob to a local file, emitting progress.
+    pub async fn download_to_file<R: Runtime>(
+        &self,
+        container: &str,
+        key: &str,
+        dest: &Path,
+        transfer_id: &str,
+        handle: &Arc<TransferHandle>,
+        app: &AppHandle<R>,
+    ) -> Result<(), String> {
+        let url = self.build(&format!("{container}/{key}"), &[]);
+        let resp = self.send(reqwest::Method::GET, url, None, &[], None).await?;
+        let total = resp.content_length().unwrap_or(0);
+        super::transfer::stream_to_file(resp, total, dest, transfer_id, handle, app).await
+    }
+
+    /// Upload a local file. Small files go in one Put Blob; large files are
+    /// staged as blocks then committed with Put Block List, emitting progress
+    /// per block. `access_tier`, when set (`Hot`/`Cool`/`Cold`/`Archive`), is
+    /// applied via `x-ms-access-tier`.
+    pub async fn upload_from_file<R: Runtime>(
+        &self,
+        local: &Path,
+        container: &str,
+        key: &str,
+        access_tier: Option<&str>,
+        transfer_id: &str,
+        handle: &Arc<TransferHandle>,
+        app: &AppHandle<R>,
+    ) -> Result<(), String> {
+        use super::transfer::{emit_paused, emit_progress, read_full, MULTIPART_THRESHOLD, PART_SIZE};
+        let total = tokio::fs::metadata(local)
+            .await
+            .map_err(|e| format!("stat {}: {e}", local.display()))?
+            .len();
+        let started = Instant::now();
+        emit_progress(app, transfer_id, 0, total, started);
+
+        if total <= MULTIPART_THRESHOLD {
+            let data = tokio::fs::read(local)
+                .await
+                .map_err(|e| format!("read {}: {e}", local.display()))?;
+            let url = self.build(&format!("{container}/{key}"), &[]);
+            let mut ms_headers: Vec<(&str, &str)> = vec![("x-ms-blob-type", "BlockBlob")];
+            if let Some(tier) = access_tier {
+                ms_headers.push(("x-ms-access-tier", tier));
+            }
+            self.send(
+                reqwest::Method::PUT,
+                url,
+                Some(data),
+                &ms_headers,
+                Some("application/octet-stream"),
+            )
+            .await?;
+            emit_progress(app, transfer_id, total, total, started);
+            return Ok(());
+        }
+
+        let mut file = tokio::fs::File::open(local)
+            .await
+            .map_err(|e| format!("open {}: {e}", local.display()))?;
+        let mut buf = vec![0u8; PART_SIZE];
+        let mut block_ids: Vec<String> = Vec::new();
+        let mut uploaded: u64 = 0;
+        let mut index: u32 = 0;
+        loop {
+            if handle.is_cancelled() {
+                return Err("transfer cancelled".to_string());
+            }
+            if handle.is_paused() {
+                emit_paused(app, transfer_id, uploaded, total);
+                handle.wait_while_paused().await;
+                if handle.is_cancelled() {
+                    return Err("transfer cancelled".to_string());
+                }
+            }
+            let n = read_full(&mut file, &mut buf).await?;
+            if n == 0 {
+                break;
+            }
+            let id = block_id(index);
+            let url = self.build(
+                &format!("{container}/{key}"),
+                &[("comp", "block"), ("blockid", id.as_str())],
+            );
+            self.send(reqwest::Method::PUT, url, Some(buf[..n].to_vec()), &[], None)
+                .await?;
+            block_ids.push(id);
+            uploaded += n as u64;
+            emit_progress(app, transfer_id, uploaded, total, started);
+            index += 1;
+        }
+
+        let mut xml =
+            String::from("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<BlockList>\n");
+        for id in &block_ids {
+            xml.push_str("  <Latest>");
+            xml.push_str(id);
+            xml.push_str("</Latest>\n");
+        }
+        xml.push_str("</BlockList>");
+        let url = self.build(&format!("{container}/{key}"), &[("comp", "blocklist")]);
+        let mut ms_headers: Vec<(&str, &str)> = Vec::new();
+        if let Some(tier) = access_tier {
+            ms_headers.push(("x-ms-access-tier", tier));
+        }
+        self.send(
+            reqwest::Method::PUT,
+            url,
+            Some(xml.into_bytes()),
+            &ms_headers,
+            Some("application/xml"),
+        )
+        .await?;
+        emit_progress(app, transfer_id, total, total, started);
+        Ok(())
+    }
+
+    pub async fn ping(&self, _default_location: Option<&str>) -> Result<(), String> {
+        self.list_buckets().await.map(|_| ())
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct EnumerationResults {
+    #[serde(rename = "Containers")]
+    containers: Option<Containers>,
+    #[serde(rename = "Blobs")]
+    blobs: Option<Blobs>,
+    #[serde(rename = "NextMarker")]
+    next_marker: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct Containers {
+    #[serde(default, rename = "Container")]
+    container: Vec<ContainerXml>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContainerXml {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Properties")]
+    properties: Option<ContainerProps>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContainerProps {
+    #[serde(rename = "Last-Modified")]
+    last_modified: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct Blobs {
+    #[serde(default, rename = "Blob")]
+    blob: Vec<BlobXml>,
+    #[serde(default, rename = "BlobPrefix")]
+    blob_prefix: Vec<BlobPrefixXml>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BlobXml {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Properties")]
+    properties: Option<BlobProps>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct BlobProps {
+    #[serde(rename = "Content-Length")]
+    content_length: Option<u64>,
+    #[serde(rename = "Last-Modified")]
+    last_modified: Option<String>,
+    #[serde(rename = "Etag", alias = "ETag")]
+    etag: Option<String>,
+    #[serde(rename = "AccessTier")]
+    access_tier: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BlobPrefixXml {
+    #[serde(rename = "Name")]
+    name: String,
+}
+
+#[cfg(test)]
+mod it {
+    use super::*;
+
+    /// End-to-end round trip against Azurite. Skipped unless `TAOMNI_AZ_IT` is
+    /// set. Uses Azurite's well-known public dev account/key (not a secret).
+    /// Exercises Shared Key signing, container/blob ops, and delimiter→folder
+    /// mapping.
+    #[tokio::test]
+    async fn azure_round_trip() {
+        if std::env::var("TAOMNI_AZ_IT").is_err() {
+            return;
+        }
+        let cs = std::env::var("TAOMNI_AZ_IT_CONNSTR").unwrap_or_else(|_| {
+            "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;".into()
+        });
+        let (account, base, auth) = parse_connection_string(&cs).expect("parse connection string");
+        let client = AzureClient::new(reqwest::Client::new(), account, base, auth);
+
+        let container = format!("taomniit{}", uuid::Uuid::new_v4().simple());
+        client.create_bucket(&container).await.expect("create container");
+
+        let buckets = client.list_buckets().await.expect("list containers");
+        assert!(buckets.iter().any(|b| b.name == container), "new container listed");
+
+        client
+            .put_object_bytes(&container, "dir/hello.txt", b"hi there".to_vec())
+            .await
+            .expect("put blob");
+        client.create_folder(&container, "emptydir").await.expect("create folder");
+
+        let root = client.list_objects(&container, "", None, 1000).await.expect("list root");
+        assert!(
+            root.entries.iter().any(|e| e.is_dir && e.name == "dir"),
+            "dir/ surfaces as a folder"
+        );
+
+        let inside = client.list_objects(&container, "dir/", None, 1000).await.expect("list dir/");
+        let file = inside.entries.iter().find(|e| !e.is_dir).expect("file under dir/");
+        assert_eq!(file.name, "hello.txt");
+        assert_eq!(file.size, 8);
+
+        let bytes = client.get_object_bytes(&container, "dir/hello.txt").await.expect("get");
+        assert_eq!(bytes, b"hi there");
+
+        // --- P3 management ops ---
+        let meta = client.head_object(&container, "dir/hello.txt").await.expect("head");
+        assert_eq!(meta.size, 8);
+
+        client
+            .copy_object(&container, "dir/hello.txt", &container, "dir2/copy.txt")
+            .await
+            .expect("copy blob");
+        let copied = client.get_object_bytes(&container, "dir2/copy.txt").await.expect("get copy");
+        assert_eq!(copied, b"hi there");
+
+        // Service SAS should be fetchable with no auth header.
+        let url = client.presign_get(&container, "dir/hello.txt", 300).expect("presign");
+        let presigned = reqwest::get(&url).await.expect("fetch sas").bytes().await.expect("bytes");
+        assert_eq!(&presigned[..], b"hi there");
+
+        client.delete_prefix(&container, "dir/").await.expect("delete_prefix");
+        let after = client.list_objects(&container, "", None, 1000).await.expect("relist");
+        assert!(!after.entries.iter().any(|e| e.name == "dir"), "dir/ gone after delete_prefix");
+
+        client.delete_object(&container, "dir2/copy.txt").await.expect("del copy");
+        client.delete_object(&container, "emptydir/").await.expect("del marker");
+        client.delete_bucket(&container).await.expect("del container");
+    }
+}
+
+
+

--- a/src-tauri/src/objectstorage/config.rs
+++ b/src-tauri/src/objectstorage/config.rs
@@ -1,0 +1,200 @@
+//! Connection config payload from the frontend and provider-preset resolution.
+
+use rusty_s3::UrlStyle;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::terminal::network::NetworkSettings;
+
+/// Connection parameters sent by the frontend (camelCase). Mirrors the shape
+/// stored in a session's `options_json`. Provider-specific fields are optional;
+/// which ones matter depends on `provider`/`engine`. Secret-bearing fields may
+/// be `vault:<uuid>` references resolved server-side via the vault.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectStorageConfig {
+    /// `aws` | `alibaba-oss` | `minio` | `r2` | `backblaze` | `wasabi`
+    /// | `tencent-cos` | `ceph` | `custom` | `azure`.
+    pub provider: String,
+    // --- S3 family ---
+    /// Full service endpoint, e.g. `https://oss-cn-hangzhou.aliyuncs.com`.
+    /// Optional for `aws` (derived from region).
+    pub endpoint: Option<String>,
+    pub region: Option<String>,
+    /// Force path-style addressing (`endpoint/bucket/key`) instead of
+    /// virtual-host (`bucket.endpoint/key`). Required by MinIO/Ceph.
+    pub path_style: Option<bool>,
+    pub access_key_id: Option<String>,
+    /// Secret access key; may be a `vault:` ref.
+    pub secret_access_key: Option<String>,
+    /// Optional STS session token; may be a `vault:` ref.
+    pub session_token: Option<String>,
+    pub default_bucket: Option<String>,
+    /// S3 credential source: `keys` (default) | `environment` | `profile`.
+    pub aws_auth: Option<String>,
+    /// Named profile for `aws_auth == "profile"` (defaults to `AWS_PROFILE` /
+    /// `default`).
+    pub aws_profile: Option<String>,
+    // --- Azure (consumed in P2) ---
+    pub account_name: Option<String>,
+    pub account_key: Option<String>,
+    pub connection_string: Option<String>,
+    pub sas_token: Option<String>,
+    pub endpoint_suffix: Option<String>,
+    pub default_container: Option<String>,
+    /// Azure auth selector: `key` | `sas` | `connstr` | `bearer` (Entra ID).
+    /// When unset the engine infers it from whichever secret field is present.
+    pub azure_auth: Option<String>,
+    /// Pasted Entra ID access token for `azure_auth == "bearer"` (may be a
+    /// `vault:` ref). Empty → obtain one from the Azure CLI at connect time.
+    pub azure_bearer_token: Option<String>,
+    // --- Network routing (P7) ---
+    /// Proxy / SSH-jump routing. When absent (or with no proxy_kind) the engine
+    /// falls back to the app-level global proxy.
+    pub network: Option<NetworkSettings>,
+    // --- Defaults (P8) ---
+    /// Default storage class / access tier applied to uploads when the caller
+    /// doesn't specify one (e.g. `STANDARD`/`GLACIER`, or Azure `Hot`/`Cool`).
+    pub storage_class: Option<String>,
+}
+
+/// Resolved S3 endpoint, addressing style, and signing region.
+pub struct S3Endpoint {
+    pub url: Url,
+    pub style: UrlStyle,
+    pub region: String,
+}
+
+impl ObjectStorageConfig {
+    /// Resolve the S3 service endpoint, addressing style and region from the
+    /// provider preset plus explicit overrides. AWS derives its endpoint from
+    /// the region; all other providers require an explicit `endpoint`.
+    pub fn resolve_s3_endpoint(&self) -> Result<S3Endpoint, String> {
+        let region = self
+            .region
+            .clone()
+            .filter(|r| !r.is_empty())
+            .unwrap_or_else(|| "us-east-1".to_string());
+
+        let endpoint = match self.endpoint.as_deref().filter(|e| !e.is_empty()) {
+            Some(e) => e.to_string(),
+            None if self.provider == "aws" => format!("https://s3.{region}.amazonaws.com"),
+            None => {
+                return Err(format!(
+                    "endpoint is required for provider '{}'",
+                    self.provider
+                ))
+            }
+        };
+        let endpoint = if endpoint.contains("://") {
+            endpoint
+        } else {
+            format!("https://{endpoint}")
+        };
+        let url = Url::parse(&endpoint).map_err(|e| format!("invalid endpoint url: {e}"))?;
+
+        // Path-style by explicit override, else by provider default. MinIO,
+        // Ceph and "custom" default to path-style; everything else uses
+        // virtual-host addressing. An SSH-jump route forces path-style so the
+        // single resolved endpoint host covers every bucket (virtual-host would
+        // put each bucket on its own unresolved subdomain).
+        let jump = self
+            .network
+            .as_ref()
+            .map(|n| n.uses_jump_host())
+            .unwrap_or(false);
+        let path_style = self.path_style.unwrap_or_else(|| {
+            matches!(self.provider.as_str(), "minio" | "ceph" | "custom")
+        }) || jump;
+        let style = if path_style {
+            UrlStyle::Path
+        } else {
+            UrlStyle::VirtualHost
+        };
+
+        Ok(S3Endpoint { url, style, region })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(provider: &str, endpoint: Option<&str>, region: Option<&str>) -> ObjectStorageConfig {
+        ObjectStorageConfig {
+            provider: provider.into(),
+            endpoint: endpoint.map(Into::into),
+            region: region.map(Into::into),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn aws_derives_endpoint_from_region() {
+        let e = cfg("aws", None, Some("eu-west-1"))
+            .resolve_s3_endpoint()
+            .unwrap();
+        assert_eq!(e.url.as_str(), "https://s3.eu-west-1.amazonaws.com/");
+        assert_eq!(e.region, "eu-west-1");
+        assert!(matches!(e.style, UrlStyle::VirtualHost));
+    }
+
+    #[test]
+    fn minio_defaults_to_path_style() {
+        let e = cfg("minio", Some("http://127.0.0.1:9000"), None)
+            .resolve_s3_endpoint()
+            .unwrap();
+        assert!(matches!(e.style, UrlStyle::Path));
+        assert_eq!(e.region, "us-east-1");
+    }
+
+    #[test]
+    fn non_aws_without_endpoint_errors() {
+        assert!(cfg("wasabi", None, None).resolve_s3_endpoint().is_err());
+    }
+
+    #[test]
+    fn bare_host_endpoint_gets_https_scheme() {
+        let e = cfg("alibaba-oss", Some("oss-cn-hangzhou.aliyuncs.com"), Some("oss-cn-hangzhou"))
+            .resolve_s3_endpoint()
+            .unwrap();
+        assert_eq!(e.url.scheme(), "https");
+        assert!(matches!(e.style, UrlStyle::VirtualHost));
+    }
+
+    #[test]
+    fn ssh_jump_forces_path_style_even_for_virtual_host_provider() {
+        // A virtual-host provider (aws) would normally use VirtualHost, but an
+        // SSH-jump route forces path-style so one resolved host covers all
+        // buckets.
+        let mut net = NetworkSettings::default();
+        net.proxy_kind = "ssh-tunnel".into();
+        let c = ObjectStorageConfig {
+            provider: "aws".into(),
+            region: Some("us-east-1".into()),
+            network: Some(net),
+            ..Default::default()
+        };
+        let e = c.resolve_s3_endpoint().unwrap();
+        assert!(
+            matches!(e.style, UrlStyle::Path),
+            "jump host should force path-style addressing"
+        );
+    }
+
+    #[test]
+    fn plain_proxy_does_not_force_path_style() {
+        // An HTTP/SOCKS proxy keeps the provider's default addressing (reqwest
+        // proxies bucket subdomains fine); only ssh-tunnel forces path-style.
+        let mut net = NetworkSettings::default();
+        net.proxy_kind = "socks5".into();
+        let c = ObjectStorageConfig {
+            provider: "aws".into(),
+            region: Some("us-east-1".into()),
+            network: Some(net),
+            ..Default::default()
+        };
+        let e = c.resolve_s3_endpoint().unwrap();
+        assert!(matches!(e.style, UrlStyle::VirtualHost));
+    }
+}

--- a/src-tauri/src/objectstorage/credentials.rs
+++ b/src-tauri/src/objectstorage/credentials.rs
@@ -1,0 +1,330 @@
+//! S3-family credential resolution beyond static keys (P6 cloud identity).
+//!
+//! Three sources, all dependency-free (no `aws-config`/`aws-sdk` — we keep the
+//! lightweight rusty-s3 stack and resolve credentials ourselves):
+//!
+//! - `keys`        — static access key / secret / optional session token
+//!                   (handled by the caller, which also resolves vault refs).
+//! - `environment` — `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` /
+//!                   `AWS_SESSION_TOKEN`.
+//! - `profile`     — the shared config files (`~/.aws/credentials`,
+//!                   `~/.aws/config`). A profile may carry static keys, or a
+//!                   `credential_process` command we run and parse. When a
+//!                   profile has neither (e.g. an SSO or assume-role profile),
+//!                   we fall back to running the AWS CLI's
+//!                   `aws configure export-credentials --profile P --format process`,
+//!                   which resolves SSO / assume-role / instance-role for us.
+//!
+//! `credential_process` is executed as argv (quote-aware split), never through
+//! a shell, and only ever comes from the user's own `~/.aws` files.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use rusty_s3::Credentials;
+use serde::Deserialize;
+
+/// The JSON shape emitted by a `credential_process` command and by
+/// `aws configure export-credentials --format process`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct ProcessCreds {
+    access_key_id: String,
+    secret_access_key: String,
+    #[serde(default)]
+    session_token: Option<String>,
+}
+
+impl ProcessCreds {
+    fn into_credentials(self) -> Credentials {
+        match self.session_token.filter(|t| !t.is_empty()) {
+            Some(t) => Credentials::new_with_token(self.access_key_id, self.secret_access_key, t),
+            None => Credentials::new(self.access_key_id, self.secret_access_key),
+        }
+    }
+}
+
+/// Build credentials from `AWS_*` environment variables.
+pub fn from_environment() -> Result<Credentials, String> {
+    let key = std::env::var("AWS_ACCESS_KEY_ID")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .ok_or("AWS_ACCESS_KEY_ID is not set in the environment")?;
+    let secret = std::env::var("AWS_SECRET_ACCESS_KEY")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .ok_or("AWS_SECRET_ACCESS_KEY is not set in the environment")?;
+    let token = std::env::var("AWS_SESSION_TOKEN").ok().filter(|s| !s.is_empty());
+    Ok(match token {
+        Some(t) => Credentials::new_with_token(key, secret, t),
+        None => Credentials::new(key, secret),
+    })
+}
+
+/// Resolve credentials from a named profile in the shared AWS config files,
+/// falling back to the AWS CLI for SSO / assume-role profiles.
+pub async fn from_profile(profile: Option<&str>) -> Result<Credentials, String> {
+    let profile = profile
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| std::env::var("AWS_PROFILE").ok().filter(|s| !s.is_empty()))
+        .unwrap_or_else(|| "default".to_string());
+
+    let merged = load_profile(&profile);
+
+    // 1) credential_process declared on the profile.
+    if let Some(cmd) = merged.get("credential_process").filter(|c| !c.is_empty()) {
+        return run_credential_process(cmd).await;
+    }
+    // 2) static keys on the profile.
+    if let (Some(key), Some(secret)) = (
+        merged.get("aws_access_key_id").filter(|s| !s.is_empty()),
+        merged.get("aws_secret_access_key").filter(|s| !s.is_empty()),
+    ) {
+        let token = merged
+            .get("aws_session_token")
+            .filter(|s| !s.is_empty())
+            .cloned();
+        return Ok(match token {
+            Some(t) => Credentials::new_with_token(key.clone(), secret.clone(), t),
+            None => Credentials::new(key.clone(), secret.clone()),
+        });
+    }
+    // 3) SSO / assume-role / instance-role profile: let the AWS CLI resolve it.
+    export_credentials(&profile).await
+}
+
+/// Region declared on the profile, if any — used to fill an unset config region.
+pub fn profile_region(profile: Option<&str>) -> Option<String> {
+    let profile = profile
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| std::env::var("AWS_PROFILE").ok().filter(|s| !s.is_empty()))
+        .unwrap_or_else(|| "default".to_string());
+    load_profile(&profile)
+        .get("region")
+        .filter(|s| !s.is_empty())
+        .cloned()
+}
+
+/// Merge a profile's settings from both `~/.aws/credentials` and `~/.aws/config`
+/// (credentials wins on conflict). Section naming differs between the files:
+/// `config` uses `[profile NAME]` (except `[default]`), `credentials` uses
+/// `[NAME]`.
+fn load_profile(profile: &str) -> BTreeMap<String, String> {
+    let mut merged = BTreeMap::new();
+    let dir = aws_dir();
+
+    if let Ok(text) = std::fs::read_to_string(dir.join("config")) {
+        let key = if profile == "default" {
+            "default".to_string()
+        } else {
+            format!("profile {profile}")
+        };
+        if let Some(section) = parse_ini(&text).remove(&key) {
+            merged.extend(section);
+        }
+    }
+    if let Ok(text) = std::fs::read_to_string(dir.join("credentials")) {
+        if let Some(section) = parse_ini(&text).remove(profile) {
+            merged.extend(section);
+        }
+    }
+    merged
+}
+
+fn aws_dir() -> PathBuf {
+    if let Some(p) = std::env::var_os("AWS_CONFIG_FILE") {
+        // AWS_CONFIG_FILE points at the config file; its parent is the dir.
+        if let Some(parent) = PathBuf::from(p).parent() {
+            return parent.to_path_buf();
+        }
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".aws")
+}
+
+/// Minimal INI parser: `[section]` headers and `key = value` lines. Comments
+/// (`#`/`;`) and blank lines are ignored; keys are lowercased. Nested/indented
+/// sub-settings (e.g. SSO blocks) collapse to flat keys, which is all we read.
+fn parse_ini(text: &str) -> BTreeMap<String, BTreeMap<String, String>> {
+    let mut out: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+    let mut current: Option<String> = None;
+    for raw in text.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if let Some(name) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+            current = Some(name.trim().to_string());
+            out.entry(name.trim().to_string()).or_default();
+            continue;
+        }
+        if let (Some(section), Some((k, v))) = (current.as_ref(), line.split_once('=')) {
+            out.entry(section.clone())
+                .or_default()
+                .insert(k.trim().to_ascii_lowercase(), v.trim().to_string());
+        }
+    }
+    out
+}
+
+/// Run a `credential_process` command (argv, no shell) and parse its JSON.
+async fn run_credential_process(command: &str) -> Result<Credentials, String> {
+    let argv = split_args(command);
+    let (program, args) = argv
+        .split_first()
+        .ok_or("credential_process is empty")?;
+    let output = tokio::process::Command::new(program)
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| format!("failed to run credential_process '{program}': {e}"))?;
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "credential_process exited with {}: {}",
+            output.status,
+            err.trim()
+        ));
+    }
+    parse_process_json(&output.stdout)
+}
+
+/// Resolve an SSO / assume-role / instance-role profile by delegating to the
+/// installed AWS CLI. Requires `aws` on PATH.
+async fn export_credentials(profile: &str) -> Result<Credentials, String> {
+    let output = tokio::process::Command::new("aws")
+        .args([
+            "configure",
+            "export-credentials",
+            "--profile",
+            profile,
+            "--format",
+            "process",
+        ])
+        .output()
+        .await
+        .map_err(|e| {
+            format!(
+                "profile '{profile}' has no static keys or credential_process, and the AWS CLI \
+                 (`aws`) is not available to resolve it: {e}"
+            )
+        })?;
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "`aws configure export-credentials --profile {profile}` failed: {}",
+            err.trim()
+        ));
+    }
+    parse_process_json(&output.stdout)
+}
+
+fn parse_process_json(bytes: &[u8]) -> Result<Credentials, String> {
+    let parsed: ProcessCreds = serde_json::from_slice(bytes)
+        .map_err(|e| format!("could not parse credential JSON: {e}"))?;
+    Ok(parsed.into_credentials())
+}
+
+/// Split a command line into argv, honoring single/double quotes. Good enough
+/// for `credential_process` strings (no shell metacharacter expansion, which is
+/// also what the AWS spec calls for).
+fn split_args(command: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    let mut cur = String::new();
+    let mut quote: Option<char> = None;
+    let mut has = false;
+    for c in command.chars() {
+        match quote {
+            Some(q) => {
+                if c == q {
+                    quote = None;
+                } else {
+                    cur.push(c);
+                }
+            }
+            None => match c {
+                '"' | '\'' => {
+                    quote = Some(c);
+                    has = true;
+                }
+                c if c.is_whitespace() => {
+                    if has {
+                        args.push(std::mem::take(&mut cur));
+                        has = false;
+                    }
+                }
+                c => {
+                    cur.push(c);
+                    has = true;
+                }
+            },
+        }
+    }
+    if has {
+        args.push(cur);
+    }
+    args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_basic_ini_sections() {
+        let text = "\
+# a comment
+[default]
+aws_access_key_id = AKIADEFAULT
+aws_secret_access_key = secret0
+
+[profile work]
+region = eu-west-1
+credential_process = /usr/local/bin/cred --profile work
+";
+        let ini = parse_ini(text);
+        assert_eq!(
+            ini["default"]["aws_access_key_id"], "AKIADEFAULT",
+            "default section keys"
+        );
+        assert_eq!(ini["profile work"]["region"], "eu-west-1");
+        assert_eq!(
+            ini["profile work"]["credential_process"],
+            "/usr/local/bin/cred --profile work"
+        );
+    }
+
+    #[test]
+    fn split_args_handles_quotes() {
+        assert_eq!(split_args("aws foo bar"), vec!["aws", "foo", "bar"]);
+        assert_eq!(
+            split_args(r#"cred --opt "a b c" tail"#),
+            vec!["cred", "--opt", "a b c", "tail"]
+        );
+        assert_eq!(split_args("'single quoted'"), vec!["single quoted"]);
+        assert!(split_args("   ").is_empty());
+    }
+
+    #[test]
+    fn parses_process_json_with_and_without_token() {
+        let with = br#"{"Version":1,"AccessKeyId":"AKIA","SecretAccessKey":"shh","SessionToken":"tok"}"#;
+        let creds = parse_process_json(with).unwrap();
+        assert_eq!(creds.key(), "AKIA");
+        assert_eq!(creds.token(), Some("tok"));
+
+        let without = br#"{"Version":1,"AccessKeyId":"AKIA","SecretAccessKey":"shh"}"#;
+        let creds = parse_process_json(without).unwrap();
+        assert_eq!(creds.token(), None);
+    }
+
+    #[test]
+    fn process_json_parse_error_is_descriptive() {
+        let err = parse_process_json(b"not json").unwrap_err();
+        assert!(err.contains("could not parse credential JSON"), "{err}");
+    }
+}

--- a/src-tauri/src/objectstorage/mod.rs
+++ b/src-tauri/src/objectstorage/mod.rs
@@ -1,0 +1,531 @@
+//! Object storage (S3 / S3-compatible / Azure Blob) connection sessions and
+//! management.
+//!
+//! Mirrors the database module's multi-backend dispatch: one S3-family engine
+//! (rusty-s3 over the shared reqwest client) covers AWS S3, Alibaba OSS via its
+//! S3-compatible endpoint, and any S3-compatible provider (MinIO, Cloudflare
+//! R2, Backblaze B2, Wasabi, Tencent COS, Ceph, ...); the official
+//! `azure_storage_blob` SDK covers Azure Blob. Sessions persist in the shared
+//! `sessions` table (`SessionType::S3` / `SessionType::AzureBlob`) with the
+//! provider, endpoint, addressing style, auth type and `vault:` credential
+//! refs carried in `options_json`. See `memory/object-storage-feature.md`.
+
+pub mod azure;
+pub mod config;
+pub mod credentials;
+pub mod s3;
+pub mod session;
+pub mod transfer;
+pub mod types;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use rusty_s3::Credentials;
+use tauri::{AppHandle, Emitter, State};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use url::Url;
+
+use crate::filebrowser::transfer as ft;
+use crate::proxy::ResolvedProxy;
+use crate::state::AppState;
+use crate::terminal::network::NetworkSettings;
+use azure::{AzureAuth, AzureClient};
+use config::ObjectStorageConfig;
+use s3::S3Client;
+use session::OssHandle;
+use types::{BucketEntry, ObjectListPage, ObjectMetadata};
+
+pub use session::ObjectStorageSession;
+
+/// Resolve a possibly-`vault:` reference to plaintext. Returns the original
+/// string when it isn't a vault reference (inline plaintext).
+fn resolve(state: &State<'_, AppState>, value: &Option<String>) -> Result<Option<String>, String> {
+    match value.as_deref().filter(|s| !s.is_empty()) {
+        Some(v) => match state.vault.resolve(v)? {
+            Some(z) => Ok(Some((*z).clone())),
+            None => Ok(Some(v.to_string())),
+        },
+        None => Ok(None),
+    }
+}
+
+/// Build a live session from a connection config (credential resolution +
+/// client construction). Does not insert it into the registry.
+async fn build_session(
+    state: &State<'_, AppState>,
+    session_id: String,
+    config: ObjectStorageConfig,
+) -> Result<ObjectStorageSession, String> {
+    match config.provider.as_str() {
+        "azure" => {
+            let (handle, forward_task) = build_azure(state, &config).await?;
+            Ok(ObjectStorageSession {
+                session_id,
+                handle,
+                default_location: config.default_container.clone(),
+                cancel: CancellationToken::new(),
+                forward_task,
+                default_storage_class: config.storage_class.clone(),
+            })
+        }
+        _ => {
+            // Resolve credentials per the selected source (P6): static keys
+            // (vault-resolved), environment, or a shared-config profile.
+            let creds = match config.aws_auth.as_deref() {
+                Some("environment") => credentials::from_environment()?,
+                Some("profile") => {
+                    credentials::from_profile(config.aws_profile.as_deref()).await?
+                }
+                _ => {
+                    let key = resolve(state, &config.access_key_id)?
+                        .ok_or("access key id is required")?;
+                    let secret = resolve(state, &config.secret_access_key)?
+                        .ok_or("secret access key is required")?;
+                    let token = resolve(state, &config.session_token)?;
+                    match token {
+                        Some(t) => Credentials::new_with_token(key, secret, t),
+                        None => Credentials::new(key, secret),
+                    }
+                }
+            };
+
+            // A profile may carry the region; use it when the form left region
+            // blank (matters for AWS endpoint derivation).
+            let mut config = config;
+            if config.region.as_deref().unwrap_or("").is_empty()
+                && config.aws_auth.as_deref() == Some("profile")
+            {
+                config.region = credentials::profile_region(config.aws_profile.as_deref());
+            }
+
+            let ep = config.resolve_s3_endpoint()?;
+            let (http, forward_task) =
+                build_http_client(state, config.network.as_ref(), &ep.url).await?;
+            let client = S3Client::new(http, creds, ep.url, ep.region, ep.style);
+            Ok(ObjectStorageSession {
+                session_id,
+                handle: OssHandle::S3(client),
+                default_location: config.default_bucket.clone(),
+                cancel: CancellationToken::new(),
+                forward_task,
+                default_storage_class: config.storage_class.clone(),
+            })
+        }
+    }
+}
+
+/// Construct the Azure handle plus any network-forward task. Auth precedence:
+/// connection string, then the explicit `azure_auth` selector / present secret
+/// (account key, SAS, or Entra ID bearer token).
+async fn build_azure(
+    state: &State<'_, AppState>,
+    config: &ObjectStorageConfig,
+) -> Result<(OssHandle, Option<JoinHandle<()>>), String> {
+    let (account, base, auth) = if let Some(cs) = resolve(state, &config.connection_string)? {
+        azure::parse_connection_string(&cs)?
+    } else {
+        let account = config
+            .account_name
+            .clone()
+            .filter(|s| !s.is_empty())
+            .ok_or("azure account name is required")?;
+        let base = azure::azure_base_url(
+            &account,
+            config.endpoint.as_deref(),
+            config.endpoint_suffix.as_deref(),
+        )?;
+        let auth = resolve_azure_auth(state, config).await?;
+        (account, base, auth)
+    };
+
+    let (http, forward_task) = build_http_client(state, config.network.as_ref(), &base).await?;
+    Ok((
+        OssHandle::Azure(AzureClient::new(http, account, base, auth)),
+        forward_task,
+    ))
+}
+
+/// Pick the Azure auth method from the explicit selector or, failing that, the
+/// first present secret. `bearer` mints an Entra ID token (pasted or via the
+/// Azure CLI).
+async fn resolve_azure_auth(
+    state: &State<'_, AppState>,
+    config: &ObjectStorageConfig,
+) -> Result<AzureAuth, String> {
+    if config.azure_auth.as_deref() == Some("bearer") {
+        let pasted = resolve(state, &config.azure_bearer_token)?;
+        let token = azure::acquire_bearer_token(pasted.as_deref()).await?;
+        return Ok(AzureAuth::Bearer(token));
+    }
+    if let Some(key) = resolve(state, &config.account_key)? {
+        return Ok(AzureAuth::SharedKey(azure::decode_account_key(&key)?));
+    }
+    if let Some(sas) = resolve(state, &config.sas_token)? {
+        return Ok(AzureAuth::Sas(sas.trim_start_matches('?').to_string()));
+    }
+    Err("provide an account key, SAS token, connection string, or Entra ID token".into())
+}
+
+/// Build the reqwest client for an object-storage engine, applying network
+/// routing (P7):
+/// - per-session HTTP/SOCKS5 proxy → native `reqwest` proxy;
+/// - per-session SSH jump host → a loopback forwarder to the endpoint plus a
+///   `reqwest` DNS override so TLS SNI / cert / Host stay correct;
+/// - otherwise the app-level global proxy, like every other outbound module.
+///
+/// Returns the client and, for the jump path, the forwarder task (kept alive
+/// for the session's lifetime).
+async fn build_http_client(
+    state: &State<'_, AppState>,
+    network: Option<&NetworkSettings>,
+    endpoint: &Url,
+) -> Result<(reqwest::Client, Option<JoinHandle<()>>), String> {
+    let mut builder = reqwest::Client::builder();
+    let mut forward_task = None;
+
+    let uses_proxy = network
+        .map(|n| !matches!(n.proxy_kind.as_str(), "" | "none"))
+        .unwrap_or(false);
+
+    if uses_proxy {
+        let mut net = network.cloned().expect("uses_proxy implies Some");
+        if net.uses_jump_host() {
+            crate::terminal::resolve_jump_credentials(state, &mut net)?;
+            let host = endpoint
+                .host_str()
+                .ok_or("endpoint has no host for SSH-jump routing")?
+                .to_string();
+            let port = endpoint.port_or_known_default().unwrap_or(443);
+            let fwd = crate::database::forward::start(host.clone(), port, net).await?;
+            let addr = std::net::SocketAddr::from(([127, 0, 0, 1], fwd.local_port));
+            builder = builder.resolve(&host, addr);
+            forward_task = Some(fwd.task);
+        } else {
+            crate::terminal::resolve_proxy_session(state, &mut net)?;
+            net.resolve_proxy_pass(&state.vault)?;
+            let proxy = ResolvedProxy {
+                kind: net.proxy_kind.clone(),
+                host: net.proxy_host.clone(),
+                port: net.proxy_port,
+                username: net.proxy_user.clone(),
+                password: net.proxy_pass.clone(),
+            };
+            builder = proxy.apply_to(builder);
+        }
+    } else if let Some(p) = crate::proxy::resolve_default(state).ok().flatten() {
+        builder = p.apply_to(builder);
+    }
+
+    let client = builder
+        .build()
+        .map_err(|e| format!("failed to build http client: {e}"))?;
+    Ok((client, forward_task))
+}
+
+async fn get_session(
+    state: &State<'_, AppState>,
+    session_id: &str,
+) -> Result<Arc<ObjectStorageSession>, String> {
+    state
+        .oss_sessions
+        .read()
+        .await
+        .get(session_id)
+        .cloned()
+        .ok_or_else(|| format!("No active object-storage session for {session_id}"))
+}
+
+/// Open an object-storage connection and register it under `session_id`. An
+/// existing session under the same id is replaced.
+#[tauri::command]
+pub async fn storage_attach(
+    session_id: String,
+    config: ObjectStorageConfig,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let session = build_session(&state, session_id.clone(), config).await?;
+    if let Some(old) = state
+        .oss_sessions
+        .write()
+        .await
+        .insert(session_id, Arc::new(session))
+    {
+        old.close();
+    }
+    Ok(())
+}
+
+/// Tear down a live object-storage session. Idempotent.
+#[tauri::command]
+pub async fn storage_detach(session_id: String, state: State<'_, AppState>) -> Result<(), String> {
+    if let Some(sess) = state.oss_sessions.write().await.remove(&session_id) {
+        sess.close();
+    }
+    Ok(())
+}
+
+/// Connectivity check against an already-attached session.
+#[tauri::command]
+pub async fn storage_ping(session_id: String, state: State<'_, AppState>) -> Result<(), String> {
+    get_session(&state, &session_id).await?.ping().await
+}
+
+/// Attach to a throwaway session, ping, and detach — used by the editor's
+/// "Test connection" button.
+#[tauri::command]
+pub async fn storage_test_connection(
+    config: ObjectStorageConfig,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let probe_id = format!("storage-test-{}", uuid::Uuid::new_v4());
+    let session = build_session(&state, probe_id, config).await?;
+    let result = session.ping().await;
+    session.close();
+    result
+}
+
+#[tauri::command]
+pub async fn storage_list_buckets(
+    session_id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<BucketEntry>, String> {
+    get_session(&state, &session_id).await?.list_buckets().await
+}
+
+#[tauri::command]
+pub async fn storage_list_objects(
+    session_id: String,
+    bucket: String,
+    prefix: Option<String>,
+    continuation: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<ObjectListPage, String> {
+    let sess = get_session(&state, &session_id).await?;
+    sess.list_objects(&bucket, prefix.as_deref().unwrap_or(""), continuation.as_deref(), 1000)
+        .await
+}
+
+#[tauri::command]
+pub async fn storage_get_object_bytes(
+    session_id: String,
+    bucket: String,
+    key: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<u8>, String> {
+    get_session(&state, &session_id)
+        .await?
+        .get_object_bytes(&bucket, &key)
+        .await
+}
+
+#[tauri::command]
+pub async fn storage_put_object_bytes(
+    session_id: String,
+    bucket: String,
+    key: String,
+    data: Vec<u8>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    get_session(&state, &session_id)
+        .await?
+        .put_object_bytes(&bucket, &key, data)
+        .await
+}
+
+#[tauri::command]
+pub async fn storage_delete_object(
+    session_id: String,
+    bucket: String,
+    key: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    get_session(&state, &session_id)
+        .await?
+        .delete_object(&bucket, &key)
+        .await
+}
+
+#[tauri::command]
+pub async fn storage_create_folder(
+    session_id: String,
+    bucket: String,
+    prefix: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    get_session(&state, &session_id)
+        .await?
+        .create_folder(&bucket, &prefix)
+        .await
+}
+
+#[tauri::command]
+pub async fn storage_create_bucket(
+    session_id: String,
+    bucket: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    get_session(&state, &session_id).await?.create_bucket(&bucket).await
+}
+
+#[tauri::command]
+pub async fn storage_delete_bucket(
+    session_id: String,
+    bucket: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    get_session(&state, &session_id).await?.delete_bucket(&bucket).await
+}
+
+/// Recursively delete a "folder" (everything under `prefix`).
+#[tauri::command]
+pub async fn storage_delete_prefix(
+    session_id: String,
+    bucket: String,
+    prefix: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    get_session(&state, &session_id)
+        .await?
+        .delete_prefix(&bucket, &prefix)
+        .await
+}
+
+#[tauri::command]
+pub async fn storage_head_object(
+    session_id: String,
+    bucket: String,
+    key: String,
+    state: State<'_, AppState>,
+) -> Result<ObjectMetadata, String> {
+    get_session(&state, &session_id).await?.head_object(&bucket, &key).await
+}
+
+#[tauri::command]
+pub async fn storage_copy_object(
+    session_id: String,
+    src_bucket: String,
+    src_key: String,
+    dst_bucket: String,
+    dst_key: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    get_session(&state, &session_id)
+        .await?
+        .copy_object(&src_bucket, &src_key, &dst_bucket, &dst_key)
+        .await
+}
+
+/// Rename or move an object (server-side copy + delete source).
+#[tauri::command]
+pub async fn storage_move_object(
+    session_id: String,
+    src_bucket: String,
+    src_key: String,
+    dst_bucket: String,
+    dst_key: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    get_session(&state, &session_id)
+        .await?
+        .move_object(&src_bucket, &src_key, &dst_bucket, &dst_key)
+        .await
+}
+
+/// Generate a shareable read-only URL (presigned GET for S3, service SAS for
+/// Azure), valid for `ttl_secs` seconds.
+#[tauri::command]
+pub async fn storage_share_url(
+    session_id: String,
+    bucket: String,
+    key: String,
+    ttl_secs: u64,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    get_session(&state, &session_id)
+        .await?
+        .presign_get(&bucket, &key, ttl_secs)
+}
+
+/// Download an object to a local path, streaming with progress events
+/// (`storage-progress-{transferId}` / `storage-transfer-complete-{transferId}`).
+#[tauri::command]
+pub async fn storage_download(
+    session_id: String,
+    transfer_id: String,
+    bucket: String,
+    key: String,
+    local_path: String,
+    state: State<'_, AppState>,
+    app_handle: AppHandle,
+) -> Result<(), String> {
+    let session = get_session(&state, &session_id).await?;
+    let handle = ft::register(&state, &transfer_id).await;
+    let dest = PathBuf::from(&local_path);
+    let result = session
+        .download_to_file(&bucket, &key, &dest, &transfer_id, &handle, &app_handle)
+        .await;
+    ft::unregister(&state, &transfer_id).await;
+    let final_path = dest.to_string_lossy().to_string();
+    let payload = match &result {
+        Ok(_) => ft::CompletePayload::ok(Some(final_path)),
+        Err(e) => ft::CompletePayload::err(e),
+    };
+    let _ = app_handle.emit(&format!("storage-transfer-complete-{}", transfer_id), payload);
+    result
+}
+
+/// Upload a local file to an object key, streaming with progress events.
+/// `storage_class` overrides the session's default tier for this upload.
+#[tauri::command]
+pub async fn storage_upload(
+    session_id: String,
+    transfer_id: String,
+    bucket: String,
+    key: String,
+    local_path: String,
+    storage_class: Option<String>,
+    state: State<'_, AppState>,
+    app_handle: AppHandle,
+) -> Result<(), String> {
+    let session = get_session(&state, &session_id).await?;
+    let handle = ft::register(&state, &transfer_id).await;
+    let local = PathBuf::from(&local_path);
+    let result = session
+        .upload_from_file(
+            &local,
+            &bucket,
+            &key,
+            storage_class.as_deref(),
+            &transfer_id,
+            &handle,
+            &app_handle,
+        )
+        .await;
+    ft::unregister(&state, &transfer_id).await;
+    let payload = match &result {
+        Ok(_) => ft::CompletePayload::ok(Some(key.clone())),
+        Err(e) => ft::CompletePayload::err(e),
+    };
+    let _ = app_handle.emit(&format!("storage-transfer-complete-{}", transfer_id), payload);
+    result
+}
+
+#[tauri::command]
+pub async fn storage_cancel_transfer(transfer_id: String, state: State<'_, AppState>) -> Result<(), String> {
+    ft::cancel(&state, &transfer_id).await;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn storage_pause_transfer(transfer_id: String, state: State<'_, AppState>) -> Result<(), String> {
+    ft::pause(&state, &transfer_id).await;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn storage_resume_transfer(transfer_id: String, state: State<'_, AppState>) -> Result<(), String> {
+    ft::resume(&state, &transfer_id).await;
+    Ok(())
+}

--- a/src-tauri/src/objectstorage/s3.rs
+++ b/src-tauri/src/objectstorage/s3.rs
@@ -1,0 +1,702 @@
+//! S3-family engine: builds and signs requests with rusty-s3 (sans-IO) and
+//! executes them over reqwest. Covers AWS S3 and any S3-compatible provider.
+//! Service-level ListBuckets — which rusty-s3 has no action for — is signed
+//! directly via `rusty_s3::signing::sign`.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use jiff::Timestamp;
+use reqwest::Client;
+use rusty_s3::actions::{CreateMultipartUpload, ListObjectsV2};
+use rusty_s3::{Bucket, Credentials, Method, S3Action, UrlStyle};
+use serde::Deserialize;
+use tauri::{AppHandle, Runtime};
+use url::Url;
+
+use super::types::{BucketEntry, ObjectEntry, ObjectListPage, ObjectMetadata};
+use crate::filebrowser::transfer::TransferHandle;
+
+/// Presign lifetime for one-shot signed requests. Requests are issued
+/// immediately, so a short window is plenty.
+const SIGN_TTL: Duration = Duration::from_secs(300);
+
+pub struct S3Client {
+    http: Client,
+    creds: Credentials,
+    endpoint: Url,
+    region: String,
+    style: UrlStyle,
+}
+
+impl S3Client {
+    pub fn new(
+        http: Client,
+        creds: Credentials,
+        endpoint: Url,
+        region: String,
+        style: UrlStyle,
+    ) -> Self {
+        Self { http, creds, endpoint, region, style }
+    }
+
+    fn bucket(&self, name: &str) -> Result<Bucket, String> {
+        Bucket::new(
+            self.endpoint.clone(),
+            self.style,
+            name.to_string(),
+            self.region.clone(),
+        )
+        .map_err(|e| format!("invalid bucket '{name}': {e}"))
+    }
+
+    /// Service-level: list all buckets. rusty-s3 has no action for this, so we
+    /// sign a GET on the service root directly and parse the XML ourselves.
+    pub async fn list_buckets(&self) -> Result<Vec<BucketEntry>, String> {
+        let signed = rusty_s3::signing::sign(
+            &Timestamp::now(),
+            Method::Get,
+            self.endpoint.clone(),
+            self.creds.key(),
+            self.creds.secret(),
+            self.creds.token(),
+            &self.region,
+            SIGN_TTL.as_secs(),
+            std::iter::empty::<(&str, &str)>(),
+            std::iter::empty::<(&str, &str)>(),
+        );
+        let body = self.get_text(signed).await?;
+        let parsed: ListAllMyBucketsResult =
+            quick_xml::de::from_str(&body).map_err(|e| format!("parse ListBuckets response: {e}"))?;
+        Ok(parsed
+            .buckets
+            .bucket
+            .into_iter()
+            .map(|b| BucketEntry {
+                name: b.name,
+                created_at: b.creation_date.as_deref().and_then(parse_iso8601),
+                region: None,
+            })
+            .collect())
+    }
+
+    /// List one page of objects under `prefix`, using `/` as the delimiter so
+    /// sub-prefixes surface as folders. `continuation` resumes a truncated
+    /// listing; the returned `next_token` drives lazy pagination.
+    pub async fn list_objects(
+        &self,
+        bucket: &str,
+        prefix: &str,
+        continuation: Option<&str>,
+        max_keys: usize,
+    ) -> Result<ObjectListPage, String> {
+        let b = self.bucket(bucket)?;
+        let mut action = b.list_objects_v2(Some(&self.creds));
+        action.with_delimiter("/");
+        if !prefix.is_empty() {
+            action.with_prefix(prefix.to_string());
+        }
+        if let Some(t) = continuation {
+            action.with_continuation_token(t.to_string());
+        }
+        action.with_max_keys(max_keys);
+        let url = action.sign(SIGN_TTL);
+        let body = self.get_text(url).await?;
+        let resp = ListObjectsV2::parse_response(body.as_bytes())
+            .map_err(|e| format!("parse ListObjectsV2 response: {e}"))?;
+
+        let mut entries = Vec::with_capacity(resp.common_prefixes.len() + resp.contents.len());
+        for cp in resp.common_prefixes {
+            let trimmed = cp.prefix.trim_end_matches('/');
+            let name = trimmed.rsplit('/').next().unwrap_or(trimmed).to_string();
+            entries.push(ObjectEntry {
+                name,
+                key: cp.prefix,
+                is_dir: true,
+                size: 0,
+                last_modified: None,
+                etag: None,
+                storage_class: None,
+            });
+        }
+        for c in resp.contents {
+            // Skip the zero-byte folder marker that equals the prefix itself.
+            if c.key == prefix {
+                continue;
+            }
+            let name = c.key.strip_prefix(prefix).unwrap_or(&c.key).to_string();
+            entries.push(ObjectEntry {
+                name,
+                key: c.key,
+                is_dir: false,
+                size: c.size,
+                last_modified: parse_iso8601(&c.last_modified),
+                etag: Some(c.etag.trim_matches('"').to_string()),
+                storage_class: c.storage_class,
+            });
+        }
+        Ok(ObjectListPage {
+            entries,
+            next_token: resp.next_continuation_token,
+        })
+    }
+    pub async fn get_object_bytes(&self, bucket: &str, key: &str) -> Result<Vec<u8>, String> {
+        let b = self.bucket(bucket)?;
+        let url = b.get_object(Some(&self.creds), key).sign(SIGN_TTL);
+        let resp = self.http.get(url).send().await.map_err(net_err)?;
+        let resp = self.check(resp).await?;
+        Ok(resp.bytes().await.map_err(net_err)?.to_vec())
+    }
+
+    /// HEAD an object and build its metadata from the response headers.
+    pub async fn head_object(&self, bucket: &str, key: &str) -> Result<ObjectMetadata, String> {
+        let b = self.bucket(bucket)?;
+        let url = b.head_object(Some(&self.creds), key).sign(SIGN_TTL);
+        let resp = self.http.head(url).send().await.map_err(net_err)?;
+        let resp = self.check(resp).await?;
+        let h = resp.headers();
+        let get = |name: &str| {
+            h.get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string())
+        };
+        let mut user_metadata = std::collections::BTreeMap::new();
+        for (name, value) in h.iter() {
+            if let Some(k) = name.as_str().strip_prefix("x-amz-meta-") {
+                if let Ok(v) = value.to_str() {
+                    user_metadata.insert(k.to_ascii_lowercase(), v.to_string());
+                }
+            }
+        }
+        Ok(ObjectMetadata {
+            key: key.to_string(),
+            size: get("content-length").and_then(|s| s.parse().ok()).unwrap_or(0),
+            content_type: get("content-type"),
+            etag: get("etag").map(|e| e.trim_matches('"').to_string()),
+            last_modified: get("last-modified").as_deref().and_then(parse_http_date),
+            storage_class: get("x-amz-storage-class"),
+            cache_control: get("cache-control"),
+            content_encoding: get("content-encoding"),
+            content_disposition: get("content-disposition"),
+            user_metadata,
+        })
+    }
+
+    pub async fn put_object_bytes(
+        &self,
+        bucket: &str,
+        key: &str,
+        body: Vec<u8>,
+    ) -> Result<(), String> {
+        let b = self.bucket(bucket)?;
+        let url = b.put_object(Some(&self.creds), key).sign(SIGN_TTL);
+        let resp = self.http.put(url).body(body).send().await.map_err(net_err)?;
+        self.check(resp).await?;
+        Ok(())
+    }
+
+    pub async fn delete_object(&self, bucket: &str, key: &str) -> Result<(), String> {
+        let b = self.bucket(bucket)?;
+        let url = b.delete_object(Some(&self.creds), key).sign(SIGN_TTL);
+        let resp = self.http.delete(url).send().await.map_err(net_err)?;
+        self.check(resp).await?;
+        Ok(())
+    }
+
+    /// Server-side copy, including across buckets. rusty-s3 has no copy action,
+    /// so we sign a PUT on the destination with the `x-amz-copy-source` header
+    /// included in the signature, then send that exact header.
+    pub async fn copy_object(
+        &self,
+        src_bucket: &str,
+        src_key: &str,
+        dst_bucket: &str,
+        dst_key: &str,
+    ) -> Result<(), String> {
+        let dest = self.bucket(dst_bucket)?;
+        let dest_url = dest
+            .object_url(dst_key)
+            .map_err(|e| format!("invalid destination key '{dst_key}': {e}"))?;
+        let copy_source = format!("/{}/{}", src_bucket, encode_key_path(src_key));
+        let signed = rusty_s3::signing::sign(
+            &Timestamp::now(),
+            Method::Put,
+            dest_url,
+            self.creds.key(),
+            self.creds.secret(),
+            self.creds.token(),
+            &self.region,
+            SIGN_TTL.as_secs(),
+            std::iter::empty::<(&str, &str)>(),
+            std::iter::once(("x-amz-copy-source", copy_source.as_str())),
+        );
+        let resp = self
+            .http
+            .put(signed)
+            .header("x-amz-copy-source", &copy_source)
+            .send()
+            .await
+            .map_err(net_err)?;
+        let resp = self.check(resp).await?;
+        // S3 can report a copy failure in a 200 response body. Surface it.
+        let body = resp.text().await.unwrap_or_default();
+        if body.contains("<Error") {
+            let msg = parse_s3_error(&body).unwrap_or_else(|| "copy failed".into());
+            return Err(format!("S3 copy error: {msg}"));
+        }
+        Ok(())
+    }
+
+    /// Recursively delete everything under `prefix` (its objects and the folder
+    /// marker). Lists all keys (no delimiter) then deletes with bounded
+    /// concurrency — robust across S3-compatible providers that lack the batch
+    /// DeleteObjects API.
+    pub async fn delete_prefix(&self, bucket: &str, prefix: &str) -> Result<(), String> {
+        use futures::stream::{self, StreamExt};
+        let keys = self.list_all_keys(bucket, prefix).await?;
+        let results: Vec<Result<(), String>> = stream::iter(keys.into_iter().map(|k| {
+            let bucket = bucket.to_string();
+            async move { self.delete_object(&bucket, &k).await }
+        }))
+        .buffer_unordered(16)
+        .collect()
+        .await;
+        for r in results {
+            r?;
+        }
+        Ok(())
+    }
+
+    /// Page through every object key under `prefix` (no delimiter, so nested
+    /// keys are included).
+    async fn list_all_keys(&self, bucket: &str, prefix: &str) -> Result<Vec<String>, String> {
+        let b = self.bucket(bucket)?;
+        let mut keys = Vec::new();
+        let mut token: Option<String> = None;
+        loop {
+            let mut action = b.list_objects_v2(Some(&self.creds));
+            if !prefix.is_empty() {
+                action.with_prefix(prefix.to_string());
+            }
+            if let Some(t) = &token {
+                action.with_continuation_token(t.clone());
+            }
+            action.with_max_keys(1000);
+            let url = action.sign(SIGN_TTL);
+            let body = self.get_text(url).await?;
+            let resp = ListObjectsV2::parse_response(body.as_bytes())
+                .map_err(|e| format!("parse ListObjectsV2 response: {e}"))?;
+            keys.extend(resp.contents.into_iter().map(|c| c.key));
+            match resp.next_continuation_token {
+                Some(t) => token = Some(t),
+                None => break,
+            }
+        }
+        Ok(keys)
+    }
+
+    /// Create a folder by writing a zero-byte object whose key ends in '/'.
+    pub async fn create_folder(&self, bucket: &str, prefix: &str) -> Result<(), String> {
+        let key = if prefix.ends_with('/') {
+            prefix.to_string()
+        } else {
+            format!("{prefix}/")
+        };
+        self.put_object_bytes(bucket, &key, Vec::new()).await
+    }
+
+    pub async fn create_bucket(&self, bucket: &str) -> Result<(), String> {
+        let b = self.bucket(bucket)?;
+        let url = b.create_bucket(&self.creds).sign(SIGN_TTL);
+        let resp = self.http.put(url).send().await.map_err(net_err)?;
+        self.check(resp).await?;
+        Ok(())
+    }
+
+    pub async fn delete_bucket(&self, bucket: &str) -> Result<(), String> {
+        let b = self.bucket(bucket)?;
+        let url = b.delete_bucket(&self.creds).sign(SIGN_TTL);
+        let resp = self.http.delete(url).send().await.map_err(net_err)?;
+        self.check(resp).await?;
+        Ok(())
+    }
+
+    /// Generate a presigned GET URL valid for `ttl_secs` seconds — a shareable
+    /// download link that needs no further credentials.
+    pub fn presign_get(&self, bucket: &str, key: &str, ttl_secs: u64) -> Result<String, String> {
+        let b = self.bucket(bucket)?;
+        let url = b
+            .get_object(Some(&self.creds), key)
+            .sign(Duration::from_secs(ttl_secs));
+        Ok(url.to_string())
+    }
+
+    /// Stream an object to a local file, emitting progress.
+    pub async fn download_to_file<R: Runtime>(
+        &self,
+        bucket: &str,
+        key: &str,
+        dest: &Path,
+        transfer_id: &str,
+        handle: &Arc<TransferHandle>,
+        app: &AppHandle<R>,
+    ) -> Result<(), String> {
+        let b = self.bucket(bucket)?;
+        let url = b.get_object(Some(&self.creds), key).sign(SIGN_TTL);
+        let resp = self.http.get(url).send().await.map_err(net_err)?;
+        let resp = self.check(resp).await?;
+        let total = resp.content_length().unwrap_or(0);
+        super::transfer::stream_to_file(resp, total, dest, transfer_id, handle, app).await
+    }
+
+    /// Upload a local file. Small files go in one PUT; large files use a
+    /// multipart upload (aborted on failure), emitting progress per part.
+    /// `storage_class`, when set, is applied via a signed `x-amz-storage-class`
+    /// header (on the PUT, or the multipart create for large files).
+    pub async fn upload_from_file<R: Runtime>(
+        &self,
+        local: &Path,
+        bucket: &str,
+        key: &str,
+        storage_class: Option<&str>,
+        transfer_id: &str,
+        handle: &Arc<TransferHandle>,
+        app: &AppHandle<R>,
+    ) -> Result<(), String> {
+        use super::transfer::{emit_progress, MULTIPART_THRESHOLD};
+        let total = tokio::fs::metadata(local)
+            .await
+            .map_err(|e| format!("stat {}: {e}", local.display()))?
+            .len();
+        let b = self.bucket(bucket)?;
+        let started = Instant::now();
+        emit_progress(app, transfer_id, 0, total, started);
+
+        if total <= MULTIPART_THRESHOLD {
+            let data = tokio::fs::read(local)
+                .await
+                .map_err(|e| format!("read {}: {e}", local.display()))?;
+            let mut put = b.put_object(Some(&self.creds), key);
+            if let Some(sc) = storage_class {
+                put.headers_mut().insert("x-amz-storage-class", sc.to_string());
+            }
+            let url = put.sign(SIGN_TTL);
+            let mut req = self.http.put(url).body(data);
+            if let Some(sc) = storage_class {
+                req = req.header("x-amz-storage-class", sc);
+            }
+            let resp = req.send().await.map_err(net_err)?;
+            self.check(resp).await?;
+            emit_progress(app, transfer_id, total, total, started);
+            return Ok(());
+        }
+
+        let mut create = b.create_multipart_upload(Some(&self.creds), key);
+        if let Some(sc) = storage_class {
+            create.headers_mut().insert("x-amz-storage-class", sc.to_string());
+        }
+        let create_url = create.sign(SIGN_TTL);
+        let mut create_req = self.http.post(create_url);
+        if let Some(sc) = storage_class {
+            create_req = create_req.header("x-amz-storage-class", sc);
+        }
+        let resp = create_req.send().await.map_err(net_err)?;
+        let resp = self.check(resp).await?;
+        let body = resp.bytes().await.map_err(net_err)?;
+        let upload_id = CreateMultipartUpload::parse_response(&body)
+            .map_err(|e| format!("parse multipart create: {e}"))?
+            .upload_id()
+            .to_string();
+
+        match self
+            .upload_parts(&b, key, &upload_id, local, total, transfer_id, handle, app, started)
+            .await
+        {
+            Ok(etags) => {
+                let etag_refs: Vec<&str> = etags.iter().map(String::as_str).collect();
+                let complete = b.complete_multipart_upload(
+                    Some(&self.creds),
+                    key,
+                    &upload_id,
+                    etag_refs.iter().copied(),
+                );
+                let curl = complete.sign(SIGN_TTL);
+                let cbody = complete.body();
+                let resp = self.http.post(curl).body(cbody).send().await.map_err(net_err)?;
+                let resp = self.check(resp).await?;
+                let txt = resp.text().await.unwrap_or_default();
+                if txt.contains("<Error") {
+                    let msg = parse_s3_error(&txt).unwrap_or_else(|| "complete failed".into());
+                    return Err(format!("S3 complete multipart error: {msg}"));
+                }
+                emit_progress(app, transfer_id, total, total, started);
+                Ok(())
+            }
+            Err(e) => {
+                let aurl = b
+                    .abort_multipart_upload(Some(&self.creds), key, &upload_id)
+                    .sign(SIGN_TTL);
+                let _ = self.http.delete(aurl).send().await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Read the file in `PART_SIZE` chunks and upload each as a numbered part,
+    /// returning the part ETags in order. Honors pause/cancel.
+    #[allow(clippy::too_many_arguments)]
+    async fn upload_parts<R: Runtime>(
+        &self,
+        b: &Bucket,
+        key: &str,
+        upload_id: &str,
+        local: &Path,
+        total: u64,
+        transfer_id: &str,
+        handle: &Arc<TransferHandle>,
+        app: &AppHandle<R>,
+        started: Instant,
+    ) -> Result<Vec<String>, String> {
+        use super::transfer::{emit_paused, emit_progress, read_full, PART_SIZE};
+        let mut file = tokio::fs::File::open(local)
+            .await
+            .map_err(|e| format!("open {}: {e}", local.display()))?;
+        let mut etags: Vec<String> = Vec::new();
+        let mut buf = vec![0u8; PART_SIZE];
+        let mut part_number: u16 = 1;
+        let mut uploaded: u64 = 0;
+        loop {
+            if handle.is_cancelled() {
+                return Err("transfer cancelled".to_string());
+            }
+            if handle.is_paused() {
+                emit_paused(app, transfer_id, uploaded, total);
+                handle.wait_while_paused().await;
+                if handle.is_cancelled() {
+                    return Err("transfer cancelled".to_string());
+                }
+            }
+            let n = read_full(&mut file, &mut buf).await?;
+            if n == 0 {
+                break;
+            }
+            let purl = b
+                .upload_part(Some(&self.creds), key, part_number, upload_id)
+                .sign(SIGN_TTL);
+            let resp = self
+                .http
+                .put(purl)
+                .body(buf[..n].to_vec())
+                .send()
+                .await
+                .map_err(net_err)?;
+            let resp = self.check(resp).await?;
+            let etag = resp
+                .headers()
+                .get("etag")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string())
+                .ok_or("uploaded part missing ETag")?;
+            etags.push(etag);
+            uploaded += n as u64;
+            emit_progress(app, transfer_id, uploaded, total, started);
+            part_number += 1;
+        }
+        Ok(etags)
+    }
+
+    /// Cheap connectivity check: HEAD the default bucket if one is configured,
+    /// otherwise list buckets.
+    pub async fn ping(&self, default_bucket: Option<&str>) -> Result<(), String> {
+        match default_bucket {
+            Some(b) if !b.is_empty() => {
+                let bk = self.bucket(b)?;
+                let url = bk.head_bucket(Some(&self.creds)).sign(SIGN_TTL);
+                let resp = self.http.head(url).send().await.map_err(net_err)?;
+                self.check(resp).await.map(|_| ())
+            }
+            _ => self.list_buckets().await.map(|_| ()),
+        }
+    }
+
+    async fn get_text(&self, url: Url) -> Result<String, String> {
+        let resp = self.http.get(url).send().await.map_err(net_err)?;
+        let resp = self.check(resp).await?;
+        resp.text().await.map_err(net_err)
+    }
+
+    /// Map a non-2xx response into a useful S3 error string.
+    async fn check(&self, resp: reqwest::Response) -> Result<reqwest::Response, String> {
+        let status = resp.status();
+        if status.is_success() {
+            return Ok(resp);
+        }
+        let body = resp.text().await.unwrap_or_default();
+        let msg = parse_s3_error(&body).unwrap_or_else(|| body.chars().take(300).collect());
+        Err(format!("S3 error {}: {msg}", status.as_u16()))
+    }
+}
+
+fn net_err(e: reqwest::Error) -> String {
+    format!("request failed: {e}")
+}
+
+/// Percent-encode each path segment of a key while preserving `/` separators
+/// (for the `x-amz-copy-source` header).
+fn encode_key_path(key: &str) -> String {
+    key.split('/')
+        .map(|seg| urlencoding::encode(seg).into_owned())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn parse_iso8601(s: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp())
+}
+
+/// Parse an RFC 1123 HTTP date (as returned by HEAD `Last-Modified`).
+fn parse_http_date(s: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc2822(s)
+        .ok()
+        .map(|dt| dt.timestamp())
+        .or_else(|| {
+            chrono::NaiveDateTime::parse_from_str(s, "%a, %d %b %Y %H:%M:%S GMT")
+                .ok()
+                .map(|dt| dt.and_utc().timestamp())
+        })
+}
+
+fn parse_s3_error(body: &str) -> Option<String> {
+    #[derive(Deserialize)]
+    struct S3Error {
+        #[serde(rename = "Code")]
+        code: Option<String>,
+        #[serde(rename = "Message")]
+        message: Option<String>,
+    }
+    let e: S3Error = quick_xml::de::from_str(body).ok()?;
+    match (e.code, e.message) {
+        (Some(c), Some(m)) => Some(format!("{c}: {m}")),
+        (Some(c), None) => Some(c),
+        (None, Some(m)) => Some(m),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct ListAllMyBucketsResult {
+    #[serde(default)]
+    buckets: BucketsXml,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct BucketsXml {
+    #[serde(default, rename = "Bucket")]
+    bucket: Vec<BucketXml>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct BucketXml {
+    name: String,
+    creation_date: Option<String>,
+}
+
+#[cfg(test)]
+mod it {
+    use super::*;
+    use rusty_s3::UrlStyle;
+
+    /// End-to-end round trip against a live S3-compatible endpoint (MinIO in
+    /// CI/dev). Skipped unless `TAOMNI_S3_IT_ENDPOINT` is set, so the normal
+    /// `cargo test` run stays offline. Exercises bucket/object signing, XML
+    /// list parsing, delimiter→folder mapping, and pagination plumbing.
+    #[tokio::test]
+    async fn s3_round_trip() {
+        let endpoint = match std::env::var("TAOMNI_S3_IT_ENDPOINT") {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        let key = std::env::var("TAOMNI_S3_IT_KEY").unwrap_or_else(|_| "minioadmin".into());
+        let secret = std::env::var("TAOMNI_S3_IT_SECRET").unwrap_or_else(|_| "minioadmin".into());
+
+        let client = S3Client::new(
+            reqwest::Client::new(),
+            Credentials::new(key, secret),
+            url::Url::parse(&endpoint).expect("endpoint url"),
+            "us-east-1".to_string(),
+            UrlStyle::Path,
+        );
+
+        let bucket = format!("taomni-it-{}", uuid::Uuid::new_v4().simple());
+        client.create_bucket(&bucket).await.expect("create_bucket");
+
+        let buckets = client.list_buckets().await.expect("list_buckets");
+        assert!(buckets.iter().any(|b| b.name == bucket), "new bucket listed");
+
+        client
+            .put_object_bytes(&bucket, "dir/hello.txt", b"hi there".to_vec())
+            .await
+            .expect("put_object");
+        client.create_folder(&bucket, "emptydir").await.expect("create_folder");
+
+        let root = client.list_objects(&bucket, "", None, 1000).await.expect("list root");
+        assert!(
+            root.entries.iter().any(|e| e.is_dir && e.name == "dir"),
+            "dir/ surfaces as a folder"
+        );
+        assert!(
+            root.entries.iter().all(|e| e.is_dir),
+            "root has only folders, no loose files"
+        );
+
+        let inside = client.list_objects(&bucket, "dir/", None, 1000).await.expect("list dir/");
+        let file = inside.entries.iter().find(|e| !e.is_dir).expect("file under dir/");
+        assert_eq!(file.name, "hello.txt");
+        assert_eq!(file.size, 8);
+
+        let bytes = client.get_object_bytes(&bucket, "dir/hello.txt").await.expect("get");
+        assert_eq!(bytes, b"hi there");
+
+        // --- P3 management ops ---
+        let meta = client.head_object(&bucket, "dir/hello.txt").await.expect("head");
+        assert_eq!(meta.size, 8);
+
+        // Server-side copy (same bucket) then verify the copy's bytes.
+        client
+            .copy_object(&bucket, "dir/hello.txt", &bucket, "dir2/copy.txt")
+            .await
+            .expect("copy");
+        let copied = client.get_object_bytes(&bucket, "dir2/copy.txt").await.expect("get copy");
+        assert_eq!(copied, b"hi there");
+
+        // Presigned GET should be fetchable with no further credentials.
+        let url = client.presign_get(&bucket, "dir/hello.txt", 300).expect("presign");
+        let presigned = reqwest::get(&url).await.expect("fetch presigned").bytes().await.expect("bytes");
+        assert_eq!(&presigned[..], b"hi there");
+
+        // Recursive delete removes everything under the prefix.
+        client.delete_prefix(&bucket, "dir/").await.expect("delete_prefix");
+        let after = client.list_objects(&bucket, "", None, 1000).await.expect("relist");
+        assert!(!after.entries.iter().any(|e| e.name == "dir"), "dir/ gone after delete_prefix");
+
+        // cleanup
+        client.delete_object(&bucket, "dir2/copy.txt").await.expect("del copy");
+        client.delete_object(&bucket, "emptydir/").await.expect("del marker");
+        client.delete_bucket(&bucket).await.expect("del bucket");
+    }
+
+    // NOTE: the multipart-upload + streaming-download paths
+    // (`upload_from_file`/`download_to_file`) need a Tauri `AppHandle` for
+    // progress emission. Driving them in a unit test requires
+    // `tauri::test::mock_app()` (the `test` feature), which fails to link a
+    // bare test binary on Windows (STATUS_ENTRYPOINT_NOT_FOUND from the
+    // windowing DLLs). Those paths are therefore covered by manual smoke
+    // testing through the UI rather than an automated round-trip here.
+}

--- a/src-tauri/src/objectstorage/session.rs
+++ b/src-tauri/src/objectstorage/session.rs
@@ -1,0 +1,205 @@
+//! A live object-storage connection held in `AppState::oss_sessions`, with
+//! engine-agnostic dispatch over the S3 and Azure backends.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tauri::{AppHandle, Runtime};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use super::azure::AzureClient;
+use super::s3::S3Client;
+use super::types::{BucketEntry, ObjectListPage, ObjectMetadata};
+use crate::filebrowser::transfer::TransferHandle;
+
+/// Per-engine client handle.
+pub enum OssHandle {
+    S3(S3Client),
+    Azure(AzureClient),
+}
+
+/// A live object-storage connection, keyed by the frontend session id.
+pub struct ObjectStorageSession {
+    pub session_id: String,
+    pub handle: OssHandle,
+    /// Default bucket (S3) or container (Azure) to open into, if configured.
+    pub default_location: Option<String>,
+    /// Cancels in-flight list/transfer operations when the session is detached.
+    pub cancel: CancellationToken,
+    /// Loopback forwarder task when the session routes through an SSH jump host
+    /// (P7). Aborted on close to release the bound local port and bridges.
+    pub forward_task: Option<JoinHandle<()>>,
+    /// Default storage class / access tier for uploads when the caller doesn't
+    /// pass one (P8).
+    pub default_storage_class: Option<String>,
+}
+
+impl ObjectStorageSession {
+    /// Signal any in-flight operations on this session to stop.
+    pub fn close(&self) {
+        self.cancel.cancel();
+        if let Some(task) = &self.forward_task {
+            task.abort();
+        }
+    }
+
+    pub async fn list_buckets(&self) -> Result<Vec<BucketEntry>, String> {
+        match &self.handle {
+            OssHandle::S3(c) => c.list_buckets().await,
+            OssHandle::Azure(c) => c.list_buckets().await,
+        }
+    }
+
+    pub async fn list_objects(
+        &self,
+        bucket: &str,
+        prefix: &str,
+        continuation: Option<&str>,
+        max_keys: usize,
+    ) -> Result<ObjectListPage, String> {
+        match &self.handle {
+            OssHandle::S3(c) => c.list_objects(bucket, prefix, continuation, max_keys).await,
+            OssHandle::Azure(c) => c.list_objects(bucket, prefix, continuation, max_keys).await,
+        }
+    }
+
+    pub async fn get_object_bytes(&self, bucket: &str, key: &str) -> Result<Vec<u8>, String> {
+        match &self.handle {
+            OssHandle::S3(c) => c.get_object_bytes(bucket, key).await,
+            OssHandle::Azure(c) => c.get_object_bytes(bucket, key).await,
+        }
+    }
+
+    pub async fn put_object_bytes(&self, bucket: &str, key: &str, data: Vec<u8>) -> Result<(), String> {
+        match &self.handle {
+            OssHandle::S3(c) => c.put_object_bytes(bucket, key, data).await,
+            OssHandle::Azure(c) => c.put_object_bytes(bucket, key, data).await,
+        }
+    }
+
+    pub async fn delete_object(&self, bucket: &str, key: &str) -> Result<(), String> {
+        match &self.handle {
+            OssHandle::S3(c) => c.delete_object(bucket, key).await,
+            OssHandle::Azure(c) => c.delete_object(bucket, key).await,
+        }
+    }
+
+    /// Recursively delete everything under `prefix` (a "folder").
+    pub async fn delete_prefix(&self, bucket: &str, prefix: &str) -> Result<(), String> {
+        match &self.handle {
+            OssHandle::S3(c) => c.delete_prefix(bucket, prefix).await,
+            OssHandle::Azure(c) => c.delete_prefix(bucket, prefix).await,
+        }
+    }
+
+    pub async fn head_object(&self, bucket: &str, key: &str) -> Result<ObjectMetadata, String> {
+        match &self.handle {
+            OssHandle::S3(c) => c.head_object(bucket, key).await,
+            OssHandle::Azure(c) => c.head_object(bucket, key).await,
+        }
+    }
+
+    pub async fn copy_object(
+        &self,
+        src_bucket: &str,
+        src_key: &str,
+        dst_bucket: &str,
+        dst_key: &str,
+    ) -> Result<(), String> {
+        match &self.handle {
+            OssHandle::S3(c) => c.copy_object(src_bucket, src_key, dst_bucket, dst_key).await,
+            OssHandle::Azure(c) => c.copy_object(src_bucket, src_key, dst_bucket, dst_key).await,
+        }
+    }
+
+    /// Rename/move = server-side copy then delete the source.
+    pub async fn move_object(
+        &self,
+        src_bucket: &str,
+        src_key: &str,
+        dst_bucket: &str,
+        dst_key: &str,
+    ) -> Result<(), String> {
+        self.copy_object(src_bucket, src_key, dst_bucket, dst_key).await?;
+        self.delete_object(src_bucket, src_key).await
+    }
+
+    /// Build a shareable read-only URL (presigned for S3, service SAS for Azure).
+    pub fn presign_get(&self, bucket: &str, key: &str, ttl_secs: u64) -> Result<String, String> {
+        match &self.handle {
+            OssHandle::S3(c) => c.presign_get(bucket, key, ttl_secs),
+            OssHandle::Azure(c) => c.presign_get(bucket, key, ttl_secs),
+        }
+    }
+
+    pub async fn download_to_file<R: Runtime>(
+        &self,
+        bucket: &str,
+        key: &str,
+        dest: &Path,
+        transfer_id: &str,
+        handle: &Arc<TransferHandle>,
+        app: &AppHandle<R>,
+    ) -> Result<(), String> {
+        match &self.handle {
+            OssHandle::S3(c) => {
+                c.download_to_file(bucket, key, dest, transfer_id, handle, app).await
+            }
+            OssHandle::Azure(c) => {
+                c.download_to_file(bucket, key, dest, transfer_id, handle, app).await
+            }
+        }
+    }
+
+    pub async fn upload_from_file<R: Runtime>(
+        &self,
+        local: &Path,
+        bucket: &str,
+        key: &str,
+        storage_class: Option<&str>,
+        transfer_id: &str,
+        handle: &Arc<TransferHandle>,
+        app: &AppHandle<R>,
+    ) -> Result<(), String> {
+        // Per-upload override, else the session's configured default.
+        let sc = storage_class.or(self.default_storage_class.as_deref());
+        match &self.handle {
+            OssHandle::S3(c) => {
+                c.upload_from_file(local, bucket, key, sc, transfer_id, handle, app).await
+            }
+            OssHandle::Azure(c) => {
+                c.upload_from_file(local, bucket, key, sc, transfer_id, handle, app).await
+            }
+        }
+    }
+
+    pub async fn create_folder(&self, bucket: &str, prefix: &str) -> Result<(), String> {
+        match &self.handle {
+            OssHandle::S3(c) => c.create_folder(bucket, prefix).await,
+            OssHandle::Azure(c) => c.create_folder(bucket, prefix).await,
+        }
+    }
+
+    pub async fn create_bucket(&self, bucket: &str) -> Result<(), String> {
+        match &self.handle {
+            OssHandle::S3(c) => c.create_bucket(bucket).await,
+            OssHandle::Azure(c) => c.create_bucket(bucket).await,
+        }
+    }
+
+    pub async fn delete_bucket(&self, bucket: &str) -> Result<(), String> {
+        match &self.handle {
+            OssHandle::S3(c) => c.delete_bucket(bucket).await,
+            OssHandle::Azure(c) => c.delete_bucket(bucket).await,
+        }
+    }
+
+    pub async fn ping(&self) -> Result<(), String> {
+        let default = self.default_location.as_deref();
+        match &self.handle {
+            OssHandle::S3(c) => c.ping(default).await,
+            OssHandle::Azure(c) => c.ping(default).await,
+        }
+    }
+}

--- a/src-tauri/src/objectstorage/transfer.rs
+++ b/src-tauri/src/objectstorage/transfer.rs
@@ -1,0 +1,114 @@
+//! Shared streaming-transfer plumbing for the object-storage engines:
+//! progress/paused event emission and a response→file streamer used by both
+//! the S3 and Azure download paths. Reuses `filebrowser::transfer`'s
+//! `TransferHandle`/`ProgressPayload` so the frontend's `FileTransferQueue`
+//! treats object-storage transfers exactly like SFTP ones (events are just
+//! named `storage-*` instead of `sftp-*`).
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+use futures::StreamExt;
+use tauri::{AppHandle, Emitter, Runtime};
+use tokio::io::AsyncWriteExt;
+
+use crate::filebrowser::transfer::{ProgressPayload, TransferHandle};
+
+/// Part/buffer size for multipart uploads and chunked reads (8 MiB). Above the
+/// S3 5 MiB minimum part size, and a reasonable block size for Azure.
+pub const PART_SIZE: usize = 8 * 1024 * 1024;
+
+/// Files at or below this size upload in a single request; larger files use the
+/// engine's chunked path (S3 multipart / Azure block list).
+pub const MULTIPART_THRESHOLD: u64 = PART_SIZE as u64;
+
+pub fn emit_progress<R: Runtime>(
+    app: &AppHandle<R>,
+    transfer_id: &str,
+    bytes: u64,
+    total: u64,
+    started: Instant,
+) {
+    let secs = started.elapsed().as_secs_f64().max(0.001);
+    let rate = bytes as f64 / secs;
+    let remaining = total.saturating_sub(bytes) as f64;
+    let eta = if rate > 0.0 { remaining / rate } else { 0.0 };
+    let _ = app.emit(
+        &format!("storage-progress-{}", transfer_id),
+        ProgressPayload { bytes, total, rate, eta },
+    );
+}
+
+pub fn emit_paused<R: Runtime>(app: &AppHandle<R>, transfer_id: &str, bytes: u64, total: u64) {
+    let _ = app.emit(
+        &format!("storage-paused-{}", transfer_id),
+        ProgressPayload { bytes, total, rate: 0.0, eta: 0.0 },
+    );
+}
+
+/// Stream a checked HTTP response body to `dest`, emitting progress and honoring
+/// pause/cancel. `total` is the expected byte count (0 when unknown).
+pub async fn stream_to_file<R: Runtime>(
+    resp: reqwest::Response,
+    total: u64,
+    dest: &Path,
+    transfer_id: &str,
+    handle: &Arc<TransferHandle>,
+    app: &AppHandle<R>,
+) -> Result<(), String> {
+    if let Some(parent) = dest.parent() {
+        let _ = tokio::fs::create_dir_all(parent).await;
+    }
+    let mut file = tokio::fs::File::create(dest)
+        .await
+        .map_err(|e| format!("create {}: {e}", dest.display()))?;
+    let started = Instant::now();
+    emit_progress(app, transfer_id, 0, total, started);
+    let mut written: u64 = 0;
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        if handle.is_cancelled() {
+            return Err("transfer cancelled".to_string());
+        }
+        if handle.is_paused() {
+            emit_paused(app, transfer_id, written, total);
+            handle.wait_while_paused().await;
+            if handle.is_cancelled() {
+                return Err("transfer cancelled".to_string());
+            }
+        }
+        let chunk = chunk.map_err(|e| format!("download stream error: {e}"))?;
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| format!("write {}: {e}", dest.display()))?;
+        written += chunk.len() as u64;
+        emit_progress(app, transfer_id, written, total, started);
+    }
+    file.flush()
+        .await
+        .map_err(|e| format!("flush {}: {e}", dest.display()))?;
+    Ok(())
+}
+
+/// Read up to `buf.len()` bytes, looping until the buffer is full or EOF. The
+/// chunked-upload paths need full parts (except the last), which a single
+/// `read` does not guarantee.
+pub async fn read_full(
+    file: &mut tokio::fs::File,
+    buf: &mut [u8],
+) -> Result<usize, String> {
+    use tokio::io::AsyncReadExt;
+    let mut filled = 0;
+    while filled < buf.len() {
+        let n = file
+            .read(&mut buf[filled..])
+            .await
+            .map_err(|e| format!("read local file: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        filled += n;
+    }
+    Ok(filled)
+}

--- a/src-tauri/src/objectstorage/types.rs
+++ b/src-tauri/src/objectstorage/types.rs
@@ -1,0 +1,72 @@
+//! Wire DTOs shared between the object-storage backend and the frontend.
+//! All fields serialize as camelCase to match the TypeScript types in
+//! `src/types/objectStorage.ts`.
+
+use serde::{Deserialize, Serialize};
+
+/// A bucket (S3) or container (Azure) at the account/service root.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BucketEntry {
+    pub name: String,
+    /// Creation time, seconds since the UNIX epoch, when the provider reports it.
+    pub created_at: Option<i64>,
+    pub region: Option<String>,
+}
+
+/// One row in an object listing: either a real object or a synthetic "folder"
+/// derived from a common prefix (delimiter-based listing).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectEntry {
+    /// Display name — the last path segment relative to the current prefix.
+    pub name: String,
+    /// Full object key, or the common prefix (with trailing `/`) for a folder.
+    pub key: String,
+    /// True for a common-prefix folder, false for a real object.
+    pub is_dir: bool,
+    pub size: u64,
+    /// Last-modified time, seconds since the UNIX epoch.
+    pub last_modified: Option<i64>,
+    pub etag: Option<String>,
+    pub storage_class: Option<String>,
+}
+
+/// One page of an object listing. `next_token` is the continuation token for
+/// lazy pagination of large buckets; `None` means the listing is complete.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectListPage {
+    pub entries: Vec<ObjectEntry>,
+    pub next_token: Option<String>,
+}
+
+/// Detailed metadata for a single object, from a HEAD request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectMetadata {
+    pub key: String,
+    pub size: u64,
+    pub content_type: Option<String>,
+    pub etag: Option<String>,
+    /// Last-modified time, seconds since the UNIX epoch.
+    pub last_modified: Option<i64>,
+    pub storage_class: Option<String>,
+    pub cache_control: Option<String>,
+    pub content_encoding: Option<String>,
+    pub content_disposition: Option<String>,
+    /// User-defined metadata (`x-amz-meta-*` / `x-ms-meta-*`), keys lowercased.
+    pub user_metadata: std::collections::BTreeMap<String, String>,
+}
+
+/// Progress tick for an upload/download, emitted on `storage-progress-{transferId}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageTransferProgress {
+    pub bytes: u64,
+    pub total: u64,
+    /// Throughput in bytes/sec.
+    pub rate: f64,
+    /// Estimated seconds remaining.
+    pub eta: f64,
+}

--- a/src-tauri/src/session/models.rs
+++ b/src-tauri/src/session/models.rs
@@ -41,6 +41,16 @@ pub enum SessionType {
     Redis,
     HBaseShell,
     Proxy,
+    /// S3 and any S3-compatible object storage (AWS S3, Alibaba OSS via its
+    /// S3-compatible endpoint, MinIO, Cloudflare R2, Backblaze B2, Wasabi,
+    /// Tencent COS, Ceph, ...). The concrete provider + endpoint + addressing
+    /// style live in `options_json` (`provider`, `endpoint`, `region`,
+    /// `pathStyle`, `authType`, credential `vault:` refs, `defaultBucket`).
+    S3,
+    /// Azure Blob storage (official azure_storage_blob SDK). `options_json`
+    /// carries `accountName`, `endpointSuffix`, `authType` and the credential
+    /// `vault:` refs (account key / connection string / SAS / Entra ID).
+    AzureBlob,
 }
 
 impl SessionType {
@@ -62,6 +72,8 @@ impl SessionType {
             Self::Redis => "Redis",
             Self::HBaseShell => "HBaseShell",
             Self::Proxy => "Proxy",
+            Self::S3 => "S3",
+            Self::AzureBlob => "AzureBlob",
         }
     }
 
@@ -83,6 +95,8 @@ impl SessionType {
             "Redis" => Self::Redis,
             "HBaseShell" => Self::HBaseShell,
             "Proxy" => Self::Proxy,
+            "S3" => Self::S3,
+            "AzureBlob" => Self::AzureBlob,
             _ => Self::SSH,
         }
     }
@@ -101,6 +115,8 @@ impl SessionType {
             Self::Redis => 6379,
             Self::HBaseShell => 8080,
             Self::Proxy => 3128,
+            // Object storage speaks HTTPS; the real endpoint lives in options_json.
+            Self::S3 | Self::AzureBlob => 443,
             Self::Serial | Self::LocalShell | Self::File => 0,
         }
     }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -10,6 +10,7 @@ use crate::database::DbSession;
 use crate::filebrowser::sftp::ActiveSftp;
 use crate::filebrowser::transfer::TransferHandle;
 use crate::hbase::HBaseSession;
+use crate::objectstorage::ObjectStorageSession;
 use crate::rdp::ws::RdpSession;
 use crate::servers::ServerRegistry;
 use crate::terminal::{ActiveTerminal, TerminalOutputChannel};
@@ -48,6 +49,10 @@ pub struct AppState {
     pub db_connections: Arc<RwLock<HashMap<String, Arc<DbSession>>>>,
     /// Live JVM-free HBase shell sessions over HBase REST/Stargate.
     pub hbase_sessions: Arc<RwLock<HashMap<String, Arc<HBaseSession>>>>,
+    /// Live object-storage connections (S3 / S3-compatible / Azure Blob),
+    /// keyed by session id. Each holds the per-engine client handle plus a
+    /// cancellation token for in-flight list/transfer operations.
+    pub oss_sessions: Arc<RwLock<HashMap<String, Arc<ObjectStorageSession>>>>,
     pub read_handles: Arc<Mutex<HashMap<String, ReadStreamHandle>>>,
     pub write_handles: Arc<Mutex<HashMap<String, WriteStreamHandle>>>,
     /// Pending keyboard-interactive auth rounds, keyed by request id. See
@@ -76,6 +81,7 @@ impl AppState {
             rdp_sessions: Arc::new(RwLock::new(HashMap::new())),
             db_connections: Arc::new(RwLock::new(HashMap::new())),
             hbase_sessions: Arc::new(RwLock::new(HashMap::new())),
+            oss_sessions: Arc::new(RwLock::new(HashMap::new())),
             read_handles: Arc::new(Mutex::new(HashMap::new())),
             write_handles: Arc::new(Mutex::new(HashMap::new())),
             ssh_auth_responders: Arc::new(Mutex::new(HashMap::new())),

--- a/src-tauri/src/terminal/network.rs
+++ b/src-tauri/src/terminal/network.rs
@@ -8,18 +8,18 @@
 use std::time::Duration;
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{lookup_host, TcpStream};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkForward {
     pub local: String,
     pub remote: String,
 }
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkSettings {
     #[serde(default = "default_proxy_kind")]

--- a/src/components/filebrowser/FilePanel.tsx
+++ b/src/components/filebrowser/FilePanel.tsx
@@ -3,7 +3,7 @@ import { Folder, File as FileIcon, Link as LinkIcon, HardDrive, ChevronDown, Hel
 import { PathBreadcrumb } from "./PathBreadcrumb";
 import { FileToolbar } from "./FileToolbar";
 import { useContextMenu, type MenuItem } from "../ContextMenu";
-import { useSftpStore, WINDOWS_DRIVES_ROOT, type PaneSide } from "../../stores/sftpStore";
+import { useSftpStore, WINDOWS_DRIVES_ROOT, type PaneSide, type FilePanelStoreHook } from "../../stores/sftpStore";
 import {
   basename,
   formatBytes,
@@ -76,6 +76,13 @@ function clampCol(n: number): number {
 interface FilePanelProps {
   sessionId: string;
   side: PaneSide;
+  /**
+   * Optional store driving this panel. Defaults to the SFTP store. The
+   * object-storage browser passes its own store (same {@link FilePanelStore}
+   * surface) so the panel renders buckets/objects with no SFTP coupling. Must
+   * be stable across the component's lifetime (don't swap stores per render).
+   */
+  store?: FilePanelStoreHook;
   /** Optional subtitle (e.g. host) shown in muted text next to the LOCAL/REMOTE badge. */
   subtitle?: string;
   detachable?: boolean;
@@ -118,6 +125,7 @@ const SUPPORTED_PREVIEW_EXT = new Set([
 export function FilePanel({
   sessionId,
   side,
+  store,
   subtitle,
   detachable,
   onDetach,
@@ -144,14 +152,17 @@ export function FilePanel({
   const t = useT();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
-  const session = useSftpStore((s) => s.sessions[sessionId]);
-  const navigate = useSftpStore((s) => s.navigate);
-  const navigateBack = useSftpStore((s) => s.navigateBack);
-  const navigateForward = useSftpStore((s) => s.navigateForward);
-  const navigateUp = useSftpStore((s) => s.navigateUp);
-  const refresh = useSftpStore((s) => s.refreshPane);
-  const setSelection = useSftpStore((s) => s.setSelection);
-  const toggleHidden = useSftpStore((s) => s.toggleHidden);
+  // `store` is stable per mount (see prop docs), so the conditional default
+  // resolves to one consistent hook identity across renders.
+  const useStore = (store ?? useSftpStore) as FilePanelStoreHook;
+  const session = useStore((s) => s.sessions[sessionId]);
+  const navigate = useStore((s) => s.navigate);
+  const navigateBack = useStore((s) => s.navigateBack);
+  const navigateForward = useStore((s) => s.navigateForward);
+  const navigateUp = useStore((s) => s.navigateUp);
+  const refresh = useStore((s) => s.refreshPane);
+  const setSelection = useStore((s) => s.setSelection);
+  const toggleHidden = useStore((s) => s.toggleHidden);
   const ctx = useContextMenu();
 
   const [sortKey, setSortKey] = useState<"name" | "size" | "mtime" | "type">("name");
@@ -297,7 +308,7 @@ export function FilePanel({
       setDraggingOver(false);
       const payload = detail.data.payload as CrossPaneDragPayload | null;
       if (!payload) return;
-      const otherPane = useSftpStore.getState().sessions[payload.sessionId]?.[payload.side];
+      const otherPane = useStore.getState().sessions[payload.sessionId]?.[payload.side];
       if (!otherPane) return;
       const entries = otherPane.entries.filter((entry) => payload.paths.includes(entry.path));
       if (entries.length > 0) onCrossPaneDrop?.(entries);

--- a/src/components/objectstorage/ObjectStorageBrowser.tsx
+++ b/src/components/objectstorage/ObjectStorageBrowser.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useState, useCallback } from "react";
+import { Group as PanelGroup, Panel, Separator as PanelResizeHandle } from "react-resizable-panels";
+import { FilePanel } from "../filebrowser/FilePanel";
+import { FileTransferQueue } from "../filebrowser/FileTransferQueue";
+import type { MenuItem } from "../ContextMenu";
+import { useObjectStorageStore } from "../../stores/objectStorageStore";
+import type { FilePanelStoreHook } from "../../stores/sftpStore";
+import { useObjectStorageController, splitRemote } from "../../lib/objectStorageController";
+import { storageHeadObject } from "../../lib/objectStorage";
+import { presetFor, type ObjectStorageConfig } from "../../types/objectStorage";
+import { formatBytes, type FileEntry } from "../../lib/sftp";
+import { confirmAppDialog, promptAppDialog, alertAppDialog } from "../../lib/appDialogs";
+
+const storeHook = useObjectStorageStore as unknown as FilePanelStoreHook;
+
+interface ObjectStorageBrowserProps {
+  sessionId: string;
+  config: ObjectStorageConfig;
+  title?: string;
+}
+
+export function ObjectStorageBrowser({ sessionId, config, title }: ObjectStorageBrowserProps) {
+  const attach = useObjectStorageStore((s) => s.attach);
+  const detach = useObjectStorageStore((s) => s.detach);
+  const navigate = useObjectStorageStore((s) => s.navigate);
+  const session = useObjectStorageStore((s) => s.sessions[sessionId]);
+  const ctl = useObjectStorageController(sessionId);
+  const [remoteFilter, setRemoteFilter] = useState("");
+  const [localFilter, setLocalFilter] = useState("");
+
+  useEffect(() => {
+    void attach(sessionId, config).catch(() => {});
+    return () => {
+      void detach(sessionId);
+    };
+    // Re-attach only if the session identity changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId]);
+
+  const remotePane = session?.remote;
+  const localPane = session?.local;
+  const providerLabel = presetFor(config.provider).label;
+
+  const showMetadata = useCallback(
+    async (entry: FileEntry) => {
+      const { bucket, key } = splitRemote(entry.path);
+      if (!bucket || !key || entry.fileType === "dir") return;
+      try {
+        const meta = await storageHeadObject(sessionId, bucket, key);
+        const lines = [
+          `Key: ${meta.key}`,
+          `Size: ${formatBytes(meta.size)} (${meta.size} bytes)`,
+          meta.contentType ? `Content-Type: ${meta.contentType}` : null,
+          meta.etag ? `ETag: ${meta.etag}` : null,
+          meta.lastModified ? `Modified: ${new Date(meta.lastModified * 1000).toLocaleString()}` : null,
+          meta.storageClass ? `Storage class: ${meta.storageClass}` : null,
+          meta.cacheControl ? `Cache-Control: ${meta.cacheControl}` : null,
+          ...Object.entries(meta.userMetadata).map(([k, v]) => `x-meta ${k}: ${v}`),
+        ].filter(Boolean);
+        await alertAppDialog({ title: entry.name, message: lines.join("\n") });
+      } catch (err) {
+        await alertAppDialog({ title: "Metadata", message: err instanceof Error ? err.message : String(err) });
+      }
+    },
+    [sessionId],
+  );
+
+  const share = useCallback(
+    async (entry: FileEntry) => {
+      const ttlStr = await promptAppDialog({
+        title: "Share link",
+        label: "Expiry (seconds)",
+        initialValue: "3600",
+      });
+      if (ttlStr == null) return;
+      const ttl = Math.max(1, parseInt(ttlStr, 10) || 3600);
+      const url = await ctl.shareUrl(entry, ttl);
+      if (url) await alertAppDialog({ title: "Share link (copied)", message: url });
+    },
+    [ctl],
+  );
+
+  const confirmDelete = useCallback(
+    async (entries: FileEntry[]) => {
+      const isBucket = entries.some((e) => !splitRemote(e.path).key);
+      const ok = await confirmAppDialog({
+        title: "Delete",
+        message: isBucket
+          ? `Delete bucket "${entries[0]?.name}" and stop? This cannot be undone.`
+          : `Delete ${entries.length} item(s)? Folders are deleted recursively.`,
+        danger: true,
+        confirmLabel: "Delete",
+      });
+      if (!ok) return;
+      for (const e of entries) await ctl.remove(e);
+    },
+    [ctl],
+  );
+
+  const remoteDir = remotePane?.path ?? "/";
+  const localDir = localPane?.path ?? "";
+
+  const onRemoteDoubleClick = useCallback(
+    (entry: FileEntry) => {
+      if (entry.fileType === "dir") void navigate(sessionId, "remote", entry.path);
+      else void ctl.download(entry, localDir);
+    },
+    [ctl, localDir, navigate, sessionId],
+  );
+
+  const onLocalDoubleClick = useCallback(
+    (entry: FileEntry) => {
+      if (entry.fileType === "dir") void navigate(sessionId, "local", entry.path);
+    },
+    [navigate, sessionId],
+  );
+
+  const remoteItemMenu = useCallback(
+    (entry: FileEntry, _anchor: { x: number; y: number }, selected: FileEntry[]): MenuItem[] => {
+      const isFile = entry.fileType === "file";
+      const { key } = splitRemote(entry.path);
+      const items: MenuItem[] = [
+        { label: "Download", onClick: () => void selected.forEach((e) => void ctl.download(e, localDir)) },
+      ];
+      if (isFile) {
+        items.push({ label: "Share link…", onClick: () => void share(entry) });
+        items.push({ label: "Properties…", onClick: () => void showMetadata(entry) });
+      }
+      if (key) {
+        items.push({ separator: true, label: "" });
+        items.push({
+          label: "Rename…",
+          onClick: async () => {
+            const name = await promptAppDialog({ title: "Rename", label: "New name", initialValue: entry.name });
+            if (name && name !== entry.name) await ctl.rename(entry, name);
+          },
+        });
+        items.push({
+          label: "Copy to…",
+          onClick: async () => {
+            const dest = await promptAppDialog({
+              title: "Copy to",
+              label: "Destination prefix (/bucket/prefix/)",
+              initialValue: remoteDir,
+            });
+            if (dest) await ctl.copyTo(entry, dest);
+          },
+        });
+      }
+      items.push({ separator: true, label: "" });
+      items.push({ label: "Delete", danger: true, onClick: () => void confirmDelete(selected) });
+      return items;
+    },
+    [confirmDelete, ctl, localDir, remoteDir, share, showMetadata],
+  );
+
+  const remoteEmptyMenu = useCallback((): MenuItem[] => {
+    const atRoot = remoteDir === "/" || !splitRemote(remoteDir).bucket;
+    return [
+      {
+        label: atRoot ? "New bucket…" : "New folder…",
+        onClick: async () => {
+          const name = await promptAppDialog({ title: atRoot ? "New bucket" : "New folder", label: "Name" });
+          if (name) await ctl.mkdir(remoteDir, name);
+        },
+      },
+    ];
+  }, [ctl, remoteDir]);
+
+  const localItemMenu = useCallback(
+    (_entry: FileEntry, _anchor: { x: number; y: number }, selected: FileEntry[]): MenuItem[] => [
+      { label: "Upload to object store", onClick: () => void selected.forEach((e) => void ctl.upload(e, remoteDir)) },
+    ],
+    [ctl, remoteDir],
+  );
+
+  return (
+    <div className="h-full w-full flex flex-col min-h-0">
+      <div
+        className="h-7 flex items-center px-3 text-[11px] border-b shrink-0 gap-2"
+        style={{ borderColor: "var(--taomni-divider)", background: "var(--taomni-quick-bg)" }}
+      >
+        <span className="font-semibold">{title ?? providerLabel}</span>
+        <span style={{ color: "var(--taomni-text-muted)" }}>{providerLabel}</span>
+        {session?.error && <span className="text-red-500 truncate">{session.error}</span>}
+      </div>
+      <div className="flex-1 min-h-0">
+        <PanelGroup orientation="horizontal" id={`oss-browser-${sessionId}`}>
+          <Panel id="remote" defaultSize="55%" minSize="20%" className="flex flex-col min-h-0 min-w-0">
+            <FilePanel
+              sessionId={sessionId}
+              side="remote"
+              store={storeHook}
+              subtitle={providerLabel}
+              onItemDoubleClick={onRemoteDoubleClick}
+              onItemContext={remoteItemMenu}
+              onEmptyContext={remoteEmptyMenu}
+              filterText={remoteFilter}
+              onFilterTextChange={setRemoteFilter}
+              acceptCrossPane
+              onCrossPaneDrop={(entries) => entries.forEach((e) => void ctl.upload(e, remoteDir))}
+              onDownloadSelected={(entries) => entries.forEach((e) => void ctl.download(e, localDir))}
+              onUploadPathsFromDisk={(paths) =>
+                paths.forEach((p) => {
+                  const name = p.split(/[\\/]/).pop() ?? p;
+                  const { bucket } = splitRemote(remoteDir);
+                  if (bucket) void ctl.upload({ name, path: p, fileType: "file", size: 0, mtime: 0, mode: 0, isHidden: false }, remoteDir);
+                })
+              }
+              onDeleteSelected={(entries) => void confirmDelete(entries)}
+              onNewFolder={async () => {
+                const atRoot = remoteDir === "/" || !splitRemote(remoteDir).bucket;
+                const name = await promptAppDialog({ title: atRoot ? "New bucket" : "New folder", label: "Name" });
+                if (name) await ctl.mkdir(remoteDir, name);
+              }}
+            />
+          </Panel>
+          <PanelResizeHandle className="w-[3px] bg-[var(--taomni-divider)] hover:bg-[var(--taomni-accent)] cursor-col-resize" />
+          <Panel id="local" defaultSize="45%" minSize="20%" className="flex flex-col min-h-0 min-w-0">
+            <FilePanel
+              sessionId={sessionId}
+              side="local"
+              store={storeHook}
+              subtitle="local"
+              onItemDoubleClick={onLocalDoubleClick}
+              onItemContext={localItemMenu}
+              filterText={localFilter}
+              onFilterTextChange={setLocalFilter}
+              acceptCrossPane
+              onCrossPaneDrop={(entries) => entries.forEach((e) => void ctl.download(e, localDir))}
+              onUploadSelected={(entries) => entries.forEach((e) => void ctl.upload(e, remoteDir))}
+            />
+          </Panel>
+        </PanelGroup>
+      </div>
+      <FileTransferQueue
+        sessionId={sessionId}
+        onCancel={ctl.cancelTransfer}
+        onPause={ctl.pauseTransfer}
+        onResume={ctl.resumeTransfer}
+        compact
+      />
+    </div>
+  );
+}
+

--- a/src/components/session/ObjectStorageSettings.tsx
+++ b/src/components/session/ObjectStorageSettings.tsx
@@ -1,0 +1,323 @@
+import { useState } from "react";
+import {
+  PROVIDER_PRESETS,
+  presetFor,
+  engineForProvider,
+  type ObjectStorageConfig,
+  type ObjectStorageProvider,
+  type AwsAuthSource,
+  type AzureAuthSource,
+} from "../../types/objectStorage";
+import { storageTestConnection } from "../../lib/objectStorage";
+import { parseSessionOptions } from "../../lib/terminalProfile";
+
+/** Editor-local form state for an object-storage connection. Secrets are kept
+ * as plaintext while editing; the save path swaps them for `vault:` refs. */
+export interface OssFormState {
+  provider: ObjectStorageProvider;
+  endpoint: string;
+  region: string;
+  pathStyle: boolean;
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string;
+  defaultBucket: string;
+  /** S3 credential source. */
+  awsAuth: AwsAuthSource;
+  awsProfile: string;
+  accountName: string;
+  accountKey: string;
+  connectionString: string;
+  sasToken: string;
+  endpointSuffix: string;
+  defaultContainer: string;
+  /** Azure auth source. */
+  azureAuth: AzureAuthSource;
+  azureBearerToken: string;
+  /** Default storage class / access tier for uploads. */
+  storageClass: string;
+}
+
+export function emptyOssForm(): OssFormState {
+  return {
+    provider: "aws",
+    endpoint: "",
+    region: "",
+    pathStyle: false,
+    accessKeyId: "",
+    secretAccessKey: "",
+    sessionToken: "",
+    defaultBucket: "",
+    awsAuth: "keys",
+    awsProfile: "",
+    accountName: "",
+    accountKey: "",
+    connectionString: "",
+    sasToken: "",
+    endpointSuffix: "",
+    defaultContainer: "",
+    azureAuth: "key",
+    azureBearerToken: "",
+    storageClass: "",
+  };
+}
+
+/** Hydrate the form from a session's options_json. */
+export function ossFormFromOptions(optionsJson: string | null | undefined): OssFormState {
+  const o = parseSessionOptions(optionsJson);
+  const s = (k: string) => (typeof o[k] === "string" ? (o[k] as string) : "");
+  const provider = (s("provider") as ObjectStorageProvider) || "aws";
+  const awsAuthRaw = s("awsAuth");
+  const awsAuth: AwsAuthSource =
+    awsAuthRaw === "environment" || awsAuthRaw === "profile" ? awsAuthRaw : "keys";
+  const azureAuthRaw = s("azureAuth");
+  const azureAuth: AzureAuthSource =
+    azureAuthRaw === "sas" || azureAuthRaw === "connstr" || azureAuthRaw === "bearer"
+      ? azureAuthRaw
+      : "key";
+  return {
+    provider: PROVIDER_PRESETS.some((p) => p.id === provider) ? provider : "aws",
+    endpoint: s("endpoint"),
+    region: s("region"),
+    pathStyle: typeof o.pathStyle === "boolean" ? o.pathStyle : presetFor(provider).pathStyle ?? false,
+    accessKeyId: s("accessKeyId"),
+    secretAccessKey: s("secretAccessKey"),
+    sessionToken: s("sessionToken"),
+    defaultBucket: s("defaultBucket"),
+    awsAuth,
+    awsProfile: s("awsProfile"),
+    accountName: s("accountName"),
+    accountKey: s("accountKey"),
+    connectionString: s("connectionString"),
+    sasToken: s("sasToken"),
+    endpointSuffix: s("endpointSuffix"),
+    defaultContainer: s("defaultContainer"),
+    azureAuth,
+    azureBearerToken: s("azureBearerToken"),
+    storageClass: s("storageClass"),
+  };
+}
+
+/** Build the wire config from form state (secrets as-is — plaintext or refs). */
+export function ossFormToConfig(f: OssFormState): ObjectStorageConfig {
+  const isAzure = engineForProvider(f.provider) === "azure";
+  return {
+    provider: f.provider,
+    endpoint: f.endpoint || null,
+    region: f.region || null,
+    pathStyle: f.pathStyle,
+    accessKeyId: f.accessKeyId || null,
+    secretAccessKey: f.secretAccessKey || null,
+    sessionToken: f.sessionToken || null,
+    defaultBucket: f.defaultBucket || null,
+    awsAuth: !isAzure ? f.awsAuth : null,
+    awsProfile: !isAzure && f.awsAuth === "profile" ? f.awsProfile || null : null,
+    accountName: f.accountName || null,
+    accountKey: f.accountKey || null,
+    connectionString: f.connectionString || null,
+    sasToken: f.sasToken || null,
+    endpointSuffix: f.endpointSuffix || null,
+    defaultContainer: f.defaultContainer || null,
+    azureAuth: isAzure ? f.azureAuth : null,
+    azureBearerToken: isAzure && f.azureAuth === "bearer" ? f.azureBearerToken || null : null,
+    storageClass: f.storageClass || null,
+  };
+}
+
+// PLACEHOLDER_FORM_COMPONENT
+
+interface ObjectStorageSettingsProps {
+  value: OssFormState;
+  onChange: (next: OssFormState) => void;
+  saveInVault: boolean;
+  setSaveInVault: (v: boolean) => void;
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[11px]" style={{ color: "var(--taomni-text-muted)" }}>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+export function ObjectStorageSettings({ value, onChange, saveInVault, setSaveInVault }: ObjectStorageSettingsProps) {
+  const [test, setTest] = useState<{ ok: boolean; msg: string } | null>(null);
+  const [testing, setTesting] = useState(false);
+  const engine = engineForProvider(value.provider);
+  const preset = presetFor(value.provider);
+  const patch = (p: Partial<OssFormState>) => onChange({ ...value, ...p });
+
+  const runTest = async () => {
+    setTesting(true);
+    setTest(null);
+    try {
+      await storageTestConnection(ossFormToConfig(value));
+      setTest({ ok: true, msg: "Connection succeeded." });
+    } catch (err) {
+      setTest({ ok: false, msg: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const input = "taomni-input w-full";
+
+  return (
+    <div data-testid="session-objectstorage-section" className="grid grid-cols-2 gap-x-3 gap-y-2.5 text-[12px]">
+      <Row label="Provider">
+        <select
+          className={input}
+          value={value.provider}
+          onChange={(e) => {
+            const provider = e.target.value as ObjectStorageProvider;
+            patch({ provider, pathStyle: presetFor(provider).pathStyle ?? false });
+          }}
+        >
+          {PROVIDER_PRESETS.map((p) => (
+            <option key={p.id} value={p.id}>{p.label}</option>
+          ))}
+        </select>
+      </Row>
+
+      {engine === "s3" ? (
+        <>
+          <Row label={preset.endpointDerived ? "Region (endpoint derived)" : "Region"}>
+            <input className={input} value={value.region} placeholder="us-east-1" onChange={(e) => patch({ region: e.target.value })} />
+          </Row>
+          {!preset.endpointDerived && (
+            <Row label="Endpoint">
+              <input className={input} value={value.endpoint} placeholder={preset.endpointHint} onChange={(e) => patch({ endpoint: e.target.value })} />
+            </Row>
+          )}
+          <Row label="Authentication">
+            <select className={input} value={value.awsAuth} onChange={(e) => patch({ awsAuth: e.target.value as AwsAuthSource })}>
+              <option value="keys">Access keys</option>
+              <option value="environment">Environment variables (AWS_*)</option>
+              <option value="profile">Shared profile (~/.aws)</option>
+            </select>
+          </Row>
+          {value.awsAuth === "keys" && (
+            <>
+              <Row label="Access key ID">
+                <input className={input} value={value.accessKeyId} autoComplete="off" onChange={(e) => patch({ accessKeyId: e.target.value })} />
+              </Row>
+              <Row label="Secret access key">
+                <input className={input} type="password" value={value.secretAccessKey} autoComplete="off" onChange={(e) => patch({ secretAccessKey: e.target.value })} />
+              </Row>
+              <Row label="Session token (optional)">
+                <input className={input} type="password" value={value.sessionToken} autoComplete="off" onChange={(e) => patch({ sessionToken: e.target.value })} />
+              </Row>
+            </>
+          )}
+          {value.awsAuth === "profile" && (
+            <Row label="Profile name (blank = AWS_PROFILE / default)">
+              <input className={input} value={value.awsProfile} placeholder="default" autoComplete="off" onChange={(e) => patch({ awsProfile: e.target.value })} />
+            </Row>
+          )}
+          {value.awsAuth === "environment" && (
+            <p className="col-span-2 text-[11px]" style={{ color: "var(--taomni-text-muted)" }}>
+              Uses AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (and AWS_SESSION_TOKEN) from the app's environment at connect time.
+            </p>
+          )}
+          {value.awsAuth === "profile" && (
+            <p className="col-span-2 text-[11px]" style={{ color: "var(--taomni-text-muted)" }}>
+              Reads ~/.aws/credentials and ~/.aws/config. SSO / assume-role / instance-role profiles are resolved via the AWS CLI (<code>aws configure export-credentials</code>).
+            </p>
+          )}
+          <Row label="Default bucket (optional)">
+            <input className={input} value={value.defaultBucket} onChange={(e) => patch({ defaultBucket: e.target.value })} />
+          </Row>
+          <Row label="Default storage class (optional)">
+            <input className={input} list="oss-s3-classes" value={value.storageClass} placeholder="STANDARD" onChange={(e) => patch({ storageClass: e.target.value })} />
+            <datalist id="oss-s3-classes">
+              <option value="STANDARD" />
+              <option value="STANDARD_IA" />
+              <option value="ONEZONE_IA" />
+              <option value="INTELLIGENT_TIERING" />
+              <option value="GLACIER" />
+              <option value="GLACIER_IR" />
+              <option value="DEEP_ARCHIVE" />
+            </datalist>
+          </Row>
+          <label className="flex items-center gap-2 col-span-2">
+            <input type="checkbox" checked={value.pathStyle} onChange={(e) => patch({ pathStyle: e.target.checked })} />
+            <span>Force path-style addressing (required by MinIO / Ceph)</span>
+          </label>
+        </>
+      ) : (
+        <>
+          <Row label="Account name">
+            <input className={input} value={value.accountName} onChange={(e) => patch({ accountName: e.target.value })} />
+          </Row>
+          <Row label="Endpoint suffix (optional)">
+            <input className={input} value={value.endpointSuffix} placeholder="core.windows.net" onChange={(e) => patch({ endpointSuffix: e.target.value })} />
+          </Row>
+          <Row label="Authentication">
+            <select className={input} value={value.azureAuth} onChange={(e) => patch({ azureAuth: e.target.value as AzureAuthSource })}>
+              <option value="key">Account key</option>
+              <option value="sas">SAS token</option>
+              <option value="connstr">Connection string</option>
+              <option value="bearer">Entra ID (Azure AD)</option>
+            </select>
+          </Row>
+          {value.azureAuth === "key" && (
+            <Row label="Account key">
+              <input className={input} type="password" value={value.accountKey} autoComplete="off" onChange={(e) => patch({ accountKey: e.target.value })} />
+            </Row>
+          )}
+          {value.azureAuth === "sas" && (
+            <Row label="SAS token">
+              <input className={input} type="password" value={value.sasToken} autoComplete="off" onChange={(e) => patch({ sasToken: e.target.value })} />
+            </Row>
+          )}
+          {value.azureAuth === "connstr" && (
+            <Row label="Connection string">
+              <input className={input} type="password" value={value.connectionString} autoComplete="off" onChange={(e) => patch({ connectionString: e.target.value })} />
+            </Row>
+          )}
+          {value.azureAuth === "bearer" && (
+            <>
+              <Row label="Access token (optional — blank uses Azure CLI)">
+                <input className={input} type="password" value={value.azureBearerToken} autoComplete="off" onChange={(e) => patch({ azureBearerToken: e.target.value })} />
+              </Row>
+              <p className="col-span-2 text-[11px]" style={{ color: "var(--taomni-text-muted)" }}>
+                Leave blank to obtain a token from the Azure CLI (<code>az account get-access-token</code>; run <code>az login</code> first). Share links (SAS) are unavailable with Entra ID auth.
+              </p>
+            </>
+          )}
+          <Row label="Default container (optional)">
+            <input className={input} value={value.defaultContainer} onChange={(e) => patch({ defaultContainer: e.target.value })} />
+          </Row>
+          <Row label="Default access tier (optional)">
+            <input className={input} list="oss-azure-tiers" value={value.storageClass} placeholder="Hot" onChange={(e) => patch({ storageClass: e.target.value })} />
+            <datalist id="oss-azure-tiers">
+              <option value="Hot" />
+              <option value="Cool" />
+              <option value="Cold" />
+              <option value="Archive" />
+            </datalist>
+          </Row>
+        </>
+      )}
+
+      <label className="flex items-center gap-2 col-span-2">
+        <input type="checkbox" checked={saveInVault} onChange={(e) => setSaveInVault(e.target.checked)} />
+        <span>Save secrets in vault (recommended)</span>
+      </label>
+
+      <div className="col-span-2 flex items-center gap-3">
+        <button type="button" className="taomni-btn" disabled={testing} onClick={() => void runTest()}>
+          {testing ? "Testing…" : "Test connection"}
+        </button>
+        {test && (
+          <span className="text-[11px]" style={{ color: test.ok ? "var(--taomni-accent)" : "#d33" }}>
+            {test.msg}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/session/SessionEditor.tsx
+++ b/src/components/session/SessionEditor.tsx
@@ -82,6 +82,12 @@ import {
   type RdpOptions,
 } from "../../types/rdp";
 import { RdpOptionsForm } from "./forms/RdpOptionsForm";
+import {
+  ObjectStorageSettings,
+  ossFormFromOptions,
+  type OssFormState,
+} from "./ObjectStorageSettings";
+import { engineForProvider } from "../../types/objectStorage";
 import { WslOptionsForm } from "./forms/WslOptionsForm";
 import { TerminalAppearanceSettings } from "../terminal/TerminalAppearanceSettings";
 import { useT, type TranslateFn } from "../../lib/i18n";
@@ -101,7 +107,7 @@ type Proto =
   | "MySQL" | "PostgreSQL" | "ClickHouse" | "Presto" | "Redis" | "HBaseShell"
   | "Proxy";
 
-type SectionTab = "advanced" | "terminal" | "network" | "bookmark" | "rdp" | "database" | "mappings" | "proxy";
+type SectionTab = "advanced" | "terminal" | "network" | "bookmark" | "rdp" | "database" | "mappings" | "proxy" | "objectstorage";
 
 const PROTOS: { id: Proto; icon: React.ReactNode; color: string }[] = [
   { id: "SSH",     icon: <TerminalIcon className="w-7 h-7" />, color: "#2b5d8b" },
@@ -137,17 +143,22 @@ const DEFAULT_PORTS: Record<string, number> = {
 
 const DB_PROTOS: Proto[] = ["MySQL", "PostgreSQL", "ClickHouse", "Presto", "Redis"];
 
-/** Map UI proto to the backend session_type string. */
+/** Map UI proto to the backend session_type string. Object storage ("S3"
+ * proto) is resolved to "S3" vs "AzureBlob" by the caller based on the
+ * selected provider. */
 function protoToSessionType(p: Proto): string {
   const map: Partial<Record<Proto, string>> = {
     Rlogin: "Telnet", Shell: "LocalShell",
-    Browser: "LocalShell", Mosh: "SSH", S3: "SFTP", WSL: "LocalShell",
+    Browser: "LocalShell", Mosh: "SSH", WSL: "LocalShell",
   };
   return map[p] ?? p;
 }
 
 function sessionTypeToProto(type: string | undefined, optionsJson?: string | null): Proto {
   if (type === "Proxy") return "Proxy";
+  // S3-family and Azure Blob both surface under the single "S3" (object
+  // storage) tile; the concrete provider lives in options_json.
+  if (type === "S3" || type === "AzureBlob") return "S3";
   if (type === "LocalShell") {
     const options = parseSessionOptions(optionsJson);
     const path = typeof options.localShellPath === "string" ? options.localShellPath : "";
@@ -1810,6 +1821,9 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
     parsePathMappingsFromOptions(session?.options_json),
   );
 
+  /* --- object storage (S3 / Azure Blob) --- */
+  const [oss, setOss] = useState<OssFormState>(() => ossFormFromOptions(session?.options_json));
+
   /* --- network settings --- */
   const [networkSettings, setNetworkSettings] = useState<NetworkSettingsValue>(
     () => getSessionNetworkSettings(session?.options_json),
@@ -1824,12 +1838,13 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
   const [saveError, setSaveError] = useState<string | null>(null);
 
   /* --- derived --- */
-  const needsHost = !["Serial", "File", "Shell", "WSL", "HBaseShell"].includes(proto);
+  const needsHost = !["Serial", "File", "Shell", "WSL", "HBaseShell", "S3"].includes(proto);
   const isSSH = ["SSH", "SFTP"].includes(proto);
   const isRdp = proto === "RDP";
   const isDb = DB_PROTOS.includes(proto);
   const isHBase = proto === "HBaseShell";
   const isProxy = proto === "Proxy";
+  const isObjectStorage = proto === "S3";
   const folderOptions = useMemo(() => {
     const options = new Set<string>([
       SESSION_ROOT_LABEL,
@@ -1863,6 +1878,8 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
     if (DB_PROTOS.includes(p) || p === "HBaseShell") setSection("database");
     // Proxy proto opens to its settings tab.
     if (p === "Proxy") setSection("proxy");
+    // Object storage opens straight to its settings tab.
+    if (p === "S3") setSection("objectstorage");
   };
 
   /* Keep authMethod in sync with the radio group */
@@ -1888,11 +1905,15 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
     networkSettingsValue = networkSettings,
     proxyPassValue = networkSettings.proxyPass,
     jumpPasswordValue = networkSettings.jumpPassword,
+    ossConfigValue,
   }: {
     passwordRefValue?: string;
     networkSettingsValue?: NetworkSettingsValue;
     proxyPassValue?: string;
     jumpPasswordValue?: string;
+    /** Resolved object-storage option map (secrets already swapped for vault
+     *  refs by handleSave). Falls back to current form state when omitted. */
+    ossConfigValue?: Record<string, unknown>;
   } = {}): string => {
     const previousOptions = stripDeprecatedCwdOptions(parseSessionOptions(session?.options_json));
     const wslOverrides: Record<string, unknown> =
@@ -1921,6 +1942,30 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
     const proxyOverrides: Record<string, unknown> = isProxy
       ? { proxyKind, testUrl: proxyTestUrl }
       : {};
+    const ossOverrides: Record<string, unknown> =
+      proto === "S3"
+        ? (ossConfigValue ?? {
+            provider: oss.provider,
+            endpoint: oss.endpoint,
+            region: oss.region,
+            pathStyle: oss.pathStyle,
+            accessKeyId: oss.accessKeyId,
+            secretAccessKey: oss.secretAccessKey,
+            sessionToken: oss.sessionToken,
+            defaultBucket: oss.defaultBucket,
+            awsAuth: oss.awsAuth,
+            awsProfile: oss.awsProfile,
+            accountName: oss.accountName,
+            accountKey: oss.accountKey,
+            connectionString: oss.connectionString,
+            sasToken: oss.sasToken,
+            endpointSuffix: oss.endpointSuffix,
+            defaultContainer: oss.defaultContainer,
+            azureAuth: oss.azureAuth,
+            azureBearerToken: oss.azureBearerToken,
+            storageClass: oss.storageClass,
+          })
+        : {};
     const hbaseOverrides: Record<string, unknown> = isHBase
       ? {
           hbaseNamespace,
@@ -1968,6 +2013,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
       ...dbOverrides,
       ...proxyOverrides,
       ...hbaseOverrides,
+      ...ossOverrides,
     });
   };
 
@@ -1982,13 +2028,18 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
     const displayName = name
       || (proto === "WSL"
         ? t("sessionEditor2.wslDefaultName", { distro: wslOptions.distro || "Linux" })
-        : (proto === "File" && host
-          ? (host.split(/[\\/]/).filter(Boolean).pop() || host)
-          : (host ? `${username ? username + "@" : ""}${host}` : "Local terminal")));
+        : proto === "S3"
+          ? (oss.defaultBucket || oss.defaultContainer || oss.accountName || oss.endpoint || "Object Storage")
+          : (proto === "File" && host
+            ? (host.split(/[\\/]/).filter(Boolean).pop() || host)
+            : (host ? `${username ? username + "@" : ""}${host}` : "Local terminal")));
     return {
       id: session?.id ?? crypto.randomUUID(),
       name: displayName,
-      session_type: protoToSessionType(proto),
+      session_type:
+        proto === "S3"
+          ? (engineForProvider(oss.provider) === "azure" ? "AzureBlob" : "S3")
+          : protoToSessionType(proto),
       group_path: toStoredGroupPath(groupPath),
       host,
       port: parseInt(port) || DEFAULT_PORTS[proto] || 0,
@@ -2139,11 +2190,77 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
     }
 
     setPasswordRef(nextPasswordRef);
+
+    // Object-storage secrets: swap freshly-typed plaintext for vault refs when
+    // "Save secrets in vault" is on. When off, secrets are stored as plaintext
+    // in options_json (the backend resolve() accepts either form).
+    let ossConfigValue: Record<string, unknown> | undefined;
+    if (proto === "S3") {
+      const isAzure = engineForProvider(oss.provider) === "azure";
+      const label = oss.defaultBucket || oss.defaultContainer || oss.accountName || oss.endpoint || oss.provider;
+      const secretFields: Array<{ key: keyof OssFormState; kind: string }> = isAzure
+        ? [
+            { key: "accountKey", kind: "azure-account-key" },
+            { key: "sasToken", kind: "azure-sas" },
+            { key: "connectionString", kind: "azure-connstr" },
+            { key: "azureBearerToken", kind: "azure-bearer" },
+          ]
+        : [
+            { key: "secretAccessKey", kind: "s3-secret-key" },
+            { key: "sessionToken", kind: "s3-session-token" },
+          ];
+      const resolved: Record<string, string> = {};
+      for (const { key, kind } of secretFields) {
+        const value = oss[key] as string;
+        if (!value || isVaultReference(value) || !saveInVault) {
+          resolved[key] = value;
+          continue;
+        }
+        const ready = await ensureVaultReady(t("vault.gateReasonSession"));
+        if (!ready) {
+          setSaveError(t("sessionEditor2.errVaultLockedSave"));
+          return;
+        }
+        try {
+          const r = await vaultPut(kind, `${kind} ${label}`, value);
+          resolved[key] = r.reference;
+        } catch (err) {
+          if (isVaultLockedError(err)) setSaveError(t("sessionEditor2.errVaultLockedSave"));
+          else setSaveError(err instanceof Error ? err.message : String(err));
+          return;
+        }
+      }
+      const next: OssFormState = { ...oss, ...(resolved as Partial<OssFormState>) };
+      setOss(next);
+      ossConfigValue = {
+        provider: next.provider,
+        endpoint: next.endpoint,
+        region: next.region,
+        pathStyle: next.pathStyle,
+        accessKeyId: next.accessKeyId,
+        secretAccessKey: next.secretAccessKey,
+        sessionToken: next.sessionToken,
+        defaultBucket: next.defaultBucket,
+        awsAuth: next.awsAuth,
+        awsProfile: next.awsProfile,
+        accountName: next.accountName,
+        accountKey: next.accountKey,
+        connectionString: next.connectionString,
+        sasToken: next.sasToken,
+        endpointSuffix: next.endpointSuffix,
+        defaultContainer: next.defaultContainer,
+        azureAuth: next.azureAuth,
+        azureBearerToken: next.azureBearerToken,
+        storageClass: next.storageClass,
+      };
+    }
+
     const config = buildConfig({
       options_json: buildOptionsJson({
         passwordRefValue: nextPasswordRef,
         proxyPassValue: nextProxyPass,
         jumpPasswordValue: nextJumpPass,
+        ossConfigValue,
       }),
     });
 
@@ -2227,6 +2344,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
     setWslOptions(parseWslOptions(session?.options_json));
     setRdpOptions(parseRdpOptions(session?.options_json));
     setPathMappings(parsePathMappingsFromOptions(session?.options_json));
+    setOss(ossFormFromOptions(session?.options_json));
     setSaveError(null);
     setTestResult(null);
   };
@@ -2532,6 +2650,14 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
           : []),
         { id: "bookmark", label: t("sessionEditor2.sectionBookmark"), icon: <Bookmark className="w-3 h-3 inline -mt-0.5 mr-1" /> },
       ]
+    : isObjectStorage
+    ? [
+        { id: "objectstorage", label: "Object storage", icon: <Cloud className="w-3 h-3 inline -mt-0.5 mr-1" /> },
+        // Object storage (HTTPS) can route through an HTTP/SOCKS5 proxy or an
+        // SSH jump host, just like the DB engines.
+        { id: "network", label: t("sessionEditor2.sectionNetwork"), icon: <Network className="w-3 h-3 inline -mt-0.5 mr-1" /> },
+        { id: "bookmark", label: t("sessionEditor2.sectionBookmark"), icon: <Bookmark className="w-3 h-3 inline -mt-0.5 mr-1" /> },
+      ]
     : [
         ...(isSSH
           ? [{ id: "advanced" as SectionTab, label: t("sessionEditor2.sectionAdvancedSsh"), icon: <Shield className="w-3 h-3 inline -mt-0.5 mr-1" /> }]
@@ -2557,6 +2683,8 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
       ? "bookmark"
       : isProxy
         ? (section === "proxy" || section === "bookmark" ? section : "proxy")
+        : isObjectStorage
+        ? (section === "objectstorage" || section === "bookmark" || section === "network" ? section : "objectstorage")
         : isDb || isHBase
         ? (section === "database" || section === "bookmark" || (isDb && section === "network") ? section : "database")
         : section === "advanced" && !isSSH
@@ -2990,6 +3118,16 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
               />
             </div>
           )}
+          {activeSection === "objectstorage" && isObjectStorage && (
+            <div data-testid="session-objectstorage-wrap">
+              <ObjectStorageSettings
+                value={oss}
+                onChange={setOss}
+                saveInVault={saveInVault}
+                setSaveInVault={setSaveInVault}
+              />
+            </div>
+          )}
           {activeSection === "proxy" && isProxy && (
             <div data-testid="session-proxy-section" className="grid grid-cols-12 gap-x-3 gap-y-2.5 text-[12px]">
               <Field label={t("sessionEditor2.proxyKindLabel")}>
@@ -3009,7 +3147,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
               </Field>
             </div>
           )}
-          {activeSection === "network" && !isDb && (
+          {activeSection === "network" && !isDb && !isObjectStorage && (
             <NetworkSettings
               t={t}
               value={networkSettings}
@@ -3024,7 +3162,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
               onSaveAsProxySession={() => void handleSaveAsProxySession()}
             />
           )}
-          {activeSection === "network" && isDb && (
+          {activeSection === "network" && (isDb || isObjectStorage) && (
             <DbNetworkSettings
               t={t}
               value={networkSettings}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -38,6 +38,8 @@ import { SettingsPanel } from "../components/settings/SettingsPanel";
 import { TunnelManager } from "../components/tunnel/TunnelManager";
 import { FileBrowser } from "../components/filebrowser/FileBrowser";
 import { LocalFileBrowserPanel } from "../components/filebrowser/LocalFileBrowserPanel";
+import { ObjectStorageBrowser } from "../components/objectstorage/ObjectStorageBrowser";
+import { sessionToObjectStorageConfig, objectStorageHasVaultSecret } from "../lib/objectStorage";
 import { SftpSidebar } from "../components/filebrowser/SftpSidebar";
 import { useSftpStore } from "../stores/sftpStore";
 import { getAppPlatform, isTauriRuntime } from "../lib/runtime";
@@ -1209,6 +1211,23 @@ export function MainLayout() {
     void markConnected(session.id);
   }, [addTab, markConnected]);
 
+  const openObjectStorageTab = useCallback((session: SessionConfig) => {
+    const id = `object-storage-${session.id}-${Date.now()}`;
+    const config = sessionToObjectStorageConfig(session);
+    const title = session.name || session.host || "Object Storage";
+    addTab({
+      id,
+      type: "object-storage",
+      title,
+      sessionId: session.id,
+      closable: true,
+      // The browser keys its live store by the tab session id (not the saved
+      // session id) so two tabs for the same saved session stay independent.
+      objectStorage: { sessionId: id, config },
+    });
+    void markConnected(session.id);
+  }, [addTab, markConnected]);
+
   // Open a local path or URL: URLs and files always go to the system handler;
   // folders open in an embedded Taomni tab when `embedFolder` is true, otherwise
   // they fall through to the OS file manager via sftpOpenPath.
@@ -1424,6 +1443,15 @@ export function MainLayout() {
       }
     } else if (session.session_type === "Proxy") {
       openProxyTestTab(session);
+    } else if (session.session_type === "S3" || session.session_type === "AzureBlob") {
+      // Secrets are vault: refs in options_json; resolve happens server-side on
+      // attach. If any secret is vault-backed and the vault is locked, unlock
+      // first so the attach doesn't fail with a cryptic error.
+      if (objectStorageHasVaultSecret(session)) {
+        const vaultState = useVaultStore.getState().state;
+        if (vaultState !== "unlocked" && vaultState !== "empty") return queueVaultUnlock(session);
+      }
+      openObjectStorageTab(session);
     } else {
       openUnsupportedTab(session);
       void markConnected(session.id);
@@ -1441,6 +1469,7 @@ export function MainLayout() {
     openDbTab,
     openHBaseShellTab,
     openProxyTestTab,
+    openObjectStorageTab,
     queueVaultUnlock,
   ]);
 
@@ -1805,6 +1834,7 @@ export function MainLayout() {
   const vncTabs = tabs.filter((t) => t.type === "vnc" && t.vnc);
   const rdpTabs = tabs.filter((t) => t.type === "rdp" && t.rdp);
   const fileBrowserTabs = tabs.filter((t) => t.type === "file-browser" && t.fileBrowser);
+  const objectStorageTabs = tabs.filter((t) => t.type === "object-storage" && t.objectStorage);
   const dbTabs = tabs.filter((t) => t.type === "database" && t.db);
   const redisTabs = tabs.filter((t) => t.type === "redis" && t.db);
   const hbaseTabs = tabs.filter((t) => t.type === "hbase-shell" && t.hbase);
@@ -2470,6 +2500,26 @@ export function MainLayout() {
                       <LocalFileBrowserPanel
                         tabId={tab.id}
                         initialPath={tab.fileBrowser.initialPath}
+                      />
+                    </div>
+                  );
+                })}
+
+                {/* Object-storage (S3 / Azure Blob) browser tabs — always
+                    mounted so in-flight transfers survive tab switches. */}
+                {objectStorageTabs.map((tab) => {
+                  if (!tab.objectStorage) return null;
+                  const isActive = activeTabId === tab.id;
+                  return (
+                    <div
+                      key={tab.id}
+                      className="absolute inset-0"
+                      style={{ display: isActive ? "block" : "none" }}
+                    >
+                      <ObjectStorageBrowser
+                        sessionId={tab.objectStorage.sessionId}
+                        config={tab.objectStorage.config}
+                        title={tab.title}
                       />
                     </div>
                   );

--- a/src/lib/objectStorage.ts
+++ b/src/lib/objectStorage.ts
@@ -1,0 +1,251 @@
+// IPC wrappers + event listeners for the object-storage feature. Mirrors
+// `lib/sftp.ts`. Transfer progress/complete events reuse the SFTP payload
+// shapes (the backend emits identical structures on `storage-*` channels).
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { withVaultLockedNotice, type SessionConfig } from "./ipc";
+import { parseSessionOptions } from "./terminalProfile";
+import { normalizeNetworkSettings, toNetworkSettingsPayload } from "./networkSettings";
+import type {
+  BucketEntry,
+  ObjectListPage,
+  ObjectMetadata,
+  ObjectStorageConfig,
+  ObjectStorageProvider,
+} from "../types/objectStorage";
+import type { TransferCompletePayload, TransferProgressPayload } from "./sftp";
+
+/** Secret-bearing config keys, stored in `options_json` as `vault:` refs. */
+const OSS_SECRET_KEYS = [
+  "secretAccessKey",
+  "sessionToken",
+  "accountKey",
+  "connectionString",
+  "sasToken",
+  "azureBearerToken",
+] as const;
+
+/**
+ * Build an {@link ObjectStorageConfig} from a saved S3/AzureBlob session. All
+ * fields (including `vault:` secret refs) live in `options_json` under the keys
+ * the editor writes; the backend resolves vault refs on attach.
+ */
+export function sessionToObjectStorageConfig(session: SessionConfig): ObjectStorageConfig {
+  const o = parseSessionOptions(session.options_json);
+  const str = (k: string): string | null => (typeof o[k] === "string" ? (o[k] as string) : null);
+  const bool = (k: string): boolean | null => (typeof o[k] === "boolean" ? (o[k] as boolean) : null);
+  const provider =
+    (str("provider") as ObjectStorageProvider | null) ??
+    (session.session_type === "AzureBlob" ? "azure" : "aws");
+  // Route through the per-session network settings (proxy / SSH jump) when one
+  // is configured; otherwise leave `network` unset so the backend falls back to
+  // the app-level global proxy.
+  const ns = normalizeNetworkSettings(o.networkSettings);
+  const network =
+    ns.proxyKind && ns.proxyKind !== "none" ? toNetworkSettingsPayload(ns) : null;
+  return {
+    provider,
+    endpoint: str("endpoint"),
+    region: str("region"),
+    pathStyle: bool("pathStyle"),
+    accessKeyId: str("accessKeyId"),
+    secretAccessKey: str("secretAccessKey"),
+    sessionToken: str("sessionToken"),
+    defaultBucket: str("defaultBucket"),
+    awsAuth: (str("awsAuth") as ObjectStorageConfig["awsAuth"]) ?? null,
+    awsProfile: str("awsProfile"),
+    accountName: str("accountName"),
+    accountKey: str("accountKey"),
+    connectionString: str("connectionString"),
+    sasToken: str("sasToken"),
+    endpointSuffix: str("endpointSuffix"),
+    defaultContainer: str("defaultContainer"),
+    azureAuth: (str("azureAuth") as ObjectStorageConfig["azureAuth"]) ?? null,
+    azureBearerToken: str("azureBearerToken"),
+    network,
+    storageClass: str("storageClass"),
+  };
+}
+
+/** True if any object-storage secret in the session is a locked `vault:` ref. */
+export function objectStorageHasVaultSecret(session: SessionConfig): boolean {
+  const o = parseSessionOptions(session.options_json);
+  return OSS_SECRET_KEYS.some((k) => typeof o[k] === "string" && (o[k] as string).startsWith("vault:"));
+}
+
+export async function storageAttach(
+  sessionId: string,
+  config: ObjectStorageConfig,
+): Promise<void> {
+  return withVaultLockedNotice(() =>
+    invoke("storage_attach", { sessionId, config }),
+  );
+}
+
+export async function storageDetach(sessionId: string): Promise<void> {
+  return invoke("storage_detach", { sessionId });
+}
+
+export async function storagePing(sessionId: string): Promise<void> {
+  return invoke("storage_ping", { sessionId });
+}
+
+export async function storageTestConnection(
+  config: ObjectStorageConfig,
+): Promise<void> {
+  return withVaultLockedNotice(() =>
+    invoke("storage_test_connection", { config }),
+  );
+}
+
+export async function storageListBuckets(sessionId: string): Promise<BucketEntry[]> {
+  return invoke<BucketEntry[]>("storage_list_buckets", { sessionId });
+}
+
+export async function storageListObjects(
+  sessionId: string,
+  bucket: string,
+  prefix: string,
+  continuation: string | null = null,
+): Promise<ObjectListPage> {
+  return invoke<ObjectListPage>("storage_list_objects", {
+    sessionId,
+    bucket,
+    prefix,
+    continuation,
+  });
+}
+
+export async function storageDeleteObject(
+  sessionId: string,
+  bucket: string,
+  key: string,
+): Promise<void> {
+  return invoke("storage_delete_object", { sessionId, bucket, key });
+}
+
+export async function storageDeletePrefix(
+  sessionId: string,
+  bucket: string,
+  prefix: string,
+): Promise<void> {
+  return invoke("storage_delete_prefix", { sessionId, bucket, prefix });
+}
+
+export async function storageCreateFolder(
+  sessionId: string,
+  bucket: string,
+  prefix: string,
+): Promise<void> {
+  return invoke("storage_create_folder", { sessionId, bucket, prefix });
+}
+
+export async function storageCreateBucket(sessionId: string, bucket: string): Promise<void> {
+  return invoke("storage_create_bucket", { sessionId, bucket });
+}
+
+export async function storageDeleteBucket(sessionId: string, bucket: string): Promise<void> {
+  return invoke("storage_delete_bucket", { sessionId, bucket });
+}
+
+export async function storageHeadObject(
+  sessionId: string,
+  bucket: string,
+  key: string,
+): Promise<ObjectMetadata> {
+  return invoke<ObjectMetadata>("storage_head_object", { sessionId, bucket, key });
+}
+
+export async function storageCopyObject(
+  sessionId: string,
+  srcBucket: string,
+  srcKey: string,
+  dstBucket: string,
+  dstKey: string,
+): Promise<void> {
+  return invoke("storage_copy_object", { sessionId, srcBucket, srcKey, dstBucket, dstKey });
+}
+
+export async function storageMoveObject(
+  sessionId: string,
+  srcBucket: string,
+  srcKey: string,
+  dstBucket: string,
+  dstKey: string,
+): Promise<void> {
+  return invoke("storage_move_object", { sessionId, srcBucket, srcKey, dstBucket, dstKey });
+}
+
+export async function storageShareUrl(
+  sessionId: string,
+  bucket: string,
+  key: string,
+  ttlSecs: number,
+): Promise<string> {
+  return invoke<string>("storage_share_url", { sessionId, bucket, key, ttlSecs });
+}
+
+export async function storageDownload(
+  sessionId: string,
+  transferId: string,
+  bucket: string,
+  key: string,
+  localPath: string,
+): Promise<void> {
+  return invoke("storage_download", { sessionId, transferId, bucket, key, localPath });
+}
+
+export async function storageUpload(
+  sessionId: string,
+  transferId: string,
+  bucket: string,
+  key: string,
+  localPath: string,
+  storageClass?: string | null,
+): Promise<void> {
+  return invoke("storage_upload", {
+    sessionId,
+    transferId,
+    bucket,
+    key,
+    localPath,
+    storageClass: storageClass || null,
+  });
+}
+
+export async function storageCancelTransfer(transferId: string): Promise<void> {
+  return invoke("storage_cancel_transfer", { transferId });
+}
+
+export async function storagePauseTransfer(transferId: string): Promise<void> {
+  return invoke("storage_pause_transfer", { transferId });
+}
+
+export async function storageResumeTransfer(transferId: string): Promise<void> {
+  return invoke("storage_resume_transfer", { transferId });
+}
+
+export function listenStorageProgress(
+  transferId: string,
+  cb: (payload: TransferProgressPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<TransferProgressPayload>(`storage-progress-${transferId}`, (e) => cb(e.payload));
+}
+
+export function listenStoragePaused(
+  transferId: string,
+  cb: (payload: TransferProgressPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<TransferProgressPayload>(`storage-paused-${transferId}`, (e) => cb(e.payload));
+}
+
+export function listenStorageComplete(
+  transferId: string,
+  cb: (payload: TransferCompletePayload) => void,
+): Promise<UnlistenFn> {
+  return listen<TransferCompletePayload>(
+    `storage-transfer-complete-${transferId}`,
+    (e) => cb(e.payload),
+  );
+}

--- a/src/lib/objectStorageController.ts
+++ b/src/lib/objectStorageController.ts
@@ -1,0 +1,370 @@
+import { useCallback } from "react";
+import { joinPath, sftpListLocal, sftpLocalHome, type FileEntry } from "./sftp";
+import {
+  listenStorageComplete,
+  listenStoragePaused,
+  listenStorageProgress,
+  storageCancelTransfer,
+  storageCopyObject,
+  storageCreateBucket,
+  storageCreateFolder,
+  storageDeleteBucket,
+  storageDeleteObject,
+  storageDeletePrefix,
+  storageDownload,
+  storageListObjects,
+  storageMoveObject,
+  storagePauseTransfer,
+  storageResumeTransfer,
+  storageShareUrl,
+  storageUpload,
+} from "./objectStorage";
+import { newTransferId, useTransferStore } from "../stores/transferStore";
+import { useObjectStorageStore } from "../stores/objectStorageStore";
+import { useAppStore } from "../stores/appStore";
+import type { PaneSide } from "../stores/sftpStore";
+
+/** Split a remote object path ("/bucket/a/b.txt") into bucket + key. */
+export function splitRemote(path: string): { bucket: string; key: string } {
+  const trimmed = path.replace(/^\/+/, "");
+  const i = trimmed.indexOf("/");
+  if (i < 0) return { bucket: trimmed, key: "" };
+  return { bucket: trimmed.slice(0, i), key: trimmed.slice(i + 1) };
+}
+
+/** Parent prefix of a key ("a/b/c.txt" -> "a/b/", "c.txt" -> ""). */
+function parentPrefix(key: string): string {
+  const trimmed = key.endsWith("/") ? key.slice(0, -1) : key;
+  const i = trimmed.lastIndexOf("/");
+  return i < 0 ? "" : trimmed.slice(0, i + 1);
+}
+
+export function useObjectStorageController(sessionId: string) {
+  const refreshPane = useObjectStorageStore((s) => s.refreshPane);
+  const setStatus = useAppStore((s) => s.setStatusMessage);
+  const addTransfer = useTransferStore((s) => s.add);
+  const patchTransfer = useTransferStore((s) => s.patch);
+  const setTransferState = useTransferStore((s) => s.setState);
+
+  const startTracking = useCallback(
+    async (transferId: string, refreshSide: PaneSide) => {
+      let unlistenProgress: (() => void) | null = null;
+      let unlistenComplete: (() => void) | null = null;
+      let unlistenPaused: (() => void) | null = null;
+      const [p, pa, c] = await Promise.all([
+        listenStorageProgress(transferId, (payload) => {
+          patchTransfer(transferId, {
+            bytes: payload.bytes,
+            size: payload.total || undefined,
+            rate: payload.rate,
+            eta: payload.eta,
+            state: "running",
+          });
+        }),
+        listenStoragePaused(transferId, (payload) => {
+          patchTransfer(transferId, { bytes: payload.bytes, rate: 0, eta: 0, state: "paused" });
+        }),
+        listenStorageComplete(transferId, (payload) => {
+          if (payload.success) {
+            setTransferState(transferId, "done");
+            void refreshPane(sessionId, refreshSide);
+          } else {
+            const isCancel = (payload.error || "").toLowerCase().includes("cancel");
+            setTransferState(transferId, isCancel ? "cancelled" : "error", payload.error ?? "transfer failed");
+          }
+          unlistenProgress?.();
+          unlistenComplete?.();
+          unlistenPaused?.();
+        }),
+      ]);
+      unlistenProgress = p;
+      unlistenPaused = pa;
+      unlistenComplete = c;
+    },
+    [patchTransfer, refreshPane, sessionId, setTransferState],
+  );
+
+  const downloadFile = useCallback(
+    async (bucket: string, key: string, localPath: string, size: number) => {
+      const transferId = newTransferId();
+      addTransfer({
+        id: transferId,
+        sessionId,
+        direction: "download",
+        kind: "file",
+        localPath,
+        remotePath: `/${bucket}/${key}`,
+        size,
+        bytes: 0,
+        rate: 0,
+        eta: 0,
+        state: "queued",
+        startedAt: Date.now(),
+      });
+      await startTracking(transferId, "local");
+      try {
+        await storageDownload(sessionId, transferId, bucket, key, localPath);
+      } catch (err) {
+        setStatus(`Download failed: ${err instanceof Error ? err.message : err}`);
+      }
+    },
+    [addTransfer, sessionId, setStatus, startTracking],
+  );
+
+  const uploadFile = useCallback(
+    async (localPath: string, bucket: string, key: string, size: number) => {
+      const transferId = newTransferId();
+      addTransfer({
+        id: transferId,
+        sessionId,
+        direction: "upload",
+        kind: "file",
+        localPath,
+        remotePath: `/${bucket}/${key}`,
+        size,
+        bytes: 0,
+        rate: 0,
+        eta: 0,
+        state: "queued",
+        startedAt: Date.now(),
+      });
+      await startTracking(transferId, "remote");
+      try {
+        await storageUpload(sessionId, transferId, bucket, key, localPath);
+      } catch (err) {
+        setStatus(`Upload failed: ${err instanceof Error ? err.message : err}`);
+      }
+    },
+    [addTransfer, sessionId, setStatus, startTracking],
+  );
+
+  // Recursively download every object under `prefix` into `localBase`,
+  // enqueuing one transfer per file. Subfolders descend (delimiter listing).
+  const downloadPrefixTree = useCallback(
+    async (bucket: string, prefix: string, localBase: string) => {
+      let token: string | null = null;
+      do {
+        const page = await storageListObjects(sessionId, bucket, prefix, token);
+        for (const e of page.entries) {
+          if (e.isDir) {
+            await downloadPrefixTree(bucket, e.key, joinPath(localBase, e.name));
+          } else {
+            await downloadFile(bucket, e.key, joinPath(localBase, e.name), e.size);
+          }
+        }
+        token = page.nextToken ?? null;
+      } while (token);
+    },
+    [downloadFile, sessionId],
+  );
+
+  const uploadDirTree = useCallback(
+    async (localDir: string, bucket: string, destPrefix: string) => {
+      const entries = await sftpListLocal(localDir).catch(() => [] as FileEntry[]);
+      for (const e of entries) {
+        if (e.fileType === "dir") {
+          await uploadDirTree(e.path, bucket, `${destPrefix}${e.name}/`);
+        } else if (e.fileType === "file") {
+          await uploadFile(e.path, bucket, `${destPrefix}${e.name}`, e.size);
+        }
+      }
+    },
+    [uploadFile],
+  );
+
+  const download = useCallback(
+    async (entry: FileEntry, localDir: string) => {
+      let dir = localDir;
+      if (!dir) dir = await sftpLocalHome().catch(() => "");
+      if (!dir) {
+        setStatus("Download failed: pick a folder in the LOCAL pane first.");
+        return;
+      }
+      const { bucket, key } = splitRemote(entry.path);
+      if (!bucket) return;
+      if (entry.fileType === "dir") {
+        await downloadPrefixTree(bucket, key, joinPath(dir, entry.name));
+      } else {
+        await downloadFile(bucket, key, joinPath(dir, entry.name), entry.size);
+      }
+    },
+    [downloadFile, downloadPrefixTree, setStatus],
+  );
+
+  const upload = useCallback(
+    async (entry: FileEntry, remoteDir: string) => {
+      const { bucket, key: prefix } = splitRemote(remoteDir);
+      if (!bucket) {
+        setStatus("Upload failed: open a bucket first.");
+        return;
+      }
+      if (entry.fileType === "dir") {
+        await uploadDirTree(entry.path, bucket, `${prefix}${entry.name}/`);
+      } else {
+        await uploadFile(entry.path, bucket, `${prefix}${entry.name}`, entry.size);
+      }
+    },
+    [setStatus, uploadDirTree, uploadFile],
+  );
+
+  // Create a folder, or — at the bucket-list root — a new bucket.
+  const mkdir = useCallback(
+    async (remoteParent: string, name: string) => {
+      const { bucket, key: prefix } = splitRemote(remoteParent);
+      try {
+        if (!bucket) {
+          await storageCreateBucket(sessionId, name);
+        } else {
+          await storageCreateFolder(sessionId, bucket, `${prefix}${name}`);
+        }
+        await refreshPane(sessionId, "remote");
+      } catch (err) {
+        setStatus(`Create failed: ${err instanceof Error ? err.message : err}`);
+      }
+    },
+    [refreshPane, sessionId, setStatus],
+  );
+
+  const remove = useCallback(
+    async (entry: FileEntry) => {
+      const { bucket, key } = splitRemote(entry.path);
+      try {
+        if (!key) {
+          await storageDeleteBucket(sessionId, bucket);
+        } else if (entry.fileType === "dir") {
+          await storageDeletePrefix(sessionId, bucket, key);
+        } else {
+          await storageDeleteObject(sessionId, bucket, key);
+        }
+        await refreshPane(sessionId, "remote");
+      } catch (err) {
+        setStatus(`Delete failed: ${err instanceof Error ? err.message : err}`);
+      }
+    },
+    [refreshPane, sessionId, setStatus],
+  );
+
+  const rename = useCallback(
+    async (entry: FileEntry, newName: string) => {
+      const { bucket, key } = splitRemote(entry.path);
+      if (!bucket || !key) {
+        setStatus("Rename is not supported for buckets.");
+        return;
+      }
+      try {
+        const prefix = parentPrefix(key);
+        if (entry.fileType === "dir") {
+          // Move every object under the old prefix to the new prefix.
+          const oldPrefix = key.endsWith("/") ? key : `${key}/`;
+          const newPrefix = `${prefix}${newName}/`;
+          let token: string | null = null;
+          const moves: Array<{ from: string; to: string }> = [];
+          const walk = async (p: string): Promise<void> => {
+            let tk: string | null = null;
+            do {
+              const page = await storageListObjects(sessionId, bucket, p, tk);
+              for (const e of page.entries) {
+                if (e.isDir) await walk(e.key);
+                else moves.push({ from: e.key, to: newPrefix + e.key.slice(oldPrefix.length) });
+              }
+              tk = page.nextToken ?? null;
+            } while (tk);
+          };
+          await walk(oldPrefix);
+          void token;
+          for (const m of moves) {
+            await storageMoveObject(sessionId, bucket, m.from, bucket, m.to);
+          }
+        } else {
+          await storageMoveObject(sessionId, bucket, key, bucket, `${prefix}${newName}`);
+        }
+        await refreshPane(sessionId, "remote");
+      } catch (err) {
+        setStatus(`Rename failed: ${err instanceof Error ? err.message : err}`);
+      }
+    },
+    [refreshPane, sessionId, setStatus],
+  );
+
+  const copyTo = useCallback(
+    async (entry: FileEntry, destRemoteDir: string) => {
+      const src = splitRemote(entry.path);
+      const dst = splitRemote(destRemoteDir);
+      if (!src.bucket || !dst.bucket || entry.fileType === "dir") {
+        setStatus("Copy currently supports single objects between buckets/prefixes.");
+        return;
+      }
+      try {
+        await storageCopyObject(sessionId, src.bucket, src.key, dst.bucket, `${dst.key}${entry.name}`);
+        await refreshPane(sessionId, "remote");
+      } catch (err) {
+        setStatus(`Copy failed: ${err instanceof Error ? err.message : err}`);
+      }
+    },
+    [refreshPane, sessionId, setStatus],
+  );
+
+  const shareUrl = useCallback(
+    async (entry: FileEntry, ttlSecs: number): Promise<string | null> => {
+      const { bucket, key } = splitRemote(entry.path);
+      if (!bucket || !key || entry.fileType === "dir") {
+        setStatus("Share links are for single objects only.");
+        return null;
+      }
+      try {
+        const url = await storageShareUrl(sessionId, bucket, key, ttlSecs);
+        try {
+          await navigator.clipboard.writeText(url);
+          setStatus("Share link copied to clipboard.");
+        } catch {
+          setStatus("Share link generated.");
+        }
+        return url;
+      } catch (err) {
+        setStatus(`Share failed: ${err instanceof Error ? err.message : err}`);
+        return null;
+      }
+    },
+    [sessionId, setStatus],
+  );
+
+  const cancelTransfer = useCallback(async (transferId: string) => {
+    try {
+      await storageCancelTransfer(transferId);
+      setTransferState(transferId, "cancelled");
+    } catch (err) {
+      setStatus(`Cancel failed: ${err instanceof Error ? err.message : err}`);
+    }
+  }, [setStatus, setTransferState]);
+
+  const pauseTransfer = useCallback(async (transferId: string) => {
+    try {
+      await storagePauseTransfer(transferId);
+      patchTransfer(transferId, { state: "paused", rate: 0, eta: 0 });
+    } catch (err) {
+      setStatus(`Pause failed: ${err instanceof Error ? err.message : err}`);
+    }
+  }, [patchTransfer, setStatus]);
+
+  const resumeTransfer = useCallback(async (transferId: string) => {
+    try {
+      await storageResumeTransfer(transferId);
+      patchTransfer(transferId, { state: "running" });
+    } catch (err) {
+      setStatus(`Resume failed: ${err instanceof Error ? err.message : err}`);
+    }
+  }, [patchTransfer, setStatus]);
+
+  return {
+    download,
+    upload,
+    mkdir,
+    remove,
+    rename,
+    copyTo,
+    shareUrl,
+    cancelTransfer,
+    pauseTransfer,
+    resumeTransfer,
+  };
+}

--- a/src/stores/objectStorageStore.ts
+++ b/src/stores/objectStorageStore.ts
@@ -1,0 +1,458 @@
+import { create } from "zustand";
+import {
+  sftpListLocal,
+  sftpLocalHome,
+  sftpLocalDrives,
+  type FileEntry,
+} from "../lib/sftp";
+import {
+  storageAttach,
+  storageDetach,
+  storageListBuckets,
+  storageListObjects,
+} from "../lib/objectStorage";
+import type { ObjectEntry, ObjectStorageConfig, BucketEntry } from "../types/objectStorage";
+import { WINDOWS_DRIVES_ROOT, type PaneSide, type PaneState } from "./sftpStore";
+
+// Remote path scheme: "/" is the bucket-list root; "/{bucket}/{prefix...}"
+// addresses a prefix inside a bucket. Folder entry paths keep a trailing "/".
+export const OBJ_ROOT = "/";
+
+/** Parse a remote path into bucket + key-prefix, or null for the bucket root. */
+export function parseRemotePath(path: string): { bucket: string; prefix: string } | null {
+  const trimmed = path.replace(/^\/+/, "");
+  if (!trimmed) return null;
+  const parts = trimmed.split("/").filter(Boolean);
+  const bucket = parts[0];
+  const rest = parts.slice(1).join("/");
+  return { bucket, prefix: rest ? `${rest}/` : "" };
+}
+
+function mapBucket(b: BucketEntry): FileEntry {
+  return {
+    name: b.name,
+    path: `/${b.name}`,
+    size: 0,
+    mtime: b.createdAt ?? 0,
+    mode: 0,
+    fileType: "dir",
+    isHidden: false,
+  };
+}
+
+function mapObject(bucket: string, e: ObjectEntry): FileEntry {
+  return {
+    name: e.name,
+    path: `/${bucket}/${e.key}`,
+    size: e.size,
+    mtime: e.lastModified ?? 0,
+    mode: 0,
+    fileType: e.isDir ? "dir" : "file",
+    isHidden: false,
+  };
+}
+
+/** Cap pagination so a pathological bucket can't lock up the UI. */
+const MAX_PAGES = 50;
+const MAX_ENTRIES = 20000;
+
+async function listRemote(sessionId: string, path: string): Promise<FileEntry[]> {
+  const parsed = parseRemotePath(path);
+  if (!parsed) {
+    const buckets = await storageListBuckets(sessionId);
+    return buckets.map(mapBucket);
+  }
+  const { bucket, prefix } = parsed;
+  const out: FileEntry[] = [];
+  let token: string | null = null;
+  let pages = 0;
+  do {
+    const page = await storageListObjects(sessionId, bucket, prefix, token);
+    for (const e of page.entries) out.push(mapObject(bucket, e));
+    token = page.nextToken ?? null;
+    pages += 1;
+  } while (token && pages < MAX_PAGES && out.length < MAX_ENTRIES);
+  return out;
+}
+
+async function listSide(sessionId: string, side: PaneSide, path: string): Promise<FileEntry[]> {
+  if (side === "remote") return listRemote(sessionId, path);
+  if (path === WINDOWS_DRIVES_ROOT) {
+    const drives = await sftpLocalDrives();
+    return drives.map<FileEntry>((d) => ({
+      name: d.label,
+      path: d.path,
+      fileType: "dir",
+      size: 0,
+      mtime: 0,
+      mode: 0,
+      isHidden: false,
+    }));
+  }
+  return sftpListLocal(path);
+}
+
+export interface ObjStorageSessionState {
+  sessionId: string;
+  attached: boolean;
+  attaching: boolean;
+  homeDir: string | null;
+  error: string | null;
+  remote: PaneState;
+  local: PaneState;
+  config: ObjectStorageConfig | null;
+}
+
+interface ObjStorageStoreState {
+  sessions: Record<string, ObjStorageSessionState>;
+  attach: (sessionId: string, config: ObjectStorageConfig) => Promise<void>;
+  detach: (sessionId: string) => Promise<void>;
+  ensureSession: (sessionId: string) => ObjStorageSessionState;
+  refreshPane: (sessionId: string, side: PaneSide) => Promise<void>;
+  navigate: (sessionId: string, side: PaneSide, path: string) => Promise<void>;
+  navigateBack: (sessionId: string, side: PaneSide) => Promise<void>;
+  navigateForward: (sessionId: string, side: PaneSide) => Promise<void>;
+  navigateUp: (sessionId: string, side: PaneSide) => Promise<void>;
+  navigateHome: (sessionId: string, side: PaneSide) => Promise<void>;
+  setSelection: (sessionId: string, side: PaneSide, selection: string[]) => void;
+  toggleHidden: (sessionId: string, side: PaneSide) => void;
+}
+
+function emptyPane(): PaneState {
+  return {
+    path: "",
+    entries: [],
+    selection: [],
+    loading: false,
+    error: null,
+    history: [],
+    historyIndex: -1,
+    showHidden: false,
+  };
+}
+
+function freshSession(sessionId: string): ObjStorageSessionState {
+  return {
+    sessionId,
+    attached: false,
+    attaching: false,
+    homeDir: null,
+    error: null,
+    remote: emptyPane(),
+    local: emptyPane(),
+    config: null,
+  };
+}
+
+function pushHistory(pane: PaneState, path: string): PaneState {
+  if (pane.history[pane.historyIndex] === path) return pane;
+  const trimmed = pane.history.slice(0, pane.historyIndex + 1);
+  trimmed.push(path);
+  return { ...pane, history: trimmed, historyIndex: trimmed.length - 1 };
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+const refCounts = new Map<string, number>();
+const inFlight = new Map<string, Promise<void>>();
+
+// CONTINUED below — store body appended via the editor.
+export const useObjectStorageStore = create<ObjStorageStoreState>((set, get) => ({
+  sessions: {},
+
+  ensureSession: (sessionId) => {
+    const existing = get().sessions[sessionId];
+    if (existing) return existing;
+    const next = freshSession(sessionId);
+    set((state) => ({ sessions: { ...state.sessions, [sessionId]: next } }));
+    return next;
+  },
+
+  attach: async (sessionId, config) => {
+    refCounts.set(sessionId, (refCounts.get(sessionId) ?? 0) + 1);
+    const pending = inFlight.get(sessionId);
+    if (pending) {
+      try {
+        await pending;
+      } catch {
+        const remaining = (refCounts.get(sessionId) ?? 1) - 1;
+        if (remaining > 0) refCounts.set(sessionId, remaining);
+        else refCounts.delete(sessionId);
+        throw new Error(get().sessions[sessionId]?.error ?? "attach failed");
+      }
+      return;
+    }
+    if (get().sessions[sessionId]?.attached) return;
+
+    set((state) => ({
+      sessions: {
+        ...state.sessions,
+        [sessionId]: { ...(state.sessions[sessionId] ?? freshSession(sessionId)), attaching: true, error: null, config },
+      },
+    }));
+
+    const attachPromise = (async () => {
+      try {
+        await storageAttach(sessionId, config);
+        const home = config.defaultBucket || config.defaultContainer;
+        const remotePath = home ? `/${home}` : OBJ_ROOT;
+        const localHome = await sftpLocalHome().catch(() => "");
+        const remoteEntries = await listSide(sessionId, "remote", remotePath).catch(() => []);
+        const localEntries = localHome
+          ? await listSide(sessionId, "local", localHome).catch(() => [])
+          : [];
+        set((state) => ({
+          sessions: {
+            ...state.sessions,
+            [sessionId]: {
+              ...(state.sessions[sessionId] ?? freshSession(sessionId)),
+              attached: true,
+              attaching: false,
+              homeDir: remotePath,
+              config,
+              remote: { ...emptyPane(), path: remotePath, entries: remoteEntries, history: [remotePath], historyIndex: 0 },
+              local: { ...emptyPane(), path: localHome, entries: localEntries, history: localHome ? [localHome] : [], historyIndex: localHome ? 0 : -1 },
+            },
+          },
+        }));
+        if ((refCounts.get(sessionId) ?? 0) === 0) {
+          await storageDetach(sessionId).catch(() => {});
+          set((state) => {
+            const next = { ...state.sessions };
+            delete next[sessionId];
+            return { sessions: next };
+          });
+        }
+      } catch (err) {
+        set((state) => ({
+          sessions: {
+            ...state.sessions,
+            [sessionId]: { ...(state.sessions[sessionId] ?? freshSession(sessionId)), attaching: false, error: errMsg(err) },
+          },
+        }));
+        throw err;
+      }
+    })();
+    inFlight.set(sessionId, attachPromise);
+    try {
+      await attachPromise;
+    } catch (err) {
+      const remaining = (refCounts.get(sessionId) ?? 1) - 1;
+      if (remaining > 0) refCounts.set(sessionId, remaining);
+      else refCounts.delete(sessionId);
+      throw err;
+    } finally {
+      if (inFlight.get(sessionId) === attachPromise) inFlight.delete(sessionId);
+    }
+  },
+
+  detach: async (sessionId) => {
+    const remaining = (refCounts.get(sessionId) ?? 0) - 1;
+    if (remaining > 0) {
+      refCounts.set(sessionId, remaining);
+      return;
+    }
+    refCounts.delete(sessionId);
+    if (inFlight.has(sessionId)) return;
+    await storageDetach(sessionId).catch((err) => console.warn("[oss-store] detach failed:", err));
+    set((state) => {
+      const next = { ...state.sessions };
+      delete next[sessionId];
+      return { sessions: next };
+    });
+  },
+
+  refreshPane: async (sessionId, side) => {
+    const session = get().sessions[sessionId];
+    if (!session) return;
+    const pane = session[side];
+    set((state) => ({
+      sessions: {
+        ...state.sessions,
+        [sessionId]: { ...session, [side]: { ...pane, loading: true, error: null } },
+      },
+    }));
+    try {
+      const entries = await listSide(sessionId, side, pane.path);
+      set((state) => {
+        const cur = state.sessions[sessionId];
+        if (!cur) return state;
+        return {
+          sessions: {
+            ...state.sessions,
+            [sessionId]: { ...cur, [side]: { ...cur[side], entries, loading: false, error: null } },
+          },
+        };
+      });
+    } catch (err) {
+      const message = errMsg(err);
+      set((state) => {
+        const cur = state.sessions[sessionId];
+        if (!cur) return state;
+        return {
+          sessions: {
+            ...state.sessions,
+            [sessionId]: { ...cur, [side]: { ...cur[side], loading: false, error: message } },
+          },
+        };
+      });
+    }
+  },
+
+  navigate: async (sessionId, side, path) => {
+    const sess = get().ensureSession(sessionId);
+    const prev = sess[side];
+    set((state) => ({
+      sessions: {
+        ...state.sessions,
+        [sessionId]: { ...state.sessions[sessionId], [side]: { ...prev, loading: true, error: null, path } },
+      },
+    }));
+    try {
+      const entries = await listSide(sessionId, side, path);
+      set((state) => {
+        const cur = state.sessions[sessionId];
+        if (!cur) return state;
+        const after = pushHistory(
+          { ...cur[side], path, entries, loading: false, error: null, selection: [] },
+          path,
+        );
+        return { sessions: { ...state.sessions, [sessionId]: { ...cur, [side]: after } } };
+      });
+    } catch (err) {
+      const message = errMsg(err);
+      set((state) => {
+        const cur = state.sessions[sessionId];
+        if (!cur) return state;
+        return {
+          sessions: {
+            ...state.sessions,
+            [sessionId]: { ...cur, [side]: { ...cur[side], loading: false, error: message } },
+          },
+        };
+      });
+    }
+  },
+
+  navigateBack: async (sessionId, side) => {
+    const sess = get().sessions[sessionId];
+    if (!sess) return;
+    const pane = sess[side];
+    if (pane.historyIndex <= 0) return;
+    const idx = pane.historyIndex - 1;
+    const path = pane.history[idx];
+    await applyHistoryNav(set, get, sessionId, side, idx, path);
+  },
+
+  navigateForward: async (sessionId, side) => {
+    const sess = get().sessions[sessionId];
+    if (!sess) return;
+    const pane = sess[side];
+    if (pane.historyIndex >= pane.history.length - 1) return;
+    const idx = pane.historyIndex + 1;
+    const path = pane.history[idx];
+    await applyHistoryNav(set, get, sessionId, side, idx, path);
+  },
+
+  navigateUp: async (sessionId, side) => {
+    const sess = get().sessions[sessionId];
+    if (!sess) return;
+    const path = sess[side].path;
+    if (!path || path === "/" || path === WINDOWS_DRIVES_ROOT) return;
+    if (side === "local" && /^[A-Z]:\\?$/i.test(path)) {
+      await get().navigate(sessionId, side, WINDOWS_DRIVES_ROOT);
+      return;
+    }
+    const isWin = side === "local" && path.includes("\\");
+    const sep = isWin ? "\\" : "/";
+    const trimmed = path.endsWith(sep) ? path.slice(0, -1) : path;
+    const idx = trimmed.lastIndexOf(sep);
+    let parent: string;
+    if (idx <= 0) parent = isWin ? path.slice(0, 3) : "/";
+    else parent = trimmed.slice(0, idx);
+    await get().navigate(sessionId, side, parent);
+  },
+
+  navigateHome: async (sessionId, side) => {
+    if (side === "remote") {
+      const sess = get().sessions[sessionId];
+      await get().navigate(sessionId, side, sess?.homeDir ?? OBJ_ROOT);
+    } else {
+      const home = await sftpLocalHome().catch(() => "");
+      if (home) await get().navigate(sessionId, side, home);
+    }
+  },
+
+  setSelection: (sessionId, side, selection) => {
+    set((state) => {
+      const cur = state.sessions[sessionId];
+      if (!cur) return state;
+      return {
+        sessions: {
+          ...state.sessions,
+          [sessionId]: { ...cur, [side]: { ...cur[side], selection } },
+        },
+      };
+    });
+  },
+
+  toggleHidden: (sessionId, side) => {
+    set((state) => {
+      const cur = state.sessions[sessionId];
+      if (!cur) return state;
+      return {
+        sessions: {
+          ...state.sessions,
+          [sessionId]: { ...cur, [side]: { ...cur[side], showHidden: !cur[side].showHidden } },
+        },
+      };
+    });
+  },
+}));
+
+/** Shared history-navigation (back/forward) body: list `path`, update pane. */
+async function applyHistoryNav(
+  set: (fn: (state: ObjStorageStoreState) => Partial<ObjStorageStoreState>) => void,
+  get: () => ObjStorageStoreState,
+  sessionId: string,
+  side: PaneSide,
+  idx: number,
+  path: string,
+): Promise<void> {
+  const sess = get().sessions[sessionId];
+  if (!sess) return;
+  const pane = sess[side];
+  set((state) => ({
+    sessions: {
+      ...state.sessions,
+      [sessionId]: { ...sess, [side]: { ...pane, historyIndex: idx, path, loading: true } },
+    },
+  }));
+  try {
+    const entries = await listSide(sessionId, side, path);
+    set((state) => {
+      const cur = state.sessions[sessionId];
+      if (!cur) return state;
+      return {
+        sessions: {
+          ...state.sessions,
+          [sessionId]: { ...cur, [side]: { ...cur[side], entries, loading: false, error: null, selection: [] } },
+        },
+      };
+    });
+  } catch (err) {
+    const message = errMsg(err);
+    set((state) => {
+      const cur = state.sessions[sessionId];
+      if (!cur) return state;
+      return {
+        sessions: {
+          ...state.sessions,
+          [sessionId]: { ...cur, [side]: { ...cur[side], loading: false, error: message } },
+        },
+      };
+    });
+  }
+}

--- a/src/stores/sftpStore.ts
+++ b/src/stores/sftpStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { StoreApi, UseBoundStore } from "zustand";
 import {
   sftpListRemote,
   sftpListLocal,
@@ -41,6 +42,36 @@ export interface SftpSessionState {
   remote: PaneState;
   local: PaneState;
 }
+
+/**
+ * Minimal per-session shape that `FilePanel` reads. Both `useSftpStore` and
+ * the object-storage store satisfy this, so `FilePanel` can be driven by
+ * either via its optional `store` prop.
+ */
+export interface FilePanelSession {
+  homeDir: string | null;
+  local: PaneState;
+  remote: PaneState;
+}
+
+/**
+ * The slice of store actions `FilePanel` invokes. Kept deliberately small so a
+ * non-SFTP store (e.g. object storage) only has to implement navigation +
+ * selection, not the full attach/detach lifecycle.
+ */
+export interface FilePanelStore {
+  sessions: Record<string, FilePanelSession>;
+  navigate: (sessionId: string, side: PaneSide, path: string) => Promise<void>;
+  navigateBack: (sessionId: string, side: PaneSide) => Promise<void>;
+  navigateForward: (sessionId: string, side: PaneSide) => Promise<void>;
+  navigateUp: (sessionId: string, side: PaneSide) => Promise<void>;
+  refreshPane: (sessionId: string, side: PaneSide) => Promise<void>;
+  setSelection: (sessionId: string, side: PaneSide, selection: string[]) => void;
+  toggleHidden: (sessionId: string, side: PaneSide) => void;
+}
+
+/** A zustand bound-store hook that exposes the {@link FilePanelStore} surface. */
+export type FilePanelStoreHook = UseBoundStore<StoreApi<FilePanelStore>>;
 
 interface SftpStoreState {
   sessions: Record<string, SftpSessionState>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,8 +2,9 @@ import type { SshConnectInfo } from "../components/terminal/TerminalPanel";
 import type { TerminalProfile } from "../lib/terminalProfile";
 import type { NetworkSettingsPayload } from "../lib/networkSettings";
 import type { RdpOptions } from "./rdp";
+import type { ObjectStorageConfig } from "./objectStorage";
 
-export type TabKind = "terminal" | "sftp" | "rdp" | "vnc" | "nettools" | "welcome" | "settings" | "placeholder" | "file-browser" | "database" | "redis" | "hbase-shell" | "proxy-test";
+export type TabKind = "terminal" | "sftp" | "rdp" | "vnc" | "nettools" | "welcome" | "settings" | "placeholder" | "file-browser" | "database" | "redis" | "hbase-shell" | "proxy-test" | "object-storage";
 
 export interface VncConnectInfo {
   sessionId: string;
@@ -106,6 +107,12 @@ export interface FileBrowserTabInfo {
   initialPath: string;
 }
 
+/** Connection parameters for an object-storage browser tab (S3 / Azure Blob). */
+export interface ObjectStorageTabInfo {
+  sessionId: string;
+  config: ObjectStorageConfig;
+}
+
 export interface Tab {
   id: string;
   type: TabKind;
@@ -125,6 +132,7 @@ export interface Tab {
   hbase?: HBaseConnectInfo;
   fileBrowser?: FileBrowserTabInfo;
   proxyTest?: ProxyTestTabInfo;
+  objectStorage?: ObjectStorageTabInfo;
   hasNewOutput?: boolean;
   /**
    * One-shot starting directory for a freshly opened local/SSH terminal tab.

--- a/src/types/objectStorage.ts
+++ b/src/types/objectStorage.ts
@@ -1,0 +1,139 @@
+// Wire types for the object-storage feature (S3 / S3-compatible / Azure Blob).
+// These mirror the Rust DTOs in `src-tauri/src/objectstorage/{config,types}.rs`
+// (all serialized camelCase).
+
+import type { NetworkSettingsPayload } from "../lib/networkSettings";
+
+/** S3-family providers plus Azure. `custom` = arbitrary S3-compatible endpoint. */
+export type ObjectStorageProvider =
+  | "aws"
+  | "alibaba-oss"
+  | "minio"
+  | "r2"
+  | "backblaze"
+  | "wasabi"
+  | "tencent-cos"
+  | "ceph"
+  | "custom"
+  | "azure";
+
+/** Which engine a provider maps to. */
+export type ObjectStorageEngine = "s3" | "azure";
+
+export function engineForProvider(provider: ObjectStorageProvider): ObjectStorageEngine {
+  return provider === "azure" ? "azure" : "s3";
+}
+
+/**
+ * Connection parameters sent to the backend (`storage_attach` / the session's
+ * `options_json`). Secret-bearing fields may be `vault:<uuid>` references that
+ * the backend resolves; the editor stores them as vault refs on save.
+ */
+export interface ObjectStorageConfig {
+  provider: ObjectStorageProvider;
+  // --- S3 family ---
+  endpoint?: string | null;
+  region?: string | null;
+  pathStyle?: boolean | null;
+  accessKeyId?: string | null;
+  secretAccessKey?: string | null;
+  sessionToken?: string | null;
+  defaultBucket?: string | null;
+  /** S3 credential source: "keys" (default) | "environment" | "profile". */
+  awsAuth?: AwsAuthSource | null;
+  /** Named AWS profile when awsAuth === "profile". */
+  awsProfile?: string | null;
+  // --- Azure ---
+  accountName?: string | null;
+  accountKey?: string | null;
+  connectionString?: string | null;
+  sasToken?: string | null;
+  endpointSuffix?: string | null;
+  defaultContainer?: string | null;
+  /** Azure auth selector: "key" | "sas" | "connstr" | "bearer" (Entra ID). */
+  azureAuth?: AzureAuthSource | null;
+  /** Pasted Entra ID token for azureAuth === "bearer" (may be a vault ref). */
+  azureBearerToken?: string | null;
+  // --- Network routing (P7) ---
+  /** Proxy / SSH-jump routing; omitted = app-level global proxy. */
+  network?: NetworkSettingsPayload | null;
+  // --- Defaults (P8) ---
+  /** Default storage class / access tier for uploads (e.g. STANDARD, Hot). */
+  storageClass?: string | null;
+}
+
+/** S3 credential source. */
+export type AwsAuthSource = "keys" | "environment" | "profile";
+
+/** Azure auth source. `key`/`sas`/`connstr` use a stored secret; `bearer` is
+ *  Entra ID (a pasted token or one obtained from the Azure CLI). */
+export type AzureAuthSource = "key" | "sas" | "connstr" | "bearer";
+
+/** A bucket (S3) or container (Azure) at the account/service root. */
+export interface BucketEntry {
+  name: string;
+  /** Creation time, seconds since the UNIX epoch, when reported. */
+  createdAt?: number | null;
+  region?: string | null;
+}
+
+/** One row in an object listing: a real object or a synthetic folder. */
+export interface ObjectEntry {
+  name: string;
+  key: string;
+  isDir: boolean;
+  size: number;
+  lastModified?: number | null;
+  etag?: string | null;
+  storageClass?: string | null;
+}
+
+/** One page of an object listing; `nextToken` drives lazy pagination. */
+export interface ObjectListPage {
+  entries: ObjectEntry[];
+  nextToken?: string | null;
+}
+
+/** Detailed metadata for a single object, from a HEAD request. */
+export interface ObjectMetadata {
+  key: string;
+  size: number;
+  contentType?: string | null;
+  etag?: string | null;
+  lastModified?: number | null;
+  storageClass?: string | null;
+  cacheControl?: string | null;
+  contentEncoding?: string | null;
+  contentDisposition?: string | null;
+  userMetadata: Record<string, string>;
+}
+
+/** Provider presets used by the connection editor (label + defaults). */
+export interface ProviderPreset {
+  id: ObjectStorageProvider;
+  label: string;
+  engine: ObjectStorageEngine;
+  /** Default addressing style for S3 providers (true = path-style). */
+  pathStyle?: boolean;
+  /** Endpoint placeholder/hint shown in the editor. */
+  endpointHint?: string;
+  /** Whether the endpoint is derived (AWS) rather than user-entered. */
+  endpointDerived?: boolean;
+}
+
+export const PROVIDER_PRESETS: ProviderPreset[] = [
+  { id: "aws", label: "Amazon S3", engine: "s3", endpointDerived: true },
+  { id: "alibaba-oss", label: "Alibaba Cloud OSS", engine: "s3", endpointHint: "oss-cn-hangzhou.aliyuncs.com" },
+  { id: "minio", label: "MinIO", engine: "s3", pathStyle: true, endpointHint: "http://127.0.0.1:9000" },
+  { id: "r2", label: "Cloudflare R2", engine: "s3", endpointHint: "https://<account>.r2.cloudflarestorage.com" },
+  { id: "backblaze", label: "Backblaze B2", engine: "s3", endpointHint: "https://s3.<region>.backblazeb2.com" },
+  { id: "wasabi", label: "Wasabi", engine: "s3", endpointHint: "https://s3.<region>.wasabisys.com" },
+  { id: "tencent-cos", label: "Tencent COS", engine: "s3", endpointHint: "https://cos.<region>.myqcloud.com" },
+  { id: "ceph", label: "Ceph RGW", engine: "s3", pathStyle: true, endpointHint: "https://rgw.example.com" },
+  { id: "custom", label: "Custom S3-compatible", engine: "s3", pathStyle: true, endpointHint: "https://s3.example.com" },
+  { id: "azure", label: "Azure Blob Storage", engine: "azure" },
+];
+
+export function presetFor(provider: ObjectStorageProvider): ProviderPreset {
+  return PROVIDER_PRESETS.find((p) => p.id === provider) ?? PROVIDER_PRESETS[0];
+}


### PR DESCRIPTION
Add an object-storage connection type alongside SSH/SFTP/DB. Two engines: an S3-family client (rusty-s3 over reqwest) covering AWS / Alibaba OSS / MinIO / R2 / Backblaze / Wasabi / Tencent COS / Ceph, and a raw-REST Azure Blob client (hand-written Shared Key + service SAS signing). Full management: bucket/object listing with lazy pagination, head/copy/move/ rename, recursive delete, create folder/bucket, presigned/SAS share URLs, and streaming multipart upload/download with progress, pause, and cancel.

Cloud identity (no new deps): AWS environment and shared-profile credentials (credential_process plus `aws export-credentials` fallback for SSO / assume-role / instance-role), and Azure Entra ID bearer tokens (pasted or obtained via the Azure CLI). Network routing: per-session HTTP/SOCKS5 proxy and SSH jump host (loopback forward + reqwest DNS override to preserve TLS SNI), falling back to the app-level global proxy. Optional storage-class / access-tier on upload.

Frontend reuses the SFTP FilePanel (parameterized by store) for a dual-pane local <-> object-store browser, with a connection editor, auth-source and network sections, and MainLayout tab dispatch. Secrets are stored as vault references.