### PR TITLE
fix(terminal): add configurable WebGL fallback

### DIFF
--- a/src/components/terminal/TerminalAppearanceSettings.test.tsx
+++ b/src/components/terminal/TerminalAppearanceSettings.test.tsx
@@ -9,8 +9,16 @@ const ipcMocks = vi.hoisted(() => ({
   historyClear: vi.fn(async () => undefined),
 }));
 
+const runtimeMocks = vi.hoisted(() => ({
+  getAppPlatform: vi.fn(() => "linux"),
+}));
+
 vi.mock("../../lib/ipc", () => ({
   ...ipcMocks,
+}));
+
+vi.mock("../../lib/runtime", () => ({
+  getAppPlatform: runtimeMocks.getAppPlatform,
 }));
 
 function renderAppearance(profile: TerminalProfile = DEFAULT_TERMINAL_PROFILE) {
@@ -23,6 +31,8 @@ describe("TerminalAppearanceSettings", () => {
   beforeEach(() => {
     ipcMocks.listSystemFonts.mockReset();
     ipcMocks.listSystemFonts.mockResolvedValue(["Arial", "Source Code Pro", "JetBrains Mono"]);
+    runtimeMocks.getAppPlatform.mockReset();
+    runtimeMocks.getAppPlatform.mockReturnValue("linux");
   });
 
   afterEach(() => {
@@ -105,6 +115,27 @@ describe("TerminalAppearanceSettings", () => {
 
     expect(onProfileChange).toHaveBeenLastCalledWith(expect.objectContaining({
       allowRemoteOsc52Clipboard: true,
+    }));
+  });
+
+  it("hides the WebGL renderer setting outside Windows", () => {
+    renderAppearance();
+
+    expect(screen.queryByRole("checkbox", { name: "Use WebGL renderer" })).not.toBeInTheDocument();
+  });
+
+  it("updates the Windows WebGL renderer setting", async () => {
+    runtimeMocks.getAppPlatform.mockReturnValue("windows");
+    const user = userEvent.setup();
+    const { onProfileChange } = renderAppearance();
+
+    const checkbox = screen.getByRole("checkbox", { name: "Use WebGL renderer" });
+    expect(checkbox).toBeChecked();
+
+    await user.click(checkbox);
+
+    expect(onProfileChange).toHaveBeenLastCalledWith(expect.objectContaining({
+      webglRenderer: false,
     }));
   });
 });

--- a/src/components/terminal/TerminalAppearanceSettings.tsx
+++ b/src/components/terminal/TerminalAppearanceSettings.tsx
@@ -25,6 +25,7 @@ import {
 import { historyClear } from "../../lib/ipc";
 import { useT, type TranslateFn } from "../../lib/i18n";
 import { confirmAppDialog } from "../../lib/appDialogs";
+import { getAppPlatform } from "../../lib/runtime";
 
 interface TerminalAppearanceSettingsProps {
   profile: TerminalProfile;
@@ -64,6 +65,7 @@ export function TerminalAppearanceSettings({
   const cursorOptions = useMemo(() => buildCursorOptions(t), [t]);
   const rightClickOptions = useMemo(() => buildRightClickOptions(t), [t]);
   const fontState = useSystemFonts();
+  const isWindows = getAppPlatform() === "windows";
   const fontOptions = useTerminalFontOptions(fontState.fonts);
   const partitionedFonts = useMemo(() => {
     const mono: string[] = [];
@@ -375,6 +377,13 @@ export function TerminalAppearanceSettings({
               checked={profile.showScrollbar}
               onChange={(checked) => updateProfile({ showScrollbar: checked })}
             />
+            {isWindows && (
+              <CheckControl
+                label={t("terminalAppearance.webglRenderer")}
+                checked={profile.webglRenderer}
+                onChange={(checked) => updateProfile({ webglRenderer: checked })}
+              />
+            )}
             <CheckControl
               label={t("terminalAppearance.copyOnSelect")}
               checked={profile.copyOnSelect}

--- a/src/components/terminal/TerminalPanel.test.tsx
+++ b/src/components/terminal/TerminalPanel.test.tsx
@@ -68,11 +68,30 @@ const fitMocks = vi.hoisted(() => ({
   fit: vi.fn(),
 }));
 
-const webglMocks = vi.hoisted(() => ({
-  ctor: vi.fn().mockImplementation(function () {
-    return {};
-  }),
-}));
+const webglMocks = vi.hoisted(() => {
+  const instances: Array<{
+    contextLossDispose: ReturnType<typeof vi.fn>;
+    contextLossHandler: (() => void) | null;
+    dispose: ReturnType<typeof vi.fn>;
+    onContextLoss: ReturnType<typeof vi.fn>;
+  }> = [];
+
+  const ctor = vi.fn().mockImplementation(function () {
+    const instance = {
+      contextLossDispose: vi.fn(),
+      contextLossHandler: null as (() => void) | null,
+      dispose: vi.fn(),
+      onContextLoss: vi.fn((handler: () => void) => {
+        instance.contextLossHandler = handler;
+        return { dispose: instance.contextLossDispose };
+      }),
+    };
+    instances.push(instance);
+    return instance;
+  });
+
+  return { ctor, instances };
+});
 
 const ipcMocks = vi.hoisted(() => {
   const terminalExitHandlers = new Map<string, () => void>();
@@ -212,6 +231,7 @@ describe("TerminalPanel focus behavior", () => {
       ipcMocks.terminalExitHandlers.set(sessionId, callback);
       return vi.fn(() => ipcMocks.terminalExitHandlers.delete(sessionId));
     });
+    webglMocks.instances.length = 0;
     webglMocks.ctor.mockClear();
     vi.stubGlobal("ResizeObserver", ResizeObserverMock);
     vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
@@ -257,6 +277,39 @@ describe("TerminalPanel focus behavior", () => {
         value: originalPlatform,
       });
     }
+  });
+
+  it("does not load the WebGL renderer when disabled in the terminal profile", async () => {
+    render(
+      <TerminalPanel
+        visible
+        terminalProfile={{
+          ...DEFAULT_TERMINAL_PROFILE,
+          webglRenderer: false,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(terminalMocks.terminalCtor).toHaveBeenCalled();
+    });
+    expect(webglMocks.ctor).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default renderer when the WebGL context is lost", async () => {
+    render(<TerminalPanel visible terminalProfile={DEFAULT_TERMINAL_PROFILE} />);
+
+    await waitFor(() => {
+      expect(webglMocks.ctor).toHaveBeenCalledTimes(1);
+    });
+
+    const term = terminalMocks.terminalCtor.mock.results[0].value;
+    const webgl = webglMocks.instances[0];
+    webgl.contextLossHandler?.();
+
+    expect(webgl.contextLossDispose).toHaveBeenCalledTimes(1);
+    expect(webgl.dispose).toHaveBeenCalledTimes(1);
+    expect(term.refresh).toHaveBeenCalledWith(0, 23);
   });
 
   it("focuses the terminal when a hidden tab becomes active", async () => {

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -346,6 +346,7 @@ export function TerminalPanel({
   const [fontSize, setFontSize] = useState(initialProfile.fontSize);
   const [fontLigatures, setFontLigatures] = useState(initialProfile.fontLigatures);
   const [showScrollbar, setShowScrollbar] = useState(initialProfile.showScrollbar);
+  const [webglRenderer, setWebglRenderer] = useState(initialProfile.webglRenderer);
   const [readOnly, setReadOnly] = useState(initialProfile.readOnly);
   const [themeName, setThemeName] = useState(initialProfile.theme || theme);
   const [cursorStyle, setCursorStyle] = useState(initialProfile.cursorStyle);
@@ -398,6 +399,7 @@ export function TerminalPanel({
   const outputLogRef = useRef("");
   const loggingActiveRef = useRef(loggingActive);
   const copyOnSelectRef = useRef(copyOnSelect);
+  const webglRendererRef = useRef(webglRenderer);
   const allowRemoteOsc52ClipboardRef = useRef(allowRemoteOsc52Clipboard);
   const macroRecordingRef = useRef(macroRecording);
   const macroBufferRef = useRef("");
@@ -408,6 +410,10 @@ export function TerminalPanel({
   const isComposingRef = useRef(false);
   const compositionBufferRef = useRef<Uint8Array[]>([]);
   const injectedInputEchoSuppressorRef = useRef<InputEchoSuppressor | null>(null);
+  const webglAddonRef = useRef<{
+    addon: WebglAddon;
+    contextLossDisposable: { dispose: () => void } | null;
+  } | null>(null);
   const suppressNativePasteUntilRef = useRef(0);
   const middleClickSelectionRef = useRef("");
   const blockSelectionRef = useRef<TerminalBlockSelection | null>(null);
@@ -473,6 +479,47 @@ export function TerminalPanel({
   const focusTerminal = useCallback(() => {
     termRef.current?.focus();
   }, []);
+
+  const disposeTerminalWebgl = useCallback((term: Terminal | null) => {
+    const record = webglAddonRef.current;
+    if (!record) return;
+
+    webglAddonRef.current = null;
+    record.contextLossDisposable?.dispose();
+    try {
+      record.addon.dispose();
+    } catch {
+      /* WebGL addon disposal is best-effort during renderer fallback. */
+    }
+    if (term) {
+      term.refresh(0, Math.max(0, term.rows - 1));
+    }
+  }, []);
+
+  const installTerminalWebgl = useCallback((term: Terminal) => {
+    if (!shouldUseTerminalWebgl(webglRendererRef.current) || webglAddonRef.current) return;
+
+    let addon: WebglAddon | null = null;
+    let contextLossDisposable: { dispose: () => void } | null = null;
+    try {
+      addon = new WebglAddon();
+      const currentAddon = addon;
+      contextLossDisposable = currentAddon.onContextLoss(() => {
+        if (webglAddonRef.current?.addon !== currentAddon) return;
+        disposeTerminalWebgl(term);
+        setStatusMessage("Terminal WebGL renderer lost; using stable renderer");
+      });
+      term.loadAddon(currentAddon);
+      webglAddonRef.current = { addon: currentAddon, contextLossDisposable };
+    } catch {
+      contextLossDisposable?.dispose();
+      try {
+        addon?.dispose();
+      } catch {
+        /* WebGL not available. */
+      }
+    }
+  }, [disposeTerminalWebgl, setStatusMessage]);
 
   const collectReattachState = useCallback((): TerminalReattachState => {
     const term = termRef.current;
@@ -1791,6 +1838,7 @@ export function TerminalPanel({
     setFontSize(terminalProfile.fontSize);
     setFontLigatures(terminalProfile.fontLigatures);
     setShowScrollbar(terminalProfile.showScrollbar);
+    setWebglRenderer(terminalProfile.webglRenderer);
     setReadOnly(terminalProfile.readOnly);
     setThemeName(terminalProfile.theme || theme);
     setCursorStyle(terminalProfile.cursorStyle);
@@ -1979,11 +2027,7 @@ export function TerminalPanel({
       detachImeGuard = attachTerminalImeGuard(el, guard);
     }
 
-    if (shouldUseTerminalWebgl()) {
-      try {
-        term.loadAddon(new WebglAddon());
-      } catch { /* WebGL not available */ }
-    }
+    installTerminalWebgl(term);
 
     fitVisibleTerminal();
 
@@ -2464,6 +2508,7 @@ export function TerminalPanel({
         }
       }
       term.dispose();
+      webglAddonRef.current = null;
       termRef.current = null;
       fitAddonRef.current = null;
       searchAddonRef.current = null;
@@ -2476,6 +2521,18 @@ export function TerminalPanel({
       initializedRef.current = false;
     };
   }, []);
+
+  useEffect(() => {
+    webglRendererRef.current = webglRenderer;
+    const term = termRef.current;
+    if (!term) return;
+
+    if (!shouldUseTerminalWebgl(webglRenderer)) {
+      disposeTerminalWebgl(term);
+      return;
+    }
+    installTerminalWebgl(term);
+  }, [disposeTerminalWebgl, installTerminalWebgl, webglRenderer]);
 
   useEffect(() => {
     const term = termRef.current;
@@ -3729,7 +3786,8 @@ function terminalProfileSignature(profile: TerminalProfile): string {
   return JSON.stringify(profile);
 }
 
-function shouldUseTerminalWebgl(): boolean {
+function shouldUseTerminalWebgl(enabled: boolean): boolean {
+  if (!enabled) return false;
   // Tauri uses WKWebView on macOS. On Intel/older macOS builds the WebGL
   // renderer can flash, lose context, or leave the terminal blank, while
   // xterm's default renderer stays stable for PTY/SSH output.

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1603,6 +1603,7 @@ const dict = {
     rightClickPaste: "Paste clipboard",
     rightClickCopyOrPaste: "Copy selection or paste",
     showScrollbar: "Show terminal scrollbar",
+    webglRenderer: "Use WebGL renderer",
     copyOnSelect: "Copy on select",
     allowOsc52: "Allow SSH OSC 52 clipboard",
     readOnly: "Read-only terminal",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -1599,6 +1599,7 @@ export const zhCN: DeepPartial<typeof en> = {
     rightClickPaste: "粘贴剪贴板",
     rightClickCopyOrPaste: "有选区则复制，否则粘贴",
     showScrollbar: "显示终端滚动条",
+    webglRenderer: "启用 WebGL 渲染器",
     copyOnSelect: "选中即复制",
     allowOsc52: "允许 SSH OSC 52 剪贴板",
     readOnly: "终端只读",

--- a/src/lib/terminalProfile.ts
+++ b/src/lib/terminalProfile.ts
@@ -21,6 +21,7 @@ export interface TerminalProfile {
   cursorStyle: TerminalCursorStyle;
   cursorBlink: boolean;
   showScrollbar: boolean;
+  webglRenderer: boolean;
   copyOnSelect: boolean;
   allowRemoteOsc52Clipboard: boolean;
   rightClickBehavior: TerminalRightClickBehavior;
@@ -52,6 +53,7 @@ export const DEFAULT_TERMINAL_PROFILE: TerminalProfile = {
   cursorStyle: "block",
   cursorBlink: true,
   showScrollbar: true,
+  webglRenderer: true,
   copyOnSelect: false,
   allowRemoteOsc52Clipboard: false,
   rightClickBehavior: "menu",
@@ -140,6 +142,7 @@ export function normalizeTerminalProfile(input: unknown): TerminalProfile {
     ),
     cursorBlink: readBoolean(source.cursorBlink, DEFAULT_TERMINAL_PROFILE.cursorBlink),
     showScrollbar: readBoolean(source.showScrollbar, DEFAULT_TERMINAL_PROFILE.showScrollbar),
+    webglRenderer: readBoolean(source.webglRenderer, DEFAULT_TERMINAL_PROFILE.webglRenderer),
     copyOnSelect: readBoolean(source.copyOnSelect, DEFAULT_TERMINAL_PROFILE.copyOnSelect),
     allowRemoteOsc52Clipboard: readBoolean(
       source.allowRemoteOsc52Clipboard,


### PR DESCRIPTION
Add a webglRenderer terminal profile flag that defaults to enabled and is normalized for existing saved profiles.

Expose the WebGL renderer toggle only on Windows in terminal appearance settings, with English and Chinese labels.

Track the xterm WebglAddon instance so context loss disposes the addon and refreshes the terminal, falling back to the default renderer without restarting the app. The same path is used when the setting is disabled at runtime.

Cover the Windows-only settings control, disabled WebGL startup path, and context-loss fallback with focused Vitest tests.

Tests: pnpm exec tsc -b --pretty false; pnpm exec vitest run src/components/terminal/TerminalAppearanceSettings.test.tsx src/components/terminal/TerminalPanel.test.tsx; pnpm exec vitest run src/lib/sessionImportExport.test.ts src/components/session/SessionEditor.test.tsx src/layouts/MainLayout.test.tsx