### PR TITLE
feat(chat): prefer Claude Code in chat drawer

### DIFF
--- a/src/components/chat/ChatDrawer.test.tsx
+++ b/src/components/chat/ChatDrawer.test.tsx
@@ -1,0 +1,149 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatDrawer } from "./ChatDrawer";
+import { useAppStore } from "../../stores/appStore";
+import { useChatStore, type ChatThread } from "../../stores/chatStore";
+import { DEFAULT_CLAUDE_CODE_MODEL, useAiStore, type AiConfig } from "../../stores/aiStore";
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+function makeConfig(): AiConfig {
+  return {
+    asr: {
+      active: "sherpa-zipformer-zh-en",
+      providers: {
+        "sherpa-zipformer-zh-en": {
+          engine: "sherpa-onnx",
+          model: "streaming-zipformer-bilingual-zh-en-small",
+        },
+      },
+      warm_on_startup: true,
+      vad: "silero",
+    },
+    llm: {
+      active: "deepseek",
+      providers: {
+        local: {
+          base_url: "http://127.0.0.1:8080/v1",
+          api_key: "local",
+          model: "qwen3",
+          runtime: "llama-server",
+        },
+        deepseek: {
+          base_url: "https://api.deepseek.com/v1",
+          api_key: "",
+          model: "deepseek-chat",
+          runtime: "openai-compat",
+        },
+      },
+      fallback: { enabled: true, primary: "deepseek", secondary: "local", timeout_ms: 8000 },
+      task_routing: { chat_drawer: "deepseek" },
+    },
+    web_search: {
+      client_provider: "searxng",
+      client_enabled: false,
+      confirm_mode: "per_call",
+      byok_key: "",
+    },
+    cc_bridge: {
+      enabled: true,
+      binary: "auto",
+      min_version: "1.0.0",
+      default_model: DEFAULT_CLAUDE_CODE_MODEL,
+      permission_mode: "default",
+      max_turns: 20,
+      confirm_readonly: false,
+      terminal_echo_enabled: true,
+    },
+    full_local_mode: false,
+    fully_disabled: false,
+    chat_output_format: "md",
+  };
+}
+
+describe("ChatDrawer provider and echo controls", () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+    invokeMock.mockReset();
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "chat_list_threads") return Promise.resolve([]);
+      if (command === "chat_purge_old") return Promise.resolve(0);
+      if (command === "get_ai_config") return Promise.resolve(makeConfig());
+      if (command === "save_ai_config") return Promise.resolve(null);
+      return Promise.resolve(null);
+    });
+
+    const thread: ChatThread = {
+      id: "thread-1",
+      title: "New chat",
+      provider_id: "claude-code",
+      created_at: 1,
+      updated_at: 1,
+      linked_session_id: "term-1",
+      source: "drawer",
+      output_format: null,
+      cc_model: null,
+    };
+    useAiStore.setState({
+      config: makeConfig(),
+      loading: false,
+      saving: false,
+      testResults: {},
+      voiceShellEnabled: false,
+    });
+    useAppStore.setState({
+      tabs: [{ id: "term-1", type: "terminal", title: "Terminal 1", closable: true }],
+      activeTabId: "term-1",
+      sqlEcho: false,
+    });
+    useChatStore.setState({
+      threads: [thread],
+      threadsLoaded: true,
+      activeThreadId: thread.id,
+      messages: { [thread.id]: [] },
+      streamingId: {},
+      ccToolCards: {},
+      ccUsage: {},
+      sending: false,
+      drawerOpen: true,
+      drawerScope: "tab",
+      drawerTabId: "term-1",
+      tabDrawerOpenByTabId: { "term-1": true },
+      drawerWidth: 380,
+      pendingComposerText: "",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("puts Claude Code before the active LLM provider", () => {
+    render(<ChatDrawer />);
+
+    const provider = screen.getByLabelText("Thread LLM provider") as HTMLSelectElement;
+    expect(Array.from(provider.options).map((option) => option.value)).toEqual([
+      "claude-code",
+      "deepseek",
+      "local",
+    ]);
+  });
+
+  it("renders terminal echo as the same compact button style as echo toggles", () => {
+    render(<ChatDrawer />);
+
+    const echo = screen.getByTestId("chat-cc-terminal-echo-toggle");
+    expect(echo).toHaveClass("taomni-btn");
+    expect(echo).toHaveAttribute("aria-pressed", "true");
+    expect(echo).toHaveTextContent("Terminal echo: on");
+  });
+});

--- a/src/components/chat/ChatDrawer.tsx
+++ b/src/components/chat/ChatDrawer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Bot, Copy, Check, History, Plus, Globe, Link2, RefreshCw, TerminalSquare, X } from "lucide-react";
 import { useChatStore } from "../../stores/chatStore";
-import { DEFAULT_CLAUDE_CODE_MODEL, useAiStore } from "../../stores/aiStore";
+import { chatDrawerProviderIds, DEFAULT_CLAUDE_CODE_MODEL, useAiStore } from "../../stores/aiStore";
 import { useAppStore } from "../../stores/appStore";
 import { MessageBubble } from "./MessageBubble";
 import { CcToolCards } from "./CcToolCards";
@@ -88,17 +88,12 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
 
   // Provider switcher dropdown — pulls the live provider list from aiStore.
   const aiConfig = useAiStore((s) => s.config);
-  const aiProviders = aiConfig?.llm.providers;
-  const ccBridgeEnabled = aiConfig?.cc_bridge.enabled;
   const defaultCcModel = aiConfig?.cc_bridge.default_model?.trim() || DEFAULT_CLAUDE_CODE_MODEL;
   const ccTerminalEchoEnabled = aiConfig?.cc_bridge.terminal_echo_enabled ?? true;
   const globalOutputFormat = aiConfig?.chat_output_format ?? "md";
   const loadAiConfig = useAiStore((s) => s.loadConfig);
   const saveAiConfig = useAiStore((s) => s.saveConfig);
-  const providerIds = Object.keys(aiProviders ?? {});
-  if (ccBridgeEnabled) {
-    providerIds.push("claude-code");
-  }
+  const providerIds = useMemo(() => chatDrawerProviderIds(aiConfig), [aiConfig]);
   const setThreadProvider = useChatStore((s) => s.setThreadProvider);
   const setThreadCcModel = useChatStore((s) => s.setThreadCcModel);
   const setThreadOutputFormat = useChatStore((s) => s.setThreadOutputFormat);
@@ -467,20 +462,23 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
               />
             )}
             {activeThread.provider_id === "claude-code" && activeThread.linked_session_id && (
-              <label
-                className="inline-flex items-center gap-1 text-[10px] cursor-pointer select-none"
+              <button
+                type="button"
+                className={`taomni-btn h-5 px-1.5 inline-flex items-center gap-1 text-[10px] ${
+                  ccTerminalEchoEnabled
+                    ? "text-[var(--taomni-accent)]"
+                    : "text-[var(--taomni-text-muted)]"
+                }`}
+                onClick={() => setCcTerminalEcho(!ccTerminalEchoEnabled)}
+                disabled={!aiConfig}
                 title={t("chat.ccTerminalEchoTitle")}
+                aria-pressed={ccTerminalEchoEnabled}
+                aria-label={t("chat.ccTerminalEchoAria")}
+                data-testid="chat-cc-terminal-echo-toggle"
               >
-                <input
-                  type="checkbox"
-                  className="h-3 w-3"
-                  checked={ccTerminalEchoEnabled}
-                  disabled={!aiConfig}
-                  aria-label={t("chat.ccTerminalEchoAria")}
-                  onChange={(e) => setCcTerminalEcho(e.target.checked)}
-                />
-                <span>{t("chat.ccTerminalEcho")}</span>
-              </label>
+                <TerminalSquare className="w-2.5 h-2.5" />
+                <span>{ccTerminalEchoEnabled ? t("chat.ccTerminalEchoOn") : t("chat.ccTerminalEchoOff")}</span>
+              </button>
             )}
             <span className="ml-2">{t("chat.formatLabel")}</span>
             {formatLocked ? (

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1351,6 +1351,8 @@ const dict = {
     threadModelAria: "Claude Code model for this thread",
     threadModelTitle: "Model for this thread (changing it restarts the Claude Code session)",
     ccTerminalEcho: "Echo to terminal",
+    ccTerminalEchoOn: "Terminal echo: on",
+    ccTerminalEchoOff: "Terminal echo: off",
     ccTerminalEchoTitle: "Mirror Claude Code captured-run summaries into the bound terminal",
     ccTerminalEchoAria: "Echo Claude Code captured runs to terminal",
     modelDefault: "default",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -1347,6 +1347,8 @@ export const zhCN: DeepPartial<typeof en> = {
     threadModelAria: "本对话的 Claude Code 模型",
     threadModelTitle: "本对话使用的模型（切换会重启 Claude Code 会话）",
     ccTerminalEcho: "回显到终端",
+    ccTerminalEchoOn: "终端回显：开",
+    ccTerminalEchoOff: "终端回显：关",
     ccTerminalEchoTitle: "将 Claude Code 捕获执行摘要回显到绑定终端",
     ccTerminalEchoAria: "将 Claude Code 捕获执行回显到终端",
     modelDefault: "默认",

--- a/src/stores/aiStore.ts
+++ b/src/stores/aiStore.ts
@@ -89,6 +89,29 @@ export interface TestConnectionResult {
   latency_ms: number;
 }
 
+export function isClaudeCodeAvailableForChat(config: AiConfig | null | undefined): boolean {
+  return (
+    config?.cc_bridge.enabled === true &&
+    config.full_local_mode !== true &&
+    config.fully_disabled !== true
+  );
+}
+
+export function defaultChatProviderId(config: AiConfig | null | undefined): string | undefined {
+  return isClaudeCodeAvailableForChat(config) ? "claude-code" : undefined;
+}
+
+export function chatDrawerProviderIds(config: AiConfig | null | undefined): string[] {
+  const ids = Object.keys(config?.llm.providers ?? {}).filter((id) => id !== "claude-code");
+  const active = config?.llm.active;
+  const orderedLlmIds = active && ids.includes(active)
+    ? [active, ...ids.filter((id) => id !== active)]
+    : ids;
+  return isClaudeCodeAvailableForChat(config)
+    ? ["claude-code", ...orderedLlmIds]
+    : orderedLlmIds;
+}
+
 interface AiStore {
   config: AiConfig | null;
   loading: boolean;

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatStore, type ChatThread } from "./chatStore";
+import { DEFAULT_CLAUDE_CODE_MODEL, useAiStore, type AiConfig } from "./aiStore";
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+function makeConfig(overrides: Partial<AiConfig> = {}): AiConfig {
+  return {
+    asr: {
+      active: "sherpa-zipformer-zh-en",
+      providers: {
+        "sherpa-zipformer-zh-en": {
+          engine: "sherpa-onnx",
+          model: "streaming-zipformer-bilingual-zh-en-small",
+        },
+      },
+      warm_on_startup: true,
+      vad: "silero",
+    },
+    llm: {
+      active: "deepseek",
+      providers: {
+        deepseek: {
+          base_url: "https://api.deepseek.com/v1",
+          api_key: "",
+          model: "deepseek-chat",
+          runtime: "openai-compat",
+        },
+        local: {
+          base_url: "http://127.0.0.1:8080/v1",
+          api_key: "local",
+          model: "qwen3",
+          runtime: "llama-server",
+        },
+      },
+      fallback: { enabled: true, primary: "deepseek", secondary: "local", timeout_ms: 8000 },
+      task_routing: { chat_drawer: "deepseek" },
+    },
+    web_search: {
+      client_provider: "searxng",
+      client_enabled: false,
+      confirm_mode: "per_call",
+      byok_key: "",
+    },
+    cc_bridge: {
+      enabled: true,
+      binary: "auto",
+      min_version: "1.0.0",
+      default_model: DEFAULT_CLAUDE_CODE_MODEL,
+      permission_mode: "default",
+      max_turns: 20,
+      confirm_readonly: false,
+      terminal_echo_enabled: true,
+    },
+    full_local_mode: false,
+    fully_disabled: false,
+    chat_output_format: "md",
+    ...overrides,
+  };
+}
+
+describe("chatStore new thread provider selection", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    useAiStore.setState({
+      config: makeConfig(),
+      loading: false,
+      saving: false,
+      testResults: {},
+      voiceShellEnabled: false,
+    });
+    useChatStore.setState({
+      threads: [],
+      threadsLoaded: true,
+      activeThreadId: null,
+      messages: {},
+      streamingId: {},
+      ccToolCards: {},
+      ccUsage: {},
+      sending: false,
+      drawerOpen: false,
+      drawerScope: null,
+      drawerTabId: null,
+      tabDrawerOpenByTabId: {},
+      drawerWidth: 380,
+      pendingComposerText: "",
+    });
+    invokeMock.mockImplementation((command: string, args: { providerId?: string | null; linkedSessionId?: string | null }) => {
+      if (command !== "chat_new_thread") throw new Error(`unexpected command: ${command}`);
+      const thread: ChatThread = {
+        id: "thread-1",
+        title: "New chat",
+        provider_id: args.providerId ?? "deepseek",
+        created_at: 1,
+        updated_at: 1,
+        linked_session_id: args.linkedSessionId ?? null,
+        source: "drawer",
+        output_format: null,
+        cc_model: null,
+      };
+      return Promise.resolve(thread);
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses Claude Code as the default provider when it is enabled", async () => {
+    await useChatStore.getState().newThread(undefined, "term-1");
+
+    expect(invokeMock).toHaveBeenCalledWith("chat_new_thread", {
+      providerId: "claude-code",
+      linkedSessionId: "term-1",
+    });
+  });
+
+  it("keeps an explicitly selected provider even when Claude Code is enabled", async () => {
+    await useChatStore.getState().newThread("local", undefined);
+
+    expect(invokeMock).toHaveBeenCalledWith("chat_new_thread", {
+      providerId: "local",
+      linkedSessionId: null,
+    });
+  });
+
+  it("opens a Claude Code thread instead of reusing another provider as the default", async () => {
+    useChatStore.setState({
+      threads: [{
+        id: "old-thread",
+        title: "Old chat",
+        provider_id: "deepseek",
+        created_at: 1,
+        updated_at: 1,
+        linked_session_id: null,
+        source: "drawer",
+        output_format: null,
+        cc_model: null,
+      }],
+    });
+
+    await useChatStore.getState().openGlobalChat();
+
+    expect(invokeMock).toHaveBeenCalledWith("chat_new_thread", {
+      providerId: "claude-code",
+      linkedSessionId: null,
+    });
+    expect(useChatStore.getState().activeThreadId).toBe("thread-1");
+  });
+});

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -128,12 +128,27 @@ interface ChatStore {
   setDrawerWidth: (w: number) => void;
 }
 
-function latestGlobalThread(threads: ChatThread[]): ChatThread | undefined {
-  return threads.find((thread) => !thread.linked_session_id);
+function latestGlobalThread(
+  threads: ChatThread[],
+  preferredProviderId?: string | null,
+): ChatThread | undefined {
+  const candidates = threads.filter((thread) => !thread.linked_session_id);
+  if (preferredProviderId) {
+    return candidates.find((thread) => thread.provider_id === preferredProviderId);
+  }
+  return candidates[0];
 }
 
-function latestTabThread(threads: ChatThread[], tabId: string): ChatThread | undefined {
-  return threads.find((thread) => thread.linked_session_id === tabId);
+function latestTabThread(
+  threads: ChatThread[],
+  tabId: string,
+  preferredProviderId?: string | null,
+): ChatThread | undefined {
+  const candidates = threads.filter((thread) => thread.linked_session_id === tabId);
+  if (preferredProviderId) {
+    return candidates.find((thread) => thread.provider_id === preferredProviderId);
+  }
+  return candidates[0];
 }
 
 function scopeForThread(thread: ChatThread | undefined | null): {
@@ -144,6 +159,20 @@ function scopeForThread(thread: ChatThread | undefined | null): {
   return thread.linked_session_id
     ? { drawerScope: "tab", drawerTabId: thread.linked_session_id }
     : { drawerScope: "global", drawerTabId: null };
+}
+
+async function resolveDefaultProviderId(): Promise<string | null> {
+  try {
+    const { defaultChatProviderId, useAiStore } = await import("./aiStore");
+    const aiStore = useAiStore.getState();
+    if (!aiStore.config) {
+      await aiStore.loadConfig();
+    }
+    return defaultChatProviderId(useAiStore.getState().config) ?? null;
+  } catch (e) {
+    console.warn("resolve default chat provider failed:", e);
+    return null;
+  }
 }
 
 export const useChatStore = create<ChatStore>((set, get) => ({
@@ -173,8 +202,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   },
 
   newThread: async (providerId?: string, linkedSessionId?: string) => {
+    const resolvedProviderId = providerId ?? (await resolveDefaultProviderId());
     const thread = await invoke<ChatThread>("chat_new_thread", {
-      providerId: providerId ?? null,
+      providerId: resolvedProviderId,
       linkedSessionId: linkedSessionId ?? null,
     });
     const scope = scopeForThread(thread);
@@ -483,9 +513,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     if (!get().threadsLoaded) {
       await get().loadThreads();
     }
-    let thread = latestGlobalThread(get().threads);
+    const defaultProviderId = await resolveDefaultProviderId();
+    let thread = latestGlobalThread(get().threads, defaultProviderId);
     if (!thread) {
-      thread = await get().newThread(undefined, undefined);
+      thread = await get().newThread(defaultProviderId ?? undefined, undefined);
     }
     set({
       activeThreadId: thread.id,
@@ -509,9 +540,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     if (!get().threadsLoaded) {
       await get().loadThreads();
     }
-    let thread = latestTabThread(get().threads, tabId);
+    const defaultProviderId = await resolveDefaultProviderId();
+    let thread = latestTabThread(get().threads, tabId, defaultProviderId);
     if (!thread) {
-      thread = await get().newThread(undefined, tabId);
+      thread = await get().newThread(defaultProviderId ?? undefined, tabId);
     }
     set((s) => ({
       activeThreadId: thread.id,


### PR DESCRIPTION
When Claude Code is enabled in AI settings, resolve it as the chat drawer default provider instead of falling back to the active LLM provider. Opening a global or tab-bound drawer now prefers an existing Claude Code thread for that scope and creates one when none exists, while explicit provider selections still win.

Keep the provider selector aligned with that behavior by ordering Claude Code first, then the active LLM provider, then the remaining configured providers. The helper also respects full-local and fully-disabled AI modes so Claude Code is not surfaced there.

Replace the Claude Code terminal echo checkbox with the same compact button treatment used by SQL echo controls, including icon, on/off text, aria-pressed state, and localized labels.

Add focused regression coverage for default provider selection, explicit provider overrides, drawer-open reuse behavior, provider ordering, and terminal echo button styling.