### PR TITLE
fix(lanchat): reliable Linux↔Win11 text + file delivery

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,7 +7,8 @@
     "sftp-*",
     "rdp-*",
     "vnc-*",
-    "terminal-*"
+    "terminal-*",
+    "lan-chat-*"
   ],
   "permissions": [
     "core:default",

--- a/src-tauri/src/lanchat/discovery.rs
+++ b/src-tauri/src/lanchat/discovery.rs
@@ -40,6 +40,53 @@ fn local_ipv4s() -> Vec<Ipv4Addr> {
         .collect()
 }
 
+/// Local IPv4 interfaces as (address, netmask) pairs (multi-NIC aware). Used to
+/// score which of a peer's advertised addresses is actually reachable from here.
+fn local_ipv4_subnets() -> Vec<(Ipv4Addr, Ipv4Addr)> {
+    if_addrs::get_if_addrs()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|i| !i.is_loopback())
+        .filter_map(|i| match i.addr {
+            if_addrs::IfAddr::V4(v4) => Some((v4.ip, v4.netmask)),
+            if_addrs::IfAddr::V6(_) => None,
+        })
+        .collect()
+}
+
+/// Choose the advertised address most likely reachable from this host: prefer
+/// one whose subnet matches a local interface, else fall back to the first
+/// advertised address. Windows peers commonly advertise Hyper-V / WSL / VM
+/// virtual-adapter IPs (e.g. `172.x`, `192.168.56.x`) alongside their real LAN
+/// IP; picking the first arbitrarily (the old behaviour) frequently selected an
+/// unreachable one, so cross-subnet dials timed out and the peer looked online
+/// but unreachable. Returns `None` only when `candidates` is empty.
+fn pick_reachable_addr(candidates: &[Ipv4Addr]) -> Option<Ipv4Addr> {
+    pick_reachable_addr_among(candidates, &local_ipv4_subnets())
+}
+
+/// Pure core of [`pick_reachable_addr`], parameterized on the local interface
+/// (address, netmask) set so it is deterministically testable.
+fn pick_reachable_addr_among(
+    candidates: &[Ipv4Addr],
+    locals: &[(Ipv4Addr, Ipv4Addr)],
+) -> Option<Ipv4Addr> {
+    if candidates.is_empty() {
+        return None;
+    }
+    let same_subnet = |cand: &Ipv4Addr| {
+        locals.iter().any(|(lip, mask)| {
+            let m = u32::from(*mask);
+            m != 0 && (u32::from(*lip) & m) == (u32::from(*cand) & m)
+        })
+    };
+    candidates
+        .iter()
+        .find(|c| same_subnet(c))
+        .or_else(|| candidates.first())
+        .copied()
+}
+
 /// Build the `ServiceInfo` advertised for this node from its current profile.
 fn build_service_info(state: &LanChatState, control_port: u16) -> Result<ServiceInfo, String> {
     let profile = state
@@ -116,11 +163,12 @@ fn peer_from_resolved(resolved: &mdns_sd::ResolvedService, my_id: &str) -> Optio
         .get_property_val_str("name")
         .unwrap_or("")
         .to_string();
-    let addr = resolved
+    let v4s: Vec<Ipv4Addr> = resolved
         .get_addresses_v4()
         .iter()
-        .next()
-        .map(|ip| ip.to_string());
+        .filter_map(|ip| ip.to_string().parse().ok())
+        .collect();
+    let addr = pick_reachable_addr(&v4s).map(|ip| ip.to_string());
     let port = resolved
         .get_property_val_str("port")
         .and_then(|s| s.parse::<u16>().ok())
@@ -192,8 +240,20 @@ pub async fn run(app: AppHandle, state: Arc<LanChatState>, control_port: u16) {
             event = receiver.recv_async() => {
                 match event {
                     Ok(ServiceEvent::ServiceResolved(resolved)) => {
-                        if let Some(peer) = peer_from_resolved(&resolved, &my_id) {
+                        if let Some(mut peer) = peer_from_resolved(&resolved, &my_id) {
                             fullname_to_id.insert(resolved.get_fullname().to_string(), peer.id.clone());
+                            // If we already hold a live connection to this peer, its
+                            // current addr/port are proven reachable. Don't let an
+                            // mDNS re-resolve (which may now advertise a non-routable
+                            // virtual-adapter IP) overwrite them and break sends.
+                            if state.connections.read().await.contains_key(&peer.id) {
+                                if let Some(existing) = state.peers.read().await.get(&peer.id) {
+                                    if existing.addr.is_some() {
+                                        peer.addr = existing.addr.clone();
+                                        peer.port = existing.port;
+                                    }
+                                }
+                            }
                             let _ = state.store.store_peer(&peer);
                             state.peers.write().await.insert(peer.id.clone(), peer);
                             dirty = true;
@@ -234,6 +294,36 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let state = LanChatState::new(&dir);
         (dir, state)
+    }
+
+    #[test]
+    fn pick_reachable_addr_falls_back_and_handles_empty() {
+        // No candidates → None.
+        assert_eq!(pick_reachable_addr_among(&[], &[]), None);
+        // Candidates but no local-subnet info → first candidate (old behaviour,
+        // preserved as the fallback so a peer is never dropped).
+        let a: Ipv4Addr = "203.0.113.7".parse().unwrap();
+        let b: Ipv4Addr = "198.51.100.9".parse().unwrap();
+        assert_eq!(pick_reachable_addr_among(&[a, b], &[]), Some(a));
+    }
+
+    #[test]
+    fn pick_reachable_addr_prefers_same_subnet() {
+        // Local interface 192.168.1.50/24.
+        let locals = [(
+            "192.168.1.50".parse::<Ipv4Addr>().unwrap(),
+            "255.255.255.0".parse::<Ipv4Addr>().unwrap(),
+        )];
+        let lan: Ipv4Addr = "192.168.1.23".parse().unwrap(); // same /24 → reachable
+        let virt: Ipv4Addr = "172.27.96.1".parse().unwrap(); // WSL/Hyper-V style
+
+        // The same-subnet address wins even when the virtual one is advertised
+        // first (the old `.iter().next()` would have wrongly picked the virtual).
+        assert_eq!(pick_reachable_addr_among(&[virt, lan], &locals), Some(lan));
+        assert_eq!(pick_reachable_addr_among(&[lan, virt], &locals), Some(lan));
+        // With only an unreachable candidate, still return it (better than nothing;
+        // a later inbound connection corrects the address — see transport.rs).
+        assert_eq!(pick_reachable_addr_among(&[virt], &locals), Some(virt));
     }
 
     #[test]

--- a/src-tauri/src/lanchat/swarm.rs
+++ b/src-tauri/src/lanchat/swarm.rs
@@ -458,9 +458,21 @@ pub async fn send(
         "manifest": manifest.to_json(), "kind": "file", "mime": mime,
         "convId": conv_id, "groupId": group_id, "members": members,
     });
+    let mut delivered = 0usize;
     for target in &targets {
         let env = Envelope::new(frame::SWARM_OFFER, &my_id, Some(target.clone()), payload.clone());
-        let _ = transport::send_to_peer(app, state, target, env).await;
+        match transport::send_to_peer(app, state, target, env).await {
+            Ok(()) => delivered += 1,
+            Err(e) => log::warn!("lanchat: swarm offer for {file_id} to {target} failed: {e}"),
+        }
+    }
+    // If the offer reached no one (peer offline / unreachable address / firewall),
+    // surface a terminal failure instead of leaving the sender stuck on a silent
+    // "offering" card, and drop the dead seed so it does not leak.
+    if delivered == 0 && !targets.is_empty() {
+        sf.emit(app, Some("failed")).await;
+        state.swarms.write().await.remove(&file_id);
+        return Err("could not reach any recipient (peer offline or unreachable)".into());
     }
     sf.emit(app, Some("offering")).await;
     Ok(file_id)

--- a/src-tauri/src/lanchat/transport.rs
+++ b/src-tauri/src/lanchat/transport.rs
@@ -12,7 +12,7 @@
 
 use std::collections::VecDeque;
 use std::net::SocketAddr;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
@@ -58,6 +58,11 @@ fn new_codec() -> LengthDelimitedCodec {
     codec
 }
 
+/// Monotonic per-process connection id. Stamped onto every [`ConnHandle`] so the
+/// read loop's teardown only removes the map entry if it is still *its own*
+/// connection — a replaced/older socket closing later must not evict the live one.
+static CONN_SEQ: AtomicU64 = AtomicU64::new(1);
+
 /// A live connection to a peer: its id/address plus three outbound queues
 /// drained by the connection's write task — a small unbounded control queue
 /// (JSON envelopes), a bounded blocking binary-data queue (file pieces, the
@@ -66,6 +71,14 @@ fn new_codec() -> LengthDelimitedCodec {
 pub struct ConnHandle {
     pub peer_id: String,
     pub addr: SocketAddr,
+    /// Unique id for this physical connection (see [`CONN_SEQ`]).
+    conn_id: u64,
+    /// True if we dialed this connection, false if we accepted it. Drives the
+    /// deterministic glare tie-break when both peers connect simultaneously.
+    outbound: bool,
+    /// Signals the connection's read loop to tear down (used when a duplicate
+    /// connection deterministically replaces this one).
+    close: Arc<Notify>,
     control_tx: mpsc::UnboundedSender<Envelope>,
     data_tx: mpsc::Sender<bytes::Bytes>,
     /// Drop-oldest media queue + its wake signal (see [`MediaQueue`]). Read by
@@ -358,6 +371,27 @@ async fn handshake<T: AsyncRead + AsyncWrite + Unpin>(
     }
 }
 
+/// Deterministic glare tie-break: should a newly-established connection replace
+/// the existing one to the same peer? Both ends compute this identically, so
+/// they keep the *same* physical connection when they dialed each other at once.
+///
+/// Rule: keep the connection dialed by the peer with the smaller node id. A
+/// same-direction duplicate (e.g. two outbound dials racing) is always redundant
+/// — keep the existing one. For the opposite-direction glare pair, exactly one
+/// connection was dialed by the min-id peer; that is the one both ends keep.
+fn duplicate_replaces_existing(
+    new_outbound: bool,
+    existing_outbound: bool,
+    my_id: &str,
+    peer_id: &str,
+) -> bool {
+    if new_outbound == existing_outbound {
+        return false;
+    }
+    let new_dialer_id = if new_outbound { my_id } else { peer_id };
+    new_dialer_id == std::cmp::min(my_id, peer_id)
+}
+
 /// Learn / refresh a peer from a freshly established connection. Peers that
 /// mDNS never resolved (cross-segment Wi-Fi, multicast-pruned networks) are
 /// synthesized from the connection's source IP + the `hello` identity so they
@@ -374,15 +408,21 @@ async fn learn_peer_from_conn(
     let mut peers = state.peers.write().await;
     match peers.get_mut(peer_id) {
         Some(existing) => {
-            // Already known (typically from mDNS). Keep it fresh and backfill
-            // any missing reach info without forcing a roster churn.
+            // Already known (typically from mDNS). A live connection's remote IP
+            // is proven reachable, so adopt it: this corrects a stale or
+            // non-routable address that mDNS may have seeded (e.g. a Windows
+            // Hyper-V/WSL/VM virtual-adapter IP) and is the only way a peer we
+            // could never dial first (we only ever accepted from it) becomes
+            // dial-able. The listening port comes from the peer's hello — the
+            // socket's source port is ephemeral — so only override it when the
+            // hello carried one. Persist so historic reconnect uses the good
+            // address across restarts.
             existing.last_seen = now;
-            if existing.addr.is_none() {
-                existing.addr = Some(ip);
+            existing.addr = Some(ip);
+            if let Some(p) = hello.port {
+                existing.port = Some(p);
             }
-            if existing.port.is_none() {
-                existing.port = hello.port;
-            }
+            let _ = state.store.store_peer(existing);
             false
         }
         None => {
@@ -555,12 +595,6 @@ async fn setup_connection(
         }
     }
 
-    // Single connection per peer: keep the existing one, drop this duplicate.
-    if state.connections.read().await.contains_key(&peer_id) {
-        log::debug!("lanchat: duplicate connection to {peer_id} dropped");
-        return Ok(());
-    }
-
     // Trust-on-first-use pin (audit + defense in depth): record the cert on first
     // sight, block if a previously pinned cert ever changes. The latter is
     // structurally unreachable while the id==fingerprint check above holds, so a
@@ -588,17 +622,45 @@ async fn setup_connection(
     let (tx, mut rx) = mpsc::unbounded_channel::<Envelope>();
     let (data_tx, mut data_rx) = mpsc::channel::<bytes::Bytes>(DATA_QUEUE_CAP);
     let media = Arc::new(MediaQueue::new());
+    let close = Arc::new(Notify::new());
+    let outbound = expected.is_some();
+    let conn_id = CONN_SEQ.fetch_add(1, Ordering::Relaxed);
 
-    state.connections.write().await.insert(
-        peer_id.clone(),
-        ConnHandle {
-            peer_id: peer_id.clone(),
-            addr,
-            control_tx: tx.clone(),
-            data_tx,
-            media: media.clone(),
-        },
-    );
+    // Single connection per peer, decided atomically. When both peers dial each
+    // other at once ("glare"), each side must independently keep the *same* one
+    // of the two connections or both tear down and chat silently breaks. The whole
+    // check+insert holds the write lock so two concurrent setups can't both
+    // register (and then evict each other on close).
+    let handle = ConnHandle {
+        peer_id: peer_id.clone(),
+        addr,
+        conn_id,
+        outbound,
+        close: close.clone(),
+        control_tx: tx.clone(),
+        data_tx,
+        media: media.clone(),
+    };
+    let displaced = {
+        let mut conns = state.connections.write().await;
+        let old = match conns.get(&peer_id) {
+            Some(existing) => {
+                if !duplicate_replaces_existing(outbound, existing.outbound, &my_id, &peer_id) {
+                    log::debug!("lanchat: duplicate connection to {peer_id} dropped (kept existing)");
+                    return Ok(());
+                }
+                Some(existing.close.clone())
+            }
+            None => None,
+        };
+        conns.insert(peer_id.clone(), handle);
+        old
+    };
+    // Tell the displaced connection's read loop to tear down. Its teardown is
+    // conn_id-guarded, so it won't evict the entry we just inserted.
+    if let Some(old_close) = displaced {
+        old_close.notify_one();
+    }
     log::info!("lanchat: connected to {peer_id} ({addr})");
 
     // Gossip: share our known peers so the new connection can discover nodes
@@ -687,10 +749,20 @@ async fn setup_connection(
         }
     });
 
-    // Read loop owns teardown: on disconnect it removes the connection and
-    // aborts the write + ping tasks.
+    // Read loop owns teardown: on disconnect (or when displaced by a duplicate)
+    // it removes the connection and aborts the write + ping tasks.
     tokio::spawn(async move {
-        while let Some(frame_res) = read.next().await {
+        loop {
+            let frame_res = tokio::select! {
+                biased;
+                // Displaced by a deterministically-preferred duplicate: stop now
+                // so we drop our socket without evicting the replacement.
+                _ = close.notified() => break,
+                f = read.next() => match f {
+                    Some(f) => f,
+                    None => break,
+                },
+            };
             let buf = match frame_res {
                 Ok(b) => b,
                 Err(e) => {
@@ -711,7 +783,15 @@ async fn setup_connection(
                 None => log::debug!("lanchat: bad/unknown frame from {peer_id}"),
             }
         }
-        state.connections.write().await.remove(&peer_id);
+        // Only evict the map entry if it is still *this* connection: a duplicate
+        // may have deterministically replaced us, and a stale socket closing must
+        // not remove the live replacement.
+        {
+            let mut conns = state.connections.write().await;
+            if conns.get(&peer_id).map(|h| h.conn_id) == Some(conn_id) {
+                conns.remove(&peer_id);
+            }
+        }
         ping_task.abort();
         write_task.abort();
         log::info!("lanchat: disconnected from {peer_id}");
@@ -826,6 +906,32 @@ async fn dispatch_inbound(
 mod tests {
     use super::*;
     use tokio::net::TcpListener;
+
+    #[test]
+    fn glare_tie_break_keeps_same_connection_on_both_ends() {
+        // Two peers, lexically "aaa" < "bbb". Glare creates two connections:
+        // X dialed by "aaa" (inbound on "bbb"), Y dialed by "bbb" (inbound on "aaa").
+        // Whatever the local registration order, both ends must keep the *same*
+        // physical connection — the one dialed by the min id ("aaa", via X).
+        let (lo, hi) = ("aaa", "bbb");
+        // On lo's side (my=lo, peer=hi): X is outbound, Y is inbound.
+        assert!(duplicate_replaces_existing(true, false, lo, hi), "lo: X replaces existing Y");
+        assert!(!duplicate_replaces_existing(false, true, lo, hi), "lo: Y dropped, keep X");
+        // On hi's side (my=hi, peer=lo): X is inbound, Y is outbound.
+        assert!(duplicate_replaces_existing(false, true, hi, lo), "hi: X replaces existing Y");
+        assert!(!duplicate_replaces_existing(true, false, hi, lo), "hi: Y dropped, keep X");
+        // Both ends converge on X (the connection dialed by the min id).
+    }
+
+    #[test]
+    fn same_direction_duplicate_never_replaces() {
+        // A redundant dial in the same direction is always dropped, regardless of
+        // ids — only the opposite-direction glare pair triggers a replacement.
+        for (a, b) in [("aaa", "bbb"), ("bbb", "aaa")] {
+            assert!(!duplicate_replaces_existing(true, true, a, b));
+            assert!(!duplicate_replaces_existing(false, false, a, b));
+        }
+    }
 
     #[test]
     fn media_queue_is_drop_oldest_and_bounded() {


### PR DESCRIPTION
Both symptoms (text "mostly fails", file "no response") share one cause: the LAN connection is established to the wrong address or not at all, and every failure is silently swallowed. The wire protocol is correct.

- discovery: pick a reachable IPv4 (prefer one in the same subnet as a local interface) instead of the arbitrary first. Win11 advertises Hyper-V/WSL/VM virtual-adapter IPs that are non-routable from Linux, so the old `.iter().next()` frequently dialed an unreachable address.
- transport: a live connection's remote IP is proven reachable, so adopt and persist it (port from the peer's hello, not the ephemeral socket port) instead of only backfilling when None; mDNS re-resolve no longer clobbers the addr/port of a peer that currently has a live connection.
- transport: resolve connection glare deterministically. ConnHandle gains conn_id/outbound/close; the dedup check+insert is atomic under one write lock; on a duplicate both ends keep the connection dialed by the min node id (duplicate_replaces_existing); read-loop teardown only evicts when the stored conn_id still matches, so a displaced socket can't remove the live replacement.
- swarm: stop discarding the SWARM_OFFER send result. If no target was reached, emit a terminal "failed" transfer event, drop the dead seed, and return an error instead of a silent stuck "offering".
- capabilities: add `lan-chat-*` to the windows allowlist so detached LanChat windows (labeled `lan-chat-<id>`) get invoke/event/dialog permissions; without it the file picker, offer listeners, and send IPC were all denied.

Adds unit tests for the glare tie-break (both ends converge on the same connection) and the subnet-aware address picker.