### PR TITLE
fix(terminal): let text selection start from the first column

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1994,6 +1994,13 @@ export function MainLayout() {
           defaultLayout={loadResizableLayout("main-layout", ["sidebar", "content"])}
           onLayoutChanged={saveResizableLayout("main-layout")}
           className="flex-1 min-w-0"
+          // Shrink the resize hit target to match the 3px visible divider.
+          // The library default ({coarse:20, fine:10}) inflates a thin Separator's
+          // hit area symmetrically, so ~3.5px of it overflowed rightward onto the
+          // terminal's first column — there a left-edge mousedown was captured as a
+          // resize (col-resize cursor) instead of starting a text selection. Sizing
+          // the hit target to the divider width keeps it from bleeding onto content.
+          resizeTargetMinimumSize={{ coarse: 3, fine: 3 }}
         >
           <Panel
             panelRef={sidebarPanelRef}


### PR DESCRIPTION
The sidebar/content resize divider is visually 3px, but react-resizable-panels inflates a thin Separator's pointer hit area to a 10px minimum (resizeTargetMinimumSize.fine), expanded symmetrically. The extra ~3.5px overflowed rightward onto the terminal's first column, so a left-edge mousedown was captured as a resize (col-resize cursor) instead of starting a text selection — users had to start from column 2.

Size the main PanelGroup's resize hit target to the divider width ({coarse:3, fine:3}) so it no longer bleeds onto the content panel.