### PR TITLE
fix(lanchat): drop hardcoded Chinese reason from vault unlock prompt

### DIFF
--- a/src/components/detached/LanChatDetachedWindow.tsx
+++ b/src/components/detached/LanChatDetachedWindow.tsx
@@ -108,7 +108,6 @@ export default function LanChatDetachedWindow({ id }: { id: string }) {
         {headerName}
       </div>
       <VaultGate
-        reason="查看局域网聊天需要主密码解锁(与密码保险库共用)。"
         lockedTitle="局域网聊天已锁定"
         lockedHint="需要主密码解锁。该密码与应用的密码保险库共用。"
       >

--- a/src/components/lanchat/LanChatGate.tsx
+++ b/src/components/lanchat/LanChatGate.tsx
@@ -30,7 +30,6 @@ export function LanChatGate() {
 
   return (
     <VaultGate
-      reason="首次打开局域网聊天需要主密码解锁(与密码保险库共用)。"
       lockedTitle="局域网聊天已锁定"
       lockedHint="首次打开需要主密码解锁。该密码与应用的密码保险库共用。"
     >


### PR DESCRIPTION
The LanChat vault gate passed a hardcoded Chinese `reason` line to the unlock dialog, which rendered Chinese explanatory text even when the UI language was English. Remove it so the prompt shows just the title and master-password input, matching the standard SSH session unlock prompt.