### PR TITLE
fix(ssh): restore hmac-sha1 MAC for legacy servers after russh 0.61 u…

### DIFF
--- a/src-tauri/src/terminal/ssh.rs
+++ b/src-tauri/src/terminal/ssh.rs
@@ -1,7 +1,7 @@
 use russh::client::{self, KeyboardInteractiveAuthResponse};
 use russh::keys::ssh_key::{Algorithm as SshAlgorithm, EcdsaCurve, HashAlg};
 use russh::keys::{self, PrivateKey, PrivateKeyWithHashAlg, PublicKey};
-use russh::{client::Msg, kex, ChannelId, ChannelMsg, ChannelReadHalf, ChannelWriteHalf, Pty};
+use russh::{client::Msg, kex, mac, ChannelId, ChannelMsg, ChannelReadHalf, ChannelWriteHalf, Pty};
 use russh::ChannelStream;
 use std::borrow::Cow;
 use std::future::Future;
@@ -304,6 +304,24 @@ const COMPAT_HOST_KEY_ORDER: &[SshAlgorithm] = &[
     SshAlgorithm::Rsa { hash: None },
 ];
 
+/// MAC algorithms offered to the server. This mirrors russh's modern default
+/// (`SAFE_HMAC_ORDER`) but appends the SHA-1 HMACs that russh 0.61 dropped from
+/// its built-in default. Some legacy servers (older OpenSSH, Dropbear, embedded
+/// devices) only support hmac-sha1; without it the handshake fails with
+/// "No common Mac algorithm". The SHA-1 variants are listed last so modern
+/// servers still negotiate a SHA-2 MAC and only old servers fall back to SHA-1.
+/// Note: russh 0.61 implements only these MAC names — hmac-md5, umac-64,
+/// hmac-ripemd160 and the *-96 truncated variants are not available, so
+/// hmac-sha1 is the only legacy MAC we can offer.
+const COMPAT_MAC_ORDER: &[mac::Name] = &[
+    mac::HMAC_SHA512_ETM,
+    mac::HMAC_SHA256_ETM,
+    mac::HMAC_SHA512,
+    mac::HMAC_SHA256,
+    mac::HMAC_SHA1_ETM,
+    mac::HMAC_SHA1,
+];
+
 const DEFAULT_PTY_MODES: &[(Pty, u32)] = &[
     (Pty::VINTR, 3),
     (Pty::VQUIT, 28),
@@ -360,7 +378,7 @@ fn build_client_config(network: Option<&NetworkSettings>) -> Arc<client::Config>
         kex: Cow::Borrowed(COMPAT_KEX_ORDER),
         key: Cow::Borrowed(COMPAT_HOST_KEY_ORDER),
         cipher: preferred.cipher,
-        mac: preferred.mac,
+        mac: Cow::Borrowed(COMPAT_MAC_ORDER),
         compression: preferred.compression,
     };
     if let Some(n) = network {


### PR DESCRIPTION
…pgrade

Connecting to older SSH servers began failing with "SSH handshake failed: No common Mac algorithm" after the russh 0.46 -> 0.61 dependency upgrade. russh renamed its default MAC list from HMAC_ORDER to SAFE_HMAC_ORDER and dropped the SHA-1 HMACs (hmac-sha1 and hmac-sha1-etm) from it.

build_client_config() previously broadened only the KEX and host-key lists for legacy-server compatibility (COMPAT_KEX_ORDER / COMPAT_HOST_KEY_ORDER) while leaving mac at the russh default. After 0.61 that default offers only the four SHA-2 MACs, so a server that supports nothing newer than hmac-sha1 (older OpenSSH, Dropbear, embedded devices) shares no common MAC and the handshake aborts before authentication.

Add COMPAT_MAC_ORDER: the four modern SHA-2 MACs in the same order as the old default, with hmac-sha1-etm and hmac-sha1 appended at the end, and point preferred.mac at it.

Safe for existing connections: russh client negotiation (impl Select for Client) is client-preference-first per RFC 4253, so any server supporting a SHA-2 MAC still selects it before reaching the SHA-1 entries. The first four entries are identical to the previous default, and AEAD ciphers (chacha20-poly1305, aes-gcm) negotiate no separate MAC at all. SHA-1 is only chosen as a last resort for servers that would otherwise fail to connect.

Note: russh 0.61 implements only the sha1/sha2 HMAC variants; hmac-md5, umac-64, hmac-ripemd160 and the *-96 truncations cannot be offered. Verified with cargo check --lib; live handshake needs a real legacy server to confirm.