### PR TITLE
feat(hbase): hide host/port in native mode; require it only for REST

### DIFF
--- a/src-tauri/src/hbase/mod.rs
+++ b/src-tauri/src/hbase/mod.rs
@@ -525,13 +525,20 @@ fn build_native_client(
     config: &HBaseConfig,
 ) -> Result<native::client::NativeClient, String> {
     let host = config.host.trim();
-    if host.is_empty() {
-        return Err("HBase host is required".into());
-    }
-    // ZK quorum: explicit field wins; otherwise treat host:port as the quorum.
+    // Native mode bootstraps via ZooKeeper, so the ZK quorum is what matters.
+    // The explicit quorum (or one parsed from hbase-site.xml) wins; host:port is
+    // only a single-node shorthand when no quorum is configured. host is
+    // therefore optional as long as a quorum is available.
     let zk_quorum = match config.zk_quorum.as_deref().map(str::trim) {
         Some(q) if !q.is_empty() => q.to_string(),
-        _ => format!("{host}:{}", config.port),
+        _ if !host.is_empty() => format!("{host}:{}", config.port),
+        _ => {
+            return Err(
+                "HBase native mode requires a ZooKeeper quorum (set the ZK quorum \
+                 field or provide an hbase-site.xml)"
+                    .into(),
+            )
+        }
     };
     let cfg = native::client::NativeConfig {
         zk_quorum,

--- a/src/components/database/HBaseShellTab.tsx
+++ b/src/components/database/HBaseShellTab.tsx
@@ -319,14 +319,17 @@ export default function HBaseShellTab({ tabId, info, visible }: HBaseShellTabPro
 
   const endpoint = useMemo(() => {
     if (info.connectionMode === "native") {
-      const q = info.zkQuorum || `${info.host}:${info.port}`;
+      const q =
+        info.zkQuorum ||
+        (info.host ? `${info.host}:${info.port}` : "") ||
+        (info.hbaseSitePath ? "hbase-site.xml" : "ZooKeeper");
       const r = info.zkRoot || "/hbase";
       return `ZK: ${q} (${r})${info.namespace ? ` [${info.namespace}]` : ""}`;
     }
     const scheme = info.ssl ? "https" : "http";
     const path = info.restPath ? `/${info.restPath.replace(/^\/+|\/+$/g, "")}` : "";
     return `${scheme}://${info.host}:${info.port}${path}${info.namespace ? ` [${info.namespace}]` : ""}`;
-  }, [info.connectionMode, info.host, info.namespace, info.port, info.restPath, info.ssl, info.zkQuorum, info.zkRoot]);
+  }, [info.connectionMode, info.host, info.namespace, info.port, info.restPath, info.ssl, info.zkQuorum, info.zkRoot, info.hbaseSitePath]);
 
   if (connError) {
     return (

--- a/src/components/session/SessionEditor.test.tsx
+++ b/src/components/session/SessionEditor.test.tsx
@@ -561,9 +561,9 @@ describe("SessionEditor SSH settings tabs", () => {
     const { onClose } = renderEditor(undefined, { initialProto: "HBaseShell" });
 
     await waitFor(() => expect(screen.getByTestId("session-hbase-section")).toBeInTheDocument());
-    await user.type(screen.getByLabelText("Remote host"), "hbase-rest.example.com");
-    // Switch to REST mode so the REST-only fields render.
+    // Switch to REST mode first so the REST-only host/port fields render.
     await user.selectOptions(screen.getByTestId("hbase-connection-mode"), "rest");
+    await user.type(screen.getByLabelText("Remote host"), "hbase-rest.example.com");
     await user.type(screen.getByLabelText("HBase username"), "root");
     await user.type(screen.getByLabelText("HBase namespace"), "prod");
     await user.type(screen.getByLabelText("HBase REST path"), "/gateway/hbase");
@@ -593,8 +593,9 @@ describe("SessionEditor SSH settings tabs", () => {
     const { onClose } = renderEditor(undefined, { initialProto: "HBaseShell" });
 
     await waitFor(() => expect(screen.getByTestId("session-hbase-section")).toBeInTheDocument());
-    await user.type(screen.getByLabelText("Remote host"), "hbase.example.com");
-    // Native is the default mode; the ZK quorum field should be present.
+    // Native is the default mode; host/port are hidden and the ZK quorum field
+    // replaces them.
+    expect(screen.queryByLabelText("Remote host")).not.toBeInTheDocument();
     await user.type(screen.getByLabelText("HBase ZooKeeper quorum"), "zk1:2181,zk2:2181");
     await user.type(screen.getByLabelText("HBase namespace"), "prod");
 
@@ -605,7 +606,7 @@ describe("SessionEditor SSH settings tabs", () => {
     const savedOptions = JSON.parse(savedConfig.options_json);
     expect(savedConfig).toMatchObject({
       session_type: "HBaseShell",
-      host: "hbase.example.com",
+      host: "",
     });
     expect(savedOptions).toMatchObject({
       hbaseConnectionMode: "native",
@@ -620,7 +621,9 @@ describe("SessionEditor SSH settings tabs", () => {
     const { onClose } = renderEditor(undefined, { initialProto: "HBaseShell" });
 
     await waitFor(() => expect(screen.getByTestId("session-hbase-section")).toBeInTheDocument());
-    await user.type(screen.getByLabelText("Remote host"), "hbase.example.com");
+    // Native mode: no host/port fields; a ZK quorum (or hbase-site.xml) supplies
+    // the connection target, and auth is configured directly.
+    await user.type(screen.getByLabelText("HBase ZooKeeper quorum"), "zk1:2181,zk2:2181");
     await user.selectOptions(screen.getByTestId("hbase-auth-method"), "kerberos");
     await user.type(screen.getByLabelText("HBase service principal"), "hbase/_HOST@EMR.367593.COM");
     await user.type(screen.getByLabelText("HBase keytab file path"), "/path/to/keytab");
@@ -637,7 +640,7 @@ describe("SessionEditor SSH settings tabs", () => {
     const savedOptions = JSON.parse(savedConfig.options_json);
     expect(savedConfig).toMatchObject({
       session_type: "HBaseShell",
-      host: "hbase.example.com",
+      host: "",
     });
     expect(savedOptions).toMatchObject({
       hbaseConnectionMode: "native",

--- a/src/components/session/SessionEditor.tsx
+++ b/src/components/session/SessionEditor.tsx
@@ -1386,24 +1386,30 @@ function HBaseSettings({
         </span>
       </Field>
 
-      <Field label="Remote host">
-        <input
-          className="taomni-input w-64"
-          value={host}
-          aria-label="Remote host"
-          placeholder="e.g. localhost or EMR header IP"
-          onChange={(e) => setHost(e.target.value)}
-        />
-      </Field>
-      <Field label="Port">
-        <input
-          className="taomni-input w-32"
-          value={port}
-          aria-label={isNative ? "HBase port" : "HBase REST port"}
-          placeholder={isNative ? "2181" : "8080"}
-          onChange={(e) => setPort(e.target.value)}
-        />
-      </Field>
+      {/* host/port are the REST endpoint. Native mode bootstraps via the ZK
+          quorum (or hbase-site.xml), so these are hidden there. */}
+      {!isNative && (
+        <>
+          <Field label="Remote host">
+            <input
+              className="taomni-input w-64"
+              value={host}
+              aria-label="Remote host"
+              placeholder="e.g. hbase-rest.example.com"
+              onChange={(e) => setHost(e.target.value)}
+            />
+          </Field>
+          <Field label="Port">
+            <input
+              className="taomni-input w-32"
+              value={port}
+              aria-label="HBase REST port"
+              placeholder="8080"
+              onChange={(e) => setPort(e.target.value)}
+            />
+          </Field>
+        </>
+      )}
 
       {isNative && (
         <>
@@ -2408,8 +2414,22 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
   };
 
   const handleTestHBaseConnection = async () => {
-    if (!host) {
-      setTestResult({ ok: false, msg: t("sessionEditor2.errHostRequired") });
+    // Mirror the save-path validation: REST needs a host; native needs a ZK
+    // quorum, an hbase-site.xml, or a host (host/port are hidden in native mode).
+    if (hbaseConnectionMode === "rest" && !host.trim()) {
+      setTestResult({ ok: false, msg: "HBase REST host is required." });
+      return;
+    }
+    if (
+      hbaseConnectionMode !== "rest" &&
+      !hbaseSitePath.trim() &&
+      !hbaseZkQuorum.trim() &&
+      !host.trim()
+    ) {
+      setTestResult({
+        ok: false,
+        msg: "HBase ZooKeeper quorum, HBase-site.xml, or Remote host is required.",
+      });
       return;
     }
     setTesting(true);

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -284,6 +284,7 @@ function sessionToHBaseConnectInfo(session: SessionConfig, password?: string): H
     principal: str("hbasePrincipal") || null,
     keytabPath: str("hbaseKeytabPath") || null,
     krb5ConfPath: str("hbaseKrb5ConfPath") || null,
+    hbaseSitePath: str("hbaseSitePath") || null,
   };
 }
 
@@ -1173,7 +1174,15 @@ export function MainLayout() {
   const openHBaseShellTab = useCallback((session: SessionConfig, password?: string) => {
     const id = `hbase-shell-${session.id}-${Date.now()}`;
     const info = sessionToHBaseConnectInfo(session, password);
-    const title = `HBase ${session.host}:${session.port}${info.namespace ? `/${info.namespace}` : ""}`;
+    // Native mode may have no host/port (it bootstraps via ZK quorum or
+    // hbase-site.xml), so build a sensible endpoint label per mode.
+    const endpointLabel =
+      info.connectionMode === "native"
+        ? info.zkQuorum?.split(",")[0]?.trim() ||
+          (session.host ? `${session.host}:${session.port}` : "") ||
+          (info.hbaseSitePath ? "hbase-site.xml" : "ZooKeeper")
+        : `${session.host}:${session.port}`;
+    const title = `HBase ${endpointLabel}${info.namespace ? `/${info.namespace}` : ""}`;
     addTab({
       id,
       type: "hbase-shell",

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1010,6 +1010,7 @@ function toHBaseConfigPayload(info: HBaseConnectInfo): Record<string, unknown> {
     principal: info.principal ?? null,
     keytabPath: info.keytabPath ?? null,
     krb5ConfPath: info.krb5ConfPath ?? null,
+    hbaseSitePath: info.hbaseSitePath ?? null,
   };
 }
 


### PR DESCRIPTION
In native RPC mode the connection bootstraps via the ZooKeeper quorum (an explicit ZK quorum field or one parsed from hbase-site.xml), so the Remote host / Port fields are redundant. Hide them in native mode and show them only for the REST/Stargate backend, where they form the endpoint URL.

- SessionEditor: render host/port only in REST mode; the Test-connection button now uses the same mode-aware validation as Save (native accepts a ZK quorum, an hbase-site.xml, or a host) instead of always demanding a host.
- build_native_client: drop the unconditional "host is required"; use the ZK quorum when set, fall back to host:port only if a host is given, and return a clear error when neither is available. REST still requires a host.
- Plumb hbaseSitePath through the connect path (ipc payload + MainLayout connect info) — it was being dropped, so xml-only native sessions would not have connected once host is hidden.
- Native tab title and endpoint summary show the ZK quorum / hbase-site.xml instead of an empty ":0" when no host is set.
- Update HBase SessionEditor tests for the new behavior.