### PR TITLE
fix(db): handle MySQL BIT(1) parsing and CSV export empty varchar col…

### DIFF
--- a/src-tauri/src/database/sql.rs
+++ b/src-tauri/src/database/sql.rs
@@ -218,6 +218,26 @@ fn mysql_value_to_string(row: &MySqlRow, i: usize) -> Option<String> {
                 return v.map(|x| x.to_string());
             }
         }
+        "BIT" => {
+            if let Ok(v) = row.try_get::<Option<u64>, _>(i) {
+                return v.map(|x| x.to_string());
+            }
+            if let Ok(v) = row.try_get::<Option<Vec<u8>>, _>(i) {
+                return v.map(|b| {
+                    if b.is_empty() {
+                        "0".to_string()
+                    } else if b.len() == 1 {
+                        b[0].to_string()
+                    } else {
+                        let mut val: u64 = 0;
+                        for &byte in &b {
+                            val = (val << 8) | (byte as u64);
+                        }
+                        val.to_string()
+                    }
+                });
+            }
+        }
         _ => {}
     }
     // Fallback: text, then raw bytes (lossy utf8 for BLOB/VARBINARY).

--- a/src/components/database/QueryResultGrid.tsx
+++ b/src/components/database/QueryResultGrid.tsx
@@ -477,7 +477,7 @@ function cleanExportText(value: string, options: ExportOptions): string {
 }
 
 function renderTemplate(template: string, value: string): string {
-  return template.replace(/\$\{value\}\$/g, value).replace(/\$\{value\}/g, value);
+  return template.replace(/\$\{value\}\$?/g, () => value);
 }
 
 function quoteSqlIdentifier(name: string, mode: SqlDelimiterMode): string {
@@ -517,9 +517,13 @@ function serializeResult(
   const columnByName = new Map(columns.map((column, index) => [column.name, { column, index }]));
   const rowValues = limitedRows.map((row) =>
     enabledColumns.map((exportColumn) => {
-      const match = columnByName.get(exportColumn.name);
-      const sourceColumn = match?.column ?? { name: exportColumn.name, type: exportColumn.type };
-      const raw = match ? row.values[match.index] : null;
+      let originalIndex = parseInt(exportColumn.id.split('-')[1], 10);
+      if (Number.isNaN(originalIndex) || exportColumn.id.startsWith("export-col")) {
+        const match = columnByName.get(exportColumn.name);
+        originalIndex = match ? match.index : -1;
+      }
+      const sourceColumn = columns[originalIndex] ?? { name: exportColumn.name, type: exportColumn.type };
+      const raw = originalIndex >= 0 && originalIndex < columns.length ? row.values[originalIndex] : null;
       const columnOptions = exportColumn.textFunction === "none" ? options : { ...options, textFunction: exportColumn.textFunction };
       const formatted = formatValue(raw, sourceColumn, columnOptions);
       return cleanExportText(renderTemplate(exportColumn.valueTemplate || "${value}$", formatted), options);


### PR DESCRIPTION
…umns

Resolves #204: Fixed MySQL BIT(1) type parsing where it was incorrectly fallbacking to NULL instead of reading '0'/'1'. Added direct BIT mapping logic in sql.rs.

Resolves #203: Fixed CSV export where some columns (like varchars) were downloaded as empty strings. Changed QueryResultGrid.tsx export logic to securely map values using column indices encoded in cell IDs instead of name mappings to avoid mismatch errors on duplicate/custom columns, and fixed regex '$' template formatting crash.