### PR TITLE
feat: import DBeaver saved credentials

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -234,6 +234,7 @@ pub fn run() {
             session::import::import_wsl_sessions,
             session::import::import_external_bash_sessions,
             session::import::scan_local_session_files,
+            session::import::read_dbeaver_credentials_for_data_sources,
             session::import::read_plist_session_file,
             session::import_secrets::keychain::keychain_lookup_batch,
             session::import_secrets::tabby::tabby_decrypt_vault,

--- a/src-tauri/src/session/import.rs
+++ b/src-tauri/src/session/import.rs
@@ -1,7 +1,9 @@
+use super::import_secrets::crypto::aes_128_cbc_decrypt_pkcs7;
 use super::models::{AuthMethod, SessionConfig, SessionType};
 use serde::Serialize;
 use serde_json::json;
-use std::collections::HashSet;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 #[cfg(target_os = "macos")]
@@ -10,6 +12,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 const MAX_LOCAL_SESSION_FILE_BYTES: u64 = 2_000_000;
+const DBEAVER_CREDENTIALS_CONFIG_FILE: &str = "credentials-config.json";
+const DBEAVER_LOCAL_CREDENTIALS_KEY: [u8; 16] = [
+    0xba, 0xbb, 0x4a, 0x9f, 0x77, 0x4a, 0xb8, 0x53, 0xc9, 0x6c, 0x2d, 0x65, 0x3d, 0xfe, 0x54, 0x4a,
+];
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -18,6 +24,15 @@ pub struct LocalSessionFile {
     pub path: String,
     pub relative_path: String,
     pub text: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DbeaverCredentialEntry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
 }
 
 #[tauri::command]
@@ -55,6 +70,42 @@ pub fn scan_local_session_files(source: String) -> Result<Vec<LocalSessionFile>,
 }
 
 #[tauri::command]
+pub fn read_dbeaver_credentials_for_data_sources(
+    path: String,
+) -> Result<HashMap<String, DbeaverCredentialEntry>, String> {
+    let expanded = shellexpand::tilde(&path).to_string();
+    let data_sources_path = PathBuf::from(&expanded);
+    let data_sources_meta = fs::metadata(&data_sources_path)
+        .map_err(|e| format!("Failed to read DBeaver data-source metadata: {}", e))?;
+    if !data_sources_meta.is_file() {
+        return Err("The selected DBeaver data-source path is not a file.".to_string());
+    }
+    let credentials_path = data_sources_path
+        .parent()
+        .ok_or_else(|| "The selected DBeaver data-source path has no parent folder.".to_string())?
+        .join(DBEAVER_CREDENTIALS_CONFIG_FILE);
+    if !credentials_path.exists() {
+        return Ok(HashMap::new());
+    }
+
+    let credentials_meta = fs::metadata(&credentials_path)
+        .map_err(|e| format!("Failed to read DBeaver credentials metadata: {}", e))?;
+    if !credentials_meta.is_file() {
+        return Err("The DBeaver credentials-config.json path is not a file.".to_string());
+    }
+    if credentials_meta.len() > MAX_LOCAL_SESSION_FILE_BYTES {
+        return Err(
+            "The DBeaver credentials-config.json file is too large to import safely.".to_string(),
+        );
+    }
+
+    let encrypted = fs::read(&credentials_path)
+        .map_err(|e| format!("Failed to read DBeaver credentials-config.json: {}", e))?;
+    parse_dbeaver_credentials_config(&encrypted)
+        .map_err(|e| format!("Failed to decrypt DBeaver credentials-config.json: {}", e))
+}
+
+#[tauri::command]
 pub fn read_plist_session_file(path: String) -> Result<LocalSessionFile, String> {
     let expanded = shellexpand::tilde(&path).to_string();
     let path_buf = PathBuf::from(&expanded);
@@ -87,6 +138,61 @@ pub fn read_plist_session_file(path: String) -> Result<LocalSessionFile, String>
         relative_path,
         text,
     })
+}
+
+fn parse_dbeaver_credentials_config(
+    encrypted: &[u8],
+) -> Result<HashMap<String, DbeaverCredentialEntry>, String> {
+    if encrypted.len() <= 16 {
+        return Err("encrypted payload is too short".to_string());
+    }
+    let iv = &encrypted[..16];
+    let ciphertext = &encrypted[16..];
+    let plaintext = aes_128_cbc_decrypt_pkcs7(&DBEAVER_LOCAL_CREDENTIALS_KEY, iv, ciphertext)
+        .map_err(|e| e.to_string())?;
+    let parsed: Value = serde_json::from_slice(plaintext.as_slice())
+        .map_err(|e| format!("decrypted payload is not valid JSON: {}", e))?;
+    Ok(extract_dbeaver_credentials(parsed))
+}
+
+fn extract_dbeaver_credentials(parsed: Value) -> HashMap<String, DbeaverCredentialEntry> {
+    let mut out = HashMap::new();
+    let Some(root) = parsed.as_object() else {
+        return out;
+    };
+
+    for (connection_id, raw_sections) in root {
+        let Some(section_object) = raw_sections.as_object() else {
+            continue;
+        };
+        let Some(connection_section) = section_object.get("#connection").and_then(|value| value.as_object()) else {
+            continue;
+        };
+        let mut entry = DbeaverCredentialEntry::default();
+        entry.user = first_non_empty_json_field(connection_section, &["user", "username"]);
+        entry.password = first_non_empty_json_field(connection_section, &["password"]);
+        if entry.user.is_some() || entry.password.is_some() {
+            out.insert(connection_id.clone(), entry);
+        }
+    }
+
+    out
+}
+
+fn first_non_empty_json_field(
+    fields: &serde_json::Map<String, Value>,
+    names: &[&str],
+) -> Option<String> {
+    for name in names {
+        if let Some(value) = fields.get(*name) {
+            if let Some(text) = value.as_str() {
+                if !text.trim().is_empty() {
+                    return Some(text.to_string());
+                }
+            }
+        }
+    }
+    None
 }
 
 #[cfg(windows)]
@@ -796,4 +902,70 @@ fn env_join(var: &str, child: &str) -> Option<PathBuf> {
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
         .map(|base| base.join(child))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aes::Aes128;
+    use cbc::cipher::block_padding::Pkcs7;
+    use cbc::cipher::{BlockModeEncrypt, KeyIvInit};
+    use serde_json::json;
+
+    type Aes128CbcEnc = cbc::Encryptor<Aes128>;
+
+    fn encrypt_dbeaver_credentials_fixture(plaintext: &[u8]) -> Vec<u8> {
+        let iv = [0x42u8; 16];
+        let block_size = 16;
+        let pad = block_size - (plaintext.len() % block_size);
+        let mut buf = vec![0u8; plaintext.len() + pad];
+        buf[..plaintext.len()].copy_from_slice(plaintext);
+        let ct_len = Aes128CbcEnc::new_from_slices(&DBEAVER_LOCAL_CREDENTIALS_KEY, &iv)
+            .expect("key and iv lengths are fixed")
+            .encrypt_padded::<Pkcs7>(&mut buf, plaintext.len())
+            .expect("encrypt")
+            .len();
+        buf.truncate(ct_len);
+
+        let mut encrypted = iv.to_vec();
+        encrypted.extend_from_slice(&buf);
+        encrypted
+    }
+
+    #[test]
+    fn decrypts_dbeaver_credentials_config() {
+        let payload = json!({
+            "conn-1": {
+                "#connection": {
+                    "user": "db_user",
+                    "password": "db_pass"
+                },
+                "#ssh": {
+                    "password": "ssh_pass"
+                }
+            },
+            "conn-2": {
+                "#connection": {
+                    "user": "readonly"
+                }
+            }
+        })
+        .to_string();
+        let encrypted = encrypt_dbeaver_credentials_fixture(payload.as_bytes());
+
+        let parsed = parse_dbeaver_credentials_config(&encrypted).unwrap();
+
+        let first = parsed.get("conn-1").unwrap();
+        assert_eq!(first.user.as_deref(), Some("db_user"));
+        assert_eq!(first.password.as_deref(), Some("db_pass"));
+        let second = parsed.get("conn-2").unwrap();
+        assert_eq!(second.user.as_deref(), Some("readonly"));
+        assert_eq!(second.password, None);
+    }
+
+    #[test]
+    fn rejects_short_dbeaver_credentials_payload() {
+        let err = parse_dbeaver_credentials_config(&[0u8; 16]).unwrap_err();
+        assert!(err.contains("too short"));
+    }
 }

--- a/src-tauri/src/session/import_secrets/crypto.rs
+++ b/src-tauri/src/session/import_secrets/crypto.rs
@@ -1,10 +1,11 @@
-use aes::Aes256;
+use aes::{Aes128, Aes256};
 use cbc::cipher::block_padding::Pkcs7;
 use cbc::cipher::{BlockModeDecrypt, KeyIvInit};
 use sha2::Sha512;
 use zeroize::Zeroizing;
 
 type Aes256CbcDec = cbc::Decryptor<Aes256>;
+type Aes128CbcDec = cbc::Decryptor<Aes128>;
 
 #[derive(Debug)]
 pub enum SecretCryptoError {
@@ -56,14 +57,33 @@ pub fn aes_256_cbc_decrypt_pkcs7(
     Ok(Zeroizing::new(buf))
 }
 
+pub fn aes_128_cbc_decrypt_pkcs7(
+    key: &[u8],
+    iv: &[u8],
+    ciphertext: &[u8],
+) -> Result<Zeroizing<Vec<u8>>, SecretCryptoError> {
+    if key.len() != 16 || iv.len() != 16 {
+        return Err(SecretCryptoError::InvalidKeyOrIvLength);
+    }
+    let mut buf = ciphertext.to_vec();
+    let plaintext_len = Aes128CbcDec::new_from_slices(key, iv)
+        .map_err(|_| SecretCryptoError::InvalidKeyOrIvLength)?
+        .decrypt_padded::<Pkcs7>(&mut buf)
+        .map_err(|_| SecretCryptoError::BadPadding)?
+        .len();
+    buf.truncate(plaintext_len);
+    Ok(Zeroizing::new(buf))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aes::Aes256;
+    use aes::{Aes128, Aes256};
     use cbc::cipher::block_padding::Pkcs7;
     use cbc::cipher::{BlockModeEncrypt, KeyIvInit};
 
     type Aes256CbcEnc = cbc::Encryptor<Aes256>;
+    type Aes128CbcEnc = cbc::Encryptor<Aes128>;
 
     fn cbc_encrypt_pkcs7(key: &[u8; 32], iv: &[u8; 16], plaintext: &[u8]) -> Vec<u8> {
         let block_size = 16;
@@ -71,6 +91,20 @@ mod tests {
         let mut buf = vec![0u8; plaintext.len() + pad];
         buf[..plaintext.len()].copy_from_slice(plaintext);
         let ct_len = Aes256CbcEnc::new_from_slices(key, iv)
+            .expect("key and iv lengths are fixed")
+            .encrypt_padded::<Pkcs7>(&mut buf, plaintext.len())
+            .expect("encrypt")
+            .len();
+        buf.truncate(ct_len);
+        buf
+    }
+
+    fn cbc_128_encrypt_pkcs7(key: &[u8; 16], iv: &[u8; 16], plaintext: &[u8]) -> Vec<u8> {
+        let block_size = 16;
+        let pad = block_size - (plaintext.len() % block_size);
+        let mut buf = vec![0u8; plaintext.len() + pad];
+        buf[..plaintext.len()].copy_from_slice(plaintext);
+        let ct_len = Aes128CbcEnc::new_from_slices(key, iv)
             .expect("key and iv lengths are fixed")
             .encrypt_padded::<Pkcs7>(&mut buf, plaintext.len())
             .expect("encrypt")
@@ -95,6 +129,16 @@ mod tests {
         let plaintext = b"the quick brown fox jumps over the lazy dog";
         let ct = cbc_encrypt_pkcs7(&key, &iv, plaintext);
         let decoded = aes_256_cbc_decrypt_pkcs7(&key, &iv, &ct).unwrap();
+        assert_eq!(&decoded[..], plaintext);
+    }
+
+    #[test]
+    fn cbc_128_round_trip() {
+        let key = [7u8; 16];
+        let iv = [9u8; 16];
+        let plaintext = b"dbeaver credentials";
+        let ct = cbc_128_encrypt_pkcs7(&key, &iv, plaintext);
+        let decoded = aes_128_cbc_decrypt_pkcs7(&key, &iv, &ct).unwrap();
         assert_eq!(&decoded[..], plaintext);
     }
 

--- a/src/components/sidebar/SessionTree.test.tsx
+++ b/src/components/sidebar/SessionTree.test.tsx
@@ -15,6 +15,8 @@ const ipcMocks = vi.hoisted(() => ({
   listSessionGroups: vi.fn<() => Promise<SessionGroup[]>>(async () => []),
   listSessions: vi.fn<() => Promise<SessionConfig[]>>(async () => []),
   markSessionConnected: vi.fn(async () => 0),
+  readDbeaverCredentialsForDataSources: vi.fn(async () => ({})),
+  readFileBytes: vi.fn(async () => new Uint8Array()),
   readPlistSessionFile: vi.fn(async () => ({ text: "", path: "", relativePath: "" })),
   saveSession: vi.fn<(cfg: SessionConfig) => Promise<void>>(async () => undefined),
   saveSessionGroup: vi.fn(async () => undefined),
@@ -25,6 +27,10 @@ const ipcMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../lib/ipc", () => ipcMocks);
+
+vi.mock("../../lib/vaultGate", () => ({
+  ensureVaultReady: vi.fn(async () => true),
+}));
 
 function makeSession(id: string, name: string, groupPath: string): SessionConfig {
   return {

--- a/src/components/sidebar/SessionTree.tsx
+++ b/src/components/sidebar/SessionTree.tsx
@@ -32,6 +32,8 @@ import {
   isVaultLockedError,
   getHomeDir,
   keychainLookupBatch,
+  readDbeaverCredentialsForDataSources,
+  readFileBytes,
   readPlistSessionFile,
   scanLocalSessionFiles,
   selectFilePath,
@@ -89,6 +91,7 @@ import { SessionImportPreview } from "../session/SessionImportPreview";
 import { ExternalVaultUnlockDialog } from "../session/ExternalVaultUnlockDialog";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { useT } from "../../lib/i18n";
+import { ensureVaultReady } from "../../lib/vaultGate";
 
 const SESSION_DRAG_MIME = "taomni/session";
 
@@ -609,6 +612,21 @@ export function SessionTree({ onNewSession, onConnectSession, onEditSession }: S
   const prepareImportResultForSave = async (result: SessionImportResult): Promise<SessionImportResult> => {
     if (result.secrets.length === 0) return result;
 
+    const vaultReady = await ensureVaultReady(t("vault.gateReasonSession"));
+    if (!vaultReady) {
+      return {
+        ...result,
+        warnings: [...new Set([
+          ...result.warnings,
+          t("sessionTree.skippedVaultUnlockCancelled", {
+            count: result.secrets.length,
+            plural: result.secrets.length === 1 ? "" : "s",
+          }),
+        ])],
+        secrets: [],
+      };
+    }
+
     const sessionsById = new Map(result.sessions.map((session) => [session.id, { ...session }]));
     const warnings = [...result.warnings];
     let standaloneSaved = 0;
@@ -788,6 +806,48 @@ export function SessionTree({ onNewSession, onConnectSession, onEditSession }: S
         ...(extraOptions?.() ?? {}),
       });
       queueImportPreview(result, folderPath, source);
+    }).catch((error) => {
+      window.alert(error instanceof Error ? error.message : String(error));
+    });
+  };
+
+  const dbeaverCredentialOptions = async (path: string): Promise<Partial<SessionImportOptions>> => {
+    const credentials = await readDbeaverCredentialsForDataSources(path);
+    return Object.keys(credentials).length > 0 ? { dbeaverCredentials: credentials } : {};
+  };
+
+  const importDbeaverFile = (folderPath: string | null) => {
+    selectFilePath().then(async (path) => {
+      if (!path) return;
+      const text = new TextDecoder().decode(await readFileBytes(path));
+      const result = parseDbeaverSessions(text, {
+        targetFolder: folderPath,
+        existingSessions: sessions,
+        sourcePath: path,
+        ...(await dbeaverCredentialOptions(path)),
+      });
+      queueImportPreview(result, folderPath, "DBeaver");
+    }).catch((error) => {
+      window.alert(error instanceof Error ? error.message : String(error));
+    });
+  };
+
+  const importScannedDbeaverSessions = (folderPath: string | null) => {
+    scanLocalSessionFiles("dbeaver").then(async (files) => {
+      if (files.length === 0) {
+        setStatusMessage(t("sessionTree.noLocalConfigFound", { source: "DBeaver" }));
+        return;
+      }
+      const results = await Promise.all(files.map(async (file) =>
+        parseDbeaverSessions(file.text, {
+          targetFolder: folderPath,
+          existingSessions: sessions,
+          sourcePath: file.relativePath || file.path,
+          ...(await dbeaverCredentialOptions(file.path)),
+        }),
+      ));
+      const result = mergeImportResults(results);
+      queueImportPreview(result, folderPath, "DBeaver local config");
     }).catch((error) => {
       window.alert(error instanceof Error ? error.message : String(error));
     });
@@ -1003,12 +1063,12 @@ export function SessionTree({ onNewSession, onConnectSession, onEditSession }: S
           {
             label: t("sessionTree.fromDbeaverDataSources"),
             icon: <FileText className="w-3 h-3" />,
-            onClick: () => importTextSessions(folderPath, "DBeaver", ".json,.xml,data-sources.json,application/json,text/xml,application/xml,text/plain", parseDbeaverSessions),
+            onClick: () => importDbeaverFile(folderPath),
           },
           {
             label: t("sessionTree.fromLocalDbeaver"),
             icon: <FolderOpen className="w-3 h-3" />,
-            onClick: () => importScannedTextSessions(folderPath, "dbeaver", "DBeaver", parseDbeaverSessions),
+            onClick: () => importScannedDbeaverSessions(folderPath),
           },
         ],
       },

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1815,6 +1815,7 @@ const dict = {
     standaloneTabbyPassphrases: "{count} Tabby private-key passphrase(s) will be saved as standalone vault entries — assign them manually under Settings → Vault.",
     skippedStandalone: "Skipped standalone Tabby secrets because the credential vault is locked or has not been initialized.",
     skippedVaultLocked: "Skipped saved password for \"{name}\" because {reason}.",
+    skippedVaultUnlockCancelled: "Skipped {count} imported secret(s) because the credential vault was not unlocked.",
     vaultLockedReason: "the credential vault is locked or has not been initialized",
     standaloneSaved: "Saved {count} standalone secret(s) to the credential vault — assign them under Settings → Vault.",
     standaloneSkipped: "Skipped {count} standalone secret(s) because the credential vault rejected the write.",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -1811,6 +1811,7 @@ export const zhCN: DeepPartial<typeof en> = {
     standaloneTabbyPassphrases: "{count} 条 Tabby 私钥口令将作为独立条目存入凭据库 —— 请在 设置 → 凭据库 中手动关联。",
     skippedStandalone: "由于凭据库未初始化或已锁定，已跳过独立 Tabby 密钥。",
     skippedVaultLocked: "因 {reason}，已跳过“{name}”的密码保存。",
+    skippedVaultUnlockCancelled: "由于凭据库未解锁，已跳过 {count} 条导入密钥。",
     vaultLockedReason: "凭据库未初始化或已锁定",
     standaloneSaved: "已将 {count} 条独立密钥存入凭据库 —— 请在 设置 → 凭据库 中关联。",
     standaloneSkipped: "凭据库拒绝写入，已跳过 {count} 条独立密钥。",

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -440,6 +440,12 @@ export interface LocalSessionFile {
   text: string;
 }
 
+export interface DbeaverCredentialEntry {
+  user?: string | null;
+  password?: string | null;
+  sections?: Record<string, Record<string, string>>;
+}
+
 export async function importPuttySessions(): Promise<SessionConfig[]> {
   return invoke<SessionConfig[]>("import_putty_sessions", {});
 }
@@ -454,6 +460,12 @@ export async function importExternalBashSessions(): Promise<SessionConfig[]> {
 
 export async function scanLocalSessionFiles(source: string): Promise<LocalSessionFile[]> {
   return invoke<LocalSessionFile[]>("scan_local_session_files", { source });
+}
+
+export async function readDbeaverCredentialsForDataSources(
+  path: string,
+): Promise<Record<string, DbeaverCredentialEntry>> {
+  return invoke<Record<string, DbeaverCredentialEntry>>("read_dbeaver_credentials_for_data_sources", { path });
 }
 
 export async function readPlistSessionFile(path: string): Promise<LocalSessionFile> {

--- a/src/lib/sessionImportExport.test.ts
+++ b/src/lib/sessionImportExport.test.ts
@@ -426,6 +426,142 @@ describe("DBeaver session import", () => {
       dbRedisIndex: "2",
     });
   });
+
+  it("reads DBeaver credentials from auth-properties and authProperties", () => {
+    const text = JSON.stringify({
+      connections: {
+        hyphen: {
+          driver: "postgresql",
+          name: "Hyphen Auth",
+          configuration: {
+            host: "pg-auth.example.com",
+            port: "5432",
+            "auth-properties": {
+              user: "pg_auth_user",
+              password: "pg-auth-pass",
+            },
+          },
+        },
+        camel: {
+          driver: "mysql",
+          name: "Camel Auth",
+          configuration: {
+            host: "mysql-auth.example.com",
+            authProperties: {
+              username: "mysql_auth_user",
+              password: "mysql-auth-pass",
+            },
+          },
+        },
+      },
+    });
+
+    const result = parseDbeaverSessions(text, { now: 8888 });
+
+    expect(result.sessions).toHaveLength(2);
+    expect(result.sessions[0]).toMatchObject({
+      name: "Hyphen Auth",
+      session_type: "PostgreSQL",
+      host: "pg-auth.example.com",
+      port: 5432,
+      username: "pg_auth_user",
+    });
+    expect(result.sessions[1]).toMatchObject({
+      name: "Camel Auth",
+      session_type: "MySQL",
+      host: "mysql-auth.example.com",
+      port: 3306,
+      username: "mysql_auth_user",
+    });
+    expect(result.secrets.map((secret) => ({
+      sessionId: secret.sessionId,
+      kind: secret.kind,
+      value: secret.value,
+    }))).toEqual([
+      {
+        sessionId: result.sessions[0].id,
+        kind: "password",
+        value: "pg-auth-pass",
+      },
+      {
+        sessionId: result.sessions[1].id,
+        kind: "password",
+        value: "mysql-auth-pass",
+      },
+    ]);
+  });
+
+  it("merges DBeaver credentials-config entries by connection id", () => {
+    const text = JSON.stringify({
+      connections: {
+        direct: {
+          driver: "mysql",
+          name: "Direct Secure",
+          "save-password": true,
+          configuration: {
+            host: "direct.example.com",
+          },
+        },
+        sectionOnly: {
+          driver: "postgresql",
+          name: "Section Secure",
+          "save-password": true,
+          configuration: {
+            host: "section.example.com",
+          },
+        },
+      },
+    });
+
+    const result = parseDbeaverSessions(text, {
+      now: 9999,
+      dbeaverCredentials: {
+        direct: {
+          user: "direct_user",
+          password: "direct-pass",
+        },
+        sectionOnly: {
+          sections: {
+            "#connection": {
+              user: "section_user",
+              password: "section-pass",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.sessions).toHaveLength(2);
+    expect(result.sessions[0]).toMatchObject({
+      name: "Direct Secure",
+      session_type: "MySQL",
+      host: "direct.example.com",
+      username: "direct_user",
+    });
+    expect(result.sessions[1]).toMatchObject({
+      name: "Section Secure",
+      session_type: "PostgreSQL",
+      host: "section.example.com",
+      username: "section_user",
+    });
+    expect(result.secrets.map((secret) => ({
+      sessionId: secret.sessionId,
+      kind: secret.kind,
+      value: secret.value,
+    }))).toEqual([
+      {
+        sessionId: result.sessions[0].id,
+        kind: "password",
+        value: "direct-pass",
+      },
+      {
+        sessionId: result.sessions[1].id,
+        kind: "password",
+        value: "section-pass",
+      },
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
 });
 
 describe("MobaXterm session import/export", () => {

--- a/src/lib/sessionImportExport.ts
+++ b/src/lib/sessionImportExport.ts
@@ -1,4 +1,4 @@
-import type { AuthMethod, SessionConfig } from "./ipc";
+import type { AuthMethod, DbeaverCredentialEntry, SessionConfig } from "./ipc";
 import {
   groupPathContains,
   leafGroupName,
@@ -66,6 +66,7 @@ export interface SessionImportOptions {
   sourcePath?: string | null;
   homeDir?: string | null;
   includeSecrets?: boolean;
+  dbeaverCredentials?: Record<string, DbeaverCredentialEntry | null | undefined>;
 }
 
 export interface SessionImportSecret {
@@ -580,7 +581,14 @@ export function parseDbeaverSessions(text: string, options: SessionImportOptions
   let skipped = limited.skipped;
 
   for (const input of limited.rows as DbeaverConnectionInput[]) {
-    const imported = dbeaverConnectionToSession(input, options.targetFolder ?? null, now, warnings);
+    const imported = dbeaverConnectionToSession(
+      input,
+      options.targetFolder ?? null,
+      now,
+      warnings,
+      options.dbeaverCredentials?.[input.id],
+      options.dbeaverCredentials !== undefined,
+    );
     if (!imported) {
       skipped += 1;
       continue;
@@ -682,10 +690,19 @@ function dbeaverConnectionToSession(
   targetFolder: string | null,
   now: number,
   warnings: string[],
+  credential: DbeaverCredentialEntry | null | undefined,
+  credentialsLoaded: boolean,
 ): { session: SessionConfig; password?: string } | null {
   const record = input.record;
   const configuration = firstRecord(record.configuration, record.connection, record.config, record);
   const properties = firstRecord(configuration.properties, record.properties);
+  const authProperties = firstRecord(
+    configuration["auth-properties"],
+    configuration.authProperties,
+    record["auth-properties"],
+    record.authProperties,
+  );
+  const credentialSection = firstRecord(credential?.sections?.["#connection"]);
   const url = cleanText(firstNonEmptyString(
     configuration.url,
     configuration.jdbcUrl,
@@ -764,11 +781,16 @@ function dbeaverConnectionToSession(
     configuration.password,
     configuration.userPassword,
     record.password,
+    authProperties.password,
+    credential?.password,
+    credentialSection.password,
     urlInfo.password,
   ), MAX_OPTION_LENGTH);
   const hasExternalPassword = dbeaverTruthy(record["save-password"] ?? record.savePassword ?? configuration["save-password"]);
   if (!password && hasExternalPassword) {
-    warnings.push(`DBeaver connection "${label}" has a saved password, but encrypted DBeaver credentials were not imported.`);
+    warnings.push(credentialsLoaded
+      ? `DBeaver connection "${label}" has a saved password, but credentials-config.json did not contain a password for this connection.`
+      : `DBeaver connection "${label}" has a saved password, but encrypted DBeaver credentials were not imported.`);
   }
 
   const importedFolder = combineImportFolder("DBeaver", normalizeGroupPath(input.folderPath));
@@ -794,6 +816,11 @@ function dbeaverConnectionToSession(
       configuration["user.name"],
       record.user,
       record.username,
+      authProperties.user,
+      authProperties.username,
+      credential?.user,
+      credentialSection.user,
+      credentialSection.username,
       urlInfo.username,
     ), MAX_NAME_LENGTH),
     groupPath: combineImportFolder(targetFolder, importedFolder),


### PR DESCRIPTION
Add DBeaver credentials-config.json support for data-sources imports.

Backend changes:

- Add an AES-128-CBC/PKCS7 decrypt helper for DBeaver local credential blobs.

- Add read_dbeaver_credentials_for_data_sources to locate sibling credentials-config.json, decrypt it with DBeaver's local key, and return only #connection user/password by data-source id.

- Register the new Tauri command for frontend import flows.

Frontend changes:

- Add IPC types/wrapper for DBeaver credential lookup.

- Route DBeaver manual imports through Tauri file selection so the real data-sources path is available for sibling credential lookup.

- Merge decrypted credentials into parseDbeaverSessions by connection id while preserving existing direct/authProperties/url precedence.

- Ensure the Taomni vault is unlocked or initialized before saving imported secrets, so imported DBeaver passwords prompt for the master pass instead of being skipped silently.

Tests and validation:

- Cover auth-properties/authProperties and credentials-config merge behavior in session import tests.

- Cover DBeaver credentials decrypt parsing in Rust unit tests.

- Verified the provided real DBeaver files without printing secrets: 31 data-source connections, 30 credential entries, 30 matched ids, 30 users, 17 passwords, 30 imported sessions, and 17 imported password secrets.

- Commands run: pnpm exec vitest run src/lib/sessionImportExport.test.ts; pnpm exec tsc -b; cargo test --manifest-path src-tauri/Cargo.toml dbeaver_credentials -- --nocapture.