### PR TITLE
feat(cc): inject session-identity card so CC knows its bound session …

### DIFF
--- a/claudedocs/cc-agent-orchestration-plan.md
+++ b/claudedocs/cc-agent-orchestration-plan.md
@@ -128,11 +128,60 @@
 - ☐ live `chat_stream` 接 `--add-dir`(搬 `commands.rs` 逻辑),cwd 由前端 OSC-7 传入(扩 `chat_stream` 请求字段)。**注**:仅对本地工作区线程有意义;远端 SSH 线程 N/A。还需先给 CC 子进程显式设 `current_dir`(现继承 Taomni 工作目录,无意义)。
 - ☐ per-thread 模型(opus/sonnet/haiku)+ thinking 预算,在 provider 切换处暴露。
 - ☐ CC 的 `tool_use/tool_result` 渲染为结构化卡片;从 result 事件捞 token/cost/usage。
-- ☐(新增候选,讨论结论)**执行目标消歧**:让 CC 在绑定会话时优先 `run_in_terminal`(远端)而非内置 Bash(本地)——system-prompt 一句消歧,或 Strict 线程 deny 本地 Bash。小而高价值。
+- ☐(新增候选,讨论结论)**执行目标消歧**:让 CC 在绑定会话时优先 `run_in_terminal`(远端)而非内置 Bash(本地)。**已并入下方 3.S 会话身份卡**(由身份卡里的工具路由指引一句话实现);Strict 线程 deny 本地 Bash 作为可选加强保留。
 - ☐(新增候选,讨论结论)**只读命令确认降噪**:区分只读/改动命令,只读免逐条弹卡(或引导 allow-session),降低「跑→读→调整」循环的点击摩擦。
-- ❌(讨论结论)**环境事实卡** —— 不做:`read_terminal_tail` 反馈闭环已覆盖,纯优化、低优先。
+- ☐ **3.S 会话身份卡注入(本轮新增,详见下「Phase 3.S」)**:把绑定会话的非敏感身份 + 最近命令历史经 `--append-system-prompt-file` 注入 CC,让 CC 自知"我在哪个会话",减少自我定位的无谓 `list_sessions`/本地 Bash 误用。
+- ⚠️(原结论修订)**环境事实卡**:此前判「不做」是针对**命令正确性**(`read_terminal_tail` 闭环已覆盖)。本轮诉求不同 —— **会话身份感知**(CC 不知自己绑在哪个 session、误用本地 Bash、重复自我定位),闭环不覆盖。故**作用域化复活**为 3.S(仅身份 + 历史,不做命令正确性提示)。
 
 → ☐ Review gate 3。
+
+#### Phase 3.S — 会话身份卡注入(本轮细化,已锁定取舍)
+
+**目标**:CC 经常"不知道自己绑在哪个 session" → 重复调 `list_sessions` 自我定位、或在绑定远端时误用本地 `Bash`。把**绑定会话的非敏感身份 + 最近命令历史**推给 CC,让它无需本地查询即知现状。
+
+**已锁定取舍(本轮 review)**:
+- **注入方式 = 全塞 system prompt 快照**:spawn 时经 `--append-system-prompt-file` 注入一张快照(已验证 CC v2.1.185 支持 `--system-prompt` / `--append-system-prompt[-file]`)。**不**做每轮消息前言注入。
+- **v1 范围 = 身份卡 + 历史;cwd 留到下轮**。理由见下「数据可用性」:cwd 后端不持久化。
+- 为何快照可接受:CC 进程**每线程 spawn 一次、参数终生固定**(`process.rs:22`、`chat/mod.rs:512`)。身份在线程内**不变**(绑定固定),快照恒准;历史标注为"会话开始时最近命令",轻微陈旧可接受;唯一强易变项 cwd 本轮不做,故无须每轮刷新。
+
+**数据可用性(已核实,2026-06-21)**:
+- **SessionConfig**(`session/models.rs:3-24`,`sessions` 表):非敏感字段白名单 = `id / name / session_type / group_path / host / port / username / auth_method 标签 / last_connected_at`。**绝不**取 `options_json`(含 vault 凭据引用)。无明文密钥。
+- **`linked_session_id` 是终端 *tab id*,不是 `SessionConfig.id`**(`chatStore.ts:93-95`)。后端 `state.terminals` 也按 tab id 作键、`ActiveTerminal` 不存 config id(`state.rs:67`)→ **后端单凭 thread 无法解析会话元数据**。
+- **cwd 不持久化**:后端无任何内存 HashMap 存 cwd(`state.rs` 全部 HashMap 已查);所有 `cwd` 都是 spawn 瞬时参数(`pty.rs:577`)。cwd 仅前端 OSC-7 持有,按调用传参(先例 `ai/commands.rs:138` 把前端 cwd 拼成"当前工作目录：…")。**v1 不传 cwd**。
+- **命令历史在 SQLite**:`command_history` 表按 `host_key`(=`ssh:host:port:user` 或 `local`)。`history_list_recent(host_key, limit)` 可取该 host 最近命令。**非按 SessionConfig.id**,由会话的 host/port/user 推出 host_key。
+
+**实现(前端解析身份 + 后端读 DB 组卡)**:
+1. **前端**:发 CC 消息时,由绑定 tab → 终端 registry 取 `sessionId`(= `SessionConfig.id`),作为**新请求字段 `bound_session_id`** 传入(区别于 tab 维度的 `linked_session_id`)。本地/未保存线程则为空。
+2. **后端 `chat/mod.rs` CC spawn 分支(进程首建时)**:
+   - 若有 `bound_session_id` → `session::db::get_session` 取 `SessionConfig`;按白名单组身份段;由 host/port/user 推 `host_key` → 查 `command_history` 最近 N 条(如 15)。
+   - 无 → 降级为"本地工作区线程,无绑定远端会话"卡。
+   - 拼好卡 → 过 `redact::redact`(防御纵深)→ 写进程已有 obscure `temp_dir` 的 `system-prompt.txt`(随 stop/Drop 清理)→ `extra_args` 增 `--append-system-prompt-file <path>`。
+3. 卡片模板(示意):
+
+   ```text
+   你当前绑定到 Taomni 会话「<name>」:<username>@<host>:<port>(类型 SSH,认证 PrivateKey)。
+   信任级=Strict(远端,危险动作会停下等用户确认)。
+   会话 SessionConfig id=<sid>;聊天线程 thread=<tid>。
+   在本会话操作远端:用 run_in_terminal/sftp_upload,不要用本地 Bash;读回显用 read_terminal_tail。
+   该主机最近命令(会话开始时快照):
+     - <cmd1>
+     - <cmd2>
+     …
+   ```
+
+**安全**:
+- 用 `--append-system-prompt-file` 而非 `--append-system-prompt`,避免 host/user/会话名进 argv 被本机其他用户 `ps` 看到。
+- 字段白名单,不碰 `options_json`;成卡再过 `redact`。
+- Vault 锁**不挡**:SessionConfig 的 host/user 是明文列,不走 vault,锁着也能组卡,不新增解锁依赖。
+
+**边界**:
+- 未保存/本地快终端 → 身份段降级,仍给"本地工作区"+(可选)`local` 历史。
+- **绑定中途改变**:进程已用旧卡 spawn → 卡会过期。低成本兜底 = spawn 分支侦测 `bound_session_id` 与进程创建时不一致 → `stop()` 重建进程(可选,绑定改变罕见,v1 可先不做、文档标注已知限制)。
+- 历史为快照,不随会话内新命令更新(易变项延后到"每轮前言"或专用工具,本轮不做)。
+
+**测试**:身份卡内容快照测(给定 SessionConfig → 期望文本);无 `bound_session_id` 降级测;`host_key` 推导 + 历史注入测;`redact` 命中(构造含密文的 name);断言 argv **不含** host(走文件变体)。
+
+→ ☐ Review gate 3.S(并入 gate 3)。
 
 ### Phase 4 — 编排者 B 最小版 — ☐ 待办
 - ☐ 给 CC 增最小编排工具 `dispatch_subtask`(并行拉起子 CC 进程或原生 agent run),结果聚合回主 CC。
@@ -152,10 +201,11 @@
 - ✅ 废弃旧的自定义 JSON-RPC `agent/mcp_server.rs` + `lib.rs` 的 `mcp_server_start/stop/status` 注册 + stdio `--mcp-server` 分支（`main.rs` dispatch、`cc_bridge/permissions_mcp.rs`、`cc_bridge/tools_mcp.rs`）。三处均已删除，构建通过、cc_bridge 33 测试全绿；活动路径只剩 `cc_bridge/mcp_http.rs`（Streamable-HTTP）。
 
 **Phase 3(cwd + 模型 + 渲染):**
+- ☐ **3.S 会话身份卡注入**:前端传 `bound_session_id`;后端首建进程时 `get_session` + `command_history`(host_key)组卡 → `redact` → `--append-system-prompt-file`。v1 含身份 + 历史,**不含 cwd**。*(本轮新增,详见 Phase 3.S;并入旧「执行目标消歧」、作用域化复活旧「环境事实卡」)*
 - ☐ CC 子进程显式 `current_dir` + 本地工作区线程接 `--add-dir`
+- ☐ cwd 注入(前端 OSC-7 → 请求字段,先例 `ai/commands.rs:138`)*(3.S 下轮)*
 - ☐ per-thread 模型 + thinking 预算
 - ☐ `tool_use/tool_result` 结构化卡片 + result 事件的 token/cost/usage
-- ☐ 执行目标消歧(优先 `run_in_terminal`)*(讨论新增,低成本高价值)*
 - ☐ 只读命令确认降噪 *(讨论新增)*
 
 **Phase 4(编排 B 最小版):**

--- a/src-tauri/src/agent/cc_bridge/mod.rs
+++ b/src-tauri/src/agent/cc_bridge/mod.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod mcp_http;
 pub mod process;
 pub mod protocol;
+pub mod session_card;
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;

--- a/src-tauri/src/agent/cc_bridge/session_card.rs
+++ b/src-tauri/src/agent/cc_bridge/session_card.rs
@@ -1,0 +1,223 @@
+//! Phase 3.S — the "session identity card" injected into Claude Code via
+//! `--append-system-prompt-file`.
+//!
+//! Goal: CC reliably knows *which saved Taomni session a chat thread is bound
+//! to* without having to call `list_sessions` to locate itself, and prefers the
+//! remote `run_in_terminal` MCP tool over its built-in local Bash when the
+//! binding is a remote host.
+//!
+//! Snapshot-at-spawn only: a `CcProcess`'s args are fixed for the thread's life
+//! (it is spawned once and reused with `--resume`). That is fine here because
+//! the binding identity is stable within a thread; the recent-command history
+//! is a clearly-labelled start-of-session snapshot; and cwd — the only strongly
+//! volatile field — is intentionally out of scope this round.
+//!
+//! This module is intentionally pure (no DB / no `AppHandle`): the caller reads
+//! the `SessionConfig` and history, then redacts the rendered text. That keeps
+//! it unit-testable and keeps `cc_bridge` free of `crate::vault::*` (see the
+//! module warning in `cc_bridge/mod.rs`).
+
+use crate::session::models::{SessionConfig, SessionType};
+
+/// How many recent commands to snapshot into the card.
+pub const HISTORY_LIMIT: usize = 15;
+
+/// Replicate the frontend `makeHostKey` (`src/lib/history.ts`) so we read the
+/// same `command_history` bucket the terminal wrote into. Format:
+/// `ssh:{host_lowercase}:{port}:{username}` (username may be empty).
+pub fn host_key_for(session: &SessionConfig) -> String {
+    let user = session.username.clone().unwrap_or_default();
+    format!(
+        "ssh:{}:{}:{}",
+        session.host.to_lowercase(),
+        session.port,
+        user
+    )
+}
+
+/// Session types whose real work happens on a remote host, where CC should
+/// prefer `run_in_terminal` / `sftp_upload` over its built-in local Bash.
+fn is_remote(t: &SessionType) -> bool {
+    matches!(
+        t,
+        SessionType::SSH | SessionType::Telnet | SessionType::SFTP | SessionType::Serial
+    )
+}
+
+/// Render the (pre-redaction) card text.
+///
+/// - `session`: resolved bound session, or `None` for an unbound / local /
+///   unsaved-tab thread (the card then states it is a local workspace thread).
+/// - `thread_id`: the chat thread id, surfaced so CC can name itself.
+/// - `linked`: whether the thread is bound to a live terminal tab — drives the
+///   Strict-trust note, kept in sync with `mcp_http::provision_for_thread`
+///   (linked ⇒ Strict ⇒ dangerous actions pause for confirmation).
+/// - `recent`: newest-first recent commands on the session's host (may be empty).
+pub fn render_card(
+    session: Option<&SessionConfig>,
+    thread_id: &str,
+    linked: bool,
+    recent: &[String],
+) -> String {
+    let mut s = String::from("[Taomni 会话绑定 / session binding]\n");
+    match session {
+        Some(sc) => {
+            let user = sc.username.as_deref().unwrap_or("");
+            let at = if user.is_empty() {
+                String::new()
+            } else {
+                format!("{user}@")
+            };
+            s.push_str(&format!(
+                "你当前绑定到已保存会话「{}」:{}{}:{}(类型 {},认证 {})。\n",
+                sc.name,
+                at,
+                sc.host,
+                sc.port,
+                sc.session_type.as_str(),
+                sc.auth_method.as_str()
+            ));
+            s.push_str(&format!(
+                "SessionConfig id = {};聊天线程 thread = {};信任级 = {}。\n",
+                sc.id,
+                thread_id,
+                if linked { "Strict" } else { "Lenient" }
+            ));
+            if is_remote(&sc.session_type) {
+                s.push_str(
+                    "这是远端会话:操作远端请用 MCP 工具 run_in_terminal / sftp_upload\
+                     (危险动作会停下等用户确认),读回显用 read_terminal_tail;\
+                     不要用本地 Bash 执行面向远端的命令。\n",
+                );
+            }
+        }
+        None => {
+            // We could not resolve a saved SessionConfig. Be honest about what
+            // we know rather than guessing remote-vs-local: a linked thread is
+            // bound to a live terminal tab that simply was not opened from a
+            // saved session (local shell or ad-hoc connect); an unlinked thread
+            // is a global / workspace chat with no terminal at all.
+            if linked {
+                s.push_str(&format!(
+                    "本线程已绑定到一个终端标签(thread = {thread_id}),但它未关联到已保存会话\
+                     (可能是本地 shell 或临时连接),无法展示会话名 / 主机详情。\n"
+                ));
+            } else {
+                s.push_str(&format!(
+                    "本线程未绑定任何终端(全局 / 本地工作区线程;thread = {thread_id})。\n"
+                ));
+            }
+        }
+    }
+    if !recent.is_empty() {
+        s.push_str("该主机最近命令(会话开始时快照,新→旧):\n");
+        for cmd in recent {
+            s.push('-');
+            s.push(' ');
+            s.push_str(cmd);
+            s.push('\n');
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::models::{AuthMethod, SessionType};
+
+    fn sample(session_type: SessionType, username: Option<&str>, auth: AuthMethod) -> SessionConfig {
+        SessionConfig {
+            id: "sess-123".into(),
+            name: "prod-db".into(),
+            session_type,
+            group_path: None,
+            host: "Prod.Example.COM".into(),
+            port: 2222,
+            username: username.map(|s| s.to_string()),
+            auth_method: auth,
+            options_json: "{}".into(),
+            created_at: 0,
+            updated_at: 0,
+            last_connected_at: None,
+            sort_order: 0,
+        }
+    }
+
+    #[test]
+    fn host_key_matches_frontend_format() {
+        let sc = sample(SessionType::SSH, Some("deploy"), AuthMethod::Agent);
+        // lowercased host, raw port, raw username — mirrors makeHostKey().
+        assert_eq!(host_key_for(&sc), "ssh:prod.example.com:2222:deploy");
+    }
+
+    #[test]
+    fn host_key_empty_username() {
+        let sc = sample(SessionType::SSH, None, AuthMethod::Password);
+        assert_eq!(host_key_for(&sc), "ssh:prod.example.com:2222:");
+    }
+
+    #[test]
+    fn card_bound_remote_has_identity_routing_and_history() {
+        let sc = sample(
+            SessionType::SSH,
+            Some("deploy"),
+            AuthMethod::PrivateKey {
+                key_path: "/home/u/.ssh/id_ed25519".into(),
+            },
+        );
+        let recent = vec!["systemctl status nginx".to_string(), "df -h".to_string()];
+        let card = render_card(Some(&sc), "thread-9", true, &recent);
+
+        // Identity: name, user@host:port, type, auth label.
+        assert!(card.contains("「prod-db」"));
+        assert!(card.contains("deploy@Prod.Example.COM:2222"));
+        assert!(card.contains("类型 SSH"));
+        assert!(card.contains("认证 PrivateKey"));
+        // Self-identification.
+        assert!(card.contains("SessionConfig id = sess-123"));
+        assert!(card.contains("thread = thread-9"));
+        // linked ⇒ Strict.
+        assert!(card.contains("信任级 = Strict"));
+        // Tool-routing disambiguation (folds in old "执行目标消歧").
+        assert!(card.contains("run_in_terminal"));
+        assert!(card.contains("不要用本地 Bash"));
+        // History snapshot, newest first.
+        assert!(card.contains("- systemctl status nginx"));
+        assert!(card.contains("- df -h"));
+        // The key_path secret must NOT leak (we only emit the label).
+        assert!(!card.contains("id_ed25519"));
+    }
+
+    #[test]
+    fn card_unbound_not_linked_is_global_local() {
+        let card = render_card(None, "thread-local", false, &[]);
+        assert!(card.contains("未绑定任何终端"));
+        assert!(card.contains("thread = thread-local"));
+        // No remote routing note when there is no remote session.
+        assert!(!card.contains("run_in_terminal"));
+    }
+
+    #[test]
+    fn card_linked_but_unsaved_is_honest() {
+        // Bound to a live tab but no saved SessionConfig — don't claim local,
+        // don't claim remote.
+        let card = render_card(None, "t-quick", true, &[]);
+        assert!(card.contains("未关联到已保存会话"));
+        assert!(!card.contains("run_in_terminal"));
+    }
+
+    #[test]
+    fn card_lenient_when_not_linked() {
+        let sc = sample(SessionType::SSH, Some("u"), AuthMethod::Agent);
+        let card = render_card(Some(&sc), "t", false, &[]);
+        assert!(card.contains("信任级 = Lenient"));
+    }
+
+    #[test]
+    fn card_local_session_type_omits_remote_routing() {
+        let sc = sample(SessionType::LocalShell, None, AuthMethod::None);
+        let card = render_card(Some(&sc), "t", false, &[]);
+        assert!(!card.contains("run_in_terminal"));
+    }
+}

--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -185,6 +185,14 @@ pub struct ChatSendRequest {
     pub content: String,
     /// Optional terminal content to attach as @terminal context.
     pub terminal_context: Option<String>,
+    /// Phase 3.S — the `SessionConfig.id` of the saved session this CC thread
+    /// is bound to, resolved by the frontend from the linked terminal tab's
+    /// registry entry (`thread.linked_session_id` is a *tab* id, not a
+    /// `SessionConfig.id`, so the backend cannot derive this on its own). Used
+    /// to build the session-identity card injected into Claude Code. `None` for
+    /// unbound / local / unsaved-tab threads.
+    #[serde(default)]
+    pub bound_session_id: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -508,6 +516,48 @@ pub async fn chat_stream(
                     }
                 };
 
+                // Phase 3.S — assemble the session-identity card so CC knows
+                // which saved session this thread is bound to, then inject it
+                // as CC's appended system prompt. Written into the process temp
+                // dir (scrubbed on stop/drop) and passed via the *file* flag so
+                // the bound host/user never appear in argv (which other local
+                // users can read via `ps`).
+                let session_card = {
+                    let db = state.db.lock().map_err(|e| e.to_string())?;
+                    let session = req
+                        .bound_session_id
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .and_then(|sid| crate::session::db::get_session(&db, sid).ok());
+                    let recent = session
+                        .as_ref()
+                        .map(|sc| {
+                            crate::history::db_list_recent(
+                                &db,
+                                &crate::agent::cc_bridge::session_card::host_key_for(sc),
+                                crate::agent::cc_bridge::session_card::HISTORY_LIMIT,
+                            )
+                            .unwrap_or_default()
+                        })
+                        .unwrap_or_default();
+                    let raw = crate::agent::cc_bridge::session_card::render_card(
+                        session.as_ref(),
+                        &req.thread_id,
+                        thread.linked_session_id.is_some(),
+                        &recent,
+                    );
+                    redact::redact(&raw).0
+                };
+                let card_path = files.dir.join("system-prompt.txt");
+                let card_file: Option<String> = match std::fs::write(&card_path, &session_card) {
+                    Ok(()) => Some(card_path.to_string_lossy().to_string()),
+                    Err(e) => {
+                        eprintln!("[cc] session card write failed, continuing without it: {e}");
+                        None
+                    }
+                };
+
                 // Build extra args.
                 let mut extra_args = vec![
                     "--model".into(),
@@ -524,6 +574,12 @@ pub async fn chat_stream(
                     "--permission-prompt-tool".into(),
                     crate::agent::cc_bridge::config::PERMISSION_PROMPT_TOOL.into(),
                 ];
+                // Phase 3.S — inject the session-identity card (file variant
+                // keeps host/user out of argv).
+                if let Some(path) = card_file {
+                    extra_args.push("--append-system-prompt-file".into());
+                    extra_args.push(path);
+                }
                 if let Some(sid) = &resume_session {
                     extra_args.push("--resume".into());
                     extra_args.push(sid.clone());

--- a/src-tauri/src/history.rs
+++ b/src-tauri/src/history.rs
@@ -152,3 +152,23 @@ pub fn db_search(
     })?;
     rows.collect()
 }
+
+/// Non-command version: most-recently-used commands for a `host_key`, newest
+/// first. Used by the CC session-identity card (`agent::cc_bridge::session_card`)
+/// to snapshot recent activity on the bound session's host at spawn time.
+pub fn db_list_recent(
+    conn: &rusqlite::Connection,
+    host_key: &str,
+    limit: usize,
+) -> rusqlite::Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT command FROM command_history
+         WHERE host_key = ?1
+         ORDER BY last_used_at DESC
+         LIMIT ?2",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![host_key, limit as i64], |row| {
+        row.get::<_, String>(0)
+    })?;
+    rows.collect()
+}

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -195,6 +195,26 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   sendMessage: async (threadId: string, content: string, terminalContext?: string) => {
     set({ sending: true });
 
+    // Phase 3.S — resolve the saved SessionConfig.id this thread is bound to so
+    // the backend can build Claude Code's session-identity card.
+    // `thread.linked_session_id` is a terminal *tab* id; the saved-session id
+    // lives on the Tab as `sessionId` (set when the tab was opened from a saved
+    // session). Null for global / local / unsaved-tab threads — the backend
+    // then emits a degraded "local workspace" card.
+    let boundSessionId: string | null = null;
+    {
+      const tabId = get().threads.find((t) => t.id === threadId)?.linked_session_id ?? null;
+      if (tabId) {
+        try {
+          const { useAppStore } = await import("./appStore");
+          boundSessionId =
+            useAppStore.getState().tabs.find((t) => t.id === tabId)?.sessionId ?? null;
+        } catch (err) {
+          console.warn("bound_session_id resolution failed:", err);
+        }
+      }
+    }
+
     let unlisten: UnlistenFn | null = null;
     try {
       unlisten = await listen<StreamEvent>(`chat-stream:${threadId}`, (event) => {
@@ -276,7 +296,12 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       });
 
       await invoke("chat_stream", {
-        req: { thread_id: threadId, content, terminal_context: terminalContext ?? null },
+        req: {
+          thread_id: threadId,
+          content,
+          terminal_context: terminalContext ?? null,
+          bound_session_id: boundSessionId,
+        },
       });
     } catch (e) {
       if (isVaultLockedError(e)) {
@@ -300,7 +325,12 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           assistant_message: ChatMessage;
           redacted_count: number;
         }>("chat_send", {
-          req: { thread_id: threadId, content, terminal_context: terminalContext ?? null },
+          req: {
+            thread_id: threadId,
+            content,
+            terminal_context: terminalContext ?? null,
+            bound_session_id: boundSessionId,
+          },
         });
         set((s) => ({
           messages: {


### PR DESCRIPTION
…(Phase 3.S)

CC often did not know which Taomni session a chat thread was bound to, so it would re-query via list_sessions or misfire local Bash for remote intent. Inject a session-identity card into Claude Code at spawn via --append-system-prompt-file (file variant keeps the bound host/user out of argv/ps).

The card states the bound session (name, user@host:port, type, auth label), self-identifies (SessionConfig id + thread id + trust level), gives a tool-routing hint (prefer run_in_terminal/sftp_upload over local Bash on remote sessions), and snapshots the host's recent command history.

Snapshot-at-spawn only: a CcProcess is spawned once per thread and reused, so the card is built at process creation. Identity is stable within a thread; history is labelled "at session start"; cwd (the only strongly-volatile field) is deferred.

- new agent/cc_bridge/session_card.rs: pure render_card + host_key_for (mirrors the frontend makeHostKey) + HISTORY_LIMIT, with unit tests
- history.rs: db_list_recent(host_key) — recent commands for a host bucket
- chat/mod.rs: ChatSendRequest.bound_session_id; build+redact the card and write it into the process temp dir, then append --append-system-prompt-file
- chatStore.ts: resolve bound_session_id (thread.linked_session_id tab -> Tab .sessionId = SessionConfig.id) and pass it on chat_stream/chat_send
- non-sensitive field allowlist only (never options_json); card runs through redact; vault-lock does not block (host/user are plaintext columns)

Folds in the old "执行目标消歧" candidate and revives the "环境事实卡" decision scoped to session-identity awareness (distinct from command-correctness, which the read_terminal_tail loop already covers). Build green; 7 session_card unit tests pass; tsc -b + vite build clean. Not yet runtime-tested end-to-end (needs GUI).