### PR TITLE
fix(hbase): complete SASL/GSSAPI security-layer negotiation for Kerberos

### DIFF
--- a/src-tauri/src/hbase/mod.rs
+++ b/src-tauri/src/hbase/mod.rs
@@ -1807,6 +1807,105 @@ mod tests {
     }
 }
 
+#[cfg(all(test, feature = "hbase-kerberos"))]
+mod kerberos_live_tests {
+    //! End-to-end test against a live *Kerberos-secured* HBase, exercising the
+    //! exact program path the UI uses: `build_session` (which parses
+    //! hbase-site.xml, runs the keytab env setup, and builds the native client)
+    //! → `ping_backend` → `list`.
+    //!
+    //! Gated by HBASE_KRB_LIVE_TEST=1. All cluster-specific and secret values
+    //! come from the environment / on-disk files — nothing is hardcoded:
+    //!   HBASE_KRB_LIVE_TEST=1   (gate)
+    //!   HBASE_SITE_XML=/path/to/hbase-site.xml
+    //!   HBASE_KEYTAB=/path/to/service.keytab
+    //!   HBASE_KRB5_CONF=/path/to/krb5.conf
+    //!   HBASE_CLIENT_PRINCIPAL=hbase/host@REALM   (optional; else derived from keytab)
+    //!   HBASE_SERVICE_PRINCIPAL=hbase/_HOST@REALM (optional; else from hbase-site.xml)
+    //!   HBASE_EFFECTIVE_USER=hbase                (optional; default "root")
+    //! Run with:
+    //!   cargo test --lib hbase::kerberos_live_tests -- --nocapture --test-threads=1
+    use super::*;
+
+    fn env(name: &str) -> Option<String> {
+        std::env::var(name).ok().filter(|s| !s.trim().is_empty())
+    }
+
+    fn config_from_env() -> Option<HBaseConfig> {
+        if env("HBASE_KRB_LIVE_TEST").as_deref() != Some("1") {
+            return None;
+        }
+        let site = env("HBASE_SITE_XML");
+        let keytab = env("HBASE_KEYTAB");
+        Some(HBaseConfig {
+            host: String::new(),
+            port: 2181,
+            username: None,
+            password: None,
+            ssl: false,
+            timeout_secs: Some(20),
+            rest_path: None,
+            namespace: None,
+            connection_mode: Some("native".into()),
+            zk_quorum: env("HBASE_ZK_QUORUM"),
+            zk_root: env("HBASE_ZK_ROOT"),
+            effective_user: env("HBASE_EFFECTIVE_USER").or_else(|| Some("root".into())),
+            auth_method: Some("kerberos".into()),
+            service_principal: env("HBASE_SERVICE_PRINCIPAL"),
+            principal: env("HBASE_CLIENT_PRINCIPAL"),
+            keytab_path: keytab,
+            krb5_conf_path: env("HBASE_KRB5_CONF"),
+            hbase_site_path: site,
+        })
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn krb_connect_and_list() {
+        let Some(config) = config_from_env() else {
+            eprintln!("skipping: set HBASE_KRB_LIVE_TEST=1 and friends to run");
+            return;
+        };
+        eprintln!(
+            "config: zk_quorum(from xml)?, service_principal={:?}, client_principal={:?}, keytab={:?}",
+            config.service_principal, config.principal, config.keytab_path
+        );
+
+        let session = build_session(&config, None)
+            .await
+            .expect("build_session failed");
+
+        let ping = ping_backend(&session).await;
+        eprintln!("PING: {ping:?}");
+        ping.expect("ping failed");
+
+        let parsed = parse_shell_command("list").unwrap();
+        let result = match &session {
+            HBaseSessionInner::Native(c) => native_execute(c, parsed, "list".into()).await,
+            HBaseSessionInner::Rest(r) => execute_command(r, parsed, "list".into()).await,
+        }
+        .expect("list failed");
+        eprintln!("LIST: {} -> {:?}", result.message, result.rows);
+        assert!(result.message.contains("table"));
+
+        // Optional: prove `list` surfaces a real table by running a
+        // create -> list -> drop cycle (gated; only on an explicit flag because
+        // it mutates the cluster). Uses a uniquely-named temp table and drops it.
+        if env("HBASE_KRB_WRITE_TEST").as_deref() == Some("1") {
+            let HBaseSessionInner::Native(c) = &session else { return };
+            let t = format!("taomni_krb_probe_{}", std::process::id());
+            let _ = c.drop_table(&t).await; // best-effort pre-clean
+            c.create_table(&t, &[("cf".into(), Default::default())])
+                .await
+                .expect("create_table failed");
+            let listed = c.list_tables().await.expect("list_tables failed");
+            eprintln!("LIST after create: {listed:?}");
+            assert!(listed.iter().any(|n| n == &t), "created table not listed");
+            c.drop_table(&t).await.expect("drop_table failed");
+            eprintln!("create/list/drop cycle OK for {t}");
+        }
+    }
+}
+
 #[cfg(test)]
 mod native_shell_live_tests {
     //! End-to-end test of the shell-command path (parse + native_execute)

--- a/src-tauri/src/hbase/native/auth.rs
+++ b/src-tauri/src/hbase/native/auth.rs
@@ -83,10 +83,14 @@ pub mod kerberos {
         // Negotiation loop.
         loop {
             match pending.step(&challenge).map_err(|e| format!("GSSAPI step failed: {e}"))? {
-                Step::Finished((_ctx, last)) => {
-                    if let Some(tok) = last {
-                        write_token(write, &tok).await?;
-                    }
+                Step::Finished((ctx, last)) => {
+                    // The GSSAPI security context is established, but HBase's
+                    // SaslServer follows the SASL/GSSAPI mechanism (RFC 4752),
+                    // which requires a security-layer negotiation *after* context
+                    // establishment. Skipping it makes the server reject the
+                    // subsequent plaintext ConnectionHeader ("Handshake expecting
+                    // no response data from server") and drop the connection.
+                    finish_sasl_security_layer(read, write, ctx, last.as_deref()).await?;
                     return Ok(true);
                 }
                 Step::Continue((next, tok)) => {
@@ -98,6 +102,56 @@ pub mod kerberos {
                 }
             }
         }
+    }
+
+    /// Perform the RFC 4752 SASL/GSSAPI security-layer negotiation that follows
+    /// context establishment, mirroring Java `GssKrb5Client`:
+    ///   1. client sends its final context token (empty for Kerberos);
+    ///   2. server replies with a `gss_wrap`-protected offer: 1 byte QOP bitmask
+    ///      + 3 bytes (big-endian) max server message size;
+    ///   3. client replies with a `gss_wrap`-protected choice: 1 byte selected
+    ///      QOP + 3 bytes max client message size + optional authzid.
+    ///
+    /// We support only `auth` (no integrity/privacy security layer), so we pick
+    /// QOP `0x01`, advertise a zero max buffer, and send an empty authzid — after
+    /// which the plaintext ConnectionHeader and RPCs flow unwrapped.
+    async fn finish_sasl_security_layer<R, W>(
+        read: &mut R,
+        write: &mut W,
+        mut ctx: ClientCtx,
+        last_token: Option<&[u8]>,
+    ) -> Result<(), String>
+    where
+        R: AsyncReadExt + Unpin,
+        W: AsyncWriteExt + Unpin,
+    {
+        // 1. Send the final context token (empty for Kerberos mutual auth).
+        write_token(write, last_token.unwrap_or(&[])).await?;
+
+        // 2. Read the server's wrapped QOP offer.
+        read_status(read).await?;
+        let len = read.read_i32().await.map_err(ioerr)?;
+        let wrapped_offer = read_n(read, len).await?;
+        let offer = ctx
+            .unwrap(&wrapped_offer)
+            .map_err(|e| format!("SASL unwrap of server QOP offer failed: {e}"))?;
+        let qop_mask = offer.first().copied().unwrap_or(0);
+
+        // SASL QOP bits: 0x01 = auth (no layer), 0x02 = integrity, 0x04 = privacy.
+        if qop_mask & 0x01 == 0 {
+            return Err(format!(
+                "server requires a SASL security layer (QOP offer 0x{qop_mask:02x}); \
+                 only authentication (no integrity/privacy) is supported"
+            ));
+        }
+
+        // 3. Reply: QOP=auth, zero max buffer (no security layer), empty authzid.
+        let reply = [0x01u8, 0x00, 0x00, 0x00];
+        let wrapped_reply = ctx
+            .wrap(false, &reply)
+            .map_err(|e| format!("SASL wrap of QOP choice failed: {e}"))?;
+        write_token(write, &wrapped_reply).await?;
+        Ok(())
     }
 
     async fn write_token<W: AsyncWriteExt + Unpin>(


### PR DESCRIPTION
The native Kerberos auth path established the raw GSSAPI context and then sent the ConnectionHeader immediately, skipping the RFC 4752 SASL security-layer negotiation that HBase's SaslServer requires. The server treated the plaintext ConnectionHeader as a SASL token, threw "Handshake expecting no response data from server", and dropped the connection — surfacing to the client as "HBase RPC connection closed".

After context establishment, perform the security-layer exchange: send the final (empty) token, read the server's gss_wrap'd QOP offer, and reply with the selected QOP (auth-only; integrity/privacy layers are not supported and now yield a clear error instead of a silent disconnect).

Add a gated live test (HBASE_KRB_LIVE_TEST) that drives the real build_session -> ping -> list path against a Kerberos cluster, reading all cluster/secret values from environment variables.