### PR TITLE
fix(git): handle Windows paths and large diffs

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -189,7 +189,7 @@ pub async fn git_probe_path(path: String) -> Result<GitProbeResult, String> {
 #[tauri::command]
 pub async fn git_init_repo(path: String) -> Result<GitProbeResult, String> {
     blocking(move || {
-        let path_buf = PathBuf::from(&path);
+        let path_buf = git_cwd_path(&path);
         run_git_in(Some(&path_buf), ["init"])?;
         probe_path(&path)
     })
@@ -252,9 +252,9 @@ pub async fn git_blob_pair(
             .clone()
             .and_then(|p| non_empty_string(&p))
             .unwrap_or_else(|| path.clone());
-        let old_bytes = read_blob_bytes(&root, &old_ref, &old_target)?;
-        let new_bytes = read_blob_bytes(&root, &new_ref, &path)?;
-        Ok(build_blob_pair(path, old_path, old_bytes, new_bytes))
+        let old_blob = read_blob(&root, &old_ref, &old_target)?;
+        let new_blob = read_blob(&root, &new_ref, &path)?;
+        Ok(build_blob_pair(path, old_path, old_blob, new_blob))
     })
     .await
 }
@@ -1009,7 +1009,7 @@ fn snapshot(root: &Path) -> Result<GitSnapshot, String> {
 }
 
 fn probe_path(path: &str) -> Result<GitProbeResult, String> {
-    let path_buf = PathBuf::from(path);
+    let path_buf = git_cwd_path(path);
     if !git_available() {
         return Ok(GitProbeResult {
             path: path.to_string(),
@@ -1036,6 +1036,75 @@ fn probe_path(path: &str) -> Result<GitProbeResult, String> {
             error: Some(error),
         }),
     }
+}
+
+fn git_cwd_path(path: &str) -> PathBuf {
+    PathBuf::from(normalize_windows_shell_path(path).unwrap_or_else(|| path.to_string()))
+}
+
+#[cfg(windows)]
+fn normalize_windows_shell_path(path: &str) -> Option<String> {
+    let path = path.trim();
+    if path.is_empty() {
+        return None;
+    }
+
+    let drive_uri_path = path.as_bytes();
+    if drive_uri_path.len() >= 3
+        && drive_uri_path[0] == b'/'
+        && drive_uri_path[2] == b':'
+        && drive_uri_path[1].is_ascii_alphabetic()
+    {
+        let rest = match &path[3..] {
+            "" => "/",
+            rest => rest,
+        };
+        return Some(
+            format!(
+                "{}:{}",
+                (drive_uri_path[1] as char).to_ascii_uppercase(),
+                rest
+            )
+            .replace('/', "\\"),
+        );
+    }
+
+    let mut parts = path.split('/');
+    if parts.next() == Some("") {
+        match (parts.next(), parts.next()) {
+            (Some(drive), None) if is_single_drive_letter(drive) => {
+                return Some(format!("{}:\\", drive.to_ascii_uppercase()));
+            }
+            (Some(drive), Some(rest)) if is_single_drive_letter(drive) => {
+                let suffix = std::iter::once(rest)
+                    .chain(parts)
+                    .collect::<Vec<_>>()
+                    .join("\\");
+                return Some(format!("{}:\\{}", drive.to_ascii_uppercase(), suffix));
+            }
+            (Some("cygdrive"), Some(drive)) if is_single_drive_letter(drive) => {
+                let suffix = parts.collect::<Vec<_>>().join("\\");
+                return Some(if suffix.is_empty() {
+                    format!("{}:\\", drive.to_ascii_uppercase())
+                } else {
+                    format!("{}:\\{}", drive.to_ascii_uppercase(), suffix)
+                });
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+#[cfg(not(windows))]
+fn normalize_windows_shell_path(_path: &str) -> Option<String> {
+    None
+}
+
+#[cfg(windows)]
+fn is_single_drive_letter(value: &str) -> bool {
+    value.len() == 1 && value.as_bytes()[0].is_ascii_alphabetic()
 }
 
 fn git_available() -> bool {
@@ -1635,17 +1704,61 @@ fn non_empty_string(value: &str) -> Option<String> {
 }
 
 const MAX_DIFF_BYTES: usize = 2_000_000;
+const MAX_DIFF_BYTES_U64: u64 = MAX_DIFF_BYTES as u64;
 
-fn read_blob_bytes(root: &Path, reference: &str, path: &str) -> Result<Option<Vec<u8>>, String> {
+#[derive(Debug, Clone)]
+struct BlobSide {
+    exists: bool,
+    bytes: Option<Vec<u8>>,
+    size: u64,
+}
+
+impl BlobSide {
+    fn absent() -> Self {
+        Self {
+            exists: false,
+            bytes: None,
+            size: 0,
+        }
+    }
+
+    fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self {
+            size: bytes.len() as u64,
+            exists: true,
+            bytes: Some(bytes),
+        }
+    }
+
+    fn oversized(size: u64) -> Self {
+        Self {
+            exists: true,
+            bytes: None,
+            size,
+        }
+    }
+}
+
+fn read_blob(root: &Path, reference: &str, path: &str) -> Result<BlobSide, String> {
     let reference = reference.trim();
     if reference.is_empty() {
-        return Ok(None);
+        return Ok(BlobSide::absent());
     }
     if reference == ":WORKTREE" {
         let full = root.join(path);
+        let size = match fs::metadata(&full) {
+            Ok(metadata) => metadata.len(),
+            Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(BlobSide::absent());
+            }
+            Err(e) => return Err(format!("failed to stat {path}: {e}")),
+        };
+        if size > MAX_DIFF_BYTES_U64 {
+            return Ok(BlobSide::oversized(size));
+        }
         return match fs::read(&full) {
-            Ok(bytes) => Ok(Some(bytes)),
-            Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Ok(bytes) => Ok(BlobSide::from_bytes(bytes)),
+            Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => Ok(BlobSide::absent()),
             Err(e) => Err(format!("failed to read {path}: {e}")),
         };
     }
@@ -1654,6 +1767,13 @@ fn read_blob_bytes(root: &Path, reference: &str, path: &str) -> Result<Option<Ve
     } else {
         format!("{reference}:{path}")
     };
+    let size = match git_blob_size(root, &spec)? {
+        Some(size) => size,
+        None => return Ok(BlobSide::absent()),
+    };
+    if size > MAX_DIFF_BYTES_U64 {
+        return Ok(BlobSide::oversized(size));
+    }
     let output = Command::new("git")
         .current_dir(root)
         .env("LC_ALL", "C")
@@ -1664,24 +1784,44 @@ fn read_blob_bytes(root: &Path, reference: &str, path: &str) -> Result<Option<Ve
     // A path that does not exist at the requested ref is "absent" rather than an
     // error: that is the added/deleted side of a diff.
     if output.status.success() {
-        Ok(Some(output.stdout))
+        Ok(BlobSide::from_bytes(output.stdout))
     } else {
-        Ok(None)
+        Ok(BlobSide::absent())
     }
+}
+
+fn git_blob_size(root: &Path, spec: &str) -> Result<Option<u64>, String> {
+    let output = Command::new("git")
+        .current_dir(root)
+        .env("LC_ALL", "C")
+        .env("LANG", "C")
+        .args(["cat-file", "-s", spec])
+        .output()
+        .map_err(|e| format!("failed to start git: {e}"))?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let raw = String::from_utf8_lossy(&output.stdout);
+    raw.trim()
+        .parse::<u64>()
+        .map(Some)
+        .map_err(|e| format!("failed to parse blob size for {spec}: {e}"))
 }
 
 fn build_blob_pair(
     path: String,
     old_path: Option<String>,
-    old_bytes: Option<Vec<u8>>,
-    new_bytes: Option<Vec<u8>>,
+    old_blob: BlobSide,
+    new_blob: BlobSide,
 ) -> GitBlobPair {
-    let old_exists = old_bytes.is_some();
-    let new_exists = new_bytes.is_some();
-    let old_size = old_bytes.as_ref().map(|b| b.len() as u64).unwrap_or(0);
-    let new_size = new_bytes.as_ref().map(|b| b.len() as u64).unwrap_or(0);
+    let old_exists = old_blob.exists;
+    let new_exists = new_blob.exists;
+    let old_size = old_blob.size;
+    let new_size = new_blob.size;
+    let old_bytes = old_blob.bytes;
+    let new_bytes = new_blob.bytes;
     let image = is_image_path(&path);
-    let oversize = old_size as usize > MAX_DIFF_BYTES || new_size as usize > MAX_DIFF_BYTES;
+    let oversize = old_size > MAX_DIFF_BYTES_U64 || new_size > MAX_DIFF_BYTES_U64;
 
     if image && !oversize {
         return GitBlobPair {
@@ -1817,6 +1957,53 @@ fn require_non_empty(label: &str, value: &str) -> Result<(), String> {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[cfg(windows)]
+    #[test]
+    fn maps_windows_shell_paths_for_git_cwd() {
+        assert_eq!(
+            git_cwd_path("/D:/code/person/taomni"),
+            PathBuf::from(r"D:\code\person\taomni")
+        );
+        assert_eq!(
+            git_cwd_path("/d/code/person/taomni"),
+            PathBuf::from(r"D:\code\person\taomni")
+        );
+        assert_eq!(git_cwd_path("/c"), PathBuf::from(r"C:\"));
+        assert_eq!(git_cwd_path("/C:"), PathBuf::from(r"C:\"));
+        assert_eq!(
+            git_cwd_path("/cygdrive/e/work/repo"),
+            PathBuf::from(r"E:\work\repo")
+        );
+        assert_eq!(
+            git_cwd_path("/home/user/repo"),
+            PathBuf::from("/home/user/repo")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn probes_repo_from_msys_drive_path() {
+        if !git_available() {
+            return;
+        }
+
+        let tmp = TempDir::new().unwrap();
+        run_git_in(Some(tmp.path()), ["init"]).unwrap();
+
+        let native = tmp.path().to_string_lossy();
+        let bytes = native.as_bytes();
+        if bytes.len() < 3 || bytes[1] != b':' {
+            return;
+        }
+        let drive = (bytes[0] as char).to_ascii_lowercase();
+        let rest = native[2..].replace('\\', "/");
+        let msys_path = format!("/{drive}/{}", rest.trim_start_matches('/'));
+
+        let probe = probe_path(&msys_path).unwrap();
+        assert!(probe.is_repo, "{probe:?}");
+        assert!(probe.repo_root.is_some(), "{probe:?}");
+    }
 
     #[test]
     fn parses_status_with_branch_and_changes() {
@@ -1997,8 +2184,8 @@ mod tests {
         let pair = build_blob_pair(
             "notes.txt".into(),
             None,
-            None,
-            Some(b"line one\nline two\n".to_vec()),
+            BlobSide::absent(),
+            BlobSide::from_bytes(b"line one\nline two\n".to_vec()),
         );
         assert!(!pair.old_exists);
         assert!(pair.new_exists);
@@ -2012,8 +2199,8 @@ mod tests {
         let pair = build_blob_pair(
             "logo.png".into(),
             None,
-            None,
-            Some(vec![0x89, 0x50, 0x4e, 0x47]),
+            BlobSide::absent(),
+            BlobSide::from_bytes(vec![0x89, 0x50, 0x4e, 0x47]),
         );
         assert!(pair.image);
         assert!(pair.binary);
@@ -2037,15 +2224,34 @@ mod tests {
         run_git_in(Some(root), ["commit", "-m", "init"]).unwrap();
         fs::write(root.join("a.txt"), "v2\n").unwrap();
 
-        let head = read_blob_bytes(root, "HEAD", "a.txt").unwrap();
-        assert_eq!(head.as_deref(), Some(b"v1\n".as_ref()));
-        let worktree = read_blob_bytes(root, ":WORKTREE", "a.txt").unwrap();
-        assert_eq!(worktree.as_deref(), Some(b"v2\n".as_ref()));
+        let head = read_blob(root, "HEAD", "a.txt").unwrap();
+        assert!(head.exists);
+        assert_eq!(head.bytes.as_deref(), Some(b"v1\n".as_ref()));
+        let worktree = read_blob(root, ":WORKTREE", "a.txt").unwrap();
+        assert!(worktree.exists);
+        assert_eq!(worktree.bytes.as_deref(), Some(b"v2\n".as_ref()));
         // Missing path at a ref is absent, not an error.
-        assert!(read_blob_bytes(root, "HEAD", "missing.txt")
-            .unwrap()
-            .is_none());
-        assert!(read_blob_bytes(root, "", "a.txt").unwrap().is_none());
+        assert!(!read_blob(root, "HEAD", "missing.txt").unwrap().exists);
+        assert!(!read_blob(root, "", "a.txt").unwrap().exists);
+    }
+
+    #[test]
+    fn skips_oversized_worktree_blob_body() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let path = root.join("large.txt");
+        fs::write(&path, vec![b'a'; MAX_DIFF_BYTES + 1]).unwrap();
+
+        let blob = read_blob(root, ":WORKTREE", "large.txt").unwrap();
+        assert!(blob.exists);
+        assert_eq!(blob.size, (MAX_DIFF_BYTES + 1) as u64);
+        assert!(blob.bytes.is_none());
+
+        let pair = build_blob_pair("large.txt".into(), None, BlobSide::absent(), blob);
+        assert!(pair.oversize);
+        assert!(pair.new_exists);
+        assert_eq!(pair.new_size, (MAX_DIFF_BYTES + 1) as u64);
+        assert_eq!(pair.new_text, None);
     }
 
     #[test]

--- a/src/components/git/CommitLog.tsx
+++ b/src/components/git/CommitLog.tsx
@@ -14,6 +14,7 @@ import { DiffViewer } from "./DiffViewer";
 
 const ROW_H = 44;
 const LANE_W = 14;
+const AUTO_PREVIEW_FILE_LIMIT = 300;
 
 function GraphCell({ row, maxWidth }: { row: GraphRow; maxWidth: number }) {
   const width = Math.max(maxWidth, 1) * LANE_W;
@@ -105,13 +106,19 @@ export function CommitLog({ repoRoot, headOid, busy, onContextMenu, pathFilter, 
     if (!selected) {
       setFiles([]);
       setFilePath(null);
+      setPair(null);
+      setPairLoading(false);
       return;
     }
+    setFiles([]);
+    setFilePath(null);
+    setPair(null);
+    setPairLoading(false);
     gitCommitFiles(repoRoot, selected.oid)
       .then((list) => {
         if (cancelled) return;
         setFiles(list);
-        setFilePath(list[0]?.path ?? null);
+        setFilePath(list.length > AUTO_PREVIEW_FILE_LIMIT ? null : list[0]?.path ?? null);
       })
       .catch(() => {
         if (!cancelled) setFiles([]);
@@ -127,6 +134,7 @@ export function CommitLog({ repoRoot, headOid, busy, onContextMenu, pathFilter, 
     const file = files.find((f) => f.path === filePath) ?? null;
     if (!selected || !file) {
       setPair(null);
+      setPairLoading(false);
       return;
     }
     setPairLoading(true);
@@ -147,6 +155,10 @@ export function CommitLog({ repoRoot, headOid, busy, onContextMenu, pathFilter, 
 
   const graph = useMemo(() => buildGraph(entries), [entries]);
   const maxWidth = useMemo(() => graph.reduce((m, r) => Math.max(m, r.width), 1), [graph]);
+  const diffEmptyLabel =
+    files.length > AUTO_PREVIEW_FILE_LIMIT && !filePath
+      ? `Large commit (${files.length} files). Select a file to preview its diff.`
+      : "Select a file to preview its diff";
 
   // RENDER_LOG
   return (
@@ -268,7 +280,7 @@ export function CommitLog({ repoRoot, headOid, busy, onContextMenu, pathFilter, 
           </Panel>
           <PanelResizeHandle className="h-[3px] bg-[var(--taomni-divider)] hover:bg-[var(--taomni-accent)] cursor-row-resize" />
           <Panel id="log-diff" defaultSize={70} minSize={20} className="min-h-0 flex flex-col">
-            <DiffViewer pair={pair} loading={pairLoading} emptyLabel="Select a file to preview its diff" />
+            <DiffViewer pair={pair} loading={pairLoading} emptyLabel={diffEmptyLabel} />
           </Panel>
         </PanelGroup>
       </Panel>

--- a/src/components/git/CompareView.tsx
+++ b/src/components/git/CompareView.tsx
@@ -9,6 +9,8 @@ import {
 } from "../../lib/git";
 import { DiffViewer } from "./DiffViewer";
 
+const AUTO_PREVIEW_FILE_LIMIT = 300;
+
 export interface CompareViewProps {
   repoRoot: string;
   refA: string;
@@ -41,11 +43,15 @@ export function CompareView({ repoRoot, refA, refB, title, onClose }: CompareVie
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setFiles([]);
+    setFilePath(null);
+    setPair(null);
+    setPairLoading(false);
     gitCompare(repoRoot, refA, refB)
       .then((list) => {
         if (cancelled) return;
         setFiles(list);
-        setFilePath(list[0]?.path ?? null);
+        setFilePath(list.length > AUTO_PREVIEW_FILE_LIMIT ? null : list[0]?.path ?? null);
       })
       .catch(() => {
         if (!cancelled) setFiles([]);
@@ -59,11 +65,16 @@ export function CompareView({ repoRoot, refA, refB, title, onClose }: CompareVie
   }, [repoRoot, refA, refB]);
 
   const file = useMemo(() => files.find((f) => f.path === filePath) ?? null, [files, filePath]);
+  const diffEmptyLabel =
+    files.length > AUTO_PREVIEW_FILE_LIMIT && !filePath
+      ? `Large comparison (${files.length} files). Select a file to preview its diff.`
+      : "Select a file to preview its diff";
 
   useEffect(() => {
     let cancelled = false;
     if (!file) {
       setPair(null);
+      setPairLoading(false);
       return;
     }
     setPairLoading(true);
@@ -121,7 +132,7 @@ export function CompareView({ repoRoot, refA, refB, title, onClose }: CompareVie
           </Panel>
           <PanelResizeHandle className="w-[3px] bg-[var(--taomni-divider)] hover:bg-[var(--taomni-accent)] cursor-col-resize" />
           <Panel id="compare-diff" defaultSize={68} minSize={35} className="min-w-0 min-h-0 flex flex-col">
-            <DiffViewer pair={pair} loading={pairLoading} emptyLabel="Select a file to preview its diff" />
+            <DiffViewer pair={pair} loading={pairLoading} emptyLabel={diffEmptyLabel} />
           </Panel>
         </PanelGroup>
       </div>

--- a/src/components/git/DiffViewer.tsx
+++ b/src/components/git/DiffViewer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { EditorState, type Extension } from "@codemirror/state";
 import { EditorView, lineNumbers } from "@codemirror/view";
 import { syntaxHighlighting, defaultHighlightStyle } from "@codemirror/language";
@@ -24,6 +24,8 @@ interface DiffViewerProps {
 
 const VIEW_KEY = "taomni.git.diff.view";
 const WS_KEY = "taomni.git.diff.ws";
+const MAX_AUTO_RENDER_CHARS = 300_000;
+const MAX_AUTO_RENDER_LINES = 12_000;
 
 function readPref<T extends string>(key: string, fallback: T): T {
   try {
@@ -101,11 +103,17 @@ export function DiffViewer({ pair, loading, emptyLabel }: DiffViewerProps) {
   const [whitespace, setWhitespace] = useState<WhitespaceMode>(() => readPref<WhitespaceMode>(WS_KEY, "none"));
   const [highlightWords, setHighlightWords] = useState(true);
   const [diffCount, setDiffCount] = useState(0);
+  const [forceRenderLargeDiffKey, setForceRenderLargeDiffKey] = useState("");
 
   const hostRef = useRef<HTMLDivElement | null>(null);
   const mergeRef = useRef<MergeView | null>(null);
   const unifiedRef = useRef<EditorView | null>(null);
   const navRef = useRef<EditorView | null>(null);
+  const pairKey = pair
+    ? `${pair.path}\0${pair.oldPath ?? ""}\0${pair.oldSize}\0${pair.newSize}\0${pair.oldText?.length ?? -1}\0${pair.newText?.length ?? -1}`
+    : "";
+  const complexity = useMemo(() => (pair ? diffComplexity(pair) : null), [pairKey, pair]);
+  const largeTextDiff = !!complexity?.tooLarge && forceRenderLargeDiffKey !== pairKey;
 
   const renderable = useMemo(
     () =>
@@ -113,8 +121,9 @@ export function DiffViewer({ pair, loading, emptyLabel }: DiffViewerProps) {
       !pair.binary &&
       !pair.image &&
       !pair.oversize &&
+      !largeTextDiff &&
       (pair.oldText != null || pair.newText != null),
-    [pair],
+    [largeTextDiff, pair],
   );
 
   useEffect(() => writePref(VIEW_KEY, view), [view]);
@@ -219,9 +228,6 @@ export function DiffViewer({ pair, loading, emptyLabel }: DiffViewerProps) {
   if (!pair) {
     return <DiffNotice text={emptyLabel ?? "Select an item to preview its diff"} />;
   }
-  if (pair.image) {
-    return <ImageDiff pair={pair} />;
-  }
   if (pair.oversize) {
     return (
       <DiffNotice
@@ -229,11 +235,25 @@ export function DiffViewer({ pair, loading, emptyLabel }: DiffViewerProps) {
       />
     );
   }
+  if (pair.image) {
+    return <ImageDiff pair={pair} />;
+  }
   if (pair.binary) {
     return (
       <DiffNotice
         text={`Binary file — no text diff available (${formatBytes(pair.oldSize)} → ${formatBytes(pair.newSize)}).`}
       />
+    );
+  }
+  if (largeTextDiff && complexity) {
+    return (
+      <DiffNotice
+        text={`Large text diff skipped (${formatBytes(pair.oldSize)} to ${formatBytes(pair.newSize)}, ${formatLines(complexity.maxLines)}).`}
+      >
+        <button className="taomni-btn h-7 px-2 mt-3" type="button" onClick={() => setForceRenderLargeDiffKey(pairKey)}>
+          Render anyway
+        </button>
+      </DiffNotice>
     );
   }
 
@@ -288,12 +308,37 @@ export function DiffViewer({ pair, loading, emptyLabel }: DiffViewerProps) {
   );
 }
 
-function DiffNotice({ text }: { text: string }) {
+function DiffNotice({ text, children }: { text: string; children?: ReactNode }) {
   return (
-    <div className="h-full min-h-24 flex items-center justify-center px-4 text-center text-[12px] text-[var(--taomni-text-muted)]">
-      {text}
+    <div className="h-full min-h-24 flex flex-col items-center justify-center px-4 text-center text-[12px] text-[var(--taomni-text-muted)]">
+      <div>{text}</div>
+      {children}
     </div>
   );
+}
+
+function diffComplexity(pair: GitBlobPair): { tooLarge: boolean; maxLines: number } {
+  const oldText = pair.oldText ?? "";
+  const newText = pair.newText ?? "";
+  const maxChars = Math.max(oldText.length, newText.length);
+  const maxLines = Math.max(countLines(oldText), countLines(newText));
+  return {
+    tooLarge: maxChars > MAX_AUTO_RENDER_CHARS || maxLines > MAX_AUTO_RENDER_LINES,
+    maxLines,
+  };
+}
+
+function countLines(text: string): number {
+  if (!text) return 0;
+  let lines = 1;
+  for (let i = 0; i < text.length; i += 1) {
+    if (text.charCodeAt(i) === 10) lines += 1;
+  }
+  return lines;
+}
+
+function formatLines(n: number): string {
+  return `${n.toLocaleString()} line${n === 1 ? "" : "s"}`;
 }
 
 function ImageDiff({ pair }: { pair: GitBlobPair }) {


### PR DESCRIPTION
Normalize Windows shell-style paths before running git commands so Git Bash/MSYS paths such as /d/repo, /D:/repo, and /cygdrive/e/repo are probed as native Windows paths. This prevents existing repositories from being misdetected as uninitialized on Windows while preserving Linux behavior.

Avoid expensive diff previews for large changes. Blob reads now check file or git object size before loading content, oversized blobs are reported without reading their bodies, large commit/compare views skip automatic first-file preview, and very large text diffs require an explicit Render anyway action before CodeMirror/MergeView is created.

Also clear stale diff loading state when selections or comparison inputs are reset, and add Rust coverage for Windows path normalization, repo probing through an MSYS-style path, and skipping oversized worktree blob bodies.

Verified with: .\\node_modules\\.bin\\tsc.CMD -b; cargo test --lib blob; cargo test --lib maps_windows_shell_paths_for_git_cwd; cargo test --lib probes_repo_from_msys_drive_path; git diff --check.