### PR TITLE
fix(chat): keep AI runs alive across drawer tab switches

### DIFF
--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -1,5 +1,6 @@
 pub mod inline_qq;
 pub mod redact;
+pub mod run;
 pub mod store;
 
 use crate::ai::config::{default_ai_config_path, AiConfig};
@@ -468,18 +469,18 @@ fn cc_tool_result_preview(content: &str) -> String {
 
 #[tauri::command]
 pub async fn chat_stop_stream(thread_id: String, state: State<'_, AppState>) -> Result<(), String> {
-    // 1. Cancel Claude Code process if running
-    {
-        let mut registry = state.cc_processes.lock().await;
-        if let Some(process) = registry.remove(&thread_id) {
-            process.stop().await;
-        }
+    // Stop the in-flight turn regardless of provider/runtime. Claude Code also
+    // has a persistent per-thread process registry for reuse; remove that entry
+    // on explicit stop so the next turn starts from a clean bridge process.
+    let run = { state.chat_runs.lock().await.remove(&thread_id) };
+    let cc_process = { state.cc_processes.lock().await.remove(&thread_id) };
+
+    if let Some(run) = run {
+        run.stop().await;
     }
-    // 2. Cancel direct LLM streams
-    {
-        let mut tokens = state.chat_cancel_tokens.lock().unwrap();
-        if let Some(token) = tokens.remove(&thread_id) {
-            token.cancel();
+    if let Some(process) = cc_process {
+        if !process.is_stopped() {
+            process.stop().await;
         }
     }
     Ok(())
@@ -755,6 +756,10 @@ pub async fn chat_stream(
         // only a Weak<CcProcess>, so it exits cleanly once the registry drops
         // the process (provider switch / model change → recycle_thread_process).
         process.start_watchdog();
+        state.chat_runs.lock().await.insert(
+            req.thread_id.clone(),
+            run::ChatRunHandle::bridge_process("claude-code", process.clone()),
+        );
 
         // 7. Run process with callback to stream
         let assistant_id_clone = assistant_id.clone();
@@ -877,6 +882,7 @@ pub async fn chat_stream(
                 }
             })
             .await;
+        state.chat_runs.lock().await.remove(&req.thread_id);
 
         let events = match events {
             Ok(ev) => ev,
@@ -1042,13 +1048,12 @@ pub async fn chat_stream(
         }
     };
 
-    // Create/get a cancellation token for this thread
-    let cancel_token = {
-        let mut tokens = state.chat_cancel_tokens.lock().unwrap();
-        let token = tokio_util::sync::CancellationToken::new();
-        tokens.insert(req.thread_id.clone(), token.clone());
-        token
-    };
+    // Create a provider-agnostic cancellation handle for this in-flight turn.
+    let cancel_token = tokio_util::sync::CancellationToken::new();
+    state.chat_runs.lock().await.insert(
+        req.thread_id.clone(),
+        run::ChatRunHandle::direct_llm(cancel_token.clone()),
+    );
 
     let mut accumulated = String::new();
     let mut is_cancelled = false;
@@ -1075,7 +1080,7 @@ pub async fn chat_stream(
                                     id: assistant_id,
                                     message,
                                 });
-                                state.chat_cancel_tokens.lock().unwrap().remove(&req.thread_id);
+                                state.chat_runs.lock().await.remove(&req.thread_id);
                                 return Ok(());
                             }
                             Err(e) => {
@@ -1083,7 +1088,7 @@ pub async fn chat_stream(
                                     id: assistant_id,
                                     message: e.to_string(),
                                 });
-                                state.chat_cancel_tokens.lock().unwrap().remove(&req.thread_id);
+                                state.chat_runs.lock().await.remove(&req.thread_id);
                                 return Ok(());
                             }
                         }
@@ -1094,7 +1099,7 @@ pub async fn chat_stream(
         }
     }
 
-    state.chat_cancel_tokens.lock().unwrap().remove(&req.thread_id);
+    state.chat_runs.lock().await.remove(&req.thread_id);
 
     if is_cancelled {
         emit(&StreamEventOut::Error {

--- a/src-tauri/src/chat/run.rs
+++ b/src-tauri/src/chat/run.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use crate::agent::cc_bridge::process::CcProcess;
+
+#[async_trait]
+pub trait ChatBridgeRun: Send + Sync {
+    async fn stop(&self);
+}
+
+#[async_trait]
+impl ChatBridgeRun for CcProcess {
+    async fn stop(&self) {
+        CcProcess::stop(self).await;
+    }
+}
+
+/// A provider-agnostic handle for one in-flight chat turn.
+///
+/// The drawer lifecycle only ever needs to stop "the current turn for this
+/// thread". Provider-specific details stay behind this enum, so future bridge
+/// providers can add variants without changing frontend IPC semantics.
+pub enum ChatRunHandle {
+    DirectLlm {
+        cancel: CancellationToken,
+    },
+    BridgeProcess {
+        provider_id: String,
+        run: Arc<dyn ChatBridgeRun>,
+    },
+}
+
+impl ChatRunHandle {
+    pub fn direct_llm(cancel: CancellationToken) -> Self {
+        Self::DirectLlm { cancel }
+    }
+
+    pub fn bridge_process<T>(provider_id: impl Into<String>, run: Arc<T>) -> Self
+    where
+        T: ChatBridgeRun + 'static,
+    {
+        let run: Arc<dyn ChatBridgeRun> = run;
+        Self::BridgeProcess {
+            provider_id: provider_id.into(),
+            run,
+        }
+    }
+
+    pub async fn stop(self) {
+        match self {
+            Self::DirectLlm { cancel } => cancel.cancel(),
+            Self::BridgeProcess {
+                provider_id: _provider_id,
+                run,
+            } => run.stop().await,
+        }
+    }
+}
+
+pub type ChatRunRegistry = Mutex<HashMap<String, ChatRunHandle>>;

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -6,6 +6,7 @@ use tokio::sync::RwLock;
 
 use crate::agent::cc_bridge::process::CcProcess;
 use crate::ai::AppAiCtx;
+use crate::chat::run::ChatRunRegistry;
 use crate::database::DbSession;
 use crate::filebrowser::sftp::ActiveSftp;
 use crate::filebrowser::transfer::TransferHandle;
@@ -92,8 +93,8 @@ pub struct AppState {
     pub vault: Arc<Vault>,
     /// Per-thread Claude Code process registry (v2.6).
     pub cc_processes: tokio::sync::Mutex<HashMap<String, Arc<CcProcess>>>,
-    /// Cancel tokens for in-flight chat streams, keyed by thread_id.
-    pub chat_cancel_tokens: Arc<std::sync::Mutex<HashMap<String, tokio_util::sync::CancellationToken>>>,
+    /// Provider-agnostic stop handles for in-flight chat turns, keyed by thread_id.
+    pub chat_runs: Arc<ChatRunRegistry>,
     /// Pending CC side-effect tool calls awaiting frontend execution, keyed by
     /// per-call id. See [`CcToolResponder`].
     pub cc_pending_tool_calls: Arc<Mutex<HashMap<String, CcToolResponder>>>,
@@ -126,7 +127,8 @@ pub struct AppState {
     /// turn via `ChatSendRequest.bound_db_connection_id`. The SQL/Redis MCP
     /// handlers resolve their bound connection from here (CC never names a
     /// connection id, so this is the only target — scope-safe by construction).
-    pub cc_db_bindings: Arc<RwLock<HashMap<String, String>>>,    /// Top-level AI context — holds AsrManager + LlmRouter.
+    pub cc_db_bindings: Arc<RwLock<HashMap<String, String>>>,
+    /// Top-level AI context — holds AsrManager + LlmRouter.
     /// Wrapped in RwLock so save_ai_config can hot-rebuild the router.
     pub ai_ctx: Arc<RwLock<AppAiCtx>>,
     /// Decentralized LAN messenger (LanChat) runtime state. Distinct from the
@@ -161,7 +163,7 @@ impl AppState {
             db: Mutex::new(db),
             vault,
             cc_processes: tokio::sync::Mutex::new(HashMap::new()),
-            chat_cancel_tokens: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            chat_runs: Arc::new(ChatRunRegistry::new(HashMap::new())),
             cc_pending_tool_calls: Arc::new(Mutex::new(HashMap::new())),
             cc_pending_permissions: Arc::new(Mutex::new(HashMap::new())),
             captures: Arc::new(crate::agent::capture::CaptureRegistry::new(
@@ -170,7 +172,8 @@ impl AppState {
             cc_capture_cancels: Arc::new(Mutex::new(HashMap::new())),
             cc_thread_cwd: Arc::new(Mutex::new(HashMap::new())),
             cc_tab_sessions: Arc::new(Mutex::new(HashMap::new())),
-            cc_db_bindings: Arc::new(RwLock::new(HashMap::new())),            ai_ctx: Arc::new(RwLock::new(ai_ctx)),
+            cc_db_bindings: Arc::new(RwLock::new(HashMap::new())),
+            ai_ctx: Arc::new(RwLock::new(ai_ctx)),
             lanchat,
         }
     }

--- a/src/components/chat/ChatDrawer.test.tsx
+++ b/src/components/chat/ChatDrawer.test.tsx
@@ -112,6 +112,7 @@ describe("ChatDrawer provider and echo controls", () => {
       streamingId: {},
       ccToolCards: {},
       ccUsage: {},
+      sendingByThreadId: {},
       sending: false,
       drawerOpen: true,
       drawerScope: "tab",

--- a/src/components/chat/ChatDrawer.tsx
+++ b/src/components/chat/ChatDrawer.tsx
@@ -27,7 +27,7 @@ interface ChatDrawerProps {
 export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
   const t = useT();
   const {
-    threads, activeThreadId, messages, sending, drawerOpen, drawerScope, drawerWidth,
+    threads, activeThreadId, messages, sendingByThreadId, drawerOpen, drawerScope, drawerWidth,
     loadThreads, newThread, deleteThread, setActiveThread, loadMessages,
     sendMessage, toggleDrawer, setDrawerWidth, purgeOldThreads, stopSending,
   } = useChatStore();
@@ -69,6 +69,7 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
   }, [activeTabId, activeTabType]);
 
   const activeMessages = activeThreadId ? (messages[activeThreadId] ?? []) : [];
+  const sending = activeThreadId ? sendingByThreadId[activeThreadId] === true : false;
   const activeThread = threads.find((t) => t.id === activeThreadId);
   const linkedTabTitle = activeThread?.linked_session_id
     ? (

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -67,6 +67,21 @@ function makeConfig(overrides: Partial<AiConfig> = {}): AiConfig {
   };
 }
 
+function makeThread(overrides: Partial<ChatThread> = {}): ChatThread {
+  return {
+    id: "thread-1",
+    title: "New chat",
+    provider_id: "claude-code",
+    created_at: 1,
+    updated_at: 1,
+    linked_session_id: null,
+    source: "drawer",
+    output_format: null,
+    cc_model: null,
+    ...overrides,
+  };
+}
+
 describe("chatStore new thread provider selection", () => {
   beforeEach(() => {
     invokeMock.mockReset();
@@ -85,6 +100,7 @@ describe("chatStore new thread provider selection", () => {
       streamingId: {},
       ccToolCards: {},
       ccUsage: {},
+      sendingByThreadId: {},
       sending: false,
       drawerOpen: false,
       drawerScope: null,
@@ -95,17 +111,10 @@ describe("chatStore new thread provider selection", () => {
     });
     invokeMock.mockImplementation((command: string, args: { providerId?: string | null; linkedSessionId?: string | null }) => {
       if (command !== "chat_new_thread") throw new Error(`unexpected command: ${command}`);
-      const thread: ChatThread = {
-        id: "thread-1",
-        title: "New chat",
+      const thread = makeThread({
         provider_id: args.providerId ?? "deepseek",
-        created_at: 1,
-        updated_at: 1,
         linked_session_id: args.linkedSessionId ?? null,
-        source: "drawer",
-        output_format: null,
-        cc_model: null,
-      };
+      });
       return Promise.resolve(thread);
     });
   });
@@ -134,17 +143,7 @@ describe("chatStore new thread provider selection", () => {
 
   it("opens a Claude Code thread instead of reusing another provider as the default", async () => {
     useChatStore.setState({
-      threads: [{
-        id: "old-thread",
-        title: "Old chat",
-        provider_id: "deepseek",
-        created_at: 1,
-        updated_at: 1,
-        linked_session_id: null,
-        source: "drawer",
-        output_format: null,
-        cc_model: null,
-      }],
+      threads: [makeThread({ id: "old-thread", title: "Old chat", provider_id: "deepseek" })],
     });
 
     await useChatStore.getState().openGlobalChat();
@@ -154,5 +153,114 @@ describe("chatStore new thread provider selection", () => {
       linkedSessionId: null,
     });
     expect(useChatStore.getState().activeThreadId).toBe("thread-1");
+  });
+});
+
+describe("chatStore drawer lifecycle", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(null);
+    useAiStore.setState({
+      config: makeConfig(),
+      loading: false,
+      saving: false,
+      testResults: {},
+      voiceShellEnabled: false,
+    });
+    useChatStore.setState({
+      threads: [
+        makeThread({ id: "thread-a", linked_session_id: "term-a" }),
+        makeThread({ id: "thread-b", linked_session_id: "term-b" }),
+        makeThread({ id: "global-thread", linked_session_id: null }),
+      ],
+      threadsLoaded: true,
+      activeThreadId: "thread-a",
+      messages: {},
+      streamingId: {},
+      ccToolCards: {},
+      ccUsage: {},
+      sendingByThreadId: { "thread-a": true },
+      sending: true,
+      drawerOpen: true,
+      drawerScope: "tab",
+      drawerTabId: "term-a",
+      tabDrawerOpenByTabId: { "term-a": true },
+      drawerWidth: 380,
+      pendingComposerText: "",
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hides a tab-bound drawer on active-tab sync without stopping the running thread", async () => {
+    await useChatStore.getState().syncTabChatWithActiveTab("term-b");
+
+    expect(invokeMock).not.toHaveBeenCalledWith("chat_stop_stream", expect.anything());
+    expect(useChatStore.getState()).toMatchObject({
+      drawerOpen: false,
+      drawerScope: "tab",
+      drawerTabId: "term-b",
+      sending: true,
+      sendingByThreadId: { "thread-a": true },
+      tabDrawerOpenByTabId: { "term-a": true },
+    });
+  });
+
+  it("hides a tab-bound drawer when switching to a non-chat tab without stopping", async () => {
+    await useChatStore.getState().syncTabChatWithActiveTab(null);
+
+    expect(invokeMock).not.toHaveBeenCalledWith("chat_stop_stream", expect.anything());
+    expect(useChatStore.getState()).toMatchObject({
+      drawerOpen: false,
+      drawerTabId: null,
+      sending: true,
+      sendingByThreadId: { "thread-a": true },
+      tabDrawerOpenByTabId: { "term-a": true },
+    });
+  });
+
+  it("lets automatic visibility changes hide the drawer without stopping", () => {
+    useChatStore.getState().setDrawerOpen(false);
+
+    expect(invokeMock).not.toHaveBeenCalledWith("chat_stop_stream", expect.anything());
+    expect(useChatStore.getState()).toMatchObject({
+      drawerOpen: false,
+      sending: true,
+      sendingByThreadId: { "thread-a": true },
+    });
+  });
+
+  it("stops the active thread when the user explicitly closes a tab drawer", async () => {
+    await useChatStore.getState().toggleTabChat("term-a");
+
+    expect(invokeMock).toHaveBeenCalledWith("chat_stop_stream", { threadId: "thread-a" });
+    expect(useChatStore.getState()).toMatchObject({
+      drawerOpen: false,
+      sending: false,
+      sendingByThreadId: {},
+      tabDrawerOpenByTabId: { "term-a": false },
+    });
+  });
+
+  it("stops the active thread when the user explicitly closes a global drawer", async () => {
+    useChatStore.setState({
+      activeThreadId: "global-thread",
+      drawerOpen: true,
+      drawerScope: "global",
+      drawerTabId: null,
+      sendingByThreadId: { "global-thread": true },
+      sending: true,
+    });
+
+    await useChatStore.getState().toggleGlobalChat();
+
+    expect(invokeMock).toHaveBeenCalledWith("chat_stop_stream", { threadId: "global-thread" });
+    expect(useChatStore.getState()).toMatchObject({
+      drawerOpen: false,
+      sending: false,
+      sendingByThreadId: {},
+    });
   });
 });

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -90,6 +90,11 @@ interface ChatStore {
   ccToolCards: Record<string, CcToolCard[]>;
   /// Claude Code usage rollup per assistant message id (3.5), for the footer.
   ccUsage: Record<string, CcUsage>;
+  /// In-flight send state by thread. A tab switch can change `activeThreadId`
+  /// while the original turn keeps running, so lifecycle must stay thread-bound.
+  sendingByThreadId: Record<string, boolean>;
+  /// Back-compat aggregate used by older call sites/tests. Prefer
+  /// `sendingByThreadId[threadId]` when a specific drawer/thread is rendered.
   sending: boolean;
   drawerOpen: boolean;
   /// "global" for title/status/shortcut entry points, "tab" for terminal-bound chat.
@@ -128,6 +133,8 @@ interface ChatStore {
   /// Export every thread + message to `outPath` as JSON.
   exportArchive: (outPath: string) => Promise<number>;
   toggleDrawer: () => void;
+  /// Visibility-only primitive. Do not stop in-flight AI work here; callers that
+  /// mean "user explicitly closed the drawer" should use the toggle/close paths.
   setDrawerOpen: (open: boolean) => void;
   openGlobalChat: () => Promise<void>;
   toggleGlobalChat: () => Promise<void>;
@@ -170,6 +177,27 @@ function scopeForThread(thread: ChatThread | undefined | null): {
     : { drawerScope: "global", drawerTabId: null };
 }
 
+function nextSendingAggregate(sendingByThreadId: Record<string, boolean>): boolean {
+  return Object.values(sendingByThreadId).some(Boolean);
+}
+
+function nextThreadSendingState(
+  current: Record<string, boolean>,
+  threadId: string,
+  sending: boolean,
+): Pick<ChatStore, "sendingByThreadId" | "sending"> {
+  const next = { ...current };
+  if (sending) {
+    next[threadId] = true;
+  } else {
+    delete next[threadId];
+  }
+  return {
+    sendingByThreadId: next,
+    sending: nextSendingAggregate(next),
+  };
+}
+
 async function resolveDefaultProviderId(): Promise<string | null> {
   try {
     const { defaultChatProviderId, useAiStore } = await import("./aiStore");
@@ -192,6 +220,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   streamingId: {},
   ccToolCards: {},
   ccUsage: {},
+  sendingByThreadId: {},
   sending: false,
   drawerOpen: false,
   drawerScope: null,
@@ -287,7 +316,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   },
 
   sendMessage: async (threadId: string, content: string, terminalContext?: string) => {
-    set({ sending: true });
+    set((s) => nextThreadSendingState(s.sendingByThreadId, threadId, true));
 
     // Phase 3.S — resolve the saved SessionConfig.id this thread is bound to so
     // the backend can build Claude Code's session-identity card.
@@ -511,7 +540,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       }
     } finally {
       if (unlisten) unlisten();
-      set({ sending: false });
+      set((s) => nextThreadSendingState(s.sendingByThreadId, threadId, false));
     }
   },
 
@@ -521,7 +550,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     } catch (e) {
       console.error("chat_stop_stream failed:", e);
     }
-    set({ sending: false });
+    set((s) => nextThreadSendingState(s.sendingByThreadId, threadId, false));
   },
 
   toggleDrawer: () => {
@@ -539,12 +568,6 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     });
   },
   setDrawerOpen: (open) => {
-    if (!open) {
-      const s = get();
-      if (s.activeThreadId) {
-        void get().stopSending(s.activeThreadId);
-      }
-    }
     set({ drawerOpen: open });
   },
   setDrawerWidth: (w) => set({ drawerWidth: Math.max(50, Math.min(720, w)) }),
@@ -619,9 +642,6 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
     if (!tabId) {
       if (s.drawerScope === "tab" && s.drawerOpen) {
-        if (s.activeThreadId) {
-          void get().stopSending(s.activeThreadId);
-        }
         set({ drawerOpen: false, drawerTabId: null });
       }
       return;
@@ -633,9 +653,6 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     }
 
     if (s.drawerScope === "tab" && s.drawerOpen) {
-      if (s.activeThreadId) {
-        void get().stopSending(s.activeThreadId);
-      }
       set({ drawerOpen: false, drawerTabId: tabId });
     }
   },


### PR DESCRIPTION
The chat drawer lifecycle previously treated active-tab synchronization as a drawer close. When a tab-bound drawer was hidden because the user switched to another tab, chatStore called stopSending(), which invoked chat_stop_stream and killed the active AI run. This was especially visible with Claude Code bridge, but the behavior was wrong for every chat provider and would affect future bridge runtimes as well.\n\nChange the frontend lifecycle so visibility-only paths do not stop in-flight work:\n- make setDrawerOpen(false) a pure visibility change for responsive/automatic hiding\n- remove stopSending() from syncTabChatWithActiveTab() so tab switches only hide/sync the drawer\n- keep explicit user close actions, such as toggleTabChat(), toggleGlobalChat(), and the drawer close button, as the only frontend paths that stop the active thread\n- track sending state by thread via sendingByThreadId so an in-flight turn remains associated with its original thread even if activeThreadId changes\n\nAdd a provider-agnostic backend run registry for in-flight chat turns:\n- introduce chat::run::ChatRunHandle and ChatBridgeRun\n- register direct LLM streams through a cancellation token handle\n- register Claude Code bridge turns through the same stop abstraction\n- keep chat_stop_stream(thread_id) as the single IPC stop entry point, ready for future Codex/Agy/Kiro-style bridge providers to implement ChatBridgeRun without changing frontend semantics\n\nAdd regression coverage for the lifecycle contract:\n- active-tab sync to another chat-capable tab does not call chat_stop_stream\n- active-tab sync to a non-chat tab does not call chat_stop_stream\n- automatic setDrawerOpen(false) does not stop AI work\n- explicit global/tab drawer close still stops the active thread\n\nVerified with:\n- vitest run src/stores/chatStore.test.ts src/components/chat/ChatDrawer.test.tsx\n- tsc -b\n- npm test\n- cargo check\n- cargo test chat::cc_tool_use_tests\n- git diff --check