### PR TITLE
feat(db): add full value viewer for query results

### DIFF
--- a/.agents/skills/qa-ui-auto/references/testid-catalog.md
+++ b/.agents/skills/qa-ui-auto/references/testid-catalog.md
@@ -100,6 +100,10 @@
 - `[data-testid="schema-tree"]` — display [optional] — F-DB-1.schema-tree
 - `[data-testid="sql-editor"]` — display [optional] — F-DB-1.sql-editor
 - `[data-testid="query-result-grid"]` — display [optional] — F-DB-1.query-result-grid
+- `[data-testid="query-cell-value-dialog"]` — display [optional] — F-DB-1.query-cell-value-dialog
+- `[data-testid="query-cell-value-text"]` — display [optional] — F-DB-1.query-cell-value-text
+- `[data-testid="query-cell-value-copy"]` — interactive [optional] — F-DB-1.query-cell-value-copy
+- `[data-testid="query-cell-value-wrap"]` — interactive [optional] — F-DB-1.query-cell-value-wrap
 - `select[aria-label="Schema"]` — interactive [optional] — F-DB-1.schema-select
 - `[data-testid="db-schema-drawer-handle"]` — interactive [optional] — F-DB-1.schema-drawer-handle
 - `[data-testid="db-floating-toolbar"]` — display [optional] — F-DB-1.floating-toolbar

--- a/qa-ui-auto-tests/feature-list.md
+++ b/qa-ui-auto-tests/feature-list.md
@@ -3250,6 +3250,22 @@ controls:
     selector: '[data-testid="query-result-grid"]'
     kind: display
     optional: true
+  - id: query-cell-value-dialog
+    selector: '[data-testid="query-cell-value-dialog"]'
+    kind: display
+    optional: true       # opened from a live query result cell via Ctrl+Enter/context menu
+  - id: query-cell-value-text
+    selector: '[data-testid="query-cell-value-text"]'
+    kind: display
+    optional: true
+  - id: query-cell-value-copy
+    selector: '[data-testid="query-cell-value-copy"]'
+    kind: interactive
+    optional: true
+  - id: query-cell-value-wrap
+    selector: '[data-testid="query-cell-value-wrap"]'
+    kind: interactive
+    optional: true
   - id: schema-select
     selector: 'select[aria-label="Schema"]'
     kind: interactive
@@ -3284,7 +3300,7 @@ controls:
 - DB 会话（MySQL/PostgreSQL/ClickHouse）经 `SessionEditor` 创建（proto 选择器 + database section 由 F6.3 拥有），打开后 `MainLayout.openDbTab` 挂载 `DbClientTab`（`type:"database"`），与 SFTP/VNC 一样常驻挂载以便查询跨标签存活
 - 左侧 `SchemaTree`：懒加载 schema→table→column/index 展开（`db-schema-drawer-handle` 抽屉折叠）；右侧查询工作区为多 query 面板（最多 4 个）的 tab 布局
 - `SqlEditorPanel` 封装 CodeMirror 6：按引擎选 dialect、schema-aware 自动补全（`SQLNamespace`），暴露命令式 `SqlEditorHandle`；工具条 Run (F5) / Run selection / Cancel / Format / History / Save / Rows / Sheets / Schema 选择
-- `QueryResultGrid` 为手写虚拟化网格（行高 24 + overscan）：NULL 徽标、数值右对齐、排序、CSV/单元格复制、列显隐、聚合统计、行筛选、Table/List/Chart 视图、增删改行 + 提交/撤销
+- `QueryResultGrid` 为手写虚拟化网格（行高 24 + overscan）：NULL 徽标、数值右对齐、排序、CSV/单元格复制、完整值查看（Ctrl+Enter / 右键菜单，保留长文本和换行）、列显隐、聚合统计、行筛选、Table/List/Chart 视图、增删改行 + 提交/撤销
 - 查询工作区跨会话持久化（`queryRegistry` + `ef0b686`），结果可经 Export Grid 对话框导出
 - 浮动工具条复用共享 `FloatingToolbar`（F10.1，`db-floating-toolbar`）：Chat 入口 / 最大化 / 分离到独立窗口（`db-detach`，分离/重挂载行为属 F-Detach-1）
 - **e2e 测试限制**：实际查询需活的 MySQL/PostgreSQL/ClickHouse fixture，浏览器冒烟无法连接；smoke 只覆盖「SessionEditor 选 DB proto → 填 host/port → 保存 → 打开标签 → schema-tree / sql-editor / query-result-grid 挂载」的路由路径（参照 TC-111 RDP scaffold 模式），真实查询/编辑留待配置 DB fixture 的手动/native 回归

--- a/src/components/database/QueryResultGrid.test.tsx
+++ b/src/components/database/QueryResultGrid.test.tsx
@@ -66,6 +66,24 @@ function filterResult(): DbQueryResult {
   };
 }
 
+function longTextResult(): DbQueryResult {
+  return {
+    columns: [
+      { name: "id", type: "Int" },
+      { name: "payload", type: "Text" },
+    ],
+    rows: [
+      [
+        "1",
+        "first line\nsecond line with a long value that should stay complete when viewed from the result grid",
+      ],
+    ],
+    rowsAffected: 0,
+    durationMs: 5,
+    warnings: [],
+  };
+}
+
 describe("QueryResultGrid", () => {
   it("keeps the table header horizontally synchronized with the body scroll", () => {
     render(<QueryResultGrid result={wideResult()} />);
@@ -108,5 +126,29 @@ describe("QueryResultGrid", () => {
     fireEvent.keyDown(grid, { key: "c", ctrlKey: true });
 
     expect(vi.mocked(writeText)).toHaveBeenLastCalledWith("name\tstatus\nAnn\tactive\nAnne\tinactive");
+  });
+
+  it("opens the full cell value with Ctrl+Enter and preserves line breaks", () => {
+    const result = longTextResult();
+    const value = result.rows[0][1]!;
+    render(<QueryResultGrid result={result} />);
+
+    fireEvent.click(screen.getByText(/first line/));
+    fireEvent.keyDown(screen.getByTestId("query-result-grid-scroll"), { key: "Enter", ctrlKey: true });
+
+    expect(screen.getByTestId("query-cell-value-dialog")).toBeInTheDocument();
+    expect(screen.getByTestId("query-cell-value-text")).toHaveValue(value);
+  });
+
+  it("copies the complete cell value from the full value dialog", () => {
+    const result = longTextResult();
+    const value = result.rows[0][1]!;
+    render(<QueryResultGrid result={result} />);
+
+    fireEvent.contextMenu(screen.getByText(/first line/));
+    fireEvent.click(screen.getByTestId("context-menu-item-view-full-value"));
+    fireEvent.click(screen.getByTestId("query-cell-value-copy"));
+
+    expect(vi.mocked(writeText)).toHaveBeenLastCalledWith(value);
   });
 });

--- a/src/components/database/QueryResultGrid.tsx
+++ b/src/components/database/QueryResultGrid.tsx
@@ -37,6 +37,7 @@ import {
   Sigma,
   Table2,
   Trash2,
+  X,
 } from "lucide-react";
 import type { DbColumn, DbQueryResult } from "../../lib/ipc";
 import {
@@ -126,6 +127,12 @@ interface OpenColumnFilter {
 interface GridCellCoord {
   rowId: string;
   colIdx: number;
+}
+
+interface CellValueViewer {
+  rowNumber: number;
+  column: DbColumn;
+  value: string | null;
 }
 
 interface GridBlockSelection {
@@ -789,6 +796,7 @@ export function QueryResultGrid({
   const [exportColumns, setExportColumns] = useState<ExportColumnConfig[]>(() => defaultExportColumns(result.columns));
   const [submittingChanges, setSubmittingChanges] = useState(false);
   const [exportDialogOpen, setExportDialogOpen] = useState(false);
+  const [cellValueViewer, setCellValueViewer] = useState<CellValueViewer | null>(null);
   const [localNotice, setLocalNotice] = useState("");
   const { show: openCellMenu, showAt: openMenuAt, render: menu } = useContextMenu();
 
@@ -799,6 +807,7 @@ export function QueryResultGrid({
     setLastSelectedId(null);
     setActiveCell(null);
     setEditingCell(null);
+    setCellValueViewer(null);
   }, [result]);
 
   useEffect(() => {
@@ -1274,6 +1283,35 @@ export function QueryResultGrid({
     }
   };
 
+  const openCellValueViewer = (row: GridRow, colIdx: number): boolean => {
+    const column = result.columns[colIdx];
+    if (!column || row.status === "deleted") return false;
+    const visibleRowIndex = orderedRows.findIndex((candidate) => candidate.id === row.id);
+    const fallbackRowIndex = Math.max(0, visibleRowIndex >= 0 ? visibleRowIndex : rows.findIndex((candidate) => candidate.id === row.id));
+    setCellValueViewer({
+      rowNumber: (row.originalIndex ?? fallbackRowIndex) + 1,
+      column,
+      value: row.values[colIdx] ?? null,
+    });
+    return true;
+  };
+
+  const openActiveCellValueViewer = (): boolean => {
+    if (!activeCell) return false;
+    const row = rows.find((candidate) => candidate.id === activeCell.rowId);
+    if (!row) return false;
+    return openCellValueViewer(row, activeCell.colIdx);
+  };
+
+  const copyCellViewerValue = async (viewer: CellValueViewer) => {
+    try {
+      await writeText(viewer.value ?? "");
+      setStatus("Copied full cell value.");
+    } catch (err) {
+      setStatus(`Copy failed: ${String(err)}`);
+    }
+  };
+
   const rowsForTarget = (target: ExportTarget): GridRow[] => {
     if (target === "selection" && selectionRows.length > 0) return selectionRows;
     return nonDeletedOrderedRows;
@@ -1404,6 +1442,12 @@ export function QueryResultGrid({
       setCellBlockSelection(null);
       return;
     }
+    if (event.ctrlKey && !event.shiftKey && !event.altKey && !event.metaKey && event.key === "Enter") {
+      if (openActiveCellValueViewer()) {
+        event.preventDefault();
+      }
+      return;
+    }
     if ((event.ctrlKey || event.metaKey) && !event.shiftKey && !event.altKey && event.key.toLowerCase() === "c") {
       if (selectionRowCount > 0 || activeCell) {
         event.preventDefault();
@@ -1429,6 +1473,14 @@ export function QueryResultGrid({
           { separator: true, label: "block-selection-separator" },
         ]
       : []),
+    {
+      label: "View full value",
+      icon: <FileText className="w-3.5 h-3.5" />,
+      shortcut: "Ctrl+Enter",
+      onClick: () => void openCellValueViewer(row, colIdx),
+      disabled: row.status === "deleted",
+    },
+    { separator: true, label: "view-value-separator" },
     {
       label: "Copy cell",
       icon: <Copy className="w-3.5 h-3.5" />,
@@ -1950,7 +2002,11 @@ export function QueryResultGrid({
       )}
 
       {viewMode === "list" && (
-        <div className="flex-1 min-h-0 overflow-auto taomni-scroll-y p-2 text-[12px]">
+        <div
+          className="flex-1 min-h-0 overflow-auto taomni-scroll-y p-2 text-[12px]"
+          tabIndex={0}
+          onKeyDown={handleGridKeyDown}
+        >
           {nonDeletedOrderedRows.map((row, rowIndex) => (
             <div
               key={row.id}
@@ -1962,7 +2018,19 @@ export function QueryResultGrid({
                 {visibleColumnIndexes.map((columnIndex) => (
                   <div key={columnIndex} className="contents">
                     <div className="truncate text-[var(--taomni-text-muted)]">{result.columns[columnIndex].name}</div>
-                    <div className="min-w-0 truncate">{row.values[columnIndex] ?? <span className="text-[var(--taomni-text-muted)]">NULL</span>}</div>
+                    <div
+                      className="min-w-0 truncate rounded px-1 -mx-1 hover:bg-[var(--taomni-hover)]"
+                      title={row.values[columnIndex] ?? "NULL"}
+                      onClick={(event) => {
+                        setCellBlockSelection(null);
+                        setActiveCell({ rowId: row.id, colIdx: columnIndex });
+                        selectRow(row.id, event);
+                      }}
+                      onDoubleClick={() => openCellValueViewer(row, columnIndex)}
+                      onContextMenu={(event) => openCellMenu(event, cellMenu(row, columnIndex))}
+                    >
+                      {row.values[columnIndex] ?? <span className="text-[var(--taomni-text-muted)]">NULL</span>}
+                    </div>
                   </div>
                 ))}
               </div>
@@ -2020,6 +2088,13 @@ export function QueryResultGrid({
             setExportDialogOpen(false);
             void exportWithOptions(exportTarget, options, columns, destination);
           }}
+        />
+      )}
+      {cellValueViewer && (
+        <CellValueDialog
+          viewer={cellValueViewer}
+          onCopy={() => void copyCellViewerValue(cellValueViewer)}
+          onClose={() => setCellValueViewer(null)}
         />
       )}
       {openColumnFilter && openFilterColumn && (
@@ -2091,6 +2166,100 @@ export function QueryResultGrid({
         </div>
       )}
       {menu}
+    </div>
+  );
+}
+
+function CellValueDialog({
+  viewer,
+  onCopy,
+  onClose,
+}: {
+  viewer: CellValueViewer;
+  onCopy: () => void;
+  onClose: () => void;
+}) {
+  const [wrap, setWrap] = useState(true);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const text = viewer.value ?? "NULL";
+  const charCount = viewer.value?.length ?? 0;
+  const lineCount = viewer.value == null ? 0 : viewer.value.split(/\r\n|\r|\n/).length;
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/45"
+      onMouseDown={onClose}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Full value for ${viewer.column.name}`}
+        data-testid="query-cell-value-dialog"
+        className="w-[760px] max-w-[92vw] max-h-[86vh] flex flex-col rounded shadow-xl"
+        style={{ background: "var(--taomni-bg)", border: "1px solid var(--taomni-card-border)", color: "var(--taomni-text)" }}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="h-10 shrink-0 flex items-center gap-2 px-3" style={{ borderBottom: "1px solid var(--taomni-divider)" }}>
+          <FileText className="w-4 h-4 text-[var(--taomni-accent)]" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[12px] font-semibold" title={viewer.column.name}>
+              {viewer.column.name}
+            </div>
+            <div className="truncate text-[10px] text-[var(--taomni-text-muted)]">
+              Row {viewer.rowNumber} | {viewer.column.type} | {charCount} chars | {lineCount} lines
+            </div>
+          </div>
+          <label className="h-6 inline-flex items-center gap-1 px-1 text-[11px] text-[var(--taomni-text-muted)]">
+            <input
+              data-testid="query-cell-value-wrap"
+              type="checkbox"
+              checked={wrap}
+              onChange={(event) => setWrap(event.target.checked)}
+            />
+            Wrap
+          </label>
+          <button
+            type="button"
+            data-testid="query-cell-value-copy"
+            className="h-6 px-2 inline-flex items-center gap-1 rounded text-[11px] hover:bg-[var(--taomni-hover)]"
+            title="Copy full value"
+            onClick={onCopy}
+          >
+            <Copy className="w-3.5 h-3.5" /> Copy
+          </button>
+          <button
+            type="button"
+            className="h-6 w-6 inline-flex items-center justify-center rounded hover:bg-[var(--taomni-hover)]"
+            aria-label="Close full value"
+            onClick={onClose}
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+        <textarea
+          ref={textareaRef}
+          data-testid="query-cell-value-text"
+          className={`m-3 min-h-[280px] max-h-[calc(86vh-96px)] flex-1 resize-none rounded p-2 text-[12px] font-mono ${
+            wrap ? "whitespace-pre-wrap" : "whitespace-pre"
+          }`}
+          style={{
+            background: "var(--taomni-panel-bg)",
+            border: "1px solid var(--taomni-divider)",
+            color: viewer.value == null ? "var(--taomni-text-muted)" : "var(--taomni-text)",
+            overflow: "auto",
+          }}
+          wrap={wrap ? "soft" : "off"}
+          readOnly
+          value={text}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Issue #232 needs long database fields to be readable across every query result surface that uses the shared QueryResultGrid, without expanding virtualized row height or changing backend query decoding.

Add a shared full-value dialog opened from Ctrl+Enter on the active cell or from the cell context menu. The dialog preserves raw text and line breaks, distinguishes NULL, shows row/column/type metadata, supports copying the complete value, and includes a soft-wrap toggle.

Wire the same viewer into table and list result views while keeping existing table double-click editing behavior unchanged. This covers SQL database results and HBase shell results because both flow through DbQueryResult and QueryResultGrid.

Update focused Vitest coverage plus the qa-ui-auto F-DB-1 feature controls and generated testid catalog for the new query-cell-value controls.

Verification: pnpm test -- QueryResultGrid; pnpm build; PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto.audit --feature F-DB-1; git diff --check.