### PR TITLE
fix(chat): dismiss AI drawer without tab auto-restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ src-tauri/frameworks/
 .kiro/
 .agent/
 .codex
-CLAUDE.md
 
 # Generic AI cache / vector index
 .ai-cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Taomni is a cross-platform AI-native remote workspace for developers (a MobaXterm alternative) built with Tauri 2 + React 19 + TypeScript. It bundles local/SSH terminals, SFTP file browsing, RDP/VNC viewers, port tunneling, database clients, object storage, and LAN peer chat, with AI capabilities (command generation, agent, chat, voice) woven through the workflow.
+
+## Development Commands
+
+```bash
+pnpm install              # Install dependencies
+pnpm tauri dev            # Full desktop app dev mode (Rust + frontend, Vite on port 1980)
+pnpm dev                  # Frontend-only dev server (port 5000, uses stubs for Tauri APIs)
+pnpm build                # Build frontend (tsc -b + vite build)
+pnpm tauri build          # Build desktop app bundle (runs pnpm build first)
+pnpm test                 # Run all tests (vitest run)
+npx vitest run src/path/to/file.test.ts  # Run a single test file
+npx vitest                # Watch mode
+```
+
+Rust backend: build/check happens through `pnpm tauri dev` / `pnpm tauri build`, or run `cargo` directly inside `src-tauri/`. Default features include `hbase-kerberos`; other optional features (`voice-capture`, `screen-capture`, `native-av`, `asr-sherpa-onnx`, `vulkan-detect`, `local-llm-fim`) are off by default.
+
+## Architecture
+
+### Frontend (src/)
+- **Framework**: React 19 + TypeScript + Vite + Tailwind CSS v4
+- **State**: Zustand stores in `src/stores/` (session, sftp, transfer, app, vnc, rdp, servers, chat, ai, vault, objectStorage, capture, update, and lanchat-related lanChat/lanCall/lanWb stores)
+- **IPC layer**: `src/lib/ipc.ts` wraps Tauri `invoke()`; other `src/lib/` files handle SFTP, zmodem, themes, network settings, session import/export, terminal profiles, SQL/HBase statement parsing, object storage, and LAN RTC
+- **Terminal**: xterm.js with WebGL renderer + fit/search/web-links addons
+- **Editor**: CodeMirror 6 for the SQL client editor
+- **Layout**: `src/layouts/MainLayout.tsx` is the main shell; components organized by feature under `src/components/`
+- **i18n**: `src/lib/i18n/locales/` (en, zh-CN)
+
+### Backend (src-tauri/src/)
+- **Entry**: `lib.rs` registers ~290 Tauri commands and drives startup in `.setup()`: legacy-identity migration (`migrate.rs`) → SQLite init (`session::db::init_db`) → vault open → AI context construction (`ai::AppAiCtx::from_config`, ASR + LLM router, resolves `vault:<id>` api keys) → `app.manage(AppState)` → autostart tunnels/servers → main window creation (+ Linux `with_webview` WebRTC/media-stream enablement for LanChat)
+- **State**: `state.rs` holds the shared `AppState` — `Mutex`/`RwLock`-wrapped maps of live sessions (terminals, sftp, transfers, tunnels, servers, vnc, rdp, db, object storage), the SQLite connection, `Vault`, AI context, and LanChat state. Also defines the oneshot-responder plumbing for SSH keyboard-interactive auth and the Claude Code MCP HITL flow (`CcToolResponder`, `CcPermissionResponder`)
+- **Async**: tokio runtime for SSH, SFTP, tunnel, VNC, RDP, database, LAN, and AI operations
+
+Major modules:
+- `terminal/` — SSH (russh) + local PTY (portable-pty); proxy and single-level SSH jump host (`network.rs`, `ssh.rs`), shell-integration cwd tracking (`shell_integration.rs`), X11 forwarding (`x11_forward.rs`)
+- `filebrowser/` — SFTP + local file ops + transfer queue
+- `session/` — SQLite session/group persistence; imports from PuTTY / WSL / Tabby / OpenSSH (`import.rs`, `import_secrets/`)
+- `tunnel/` — local/remote/dynamic port forwarding with autostart
+- `proxy/`, `nettools/` — shared proxy plumbing and network utilities
+- `vnc/` — RFB protocol client + WebSocket bridge; `rdp/` — RDP client (ironrdp)
+- `servers/` — local servers, including an RDP **server** (`servers/rdp/`) with screen capture + cross-platform input injection (enigo)
+- `database/` — SQL clients (MySQL/PostgreSQL via sqlx, SQL Server via tiberius, ClickHouse via HTTP) and Redis; connections can route through proxy / SSH jump host (`forward.rs`)
+- `hbase/` — native HBase RPC client (prost protobuf + ZooKeeper region discovery, `hbase/native/`) plus a Thrift2-over-HTTP backend for Aliyun Lindorm / HBase enhanced (`hbase/thrift/`, bindings pre-generated in `idl.rs`)
+- `objectstorage/` — S3-family (rusty-s3) and Azure Blob storage with credentials, sessions, and a transfer queue
+- `lanchat/` — P2P LAN messaging/file transfer with mDNS discovery, mutual TLS (`tls.rs`), and optional native A/V media stack (`media/`, behind `native-av`)
+- `ai/` — LLM-backed shell command generation with safety auditing (`shell_safety.rs`, `network_policy.rs`, `session_safety.rs`)
+- `agent/` — agent tool execution, web search (SearXNG/Exa/Google CSE), Claude Code bridge (`cc_bridge/`, in-app Streamable-HTTP MCP server via rmcp+axum), Codex bridge (`codex_bridge/`), output capture/reduce (`capture/`, jaq jq engine)
+- `chat/` — AI chat threads/messages; `llm/` — llama.cpp sidecar; `models/` — model download manager (+ CUDA pack)
+- `voice/` + `asr/` — voice capture (cpal) + speech-to-text
+- `vault/` — encrypted credential store (argon2 + aes-gcm + OS keyring)
+- `config/`, `tab/`, `history.rs`, `serial/`, `wsl/`, `windowing/`, `appearance.rs`, `update.rs`, `perf.rs`
+
+### Vendored crates
+`src-tauri/vendor/` holds patched forks (ironrdp-connector, picky, picky-krb, sspi, winscard, portable-pty), wired in via `[patch.crates-io]` in `Cargo.toml`. Upgrading these crates requires re-applying or re-vendoring the patches.
+
+### Dev-mode Stubs
+When running `pnpm dev` (no Tauri), `vite.config.ts` aliases `@tauri-apps/api/*` and the dialog/shell/notification plugins to stub implementations in `src/stubs/` (tauri-core, tauri-event, tauri-window, tauri-shell, etc., plus sshClient/sftpClient/localVfs). Custom Vite plugins in `vite-plugins/` provide SSH, SFTP, and RDP proxy servers (Node ssh2/ws) so the frontend can be developed without the Rust backend. These plugins are only loaded when `TAURI_ENV_PLATFORM` is unset.
+
+### Communication Pattern
+Frontend calls Tauri commands (Rust `#[tauri::command]`) via `invoke()`. Terminal, SFTP, database stream, AI/chat token streams, and LanChat use Tauri events (`emit`/`listen`) for bidirectional async communication between Rust and the webview. The Claude Code agent bridge inverts this: the in-app MCP server dispatches side-effect tool calls back to the frontend via events and blocks on a oneshot until `cc_resolve_tool_call` / `cc_resolve_permission` delivers the human's outcome.
+
+## Key Conventions
+
+- App version lives in root `package.json`; `tauri.conf.json` reads it via `"version": "../package.json"`, and Vite exposes it as `__APP_VERSION__`. `Cargo.toml` has a separate Rust crate version — the published app version is the `package.json` one.
+- App identifier is `com.taomni.app`; the window has `decorations: false` — the app renders its own title bar (`src/components/window/`)
+- ES2022 build target in Vite (Tauri 2 targets modern WebView)
+- Database: SQLite named `taomni.db` in the platform app-data directory (resolved from the `com.taomni.app` identifier)
+- Release: push a `v<version>` git tag (must equal `v` + `package.json` version) to trigger GitHub Actions cross-platform builds; manual `Release Bundle` workflow runs without a tag produce artifacts only
+- Formatting: do not run project-wide `cargo fmt` (it churns large numbers of unrelated files). Only format the code you changed this session (e.g. apply rustfmt to the changed lines/files), keeping the diff minimal
+
+## Testing
+
+- Vitest with jsdom environment; setup file `src/test/setup.ts`. `.claude/worktrees/**` is excluded from test discovery (parallel worktrees carry a second React copy that crashes hooks)
+- Rust unit tests live in `#[cfg(test)] mod tests` blocks within modules; integration tests under `src-tauri/tests/`
+- UI automation tests defined as YAML under `qa-ui-auto-tests/cases/*.testcase.yaml` (Playwright-based, see `qa-ui-auto` skill)
+
+## Environment Requirements
+
+- Node.js 18+, pnpm, Rust 1.94+
+- Tauri system dependencies (WebView2 on Windows, webkit2gtk on Linux)
+- `protoc` (Protocol Buffers compiler) for the native HBase client build
+- `nasm` is required when building with the `native-av` feature (openh264 x86 asm)

--- a/src/components/chat/ChatDrawer.test.tsx
+++ b/src/components/chat/ChatDrawer.test.tsx
@@ -225,6 +225,18 @@ describe("ChatDrawer layout resizing", () => {
     vi.clearAllMocks();
   });
 
+  it("dismisses a floating drawer on outside pointer down", () => {
+    useChatStore.setState({ drawerPosition: "top" });
+    render(<ChatDrawer />);
+
+    fireEvent.pointerDown(document.body);
+
+    expect(useChatStore.getState()).toMatchObject({
+      drawerOpen: false,
+      tabDrawerOpenByTabId: { "term-1": false },
+    });
+  });
+
   it("resizes a top drawer by dragging its bottom edge", () => {
     useChatStore.setState({ drawerPosition: "top" });
     render(<ChatDrawer />);

--- a/src/components/chat/ChatDrawer.tsx
+++ b/src/components/chat/ChatDrawer.tsx
@@ -53,7 +53,7 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
     drawerHeight, drawerPosition, drawerPinned, drawerTabId,
     loadThreads, newThread, deleteThread, setActiveThread, loadMessages,
     sendMessage, hideDrawer, setDrawerWidth, setDrawerHeight, setDrawerPosition,
-    setDrawerPinned, setDrawerOpen, purgeOldThreads, stopSending,
+    setDrawerPinned, dismissDrawer, purgeOldThreads, stopSending,
   } = useChatStore();
 
   const [showHistory, setShowHistory] = useState(false);
@@ -332,12 +332,12 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
         return;
       }
       setShowPositionMenu(false);
-      setDrawerOpen(false);
+      dismissDrawer();
     };
 
     window.addEventListener("pointerdown", onPointerDown, true);
     return () => window.removeEventListener("pointerdown", onPointerDown, true);
-  }, [drawerOpen, floating, setDrawerOpen]);
+  }, [dismissDrawer, drawerOpen, floating]);
 
   // Drag-to-resize the drawer.
   const handleResizeStart = (

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -257,6 +257,25 @@ describe("chatStore drawer lifecycle", () => {
     });
   });
 
+  it("dismisses the active tab drawer and prevents tab sync from reopening it", async () => {
+    useChatStore.getState().dismissDrawer();
+
+    expect(invokeMock).not.toHaveBeenCalledWith("chat_stop_stream", expect.anything());
+    expect(useChatStore.getState()).toMatchObject({
+      drawerOpen: false,
+      sending: true,
+      sendingByThreadId: { "thread-a": true },
+      tabDrawerOpenByTabId: { "term-a": false },
+    });
+
+    await useChatStore.getState().syncTabChatWithActiveTab("term-a");
+
+    expect(useChatStore.getState()).toMatchObject({
+      drawerOpen: false,
+      tabDrawerOpenByTabId: { "term-a": false },
+    });
+  });
+
   it("hides the active tab drawer without stopping the running thread", async () => {
     await useChatStore.getState().toggleTabChat("term-a");
 

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -219,9 +219,12 @@ interface ChatStore {
   /// Export every thread + message to `outPath` as JSON.
   exportArchive: (outPath: string) => Promise<number>;
   toggleDrawer: () => void;
-  /// Visibility-only primitive. Hiding the drawer never stops in-flight AI work;
-  /// the streaming footer owns the explicit Stop action.
+  /// Visibility-only primitive. This does not change the tab auto-restore flag.
   setDrawerOpen: (open: boolean) => void;
+  /// User-driven dismissal: hide the drawer and clear the current tab's
+  /// auto-restore flag. This never stops in-flight AI work; the streaming footer
+  /// owns the explicit Stop action.
+  dismissDrawer: () => void;
   hideDrawer: () => void;
   openTabChat: (tabId: string) => Promise<void>;
   toggleTabChat: (tabId: string) => Promise<void>;
@@ -653,7 +656,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   setDrawerOpen: (open) => {
     set({ drawerOpen: open });
   },
-  hideDrawer: () => {
+  dismissDrawer: () => {
     const s = get();
     const tabId = s.drawerScope === "tab" ? s.drawerTabId : null;
     set({
@@ -662,6 +665,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         ? { tabDrawerOpenByTabId: { ...s.tabDrawerOpenByTabId, [tabId]: false } }
         : {}),
     });
+  },
+  hideDrawer: () => {
+    get().dismissDrawer();
   },
   setDrawerWidth: (w) => {
     const width = clampDrawerWidth(w);


### PR DESCRIPTION
Add a dismissDrawer store action for user-driven drawer dismissal. It hides the drawer and clears the current tab's auto-restore flag while keeping setDrawerOpen as a visibility-only primitive for transient layout state.

Route floating AI drawer outside-pointer dismissal through dismissDrawer so top/bottom Chat Tao panes stay hidden across tab focus changes until the user explicitly opens them again via the Tao ribbon click or hover. Keep hideDrawer on the same dismissal semantics for the close button.

Cover the lifecycle with store and drawer tests: dismissing a tab-bound drawer no longer stops in-flight work, clears tabDrawerOpenByTabId, and active-tab sync does not reopen it. The drawer interaction test verifies outside pointer-down dismissal clears the restore flag.

Also track repository guidance for Claude Code by unignoring CLAUDE.md and adding project overview, development commands, architecture notes, conventions, testing, and environment requirements.