### PR TITLE
fix(terminal): keep first char after Shift under macOS IME

### DIFF
--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -40,6 +40,7 @@ import {
   shouldUseLinuxImeGuard,
   TerminalImeInputGuard,
 } from "../../lib/terminalImeGuard";
+import { shouldSuppressMacImeKeydown } from "../../lib/terminal/macImeKeydown";
 import {
   readText as clipboardReadText,
   writeText as clipboardWriteText,
@@ -1897,6 +1898,20 @@ export function TerminalPanel({
       textarea.addEventListener("compositionstart", onCompositionStart);
       textarea.addEventListener("compositionend", onCompositionEnd);
 
+      // macOS IME first-character fix. macOS IMEs (Sogou/Pinyin…) deliver committed text
+      // via `input` (insertText) events but mark every keydown with keyCode 229, arriving
+      // input → keydown → keyup. xterm's _keyDown sets `_keyDownSeen` for those, and its
+      // _inputEvent then skips a composed character while the flag is set — so the first
+      // char typed with a modifier held (e.g. the `@` from Shift+2) is dropped before it
+      // reaches the PTY. Swallow keyCode-229 keydowns (capture phase, on the container so
+      // it runs before xterm's textarea handler) so the flag is never set; the character
+      // still arrives via `input`. Ctrl/Cmd combos pass through so shortcuts keep working.
+      // (Linux uses its own guard above; see shouldSuppressMacImeKeydown for details.)
+      const onMacImeKeydownCapture = (e: KeyboardEvent) => {
+        if (isMac && shouldSuppressMacImeKeydown(e)) e.stopImmediatePropagation();
+      };
+      el.addEventListener("keydown", onMacImeKeydownCapture, true);
+
       const observer = new MutationObserver(() => {
         if (isComposing) {
           observer.disconnect();
@@ -1915,6 +1930,7 @@ export function TerminalPanel({
       cleanupImePositionLock = () => {
         textarea.removeEventListener("compositionstart", onCompositionStart);
         textarea.removeEventListener("compositionend", onCompositionEnd);
+        el.removeEventListener("keydown", onMacImeKeydownCapture, true);
         observer.disconnect();
         compositionBufferRef.current = [];
       };

--- a/src/lib/terminal/macImeKeydown.test.ts
+++ b/src/lib/terminal/macImeKeydown.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { shouldSuppressMacImeKeydown } from "./macImeKeydown";
+
+// Faithful model of the relevant xterm.js 6.0 text-input path:
+//   _keyDown(): _keyDownSeen = true   (for EVERY keydown, incl. keyCode 229)
+//   _keyUp():   _keyDownSeen = false
+//   _inputEvent(insertText): emit `data` iff (!composed || !_keyDownSeen)
+// Our fix decides whether a keydown is allowed to reach xterm (and set the flag).
+class XtermInputModel {
+  keyDownSeen = false;
+  emitted: string[] = [];
+  constructor(private readonly applyFix: boolean) {}
+
+  keydown(e: { keyCode: number; ctrlKey?: boolean; metaKey?: boolean }) {
+    if (
+      this.applyFix &&
+      shouldSuppressMacImeKeydown({ keyCode: e.keyCode, ctrlKey: !!e.ctrlKey, metaKey: !!e.metaKey })
+    ) {
+      return; // suppressed before reaching xterm — flag not set
+    }
+    this.keyDownSeen = true;
+  }
+  keyup() {
+    this.keyDownSeen = false;
+  }
+  input(data: string, composed: boolean) {
+    if (data && (!composed || !this.keyDownSeen)) this.emitted.push(data);
+  }
+}
+
+// Replays the observed macOS Sogou sequence: Shift held, "2"(→@), "3"(→#).
+// Real per-char order is input → keydown → keyup; Shift is held (no keyup until end).
+function replayShiftHeldAtAndHash(model: XtermInputModel) {
+  model.keydown({ keyCode: 229 }); // Shift down (held), keyCode 229
+  model.input("@", true); // committed "@" (composed)
+  model.keydown({ keyCode: 229 });
+  model.keyup(); // "@" key down+up
+  model.input("#", true); // committed "#"
+  model.keydown({ keyCode: 229 });
+  model.keyup(); // "#" key down+up
+  model.keyup(); // Shift up
+}
+
+describe("shouldSuppressMacImeKeydown", () => {
+  it("suppresses bare/Shift IME-routed (229) keydowns", () => {
+    expect(shouldSuppressMacImeKeydown({ keyCode: 229, ctrlKey: false, metaKey: false })).toBe(true);
+  });
+  it("does NOT suppress Ctrl/Cmd combos (shortcuts must survive)", () => {
+    expect(shouldSuppressMacImeKeydown({ keyCode: 229, ctrlKey: true, metaKey: false })).toBe(false);
+    expect(shouldSuppressMacImeKeydown({ keyCode: 67, ctrlKey: false, metaKey: true })).toBe(false);
+  });
+  it("does NOT suppress normal (non-229) keys like Enter", () => {
+    expect(shouldSuppressMacImeKeydown({ keyCode: 13, ctrlKey: false, metaKey: false })).toBe(false);
+  });
+});
+
+describe("xterm input model — macOS Sogou Shift+digit", () => {
+  it("reproduces the bug WITHOUT the fix (first '@' is dropped)", () => {
+    const m = new XtermInputModel(false);
+    replayShiftHeldAtAndHash(m);
+    expect(m.emitted).toEqual(["#"]); // '@' lost
+  });
+  it("emits every character WITH the fix", () => {
+    const m = new XtermInputModel(true);
+    replayShiftHeldAtAndHash(m);
+    expect(m.emitted).toEqual(["@", "#"]);
+  });
+});

--- a/src/lib/terminal/macImeKeydown.ts
+++ b/src/lib/terminal/macImeKeydown.ts
@@ -1,0 +1,26 @@
+/**
+ * macOS IME first-character fix.
+ *
+ * On macOS, IMEs such as Sogou and the system Pinyin input deliver committed text
+ * through `input` (inputType="insertText") events, but mark every physical keydown
+ * with `keyCode === 229` (the "input method is processing" sentinel), and these
+ * events arrive in an inverted order: input → keydown → keyup.
+ *
+ * xterm.js (`Terminal._keyDown`) unconditionally sets an internal `_keyDownSeen`
+ * flag on every keydown and clears it on keyup. Its `_inputEvent` then emits the
+ * typed character only when `(!event.composed || !_keyDownSeen)`. While a modifier
+ * (Shift/Meta) is held, its keydown leaves `_keyDownSeen === true`, so the first
+ * committed character's (composed) `input` event is skipped — e.g. the first `@`
+ * from Shift+2 never reaches the PTY, while the next character is fine. English /
+ * non-IME input is unaffected because those keydowns are not keyCode 229.
+ *
+ * Fix: stop keyCode-229 keydowns from reaching xterm so the flag is never set by
+ * IME-routed keys; the character still arrives via the `input` event and is emitted
+ * normally. Ctrl/Cmd combinations are excluded so keyboard shortcuts keep working.
+ * (Linux has a dedicated IME guard — see terminalImeGuard.ts — so this is macOS-only.)
+ */
+export function shouldSuppressMacImeKeydown(
+  event: Pick<KeyboardEvent, "keyCode" | "ctrlKey" | "metaKey">,
+): boolean {
+  return event.keyCode === 229 && !event.ctrlKey && !event.metaKey;
+}


### PR DESCRIPTION
## 现象 / Symptom
macOS 上 SSH 会话里开着中文输入法(如搜狗)时,按住修饰键打出的第一个字符会丢失。先打 `1`,按住 **Shift** 再按 `2`、`3`,shell 上显示的是 `1#` —— `@`(Shift+2)根本没到 PTY,而后一个字符正常。英文 / 非 IME 输入不受影响。

## 根因 / Root cause
macOS 输入法通过 `input`(`inputType=insertText`)事件投递已提交文本,但把每个 keydown 标成 `keyCode 229`,且事件顺序是反的(`input → keydown → keyup`)。xterm.js 的 `_keyDown` 对每个 keydown 都置位内部 `_keyDownSeen`、keyup 时清除;`_inputEvent` 仅在 `(!event.composed || !_keyDownSeen)` 时才发送字符。当修饰键(Shift/Meta)被按住时,它的 keydown 让 `_keyDownSeen` 保持 `true`,于是第一个已提交字符的 composed `input` 事件被跳过。仓库现有的 IME 输入守卫只在 Linux 启用,macOS 没有兜底。

## 方案 / Fix
macOS 上在捕获阶段(挂在终端容器上,先于 xterm 的 textarea 处理)吞掉 `keyCode 229` 的 keydown,使该标志不再被 IME 路由按键置位;字符仍通过 `input` 事件正常送达。排除 `Ctrl`/`Cmd` 组合以保住快捷键。纯 Rust 的 SSH/终端逻辑与 Linux 的 IME 守卫均不受影响。

## 测试 / Testing
- 新增 `src/lib/terminal/macImeKeydown.test.ts`,建模 xterm 的 `_keyDownSeen` 路径:无修复时首字符被丢、有修复时正常发送。
- `tsc -b` 通过;vitest 全量 583 通过。
- macOS + 搜狗真机验证:`1` + 按住 Shift 打 `2 3` 现在显示 `1@#`;按住 Shift 连打 `@#$%^&` 逐个出现;普通拼音输入与 Cmd+C/V 不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)