### PR TITLE
fix(cc): normalize terminal command submission and local env prompt

### DIFF
--- a/src-tauri/src/agent/cc_bridge/session_card.rs
+++ b/src-tauri/src/agent/cc_bridge/session_card.rs
@@ -19,9 +19,28 @@
 //! module warning in `cc_bridge/mod.rs`).
 
 use crate::session::models::{SessionConfig, SessionType};
+use serde::{Deserialize, Serialize};
 
 /// How many recent commands to snapshot into the card.
 pub const HISTORY_LIMIT: usize = 15;
+
+/// Facts the frontend knows about a live local terminal tab. This is separate
+/// from `SessionConfig`: ad-hoc local terminals often have no saved session,
+/// and the backend only learns the actually launched shell id after PTY spawn.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalTerminalEnv {
+    #[serde(default)]
+    pub platform: Option<String>,
+    #[serde(default)]
+    pub shell_id: Option<String>,
+    #[serde(default)]
+    pub shell_name: Option<String>,
+    #[serde(default)]
+    pub shell_args: Option<Vec<String>>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+}
 
 /// Replicate the frontend `makeHostKey` (`src/lib/history.ts`) so we read the
 /// same `command_history` bucket the terminal wrote into. Format:
@@ -153,7 +172,7 @@ fn push_terminal_routing(s: &mut String, remote: bool) {
     }
     s.push_str(
         "不要用你内置的本地 Bash / Read / Glob / Grep 去访问本机文件系统来回答这些问题——\
-         那是另一台机器(运行 Taomni 的宿主沙箱),不是你的工作对象。\n",
+         那是另一个执行环境(运行 Taomni / Claude Code 的宿主沙箱),不是这个绑定终端会话。\n",
     );
     s.push_str(
         "你自带的 <env>(工作目录 / git 状态 / 操作系统)只描述那台宿主沙箱;判断\
@@ -171,6 +190,96 @@ fn push_terminal_routing(s: &mut String, remote: bool) {
     );
 }
 
+fn clean_opt(value: Option<&String>) -> Option<&str> {
+    value.map(|s| s.trim()).filter(|s| !s.is_empty())
+}
+
+fn shell_syntax_hint(shell_id: Option<&str>, shell_name: Option<&str>) -> Option<&'static str> {
+    let mut haystack = String::new();
+    if let Some(id) = shell_id {
+        haystack.push_str(id);
+    }
+    haystack.push(' ');
+    if let Some(name) = shell_name {
+        haystack.push_str(name);
+    }
+    let lower = haystack.to_lowercase();
+    if lower.contains("powershell") || lower.contains("pwsh") {
+        Some("命令语法按 PowerShell 生成;不要默认使用 POSIX bash 语法。")
+    } else if lower.contains("command-prompt") || lower.contains("cmd") {
+        Some("命令语法按 Windows cmd.exe 生成;不要默认使用 POSIX bash 语法。")
+    } else if lower.contains("wsl") {
+        Some("这是 WSL 入口;终端内命令语法通常按该 WSL Linux 发行版的 shell 生成。")
+    } else if lower.contains("git-bash")
+        || lower.contains("bash")
+        || lower.contains("zsh")
+        || lower.contains("sh")
+    {
+        Some("命令语法可按 POSIX shell 生成。")
+    } else {
+        None
+    }
+}
+
+fn push_local_terminal_environment(s: &mut String, env: &LocalTerminalEnv) {
+    let platform = clean_opt(env.platform.as_ref());
+    let shell_id = clean_opt(env.shell_id.as_ref());
+    let shell_name = clean_opt(env.shell_name.as_ref());
+    let cwd = clean_opt(env.cwd.as_ref());
+    let has_args = env
+        .shell_args
+        .as_ref()
+        .map(|args| args.iter().any(|arg| !arg.trim().is_empty()))
+        .unwrap_or(false);
+
+    if platform.is_none()
+        && shell_id.is_none()
+        && shell_name.is_none()
+        && cwd.is_none()
+        && !has_args
+    {
+        return;
+    }
+
+    s.push_str("[本地终端环境 / local terminal environment]\n");
+    s.push_str("这个绑定目标是用户本机上的 live local terminal,不是远程 SSH 会话。\n");
+    if let Some(platform) = platform {
+        s.push_str(&format!("宿主平台: {platform}。\n"));
+    }
+    match (shell_name, shell_id) {
+        (Some(name), Some(id)) => s.push_str(&format!("Shell: {name}(id={id})。\n")),
+        (Some(name), None) => s.push_str(&format!("Shell: {name}。\n")),
+        (None, Some(id)) => s.push_str(&format!("Shell id: {id}。\n")),
+        (None, None) => {}
+    }
+    if has_args {
+        let args = env
+            .shell_args
+            .as_ref()
+            .map(|args| {
+                args.iter()
+                    .map(|arg| arg.trim())
+                    .filter(|arg| !arg.is_empty())
+                    .take(8)
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            })
+            .unwrap_or_default();
+        if !args.is_empty() {
+            s.push_str(&format!("启动参数: {args}。\n"));
+        }
+    }
+    if let Some(cwd) = cwd {
+        s.push_str(&format!(
+            "当前工作目录快照: {cwd};若每轮消息另有「当前工作目录」,以每轮值为准。\n"
+        ));
+    }
+    if let Some(hint) = shell_syntax_hint(shell_id, shell_name) {
+        s.push_str(hint);
+        s.push('\n');
+    }
+}
+
 /// Render the (pre-redaction) card text.
 ///
 /// - `session`: resolved bound session, or `None` for an unbound / local /
@@ -185,6 +294,7 @@ pub fn render_card(
     thread_id: &str,
     linked: bool,
     recent: &[String],
+    local_env: Option<&LocalTerminalEnv>,
 ) -> String {
     let mut s = String::from("[Taomni 会话绑定 / session binding]\n");
     match session {
@@ -217,7 +327,15 @@ pub fn render_card(
             match db_routing(&sc.session_type) {
                 DbRouting::Sql => push_sql_routing(&mut s, sc.session_type.as_str()),
                 DbRouting::Redis => push_redis_routing(&mut s),
-                DbRouting::None => push_terminal_routing(&mut s, is_remote(&sc.session_type)),
+                DbRouting::None => {
+                    let remote = is_remote(&sc.session_type);
+                    if !remote {
+                        if let Some(env) = local_env {
+                            push_local_terminal_environment(&mut s, env);
+                        }
+                    }
+                    push_terminal_routing(&mut s, remote);
+                }
             }
         }
         None => {
@@ -227,10 +345,19 @@ pub fn render_card(
             // saved session (local shell or ad-hoc connect); an unlinked thread
             // is a global / workspace chat with no terminal at all.
             if linked {
-                s.push_str(&format!(
-                    "本线程已绑定到一个终端标签(thread = {thread_id}),但它未关联到已保存会话\
-                     (可能是本地 shell 或临时连接),无法展示会话名 / 主机详情。\n"
-                ));
+                if local_env.is_some() {
+                    s.push_str(&format!(
+                        "本线程已绑定到一个本地终端标签(thread = {thread_id}),但它未关联到已保存会话。\n"
+                    ));
+                } else {
+                    s.push_str(&format!(
+                        "本线程已绑定到一个终端标签(thread = {thread_id}),但它未关联到已保存会话\
+                         (可能是本地 shell 或临时连接),无法展示会话名 / 主机详情。\n"
+                    ));
+                }
+                if let Some(env) = local_env {
+                    push_local_terminal_environment(&mut s, env);
+                }
                 // ① + ② — still bound to a live terminal. We don't know
                 // remote-vs-local, so use the generic routing (no sftp); both
                 // run_in_terminal and read_terminal_tail act on the live tab.
@@ -262,7 +389,11 @@ mod tests {
     use super::*;
     use crate::session::models::{AuthMethod, SessionType};
 
-    fn sample(session_type: SessionType, username: Option<&str>, auth: AuthMethod) -> SessionConfig {
+    fn sample(
+        session_type: SessionType,
+        username: Option<&str>,
+        auth: AuthMethod,
+    ) -> SessionConfig {
         SessionConfig {
             id: "sess-123".into(),
             name: "prod-db".into(),
@@ -303,7 +434,7 @@ mod tests {
             },
         );
         let recent = vec!["systemctl status nginx".to_string(), "df -h".to_string()];
-        let card = render_card(Some(&sc), "thread-9", true, &recent);
+        let card = render_card(Some(&sc), "thread-9", true, &recent, None);
 
         // Identity: name, user@host:port, type, auth label.
         assert!(card.contains("「prod-db」"));
@@ -336,7 +467,7 @@ mod tests {
 
     #[test]
     fn card_unbound_not_linked_is_global_local() {
-        let card = render_card(None, "thread-local", false, &[]);
+        let card = render_card(None, "thread-local", false, &[], None);
         assert!(card.contains("未绑定任何终端"));
         assert!(card.contains("thread = thread-local"));
         // Truly unbound: no routing and NO env-demotion — CC's native <env> is
@@ -350,7 +481,7 @@ mod tests {
         // Bound to a live tab but no saved SessionConfig — still a terminal, so
         // ① route through it and ② demote the native <env>. Unknown remote/local
         // ⇒ generic variant (no sftp_upload).
-        let card = render_card(None, "t-quick", true, &[]);
+        let card = render_card(None, "t-quick", true, &[], None);
         assert!(card.contains("未关联到已保存会话"));
         assert!(card.contains("run_in_terminal"));
         assert!(!card.contains("sftp_upload"));
@@ -358,9 +489,48 @@ mod tests {
     }
 
     #[test]
+    fn card_unsaved_local_includes_local_terminal_environment() {
+        let env = LocalTerminalEnv {
+            platform: Some("windows".into()),
+            shell_id: Some("powershell".into()),
+            shell_name: Some("PowerShell".into()),
+            shell_args: Some(vec!["-NoLogo".into()]),
+            cwd: Some("C:\\Users\\zhyha".into()),
+        };
+        let card = render_card(None, "t-local", true, &[], Some(&env));
+        assert!(card.contains("本地终端标签"));
+        assert!(card.contains("live local terminal"));
+        assert!(card.contains("宿主平台: windows"));
+        assert!(card.contains("Shell: PowerShell(id=powershell)"));
+        assert!(card.contains("启动参数: -NoLogo"));
+        assert!(card.contains("C:\\Users\\zhyha"));
+        assert!(card.contains("命令语法按 PowerShell"));
+        assert!(card.contains("run_in_terminal"));
+        assert!(!card.contains("sftp_upload"));
+    }
+
+    #[test]
+    fn card_remote_session_ignores_local_terminal_environment() {
+        let sc = sample(SessionType::SSH, Some("deploy"), AuthMethod::Agent);
+        let env = LocalTerminalEnv {
+            platform: Some("windows".into()),
+            shell_id: Some("powershell".into()),
+            shell_name: Some("PowerShell".into()),
+            shell_args: None,
+            cwd: Some("C:\\Users\\zhyha".into()),
+        };
+        let card = render_card(Some(&sc), "t-ssh", true, &[], Some(&env));
+        assert!(card.contains("deploy@Prod.Example.COM:2222"));
+        assert!(card.contains("sftp_upload"));
+        assert!(!card.contains("live local terminal"));
+        assert!(!card.contains("PowerShell(id=powershell)"));
+        assert!(!card.contains("C:\\Users\\zhyha"));
+    }
+
+    #[test]
     fn card_lenient_when_not_linked() {
         let sc = sample(SessionType::SSH, Some("u"), AuthMethod::Agent);
-        let card = render_card(Some(&sc), "t", false, &[]);
+        let card = render_card(Some(&sc), "t", false, &[], None);
         assert!(card.contains("信任级 = Lenient"));
     }
 
@@ -370,7 +540,7 @@ mod tests {
         // via the generic variant — run_in_terminal but no remote sftp_upload —
         // and ② the native <env> demotion.
         let sc = sample(SessionType::LocalShell, None, AuthMethod::None);
-        let card = render_card(Some(&sc), "t", false, &[]);
+        let card = render_card(Some(&sc), "t", false, &[], None);
         assert!(card.contains("run_in_terminal"));
         assert!(!card.contains("sftp_upload"));
         assert!(card.contains("宿主沙箱"));
@@ -390,12 +560,18 @@ mod tests {
         ] {
             let label = engine.as_str().to_string();
             let sc = sample(engine, Some("dba"), AuthMethod::Password);
-            let card = render_card(Some(&sc), "t-sql", true, &[]);
+            let card = render_card(Some(&sc), "t-sql", true, &[], None);
             assert!(card.contains(&label), "card should name the engine {label}");
             assert!(card.contains("run_sql"), "{label}: should mention run_sql");
             assert!(card.contains("describe_table"), "{label}: schema tools");
-            assert!(card.contains("run_sql_captured"), "{label}: big-result guidance");
-            assert!(!card.contains("run_in_terminal"), "{label}: no terminal tool");
+            assert!(
+                card.contains("run_sql_captured"),
+                "{label}: big-result guidance"
+            );
+            assert!(
+                !card.contains("run_in_terminal"),
+                "{label}: no terminal tool"
+            );
             assert!(!card.contains("sftp_upload"), "{label}: no sftp");
             assert!(card.contains("宿主沙箱"), "{label}: <env> still demoted");
         }
@@ -404,7 +580,7 @@ mod tests {
     #[test]
     fn card_redis_session_routes_to_redis_tools() {
         let sc = sample(SessionType::Redis, None, AuthMethod::Password);
-        let card = render_card(Some(&sc), "t-redis", true, &[]);
+        let card = render_card(Some(&sc), "t-redis", true, &[], None);
         assert!(card.contains("Redis"));
         assert!(card.contains("redis_list_keys"));
         assert!(card.contains("redis_get_key"));

--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -229,6 +229,12 @@ pub struct ChatSendRequest {
     /// access (that is 3.2, deliberately out of scope). `None` when unknown.
     #[serde(default)]
     pub cwd: Option<String>,
+    /// Live local-terminal facts (platform / shell id / shell args / cwd) for
+    /// Claude Code's appended system prompt. Only present for local terminal
+    /// tabs; SSH/remote tabs leave this absent so their saved session card stays
+    /// the source of truth.
+    #[serde(default)]
+    pub local_terminal_env: Option<crate::agent::cc_bridge::session_card::LocalTerminalEnv>,
     /// Phase 6 — the live `db_connections` runtime id this CC thread is bound to,
     /// for SQL/Redis DB sessions. Like `cwd`, it is volatile (the frontend
     /// regenerates it on each (re)connect and the backend can't derive it), so
@@ -526,7 +532,9 @@ pub async fn chat_stream(
         if !ai_config.cc_bridge.enabled || ai_config.fully_disabled || ai_config.full_local_mode {
             emit(&StreamEventOut::Error {
                 id: assistant_id,
-                message: "Claude Code is unavailable in full-local / fully-disabled mode or is disabled.".into(),
+                message:
+                    "Claude Code is unavailable in full-local / fully-disabled mode or is disabled."
+                        .into(),
             });
             return Ok(());
         }
@@ -655,6 +663,7 @@ pub async fn chat_stream(
                         &req.thread_id,
                         thread.linked_session_id.is_some(),
                         &recent,
+                        req.local_terminal_env.as_ref(),
                     );
                     redact::redact(&raw).0
                 };
@@ -788,50 +797,67 @@ pub async fn chat_stream(
             }
             format!("{}{}", prefix, clean_content)
         };
-        let events = process.send_with_callback(&cc_message, move |evt| {
-            use crate::agent::cc_bridge::protocol::CcEvent;
-            match evt {
-                CcEvent::Partial { content } => {
-                    let _ = app_clone.emit(&event_name_clone, StreamEventOut::Token {
-                        id: assistant_id_clone.clone(),
-                        content: content.clone(),
-                    });
+        let events = process
+            .send_with_callback(&cc_message, move |evt| {
+                use crate::agent::cc_bridge::protocol::CcEvent;
+                match evt {
+                    CcEvent::Partial { content } => {
+                        let _ = app_clone.emit(
+                            &event_name_clone,
+                            StreamEventOut::Token {
+                                id: assistant_id_clone.clone(),
+                                content: content.clone(),
+                            },
+                        );
+                    }
+                    // 3.5 — emit a structured, display-only card for tool use. It
+                    // carries no machine-parseable payload, so the frontend never
+                    // re-executes it (confirmation already happened live via the
+                    // MCP permission prompt). The compact text record is persisted
+                    // separately below, so reload still shows the activity as text.
+                    CcEvent::ToolUse { id, name, input } => {
+                        let _ = app_clone.emit(
+                            &event_name_clone,
+                            StreamEventOut::CcToolActivity {
+                                id: assistant_id_clone.clone(),
+                                call_id: id.clone(),
+                                phase: "use".into(),
+                                tool: name.clone(),
+                                detail: cc_tool_arg_summary(input).unwrap_or("").to_string(),
+                            },
+                        );
+                    }
+                    CcEvent::ToolResult {
+                        tool_use_id,
+                        content,
+                    } => {
+                        let _ = app_clone.emit(
+                            &event_name_clone,
+                            StreamEventOut::CcToolActivity {
+                                id: assistant_id_clone.clone(),
+                                call_id: tool_use_id.clone(),
+                                phase: "result".into(),
+                                tool: String::new(),
+                                detail: cc_tool_result_preview(content),
+                            },
+                        );
+                    }
+                    CcEvent::Done { usage: Some(u) } => {
+                        let _ = app_clone.emit(
+                            &event_name_clone,
+                            StreamEventOut::Usage {
+                                id: assistant_id_clone.clone(),
+                                input_tokens: u.input_tokens,
+                                output_tokens: u.output_tokens,
+                                cost_usd: u.total_cost_usd,
+                                duration_ms: u.duration_ms,
+                            },
+                        );
+                    }
+                    _ => {}
                 }
-                // 3.5 — emit a structured, display-only card for tool use. It
-                // carries no machine-parseable payload, so the frontend never
-                // re-executes it (confirmation already happened live via the
-                // MCP permission prompt). The compact text record is persisted
-                // separately below, so reload still shows the activity as text.
-                CcEvent::ToolUse { id, name, input } => {
-                    let _ = app_clone.emit(&event_name_clone, StreamEventOut::CcToolActivity {
-                        id: assistant_id_clone.clone(),
-                        call_id: id.clone(),
-                        phase: "use".into(),
-                        tool: name.clone(),
-                        detail: cc_tool_arg_summary(input).unwrap_or("").to_string(),
-                    });
-                }
-                CcEvent::ToolResult { tool_use_id, content } => {
-                    let _ = app_clone.emit(&event_name_clone, StreamEventOut::CcToolActivity {
-                        id: assistant_id_clone.clone(),
-                        call_id: tool_use_id.clone(),
-                        phase: "result".into(),
-                        tool: String::new(),
-                        detail: cc_tool_result_preview(content),
-                    });
-                }
-                CcEvent::Done { usage: Some(u) } => {
-                    let _ = app_clone.emit(&event_name_clone, StreamEventOut::Usage {
-                        id: assistant_id_clone.clone(),
-                        input_tokens: u.input_tokens,
-                        output_tokens: u.output_tokens,
-                        cost_usd: u.total_cost_usd,
-                        duration_ms: u.duration_ms,
-                    });
-                }
-                _ => {}
-            }
-        }).await;
+            })
+            .await;
 
         let events = match events {
             Ok(ev) => ev,
@@ -868,7 +894,8 @@ pub async fn chat_stream(
             }
         }
 
-        let session_id = crate::agent::cc_bridge::protocol::extract_session_id(&events).or(resume_session);
+        let session_id =
+            crate::agent::cc_bridge::protocol::extract_session_id(&events).or(resume_session);
         if let Some(sid) = &session_id {
             if let Ok(db) = state.db.lock() {
                 let _ = crate::chat::store::set_cc_session_id(&db, &req.thread_id, sid);
@@ -890,7 +917,8 @@ pub async fn chat_stream(
             store::insert_message(&db, &assistant_msg).map_err(|e| e.to_string())?;
             if is_first {
                 let title = user_msg.content.chars().take(40).collect::<String>();
-                store::update_thread_title(&db, &req.thread_id, &title).map_err(|e| e.to_string())?;
+                store::update_thread_title(&db, &req.thread_id, &title)
+                    .map_err(|e| e.to_string())?;
             }
         }
 

--- a/src/components/agent/CcAgentBridge.tsx
+++ b/src/components/agent/CcAgentBridge.tsx
@@ -4,6 +4,7 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { ActionCard, type ActionCardDecision } from "./ActionCard";
 import { getTerminal } from "../../lib/terminal/terminalRegistry";
 import { formatCcTerminalEcho, type CcTerminalEcho } from "../../lib/terminal/ccEcho";
+import { buildInteractiveCommandInput } from "../../lib/terminal/commandInput";
 import { getQueryTab } from "../../lib/queryRegistry";
 import { useAiStore } from "../../stores/aiStore";
 import { useChatStore } from "../../stores/chatStore";
@@ -363,7 +364,7 @@ async function executeTool(dispatch: ToolDispatch): Promise<void> {
           output = `no live terminal for session ${tabId}`;
           break;
         }
-        term.writeInput(command + "\n");
+        term.writeInput(buildInteractiveCommandInput(command));
         ok = true;
         output = "command sent to terminal";
         break;

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -2677,6 +2677,14 @@ export function TerminalPanel({
       tabId,
       sessionId: registeredSessionId,
       title: tabTitle,
+      localEnvironment: isLocal
+        ? {
+            platform: getAppPlatform(),
+            shellId: resolvedLocalShellId ?? localShell?.id ?? null,
+            shellName: localShell?.name ?? null,
+            shellArgs: localShell?.args ?? [],
+          }
+        : null,
       getBufferText: () => {
         const t = termRef.current;
         return t ? getBufferText(t) : "";
@@ -2707,7 +2715,7 @@ export function TerminalPanel({
       unregister();
       void ccUntrackTerminal(tabId, registeredSessionId).catch(() => {});
     };
-  }, [tabId, registeredSessionId, tabTitle]);
+  }, [isLocal, localShell?.args, localShell?.id, localShell?.name, resolvedLocalShellId, tabId, registeredSessionId, tabTitle]);
 
   // Publish this terminal's capture source while it's the active tab, so the
   // screenshot actions (folded into the tab-strip `⋯` menu in the main window,

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -2233,7 +2233,7 @@ export function MainLayout() {
                             const sid = terminalSessionIds.current[tab.id];
                             if (!sid) return;
                             const escaped = p.replace(/'/g, "'\\''");
-                            void writeTerminal(sid, encodeBase64(`cd '${escaped}'\n`));
+                            void writeTerminal(sid, encodeBase64(`cd '${escaped}'\r`));
                           }}
                           onDetach={() => {
                             setSftpDetachedTabs((prev) => ({ ...prev, [tab.id]: true }));

--- a/src/lib/terminal/commandInput.test.ts
+++ b/src/lib/terminal/commandInput.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildInteractiveCommandInput } from "./commandInput";
+
+describe("buildInteractiveCommandInput", () => {
+  it("submits a single command with carriage return", () => {
+    expect(buildInteractiveCommandInput("Get-Host | Select-Object Version")).toBe(
+      "Get-Host | Select-Object Version\r",
+    );
+  });
+
+  it("does not add an extra enter when the command already has a trailing newline", () => {
+    expect(buildInteractiveCommandInput("pwd\n")).toBe("pwd\r");
+    expect(buildInteractiveCommandInput("pwd\r\n")).toBe("pwd\r");
+  });
+
+  it("normalizes multiline commands to repeated terminal enters", () => {
+    expect(buildInteractiveCommandInput("echo one\n$PSVersionTable.PSVersion")).toBe(
+      "echo one\r$PSVersionTable.PSVersion\r",
+    );
+  });
+
+  it("preserves intentional blank lines inside the command", () => {
+    expect(buildInteractiveCommandInput("cat <<'EOF'\n\nEOF")).toBe("cat <<'EOF'\r\rEOF\r");
+  });
+});

--- a/src/lib/terminal/commandInput.ts
+++ b/src/lib/terminal/commandInput.ts
@@ -1,0 +1,11 @@
+/**
+ * Build stdin for an interactive terminal command.
+ *
+ * xterm sends Enter as carriage return (`\r`) to PTYs, including Windows
+ * ConPTY and SSH PTYs. Treat command newlines as repeated Enter presses rather
+ * than OS text-file line endings; using `\n` can leave PowerShell/PSReadLine in
+ * a continuation prompt instead of submitting the command.
+ */
+export function buildInteractiveCommandInput(command: string): string {
+  return `${command.replace(/\r\n|\r|\n/g, "\r").replace(/\r+$/g, "")}\r`;
+}

--- a/src/lib/terminal/terminalRegistry.ts
+++ b/src/lib/terminal/terminalRegistry.ts
@@ -25,6 +25,16 @@ export interface TerminalRegistryEntry {
   sessionId: string;
   /** Title shown in the global chat picker ("global chat ↔ terminal X"). */
   title: string;
+  /**
+   * Facts about a bound LOCAL terminal. Absent for SSH/remote terminals, where
+   * the saved session card is the source of truth.
+   */
+  localEnvironment?: {
+    platform: string;
+    shellId?: string | null;
+    shellName?: string | null;
+    shellArgs?: string[];
+  } | null;
   /** Full scrollback as plain text. */
   getBufferText: () => string;
   /** Last `n` non-wrapped lines as plain text. */

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -34,6 +34,14 @@ export interface CcUsage {
   duration_ms?: number | null;
 }
 
+interface LocalTerminalEnv {
+  platform: string;
+  shellId?: string | null;
+  shellName?: string | null;
+  shellArgs?: string[];
+  cwd?: string | null;
+}
+
 export interface ChatMessage {
   id: string;
   thread_id: string;
@@ -296,15 +304,23 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     // bridged per-turn so the CC DB MCP can target it (the backend can't derive
     // the runtime key). Null for non-DB threads or a disconnected DB tab.
     let boundDbConnectionId: string | null = null;
+    // Local terminal facts for Claude Code's appended system prompt. Only set
+    // for a live local terminal; SSH/remote tabs deliberately leave this null.
+    let localTerminalEnv: LocalTerminalEnv | null = null;
     {
       const tabId = get().threads.find((t) => t.id === threadId)?.linked_session_id ?? null;
       if (tabId) {
         try {
           const { useAppStore } = await import("./appStore");
+          const { getTerminal } = await import("../lib/terminal/terminalRegistry");
           const appState = useAppStore.getState();
           boundSessionId = appState.tabs.find((t) => t.id === tabId)?.sessionId ?? null;
           cwd = appState.cwdByTab[tabId] ?? null;
           boundDbConnectionId = appState.dbConnByTab[tabId] ?? null;
+          const localEnv = getTerminal(tabId)?.localEnvironment ?? null;
+          if (localEnv) {
+            localTerminalEnv = { ...localEnv, cwd };
+          }
         } catch (err) {
           console.warn("bound_session_id resolution failed:", err);
         }
@@ -437,6 +453,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           terminal_context: terminalContext ?? null,
           bound_session_id: boundSessionId,
           cwd,
+          local_terminal_env: localTerminalEnv,
           bound_db_connection_id: boundDbConnectionId,
         },
       });
@@ -468,6 +485,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
             terminal_context: terminalContext ?? null,
             bound_session_id: boundSessionId,
             cwd,
+            local_terminal_env: localTerminalEnv,
             bound_db_connection_id: boundDbConnectionId,
           },
         });


### PR DESCRIPTION
Claude Code run_in_terminal was appending LF when forwarding approved commands into the live terminal. On Windows PowerShell/PSReadLine this can be interpreted as multiline editor input and leave the command at the continuation prompt instead of executing it. Add a shared interactive-command input helper that normalizes all command line endings to carriage-return terminal Enter events, and use it from the CC bridge. Also update the SFTP open-terminal-here injection to use the same interactive PTY Enter semantics.

Extend the live terminal registry with local terminal environment facts and pass them through chat requests so the Claude Code appended system prompt can distinguish local terminals from remote SSH sessions. The session card now records platform, resolved shell id/name, shell args, cwd snapshot, and shell-specific syntax hints for local terminal threads, while keeping remote SSH and DB sessions on their existing scoped routing models.

Add focused tests for interactive command input normalization and session-card local/remote environment rendering. Verified with: pnpm vitest run src/lib/terminal/commandInput.test.ts; pnpm exec tsc -b --pretty false; cargo test --manifest-path src-tauri/Cargo.toml agent::cc_bridge::session_card --lib.