### PR TITLE
feat(ai): add proxy config for providers and Claude Code

### DIFF
--- a/src-tauri/src/agent/cc_bridge/commands.rs
+++ b/src-tauri/src/agent/cc_bridge/commands.rs
@@ -25,13 +25,15 @@ pub async fn cc_detect(state: State<'_, AppState>) -> Result<CcStatusResult, Str
             binary_path: None,
         });
     }
-    let binary = if ai_ctx.config.cc_bridge.binary == "auto" {
+    let cc_bridge = ai_ctx.config.cc_bridge.clone();
+    let binary = if cc_bridge.binary == "auto" {
         None
     } else {
-        Some(ai_ctx.config.cc_bridge.binary.clone())
+        Some(cc_bridge.binary.clone())
     };
     drop(ai_ctx);
-    Ok(detect(binary.as_deref()).await)
+    let proxy = crate::agent::cc_bridge::config::resolve_global_proxy_url(&state, &cc_bridge)?;
+    Ok(detect(binary.as_deref(), proxy.as_deref()).await)
 }
 
 /// Return the raw user-supplied Claude Code `settings.json` (decrypted from the
@@ -138,6 +140,11 @@ pub async fn cc_send_message(
     let process = match existing {
         Some(p) => p,
         None => {
+            let effective_proxy =
+                crate::agent::cc_bridge::config::resolve_effective_proxy_url(
+                    &state,
+                    &config.cc_bridge,
+                )?;
             // Provision the in-app rmcp MCP server + a per-thread scoped token.
             // This alternate path is shell-only (DB flavor selection lives in
             // the active `chat_stream` path), so it uses the Shell flavor.
@@ -200,7 +207,9 @@ pub async fn cc_send_message(
             }
 
             let p = Arc::new(
-                CcProcess::new(&binary, extra_args, Some(files.dir)).with_token(cc_token.clone()),
+                CcProcess::new(&binary, extra_args, Some(files.dir))
+                    .with_proxy_url(effective_proxy)
+                    .with_token(cc_token.clone()),
             );
             let mut registry = state.cc_processes.lock().await;
             match registry.get(&req.thread_id) {
@@ -442,6 +451,11 @@ pub async fn cc_stream_message(
     let process = match existing {
         Some(p) => p,
         None => {
+            let effective_proxy =
+                crate::agent::cc_bridge::config::resolve_effective_proxy_url(
+                    &state,
+                    &config.cc_bridge,
+                )?;
             // Shell-only alternate path (see the streaming variant above).
             let flavor = crate::agent::cc_bridge::mcp_http::Flavor::Shell;
             let (cc_server_url, cc_token) =
@@ -496,7 +510,9 @@ pub async fn cc_stream_message(
             }
 
             let p = Arc::new(
-                CcProcess::new(&binary, extra_args, Some(files.dir)).with_token(cc_token.clone()),
+                CcProcess::new(&binary, extra_args, Some(files.dir))
+                    .with_proxy_url(effective_proxy)
+                    .with_token(cc_token.clone()),
             );
             let mut registry = state.cc_processes.lock().await;
             match registry.get(&req.thread_id) {
@@ -547,6 +563,9 @@ pub async fn cc_stream_message(
 #[tauri::command]
 pub async fn cc_test_settings(
     settings_json: String,
+    proxy_mode: Option<String>,
+    proxy_session_id: Option<String>,
+    proxy_url: Option<String>,
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
@@ -556,6 +575,14 @@ pub async fn cc_test_settings(
     } else {
         config.cc_bridge.binary.clone()
     };
+    let effective_proxy =
+        crate::agent::cc_bridge::config::resolve_effective_proxy_url_with_profile_override(
+            &state,
+            &config.cc_bridge,
+            proxy_mode.as_deref(),
+            proxy_session_id.as_deref(),
+            proxy_url.as_deref(),
+        )?;
 
     let thread_id = "cc_test_settings_thread".to_string();
     let event_name = "cc-test-settings-stream".to_string();
@@ -614,6 +641,7 @@ pub async fn cc_test_settings(
 
     let process = Arc::new(
         crate::agent::cc_bridge::process::CcProcess::new(&binary, extra_args, Some(files.dir))
+            .with_proxy_url(effective_proxy)
             .with_token(cc_token.clone()),
     );
 

--- a/src-tauri/src/agent/cc_bridge/config.rs
+++ b/src-tauri/src/agent/cc_bridge/config.rs
@@ -1,3 +1,4 @@
+use crate::state::AppState;
 use crate::vault::Vault;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -11,6 +12,13 @@ pub struct CcCustomSettingsProfile {
     pub enabled: bool,
     pub vault_ref: String,
     pub created_at: u64,
+    /// inherit | none | session | manual. Default is direct/no-proxy.
+    #[serde(default = "default_profile_proxy_mode")]
+    pub proxy_mode: String,
+    #[serde(default)]
+    pub proxy_session_id: Option<String>,
+    #[serde(default)]
+    pub proxy_url: Option<String>,
 }
 
 /// Configuration for the Claude Code bridge.
@@ -35,6 +43,13 @@ pub struct CcBridgeConfig {
     /// existing visible audit trail.
     #[serde(default = "default_terminal_echo_enabled")]
     pub terminal_echo_enabled: bool,
+    /// none | session | manual. Default is direct/no-proxy.
+    #[serde(default = "default_global_proxy_mode")]
+    pub proxy_mode: String,
+    #[serde(default)]
+    pub proxy_session_id: Option<String>,
+    #[serde(default)]
+    pub proxy_url: Option<String>,
     #[serde(default)]
     pub custom_settings_profiles: Vec<CcCustomSettingsProfile>,
     #[serde(default)]
@@ -43,6 +58,14 @@ pub struct CcBridgeConfig {
 
 fn default_terminal_echo_enabled() -> bool {
     true
+}
+
+fn default_global_proxy_mode() -> String {
+    "none".into()
+}
+
+fn default_profile_proxy_mode() -> String {
+    "none".into()
 }
 
 impl Default for CcBridgeConfig {
@@ -56,6 +79,9 @@ impl Default for CcBridgeConfig {
             max_turns: 20,
             confirm_readonly: false,
             terminal_echo_enabled: true,
+            proxy_mode: default_global_proxy_mode(),
+            proxy_session_id: None,
+            proxy_url: None,
             custom_settings_profiles: Vec::new(),
             active_profile_id: None,
         }
@@ -65,6 +91,36 @@ impl Default for CcBridgeConfig {
 impl CcBridgeConfig {
     pub fn normalize(&mut self) {
         self.default_model = normalize_model_name(&self.default_model);
+        self.proxy_url = self
+            .proxy_url
+            .as_ref()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        self.proxy_session_id = self
+            .proxy_session_id
+            .as_ref()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        self.proxy_mode = normalize_global_proxy_mode(&self.proxy_mode);
+        if self.proxy_url.is_some() && self.proxy_mode == "none" {
+            self.proxy_mode = "manual".into();
+        }
+        for profile in &mut self.custom_settings_profiles {
+            profile.proxy_url = profile
+                .proxy_url
+                .as_ref()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+            profile.proxy_session_id = profile
+                .proxy_session_id
+                .as_ref()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+            profile.proxy_mode = normalize_profile_proxy_mode(&profile.proxy_mode);
+            if profile.proxy_url.is_some() && profile.proxy_mode == "none" {
+                profile.proxy_mode = "manual".into();
+            }
+        }
     }
 }
 
@@ -73,6 +129,20 @@ pub fn normalize_model_name(model: &str) -> String {
     match trimmed {
         "" | "sonnet" => DEFAULT_CLAUDE_CODE_MODEL.into(),
         _ => trimmed.into(),
+    }
+}
+
+pub fn normalize_global_proxy_mode(mode: &str) -> String {
+    match mode.trim() {
+        "session" | "manual" => mode.trim().into(),
+        _ => "none".into(),
+    }
+}
+
+pub fn normalize_profile_proxy_mode(mode: &str) -> String {
+    match mode.trim() {
+        "inherit" | "session" | "manual" => mode.trim().into(),
+        _ => "none".into(),
     }
 }
 
@@ -126,6 +196,110 @@ pub fn resolve_custom_settings(
         return Ok(None);
     }
     resolve_vault_ref(&profile.vault_ref, vault)
+}
+
+fn active_enabled_profile(cfg: &CcBridgeConfig) -> Option<&CcCustomSettingsProfile> {
+    let active_id = cfg.active_profile_id.as_ref()?;
+    cfg.custom_settings_profiles
+        .iter()
+        .find(|p| &p.id == active_id && p.enabled)
+}
+
+fn resolve_profile_proxy_source(
+    state: &AppState,
+    mode: &str,
+    session_id: Option<&str>,
+    url: Option<&str>,
+) -> Result<Option<Option<String>>, String> {
+    match normalize_profile_proxy_mode(mode).as_str() {
+        "none" => Ok(Some(None)),
+        "session" => {
+            let Some(id) = session_id.map(str::trim).filter(|s| !s.is_empty()) else {
+                return Ok(None);
+            };
+            let proxy = crate::proxy::resolve_session_proxy(state, id)?;
+            Ok(Some(proxy.map(|p| p.to_url())))
+        }
+        "manual" => {
+            let Some(proxy_url) = url.map(str::trim).filter(|s| !s.is_empty()) else {
+                return Ok(None);
+            };
+            Ok(Some(Some(proxy_url.to_string())))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn resolve_global_proxy_source(
+    state: &AppState,
+    mode: &str,
+    session_id: Option<&str>,
+    url: Option<&str>,
+) -> Result<Option<String>, String> {
+    match normalize_global_proxy_mode(mode).as_str() {
+        "session" => {
+            let Some(id) = session_id.map(str::trim).filter(|s| !s.is_empty()) else {
+                return Ok(None);
+            };
+            Ok(crate::proxy::resolve_session_proxy(state, id)?.map(|p| p.to_url()))
+        }
+        "manual" => Ok(url
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)),
+        _ => Ok(None),
+    }
+}
+
+pub fn resolve_global_proxy_url(
+    state: &AppState,
+    cfg: &CcBridgeConfig,
+) -> Result<Option<String>, String> {
+    resolve_global_proxy_source(
+        state,
+        &cfg.proxy_mode,
+        cfg.proxy_session_id.as_deref(),
+        cfg.proxy_url.as_deref(),
+    )
+}
+
+pub fn resolve_effective_proxy_url(
+    state: &AppState,
+    cfg: &CcBridgeConfig,
+) -> Result<Option<String>, String> {
+    if let Some(profile) = active_enabled_profile(cfg) {
+        if let Some(profile_choice) = resolve_profile_proxy_source(
+            state,
+            &profile.proxy_mode,
+            profile.proxy_session_id.as_deref(),
+            profile.proxy_url.as_deref(),
+        )? {
+            return Ok(profile_choice);
+        }
+    }
+    resolve_global_proxy_url(state, cfg)
+}
+
+pub fn resolve_effective_proxy_url_with_profile_override(
+    state: &AppState,
+    cfg: &CcBridgeConfig,
+    proxy_mode: Option<&str>,
+    proxy_session_id: Option<&str>,
+    proxy_url: Option<&str>,
+) -> Result<Option<String>, String> {
+    if let Some(mode) = proxy_mode {
+        if let Some(profile_choice) =
+            resolve_profile_proxy_source(state, mode, proxy_session_id, proxy_url)?
+        {
+            return Ok(profile_choice);
+        }
+    }
+    resolve_global_proxy_source(
+        state,
+        &cfg.proxy_mode,
+        cfg.proxy_session_id.as_deref(),
+        cfg.proxy_url.as_deref(),
+    )
 }
 
 /// Build the effective CC `settings.json` value.

--- a/src-tauri/src/agent/cc_bridge/mod.rs
+++ b/src-tauri/src/agent/cc_bridge/mod.rs
@@ -36,6 +36,16 @@ pub(crate) fn no_console_window(cmd: &mut Command) {
     }
 }
 
+pub(crate) fn apply_proxy_env(cmd: &mut Command, proxy_url: Option<&str>) {
+    let Some(proxy) = proxy_url.map(str::trim).filter(|s| !s.is_empty()) else {
+        return;
+    };
+    cmd.env("HTTP_PROXY", proxy)
+        .env("HTTPS_PROXY", proxy)
+        .env("ALL_PROXY", proxy)
+        .env("NO_PROXY", "127.0.0.1,localhost");
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum CcStatus {
@@ -195,7 +205,7 @@ fn version_ok(found: &str, required: &str) -> bool {
 }
 
 /// Detect Claude Code CLI status.
-pub async fn detect(binary: Option<&str>) -> CcStatusResult {
+pub async fn detect(binary: Option<&str>, proxy_url: Option<&str>) -> CcStatusResult {
     let path = match binary {
         Some(b) if !b.is_empty() && b != "auto" => Some(b.to_string()),
         _ => find_claude_binary(),
@@ -257,7 +267,7 @@ pub async fn detect(binary: Option<&str>) -> CcStatusResult {
     }
 
     // Probe authentication with a minimal non-interactive call.
-    let auth_ok = probe_auth(&bin).await;
+    let auth_ok = probe_auth(&bin, proxy_url).await;
 
     if !auth_ok {
         return CcStatusResult {
@@ -279,9 +289,10 @@ pub async fn detect(binary: Option<&str>) -> CcStatusResult {
 }
 
 /// Run a minimal probe to check authentication.
-async fn probe_auth(binary: &str) -> bool {
+async fn probe_auth(binary: &str, proxy_url: Option<&str>) -> bool {
     let mut cmd = Command::new(binary);
     cmd.args(["--print", "ping", "--output-format", "json"]);
+    apply_proxy_env(&mut cmd, proxy_url);
     no_console_window(&mut cmd);
     let result = timeout(Duration::from_secs(10), cmd.output()).await;
 

--- a/src-tauri/src/agent/cc_bridge/process.rs
+++ b/src-tauri/src/agent/cc_bridge/process.rs
@@ -80,6 +80,9 @@ pub struct CcProcess {
     /// Bearer token this process uses to authenticate to the in-app rmcp MCP
     /// server. Revoked on stop/drop so a dead thread's token can't be reused.
     cc_token: Option<String>,
+    /// Optional outbound proxy URL applied to the Claude CLI child process via
+    /// standard proxy environment variables.
+    proxy_url: Option<String>,
     /// Number of turns currently using this process. The app-wide idle reaper
     /// must not stop a process until all turns have finished.
     active_turns: AtomicU32,
@@ -123,6 +126,7 @@ impl CcProcess {
             temp_dir,
             idle_timeout: Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS),
             cc_token: None,
+            proxy_url: None,
             active_turns: AtomicU32::new(0),
             last_active_at: std::sync::Mutex::new(std::time::Instant::now()),
         }
@@ -139,6 +143,13 @@ impl CcProcess {
     /// it is revoked when the process stops (builder style).
     pub fn with_token(mut self, token: impl Into<String>) -> Self {
         self.cc_token = Some(token.into());
+        self
+    }
+
+    pub fn with_proxy_url(mut self, proxy_url: Option<String>) -> Self {
+        self.proxy_url = proxy_url
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
         self
     }
 
@@ -259,6 +270,7 @@ impl CcProcess {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        super::apply_proxy_env(&mut cmd, self.proxy_url.as_deref());
         // Windows: don't pop a console window for the claude .cmd/.ps1 shim.
         super::no_console_window(&mut cmd);
 

--- a/src-tauri/src/ai/commands.rs
+++ b/src-tauri/src/ai/commands.rs
@@ -49,8 +49,19 @@ pub async fn save_ai_config(
     config.normalize();
     config.save(&path).map_err(|e| e.to_string())?;
 
+    let llm = {
+        let db = state
+            .db
+            .lock()
+            .map_err(|_| "session database is unavailable".to_string())?;
+        crate::llm::router::build_router_from_ai_with_proxy_db(
+            &config,
+            Some(state.vault.as_ref()),
+            Some(&db),
+        )
+    };
     let mut ai_ctx = state.ai_ctx.write().await;
-    ai_ctx.reload(config);
+    ai_ctx.reload_with_router(config, llm);
     Ok(())
 }
 
@@ -101,6 +112,14 @@ pub async fn test_llm_connection(
         test_api_key
     };
 
+    let proxy_url = {
+        let db = state
+            .db
+            .lock()
+            .map_err(|_| "session database is unavailable".to_string())?;
+        crate::ai::config::resolve_provider_proxy_url(&provider, Some(&db), Some(&state.vault))?
+    };
+
     let llm: Arc<dyn Llm> = match provider.runtime.as_str() {
         "anthropic" => {
             let base_url = if provider.base_url.is_empty() {
@@ -108,18 +127,20 @@ pub async fn test_llm_connection(
             } else {
                 provider.base_url.clone()
             };
-            Arc::new(AnthropicProvider::new(
+            Arc::new(AnthropicProvider::new_with_proxy_url(
                 "test",
                 base_url,
                 &api_key,
                 &provider.model,
+                proxy_url,
             ))
         }
-        _ => Arc::new(OpenAiCompatProvider::new(
+        _ => Arc::new(OpenAiCompatProvider::new_with_proxy_url(
             "test",
             &provider.base_url,
             &api_key,
             &provider.model,
+            proxy_url,
         )),
     };
 

--- a/src-tauri/src/ai/config.rs
+++ b/src-tauri/src/ai/config.rs
@@ -60,7 +60,7 @@ impl AiConfig {
     pub fn normalize(&mut self) {
         self.cc_bridge.normalize();
         self.codex_bridge.normalize();
-        self.llm.ensure_default_providers();
+        self.llm.normalize();
     }
 
     pub fn save(&self, path: &PathBuf) -> std::io::Result<()> {
@@ -144,6 +144,9 @@ impl Default for LlmConfig {
                 capabilities: LlmProviderCapabilities::default(),
                 image_model: None,
                 video_model: None,
+                proxy_mode: default_provider_proxy_mode(),
+                proxy_session_id: None,
+                proxy_url: None,
             },
         );
         providers.insert(
@@ -161,6 +164,9 @@ impl Default for LlmConfig {
                 },
                 image_model: Some("agnes-image-2.1-flash".into()),
                 video_model: Some("agnes-video-v2.0".into()),
+                proxy_mode: default_provider_proxy_mode(),
+                proxy_session_id: None,
+                proxy_url: None,
             },
         );
         providers.insert(
@@ -174,6 +180,9 @@ impl Default for LlmConfig {
                 capabilities: LlmProviderCapabilities::default(),
                 image_model: None,
                 video_model: None,
+                proxy_mode: default_provider_proxy_mode(),
+                proxy_session_id: None,
+                proxy_url: None,
             },
         );
         providers.insert(
@@ -187,6 +196,9 @@ impl Default for LlmConfig {
                 capabilities: LlmProviderCapabilities::default(),
                 image_model: None,
                 video_model: None,
+                proxy_mode: default_provider_proxy_mode(),
+                proxy_session_id: None,
+                proxy_url: None,
             },
         );
         providers.insert(
@@ -200,6 +212,9 @@ impl Default for LlmConfig {
                 capabilities: LlmProviderCapabilities::default(),
                 image_model: None,
                 video_model: None,
+                proxy_mode: default_provider_proxy_mode(),
+                proxy_session_id: None,
+                proxy_url: None,
             },
         );
         providers.insert(
@@ -213,6 +228,9 @@ impl Default for LlmConfig {
                 capabilities: LlmProviderCapabilities::default(),
                 image_model: None,
                 video_model: None,
+                proxy_mode: default_provider_proxy_mode(),
+                proxy_session_id: None,
+                proxy_url: None,
             },
         );
         providers.insert(
@@ -226,6 +244,9 @@ impl Default for LlmConfig {
                 capabilities: LlmProviderCapabilities::default(),
                 image_model: None,
                 video_model: None,
+                proxy_mode: default_provider_proxy_mode(),
+                proxy_session_id: None,
+                proxy_url: None,
             },
         );
 
@@ -254,6 +275,13 @@ impl Default for LlmConfig {
 }
 
 impl LlmConfig {
+    fn normalize(&mut self) {
+        self.ensure_default_providers();
+        for provider in self.providers.values_mut() {
+            provider.normalize();
+        }
+    }
+
     fn ensure_default_providers(&mut self) {
         self.providers
             .entry("agnes".into())
@@ -275,6 +303,9 @@ fn default_agnes_provider() -> LlmProviderConfig {
         },
         image_model: Some("agnes-image-2.1-flash".into()),
         video_model: Some("agnes-video-v2.0".into()),
+        proxy_mode: default_provider_proxy_mode(),
+        proxy_session_id: None,
+        proxy_url: None,
     }
 }
 
@@ -292,9 +323,33 @@ pub struct LlmProviderConfig {
     pub image_model: Option<String>,
     #[serde(default)]
     pub video_model: Option<String>,
+    /// none | session | manual. Default is direct/no-proxy.
+    #[serde(default = "default_provider_proxy_mode")]
+    pub proxy_mode: String,
+    #[serde(default)]
+    pub proxy_session_id: Option<String>,
+    #[serde(default)]
+    pub proxy_url: Option<String>,
 }
 
 impl LlmProviderConfig {
+    pub fn normalize(&mut self) {
+        self.proxy_url = self
+            .proxy_url
+            .as_ref()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        self.proxy_session_id = self
+            .proxy_session_id
+            .as_ref()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        self.proxy_mode = normalize_provider_proxy_mode(&self.proxy_mode);
+        if self.proxy_url.is_some() && self.proxy_mode == "none" {
+            self.proxy_mode = "manual".into();
+        }
+    }
+
     pub fn effective_api_keys(&self) -> Vec<&str> {
         let api_keys = self
             .api_keys
@@ -307,6 +362,47 @@ impl LlmProviderConfig {
         } else {
             api_keys
         }
+    }
+}
+
+fn default_provider_proxy_mode() -> String {
+    "none".into()
+}
+
+pub fn normalize_provider_proxy_mode(mode: &str) -> String {
+    match mode.trim() {
+        "session" | "manual" => mode.trim().into(),
+        _ => "none".into(),
+    }
+}
+
+pub fn resolve_provider_proxy_url(
+    provider: &LlmProviderConfig,
+    db: Option<&rusqlite::Connection>,
+    vault: Option<&crate::vault::Vault>,
+) -> Result<Option<String>, String> {
+    match normalize_provider_proxy_mode(&provider.proxy_mode).as_str() {
+        "session" => {
+            let Some(id) = provider
+                .proxy_session_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            else {
+                return Ok(None);
+            };
+            let (Some(db), Some(vault)) = (db, vault) else {
+                return Ok(None);
+            };
+            Ok(crate::proxy::resolve_session_proxy_with_db(db, vault, id)?.map(|p| p.to_url()))
+        }
+        "manual" => Ok(provider
+            .proxy_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)),
+        _ => Ok(None),
     }
 }
 

--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -7,7 +7,7 @@ pub mod shell_safety;
 pub mod tools_shell;
 
 use crate::asr::manager::AsrManager;
-use crate::llm::router::{build_router_from_ai, LlmRouter};
+use crate::llm::router::{build_router_from_ai, build_router_from_ai_with_proxy_db, LlmRouter};
 use crate::vault::Vault;
 use config::AiConfig;
 use std::sync::Arc;
@@ -28,6 +28,14 @@ pub struct AppAiCtx {
 
 impl AppAiCtx {
     pub fn from_config(cfg: AiConfig, vault: Arc<Vault>) -> Self {
+        Self::from_config_with_proxy_db(cfg, vault, None)
+    }
+
+    pub fn from_config_with_proxy_db(
+        cfg: AiConfig,
+        vault: Arc<Vault>,
+        proxy_db: Option<&rusqlite::Connection>,
+    ) -> Self {
         let asr = AsrManager::new(cfg.asr.warm_on_startup);
 
         // Best-effort: if the active ASR provider is the sherpa engine and a
@@ -58,7 +66,7 @@ impl AppAiCtx {
             }
         }
 
-        let llm = build_router_from_ai(&cfg, Some(vault.as_ref()));
+        let llm = build_router_from_ai_with_proxy_db(&cfg, Some(vault.as_ref()), proxy_db);
         Self {
             asr: Arc::new(asr),
             llm,
@@ -74,11 +82,34 @@ impl AppAiCtx {
         self.config = cfg;
     }
 
+    pub fn reload_with_proxy_db(
+        &mut self,
+        cfg: AiConfig,
+        proxy_db: Option<&rusqlite::Connection>,
+    ) {
+        self.llm = build_router_from_ai_with_proxy_db(&cfg, Some(self.vault.as_ref()), proxy_db);
+        self.config = cfg;
+    }
+
+    pub fn reload_with_router(&mut self, cfg: AiConfig, llm: LlmRouter) {
+        self.llm = llm;
+        self.config = cfg;
+    }
+
     /// Rebuild the LlmRouter against the current vault state without touching
     /// the persisted config. Called after `vault_unlock` / `vault_change_master`
     /// so providers whose api_key is `vault:<id>` start working as soon as the
     /// vault is unlocked — no Save click required.
     pub fn rebuild_router(&mut self) {
         self.llm = build_router_from_ai(&self.config, Some(self.vault.as_ref()));
+    }
+
+    pub fn rebuild_router_with_proxy_db(&mut self, proxy_db: Option<&rusqlite::Connection>) {
+        self.llm =
+            build_router_from_ai_with_proxy_db(&self.config, Some(self.vault.as_ref()), proxy_db);
+    }
+
+    pub fn replace_router(&mut self, llm: LlmRouter) {
+        self.llm = llm;
     }
 }

--- a/src-tauri/src/chat/mod.rs
+++ b/src-tauri/src/chat/mod.rs
@@ -1073,9 +1073,31 @@ async fn generate_media_with_provider_key(
     }
 }
 
+fn build_provider_http_client(
+    state: &AppState,
+    provider: &crate::ai::config::LlmProviderConfig,
+    timeout: std::time::Duration,
+) -> Result<Client, String> {
+    let proxy_url = {
+        let db = state
+            .db
+            .lock()
+            .map_err(|_| "session database is unavailable".to_string())?;
+        crate::ai::config::resolve_provider_proxy_url(provider, Some(&db), Some(&state.vault))?
+    };
+    let mut builder = Client::builder().timeout(timeout);
+    if let Some(proxy_url) = proxy_url.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
+            builder = builder.proxy(proxy);
+        }
+    }
+    builder
+        .build()
+        .map_err(|e| format!("Create provider HTTP client: {e}"))
+}
+
 async fn generate_media_with_provider_keys(
     state: &AppState,
-    client: &Client,
     app: &AppHandle,
     provider_id: &str,
     provider: &crate::ai::config::LlmProviderConfig,
@@ -1086,6 +1108,8 @@ async fn generate_media_with_provider_keys(
     let api_keys = provider.effective_api_keys();
     let key_count = api_keys.len();
     let mut last_err: Option<String> = None;
+    let client =
+        build_provider_http_client(state, provider, std::time::Duration::from_secs(360))?;
 
     for _ in 0..key_count {
         let key_index = {
@@ -1102,7 +1126,7 @@ async fn generate_media_with_provider_keys(
                 continue;
             }
         };
-        match generate_media_with_provider_key(client, app, provider, &api_key, req, kind, prompt)
+        match generate_media_with_provider_key(&client, app, provider, &api_key, req, kind, prompt)
             .await
         {
             Ok(file) => return Ok(file),
@@ -1153,10 +1177,6 @@ pub async fn chat_generate_media(
 
     let (clean_prompt, redacted_count) = redact::redact(&req.prompt);
     let ai_config = AiConfig::load(&default_ai_config_path());
-    let client = Client::builder()
-        .timeout(std::time::Duration::from_secs(360))
-        .build()
-        .map_err(|e| format!("Create generation HTTP client: {e}"))?;
 
     let generated = if let Some(group_id) = provider_group_id_from_route(&thread.provider_id) {
         let route_id = thread.provider_id.clone();
@@ -1190,7 +1210,6 @@ pub async fn chat_generate_media(
             saw_supported_provider = true;
             match generate_media_with_provider_keys(
                 state.inner(),
-                &client,
                 &app,
                 &provider_id,
                 &provider,
@@ -1247,7 +1266,6 @@ pub async fn chat_generate_media(
         }
         generate_media_with_provider_keys(
             state.inner(),
-            &client,
             &app,
             &thread.provider_id,
             &provider,
@@ -1738,6 +1756,20 @@ pub async fn chat_stream(
         let process = match existing {
             Some(p) => p,
             None => {
+                let effective_proxy =
+                    match crate::agent::cc_bridge::config::resolve_effective_proxy_url(
+                        state.inner(),
+                        &ai_config.cc_bridge,
+                    ) {
+                        Ok(proxy) => proxy,
+                        Err(e) => {
+                            emit(&StreamEventOut::Error {
+                                id: assistant_id.clone(),
+                                message: e,
+                            });
+                            return Ok(());
+                        }
+                    };
                 // Phase 6 — pick the MCP flavor from the shared agent context so
                 // the thread loads only the right tool surface: SQL, Redis, or shell.
                 let flavor = agent_ctx.flavor;
@@ -1865,6 +1897,7 @@ pub async fn chat_stream(
                         extra_args,
                         Some(files.dir),
                     )
+                    .with_proxy_url(effective_proxy)
                     .with_token(cc_token.clone()),
                 );
                 // Re-check under the lock in case a concurrent send for the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,7 +90,8 @@ pub fn run() {
             // transparently resolved by the LLM router.
             let ai_config_path = ai::config::default_ai_config_path();
             let ai_config = ai::config::AiConfig::load(&ai_config_path);
-            let ai_ctx = ai::AppAiCtx::from_config(ai_config, vault_arc.clone());
+            let ai_ctx =
+                ai::AppAiCtx::from_config_with_proxy_db(ai_config, vault_arc.clone(), Some(&conn));
 
             // Decentralized LAN messenger state (separate lanchat.sqlite).
             let lanchat_state = Arc::new(lanchat::LanChatState::new(&app_data));

--- a/src-tauri/src/llm/anthropic.rs
+++ b/src-tauri/src/llm/anthropic.rs
@@ -32,11 +32,24 @@ impl AnthropicProvider {
         api_key: impl Into<String>,
         model: impl Into<String>,
     ) -> Self {
+        Self::new_with_proxy_url(provider_id, base_url, api_key, model, None)
+    }
+
+    pub fn new_with_proxy_url(
+        provider_id: impl Into<String>,
+        base_url: impl Into<String>,
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+        proxy_url: Option<String>,
+    ) -> Self {
+        let mut builder = Client::builder().timeout(std::time::Duration::from_secs(60));
+        if let Some(proxy_url) = proxy_url.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+            if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
+                builder = builder.proxy(proxy);
+            }
+        }
         Self {
-            client: Client::builder()
-                .timeout(std::time::Duration::from_secs(60))
-                .build()
-                .expect("failed to build reqwest client"),
+            client: builder.build().expect("failed to build reqwest client"),
             base_url: base_url.into().trim_end_matches('/').to_string(),
             api_key: api_key.into(),
             model: model.into(),

--- a/src-tauri/src/llm/openai_compat.rs
+++ b/src-tauri/src/llm/openai_compat.rs
@@ -85,11 +85,24 @@ impl OpenAiCompatProvider {
         api_key: impl Into<String>,
         model: impl Into<String>,
     ) -> Self {
+        Self::new_with_proxy_url(provider_id, base_url, api_key, model, None)
+    }
+
+    pub fn new_with_proxy_url(
+        provider_id: impl Into<String>,
+        base_url: impl Into<String>,
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+        proxy_url: Option<String>,
+    ) -> Self {
+        let mut builder = Client::builder().timeout(std::time::Duration::from_secs(30));
+        if let Some(proxy_url) = proxy_url.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+            if let Ok(proxy) = reqwest::Proxy::all(proxy_url) {
+                builder = builder.proxy(proxy);
+            }
+        }
         Self {
-            client: Client::builder()
-                .timeout(std::time::Duration::from_secs(30))
-                .build()
-                .expect("failed to build reqwest client"),
+            client: builder.build().expect("failed to build reqwest client"),
             base_url: base_url.into().trim_end_matches('/').to_string(),
             api_key: api_key.into(),
             model: model.into(),

--- a/src-tauri/src/llm/router.rs
+++ b/src-tauri/src/llm/router.rs
@@ -548,7 +548,7 @@ impl LlmRouter {
 
 use super::anthropic::AnthropicProvider;
 use super::openai_compat::OpenAiCompatProvider;
-use crate::ai::config::{AiConfig, LlmConfig};
+use crate::ai::config::{resolve_provider_proxy_url, AiConfig, LlmConfig};
 
 fn task_kind_from_str(s: &str) -> Option<TaskKind> {
     Some(match s {
@@ -610,6 +610,15 @@ pub fn build_router(
     vault: Option<&crate::vault::Vault>,
     full_local_mode: bool,
 ) -> LlmRouter {
+    build_router_with_proxy_db(cfg, vault, full_local_mode, None)
+}
+
+pub fn build_router_with_proxy_db(
+    cfg: &LlmConfig,
+    vault: Option<&crate::vault::Vault>,
+    full_local_mode: bool,
+    proxy_db: Option<&rusqlite::Connection>,
+) -> LlmRouter {
     let mut router = LlmRouter::new(&cfg.active);
 
     for (id, p) in &cfg.providers {
@@ -630,6 +639,18 @@ pub fn build_router(
             continue;
         }
 
+        let proxy_url = match resolve_provider_proxy_url(p, proxy_db, vault) {
+            Ok(proxy_url) => proxy_url,
+            Err(e) => {
+                tracing::warn!(
+                    provider = %id,
+                    error = %e,
+                    "provider proxy could not be resolved; using direct connection"
+                );
+                None
+            }
+        };
+
         let mut variants: Vec<Arc<dyn Llm>> = Vec::new();
         let mut unresolved_key = false;
         for api_key in p.effective_api_keys() {
@@ -646,23 +667,27 @@ pub fn build_router(
             };
 
             let provider: Arc<dyn Llm> = match p.runtime.as_str() {
-                "openai-compat" | "llama-server" | "ollama" => Arc::new(OpenAiCompatProvider::new(
-                    id.as_str(),
-                    p.base_url.clone(),
-                    resolved_key,
-                    p.model.clone(),
-                )),
+                "openai-compat" | "llama-server" | "ollama" => {
+                    Arc::new(OpenAiCompatProvider::new_with_proxy_url(
+                        id.as_str(),
+                        p.base_url.clone(),
+                        resolved_key,
+                        p.model.clone(),
+                        proxy_url.clone(),
+                    ))
+                }
                 "anthropic" => {
                     let base_url = if p.base_url.is_empty() {
                         "https://api.anthropic.com/v1".to_string()
                     } else {
                         p.base_url.clone()
                     };
-                    Arc::new(AnthropicProvider::new(
+                    Arc::new(AnthropicProvider::new_with_proxy_url(
                         id.as_str(),
                         base_url,
                         resolved_key,
                         p.model.clone(),
+                        proxy_url.clone(),
                     ))
                 }
                 _ => unreachable!("runtime was checked above"),
@@ -726,4 +751,12 @@ pub fn build_router(
 /// Build a router from a full AiConfig (currently only forwards llm).
 pub fn build_router_from_ai(cfg: &AiConfig, vault: Option<&crate::vault::Vault>) -> LlmRouter {
     build_router(&cfg.llm, vault, cfg.full_local_mode)
+}
+
+pub fn build_router_from_ai_with_proxy_db(
+    cfg: &AiConfig,
+    vault: Option<&crate::vault::Vault>,
+    proxy_db: Option<&rusqlite::Connection>,
+) -> LlmRouter {
+    build_router_with_proxy_db(&cfg.llm, vault, cfg.full_local_mode, proxy_db)
 }

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 use tauri::State;
 
 use crate::state::AppState;
+use crate::vault::Vault;
 
 fn default_mode() -> String {
     "manual".into()
@@ -153,11 +154,11 @@ impl ResolvedProxy {
 /// entry is missing we degrade to an empty password (and log) rather than
 /// failing the whole resolution — a startup updater check must not hard-fail
 /// just because the vault hasn't been unlocked yet.
-fn resolve_password(state: &AppState, password_ref: &str) -> String {
+fn resolve_password_with_vault(vault: &Vault, password_ref: &str) -> String {
     if password_ref.is_empty() {
         return String::new();
     }
-    match state.vault.resolve(password_ref) {
+    match vault.resolve(password_ref) {
         Ok(Some(plain)) => (*plain).clone(),
         // Not a vault ref (shouldn't happen — we only store refs — but treat
         // the raw value as the password for robustness).
@@ -167,6 +168,10 @@ fn resolve_password(state: &AppState, password_ref: &str) -> String {
             String::new()
         }
     }
+}
+
+fn resolve_password(state: &AppState, password_ref: &str) -> String {
+    resolve_password_with_vault(&state.vault, password_ref)
 }
 
 /// Load the persisted config and resolve it into a concrete [`ResolvedProxy`],
@@ -219,14 +224,27 @@ pub fn resolve_session_proxy(
     if id.is_empty() {
         return Ok(None);
     }
-    let session = {
-        let db = state
-            .db
-            .lock()
-            .map_err(|_| "session database is unavailable".to_string())?;
-        crate::session::db::get_session(&db, id)
-            .map_err(|e| format!("proxy session not found: {e}"))?
-    };
+    let db = state
+        .db
+        .lock()
+        .map_err(|_| "session database is unavailable".to_string())?;
+    resolve_session_proxy_with_db(&db, &state.vault, id)
+}
+
+/// Resolve a saved `SessionType::Proxy` using explicit database/vault handles.
+/// This lets startup-time components build outbound clients before `AppState`
+/// itself exists.
+pub fn resolve_session_proxy_with_db(
+    db: &rusqlite::Connection,
+    vault: &Vault,
+    session_id: &str,
+) -> Result<Option<ResolvedProxy>, String> {
+    let id = session_id.trim();
+    if id.is_empty() {
+        return Ok(None);
+    }
+    let session = crate::session::db::get_session(db, id)
+        .map_err(|e| format!("proxy session not found: {e}"))?;
     let opts: serde_json::Value =
         serde_json::from_str(&session.options_json).unwrap_or(serde_json::Value::Null);
     let kind = opts
@@ -244,7 +262,7 @@ pub fn resolve_session_proxy(
         host: session.host,
         port: session.port,
         username: session.username.unwrap_or_default(),
-        password: resolve_password(state, &password_ref),
+        password: resolve_password_with_vault(vault, &password_ref),
     }))
 }
 

--- a/src-tauri/src/vault/mod.rs
+++ b/src-tauri/src/vault/mod.rs
@@ -447,8 +447,23 @@ pub async fn vault_unlock(
     // Vault transitioned to unlocked — rebuild the LLM router so providers
     // whose api_key is `vault:<id>` start working immediately. Without this
     // the user has to click Save in AI Settings to trigger a rebuild.
+    let cfg = {
+        let ai_ctx = state.ai_ctx.read().await;
+        ai_ctx.config.clone()
+    };
+    let llm = {
+        let db = state
+            .db
+            .lock()
+            .map_err(|_| "session database is unavailable".to_string())?;
+        crate::llm::router::build_router_from_ai_with_proxy_db(
+            &cfg,
+            Some(state.vault.as_ref()),
+            Some(&db),
+        )
+    };
     let mut ai_ctx = state.ai_ctx.write().await;
-    ai_ctx.rebuild_router();
+    ai_ctx.replace_router(llm);
     Ok(())
 }
 
@@ -458,8 +473,23 @@ pub async fn vault_lock(state: State<'_, AppState>) -> Result<(), String> {
     // After lock, providers backed by vault refs can no longer authenticate;
     // rebuild so calls fail closed with VAULT_LOCKED instead of using stale
     // plaintext that was decrypted earlier.
+    let cfg = {
+        let ai_ctx = state.ai_ctx.read().await;
+        ai_ctx.config.clone()
+    };
+    let llm = {
+        let db = state
+            .db
+            .lock()
+            .map_err(|_| "session database is unavailable".to_string())?;
+        crate::llm::router::build_router_from_ai_with_proxy_db(
+            &cfg,
+            Some(state.vault.as_ref()),
+            Some(&db),
+        )
+    };
     let mut ai_ctx = state.ai_ctx.write().await;
-    ai_ctx.rebuild_router();
+    ai_ctx.replace_router(llm);
     Ok(())
 }
 
@@ -470,8 +500,23 @@ pub async fn vault_change_master(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     state.vault.change_master(&old_password, &new_password)?;
+    let cfg = {
+        let ai_ctx = state.ai_ctx.read().await;
+        ai_ctx.config.clone()
+    };
+    let llm = {
+        let db = state
+            .db
+            .lock()
+            .map_err(|_| "session database is unavailable".to_string())?;
+        crate::llm::router::build_router_from_ai_with_proxy_db(
+            &cfg,
+            Some(state.vault.as_ref()),
+            Some(&db),
+        )
+    };
     let mut ai_ctx = state.ai_ctx.write().await;
-    ai_ctx.rebuild_router();
+    ai_ctx.replace_router(llm);
     Ok(())
 }
 

--- a/src-tauri/tests/router_vault_lock.rs
+++ b/src-tauri/tests/router_vault_lock.rs
@@ -33,6 +33,9 @@ fn make_config(api_key: String) -> AiConfig {
             capabilities: LlmProviderCapabilities::default(),
             image_model: None,
             video_model: None,
+            proxy_mode: "none".into(),
+            proxy_session_id: None,
+            proxy_url: None,
         },
     );
     providers.insert(
@@ -46,6 +49,9 @@ fn make_config(api_key: String) -> AiConfig {
             capabilities: LlmProviderCapabilities::default(),
             image_model: None,
             video_model: None,
+            proxy_mode: "none".into(),
+            proxy_session_id: None,
+            proxy_url: None,
         },
     );
 

--- a/src/components/settings/ClaudeCodePanel.tsx
+++ b/src/components/settings/ClaudeCodePanel.tsx
@@ -6,6 +6,7 @@ import { useT } from "../../lib/i18n";
 import { useVaultGate } from "../../lib/vaultGate";
 import { ClaudeCodeSettingsDialog } from "./ClaudeCodeSettingsDialog";
 import { Sliders, Shield } from "lucide-react";
+import { CodexProxyFields } from "./CodexProxyFields";
 
 interface CcStatusResult {
   status:
@@ -264,6 +265,15 @@ export function ClaudeCodePanel() {
                 onChange={(e) => saveConfig({ ...config, cc_bridge: { ...cc, max_turns: parseInt(e.target.value) || 20 } })}
               />
             </div>
+          </div>
+          <div>
+            <label className="text-[11px] text-[var(--taomni-text-muted)] block mb-1">{t("aiSettings.codexProxyTitle")}</label>
+            <CodexProxyFields
+              mode={cc.proxy_mode}
+              sessionId={cc.proxy_session_id}
+              proxyUrl={cc.proxy_url}
+              onChange={(patch) => saveConfig({ ...config, cc_bridge: { ...cc, ...patch } })}
+            />
           </div>
           <div className="text-[10px] text-[var(--taomni-text-muted)]">
             {t("aiSettings.ccLocalModeNote")}

--- a/src/components/settings/ClaudeCodeSettingsDialog.tsx
+++ b/src/components/settings/ClaudeCodeSettingsDialog.tsx
@@ -13,6 +13,7 @@ import {
   isVaultLockedError,
   VAULT_LOCKED_EVENT,
 } from "../../lib/ipc";
+import { CodexProxyFields } from "./CodexProxyFields";
 
 // Starter template for new profiles
 const SETTINGS_TEMPLATE = `{
@@ -105,7 +106,12 @@ export function ClaudeCodeSettingsDialog({ onClose }: ClaudeCodeSettingsDialogPr
         }
       });
 
-      await invoke("cc_test_settings", { settingsJson: selectedContent });
+      await invoke("cc_test_settings", {
+        settingsJson: selectedContent,
+        proxyMode: selectedProfile?.proxy_mode ?? "none",
+        proxySessionId: selectedProfile?.proxy_session_id ?? null,
+        proxyUrl: selectedProfile?.proxy_url ?? null,
+      });
     } catch (err: any) {
       if (testSessionRef.current === currentSession) {
         setTestError(err?.message || String(err));
@@ -208,6 +214,9 @@ export function ClaudeCodeSettingsDialog({ onClose }: ClaudeCodeSettingsDialogPr
       enabled: true,
       vault_ref: "", // will be generated upon save
       created_at: Date.now(),
+      proxy_mode: "none",
+      proxy_session_id: null,
+      proxy_url: null,
     };
 
     setProfiles(prev => [...prev, newProfile]);
@@ -264,6 +273,11 @@ export function ClaudeCodeSettingsDialog({ onClose }: ClaudeCodeSettingsDialogPr
   const handleUpdateName = (name: string) => {
     if (!selectedProfileId) return;
     setProfiles(prev => prev.map(p => p.id === selectedProfileId ? { ...p, name } : p));
+  };
+
+  const handleUpdateProfile = (patch: Partial<CcCustomSettingsProfile>) => {
+    if (!selectedProfileId) return;
+    setProfiles(prev => prev.map(p => p.id === selectedProfileId ? { ...p, ...patch } : p));
   };
 
   const handleToggleEnabled = (enabled: boolean) => {
@@ -348,6 +362,8 @@ export function ClaudeCodeSettingsDialog({ onClose }: ClaudeCodeSettingsDialogPr
         updatedProfiles.push({
           ...p,
           vault_ref: vaultRef,
+          proxy_session_id: p.proxy_session_id?.trim() || null,
+          proxy_url: p.proxy_url?.trim() || null,
         });
       }
 
@@ -525,6 +541,18 @@ export function ClaudeCodeSettingsDialog({ onClose }: ClaudeCodeSettingsDialogPr
                       />
                       <span>{t("aiSettings.ccCustomToggleEnable")}</span>
                     </label>
+                  </div>
+                  <div>
+                    <label className="text-[11px] text-[var(--taomni-text-muted)] block mb-1">
+                      {t("aiSettings.codexProxyTitle")}
+                    </label>
+                    <CodexProxyFields
+                      includeInherit
+                      mode={selectedProfile.proxy_mode ?? "none"}
+                      sessionId={selectedProfile.proxy_session_id}
+                      proxyUrl={selectedProfile.proxy_url}
+                      onChange={(patch) => handleUpdateProfile(patch)}
+                    />
                   </div>
                 </div>
 

--- a/src/components/settings/LlmProvidersPanel.tsx
+++ b/src/components/settings/LlmProvidersPanel.tsx
@@ -5,6 +5,7 @@ import { useVaultStore } from "../../stores/vaultStore";
 import { isVaultLockedError } from "../../lib/ipc";
 import { ensureVaultReady } from "../../lib/vaultGate";
 import { useT, type TranslateFn } from "../../lib/i18n";
+import { CodexProxyFields } from "./CodexProxyFields";
 
 const PROVIDER_LABELS: Record<string, string> = {
   deepseek:    "DeepSeek",
@@ -233,6 +234,15 @@ function ProviderRow({ id, provider, isActive, onActivate, onChange, onTest, tes
               className="taomni-input h-7 w-full text-[12px]"
               value={provider.base_url}
               onChange={(e) => onChange({ ...provider, base_url: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="text-[11px] text-[var(--taomni-text-muted)] block mb-1">{t("aiSettings.codexProxyTitle")}</label>
+            <CodexProxyFields
+              mode={provider.proxy_mode ?? "none"}
+              sessionId={provider.proxy_session_id}
+              proxyUrl={provider.proxy_url}
+              onChange={(patch) => onChange({ ...provider, ...patch })}
             />
           </div>
           <div className="flex items-center gap-2 pt-1">

--- a/src/stores/aiStore.ts
+++ b/src/stores/aiStore.ts
@@ -30,6 +30,9 @@ export interface LlmProviderConfig {
   capabilities?: LlmProviderCapabilities;
   image_model?: string | null;
   video_model?: string | null;
+  proxy_mode?: "none" | "session" | "manual" | string;
+  proxy_session_id?: string | null;
+  proxy_url?: string | null;
 }
 
 export interface LlmProviderCapabilities {
@@ -77,6 +80,9 @@ export interface CcCustomSettingsProfile {
   enabled: boolean;
   vault_ref: string;
   created_at: number;
+  proxy_mode?: "inherit" | "none" | "session" | "manual" | string;
+  proxy_session_id?: string | null;
+  proxy_url?: string | null;
 }
 
 export interface CcBridgeConfig {
@@ -90,6 +96,9 @@ export interface CcBridgeConfig {
   confirm_readonly?: boolean;
   /** Mirror finished captured runs into the bound terminal as display-only traces. */
   terminal_echo_enabled?: boolean;
+  proxy_mode?: "none" | "session" | "manual" | string;
+  proxy_session_id?: string | null;
+  proxy_url?: string | null;
   custom_settings_profiles?: CcCustomSettingsProfile[];
   active_profile_id?: string;
 }
@@ -268,6 +277,9 @@ const DEFAULT_CONFIG: AiConfig = {
     max_turns: 20,
     confirm_readonly: false,
     terminal_echo_enabled: true,
+    proxy_mode: "none",
+    proxy_session_id: undefined,
+    proxy_url: undefined,
   },
   codex_bridge: {
     enabled: false,
@@ -310,6 +322,18 @@ function normalizeCodexProfileProxyMode(mode: string | undefined | null, proxyUr
   return proxyUrl?.trim() ? "manual" : "inherit";
 }
 
+function normalizeNoProxyMode(mode: string | undefined | null, proxyUrl?: string | null): string {
+  const trimmed = (mode ?? "").trim();
+  if (trimmed === "session" || trimmed === "manual") return trimmed;
+  return proxyUrl?.trim() ? "manual" : "none";
+}
+
+function normalizeCcProfileProxyMode(mode: string | undefined | null, proxyUrl?: string | null): string {
+  const trimmed = (mode ?? "").trim();
+  if (trimmed === "inherit" || trimmed === "session" || trimmed === "manual") return trimmed;
+  return proxyUrl?.trim() ? "manual" : "none";
+}
+
 function normalizeLlmProvider(provider: LlmProviderConfig): LlmProviderConfig {
   const configuredKeys = (provider.api_keys ?? [])
     .map((key) => key ?? "")
@@ -326,6 +350,9 @@ function normalizeLlmProvider(provider: LlmProviderConfig): LlmProviderConfig {
     },
     image_model: provider.image_model ?? null,
     video_model: provider.video_model ?? null,
+    proxy_mode: normalizeNoProxyMode(provider.proxy_mode, provider.proxy_url),
+    proxy_session_id: provider.proxy_session_id?.trim() || undefined,
+    proxy_url: provider.proxy_url?.trim() || undefined,
   };
 }
 
@@ -380,8 +407,18 @@ function normalizeAiConfig(config: AiConfig): AiConfig {
       provider_groups: providerGroups,
     },
     cc_bridge: {
+      ...DEFAULT_CONFIG.cc_bridge,
       ...config.cc_bridge,
       default_model: normalizeModelName(config.cc_bridge.default_model),
+      proxy_mode: normalizeNoProxyMode(config.cc_bridge?.proxy_mode, config.cc_bridge?.proxy_url),
+      proxy_session_id: config.cc_bridge?.proxy_session_id?.trim() || undefined,
+      proxy_url: config.cc_bridge?.proxy_url?.trim() || undefined,
+      custom_settings_profiles: (config.cc_bridge?.custom_settings_profiles ?? []).map((profile) => ({
+        ...profile,
+        proxy_mode: normalizeCcProfileProxyMode(profile.proxy_mode, profile.proxy_url),
+        proxy_session_id: profile.proxy_session_id?.trim() || undefined,
+        proxy_url: profile.proxy_url?.trim() || undefined,
+      })),
     },
     codex_bridge: {
       ...DEFAULT_CONFIG.codex_bridge,


### PR DESCRIPTION
Add no-proxy-by-default proxy settings to each LLM provider and to the Claude Code bridge, matching the Codex customized profile behavior. Provider and bridge configs now support none/session/manual modes, with Claude Code custom settings profiles also supporting inherit overrides.

Wire the settings into runtime paths: LLM router construction, provider connection tests, image/video generation, Claude Code detect/auth probe, settings test runs, and chat subprocess launches now resolve and apply the effective proxy. Saved Proxy sessions are resolved through shared proxy helpers so session-based proxy selection works after startup, config save, and vault unlock/relock rebuilds.

Expose the controls in AI settings by reusing the existing CodexProxyFields component for LLM provider rows, Claude Code global settings, and Claude Code custom settings profiles. The frontend store normalizes missing proxy fields to no-proxy and preserves profile-level overrides across save/load.

Validation: pnpm build; cargo check; cargo test --test router_vault_lock.