### PR TITLE
feat(settings): show Claude Code config options when enabled without …

### DIFF
--- a/src/components/settings/ClaudeCodePanel.tsx
+++ b/src/components/settings/ClaudeCodePanel.tsx
@@ -213,8 +213,8 @@ export function ClaudeCodePanel() {
         </div>
       )}
 
-      {/* Ready — show config options */}
-      {isReady && cc.enabled && (
+      {/* Enabled: show config options even before a detection pass. */}
+      {cc.enabled && (
         <div className="space-y-2 pt-2 border-t border-[var(--taomni-divider)]">
           <div className="grid grid-cols-2 gap-3">
             <div>


### PR DESCRIPTION
…waiting for ready state

This change removes the 'isReady' check that prevented configuration options in the Claude Code settings panel from being displayed before the detection pass finishes. Now, as long as Claude Code is enabled ('cc.enabled'), the configuration section is visible immediately, improving the user experience by allowing prompt settings adjustment.