### PR TITLE
fix(git): improve diff viewer scrolling

### DIFF
--- a/src/components/git/DiffViewer.tsx
+++ b/src/components/git/DiffViewer.tsx
@@ -6,10 +6,9 @@ import {
   MergeView,
   unifiedMergeView,
   getChunks,
-  goToNextChunk,
-  goToPreviousChunk,
+  type Chunk,
 } from "@codemirror/merge";
-import { ChevronDown, ChevronUp, Columns2, Loader2, Rows2 } from "lucide-react";
+import { ChevronDown, ChevronUp, Columns2, Loader2, RefreshCw, Rows2 } from "lucide-react";
 import type { GitBlobPair } from "../../lib/git";
 import { buildDiffOverride, type WhitespaceMode } from "../../lib/diffWhitespace";
 import { languageForPath } from "./diffLanguage";
@@ -24,8 +23,10 @@ interface DiffViewerProps {
 
 const VIEW_KEY = "taomni.git.diff.view";
 const WS_KEY = "taomni.git.diff.ws";
+const SYNC_SCROLL_KEY = "taomni.git.diff.syncScroll";
 const MAX_AUTO_RENDER_CHARS = 300_000;
 const MAX_AUTO_RENDER_LINES = 12_000;
+const CONNECTOR_WIDTH = 36;
 
 function readPref<T extends string>(key: string, fallback: T): T {
   try {
@@ -63,7 +64,6 @@ function baseExtensions(language: Extension | null): Extension[] {
     lineNumbers(),
     EditorView.editable.of(false),
     EditorState.readOnly.of(true),
-    EditorView.lineWrapping,
     syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
     diffTheme,
   ];
@@ -77,175 +77,231 @@ if (typeof document !== "undefined" && !document.getElementById(STYLE_ID)) {
   const style = document.createElement("style");
   style.id = STYLE_ID;
   style.textContent = `
-.taomni-diff-host .cm-mergeView, .taomni-diff-host .cm-mergeViewEditors { height: 100%; }
-.taomni-diff-host .cm-editor { height: 100%; }
-.taomni-diff-host .cm-mergeView .cm-scroller { overflow: auto; }
+.taomni-diff-host {
+  --taomni-diff-editor-bg: #fbfdff;
+  --taomni-diff-gutter-bg: #f4f7fb;
+  --taomni-diff-text: #142033;
+  --taomni-diff-muted: #6b778c;
+  --taomni-diff-border: #d9e2ef;
+  --taomni-diff-scroll-track: #eef3f8;
+  --taomni-diff-scroll-thumb: #bac6d6;
+  --taomni-diff-added-bg: rgba(32, 135, 75, 0.14);
+  --taomni-diff-added-word: rgba(32, 135, 75, 0.28);
+  --taomni-diff-deleted-bg: rgba(210, 63, 79, 0.12);
+  --taomni-diff-deleted-word: rgba(210, 63, 79, 0.26);
+  --taomni-diff-modified-bg: rgba(42, 111, 201, 0.13);
+  --taomni-diff-modified-word: rgba(42, 111, 201, 0.27);
+  --taomni-diff-connector-added: rgba(32, 135, 75, 0.2);
+  --taomni-diff-connector-deleted: rgba(210, 63, 79, 0.18);
+  --taomni-diff-connector-modified: rgba(42, 111, 201, 0.19);
+  --taomni-diff-connector-stroke: rgba(91, 111, 140, 0.26);
+}
 
-/* Custom JetBrains-like fonts and editor defaults */
+html[data-app-theme="dark"] .taomni-diff-host {
+  --taomni-diff-editor-bg: #101720;
+  --taomni-diff-gutter-bg: #0c121a;
+  --taomni-diff-text: #dce6f3;
+  --taomni-diff-muted: #8fa1b6;
+  --taomni-diff-border: #243346;
+  --taomni-diff-scroll-track: #0c121a;
+  --taomni-diff-scroll-thumb: #405067;
+  --taomni-diff-added-bg: rgba(48, 170, 102, 0.24);
+  --taomni-diff-added-word: rgba(64, 205, 125, 0.4);
+  --taomni-diff-deleted-bg: rgba(231, 86, 103, 0.2);
+  --taomni-diff-deleted-word: rgba(255, 118, 132, 0.34);
+  --taomni-diff-modified-bg: rgba(86, 156, 245, 0.22);
+  --taomni-diff-modified-word: rgba(112, 178, 255, 0.36);
+  --taomni-diff-connector-added: rgba(48, 170, 102, 0.28);
+  --taomni-diff-connector-deleted: rgba(231, 86, 103, 0.24);
+  --taomni-diff-connector-modified: rgba(86, 156, 245, 0.26);
+  --taomni-diff-connector-stroke: rgba(143, 161, 182, 0.24);
+}
+
+.taomni-diff-host .cm-mergeView,
+.taomni-diff-host .cm-mergeViewEditors,
+.taomni-diff-host .cm-editor {
+  height: 100% !important;
+  min-height: 0;
+}
+
+.taomni-diff-host .cm-mergeView {
+  overflow: hidden !important;
+  background: var(--taomni-diff-editor-bg);
+}
+
+.taomni-diff-host .cm-mergeViewEditors {
+  align-items: stretch;
+}
+
+.taomni-diff-host .cm-mergeViewEditor {
+  min-width: 0;
+  min-height: 0;
+  background: var(--taomni-diff-editor-bg);
+}
+
+.taomni-diff-host .cm-mergeViewEditor + .cm-mergeViewEditor {
+  border-left: 1px solid var(--taomni-diff-border);
+}
+
+.taomni-diff-host .cm-mergeView .cm-editor .cm-scroller,
+.taomni-diff-host > .cm-editor .cm-scroller {
+  height: 100% !important;
+  overflow: auto !important;
+}
+
 .taomni-diff-host .cm-editor,
 .taomni-diff-host .cm-mergeView,
 .taomni-diff-host .cm-deletedChunk {
   font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace !important;
   font-size: 13px !important;
-  line-height: 1.6 !important;
+  line-height: 1.58 !important;
 }
 
-/* Light Theme Variables */
-.taomni-diff-host {
-  --intellij-diff-added-bg: rgba(46, 160, 67, 0.08);
-  --intellij-diff-added-word: rgba(46, 160, 67, 0.2);
-  --intellij-diff-deleted-bg: rgba(240, 82, 82, 0.06);
-  --intellij-diff-deleted-word: rgba(240, 82, 82, 0.18);
-  --intellij-diff-modified-bg: rgba(30, 144, 255, 0.07);
-  --intellij-diff-modified-word: rgba(30, 144, 255, 0.18);
-  --intellij-diff-spacer-bg: #f8fafc;
-  --intellij-diff-gutter-color: #94a3b8;
-  --intellij-diff-revert-hover: #e2e8f0;
-  --intellij-diff-revert-color: #2563eb;
-  --intellij-diff-divider: #e2e8f0;
-}
-
-/* Dark Theme Variables */
-html[data-app-theme="dark"] .taomni-diff-host {
-  --intellij-diff-added-bg: rgba(46, 160, 67, 0.15);
-  --intellij-diff-added-word: rgba(46, 160, 67, 0.35);
-  --intellij-diff-deleted-bg: rgba(240, 82, 82, 0.12);
-  --intellij-diff-deleted-word: rgba(240, 82, 82, 0.3);
-  --intellij-diff-modified-bg: rgba(59, 130, 246, 0.15);
-  --intellij-diff-modified-word: rgba(59, 130, 246, 0.35);
-  --intellij-diff-spacer-bg: #0f172a;
-  --intellij-diff-gutter-color: #475569;
-  --intellij-diff-revert-hover: #1e293b;
-  --intellij-diff-revert-color: #60a5fa;
-  --intellij-diff-divider: #1e293b;
-}
-
-/* Editor backgrounds and overall layout */
 .taomni-diff-host .cm-editor {
-  background-color: var(--taomni-input-bg, transparent) !important;
-  color: var(--taomni-text) !important;
+  background: var(--taomni-diff-editor-bg) !important;
+  color: var(--taomni-diff-text) !important;
 }
 
-/* Gutters */
+.taomni-diff-host .cm-line {
+  color: var(--taomni-diff-text);
+}
+
 .taomni-diff-host .cm-gutters {
-  background-color: var(--taomni-input-bg, transparent) !important;
-  color: var(--intellij-diff-gutter-color) !important;
-  border-right: 1px solid var(--intellij-diff-divider) !important;
+  background: var(--taomni-diff-gutter-bg) !important;
+  color: var(--taomni-diff-muted) !important;
+  border-right: 1px solid var(--taomni-diff-border) !important;
 }
 
-/* Changed lines and word highlights in split view */
-.taomni-diff-host .cm-merge-a .cm-changedLine {
-  background-color: var(--intellij-diff-deleted-bg) !important;
+.taomni-diff-host .cm-activeLine,
+.taomni-diff-host .cm-activeLineGutter {
+  background: color-mix(in srgb, var(--taomni-accent) 10%, transparent) !important;
 }
+
+.taomni-diff-host .cm-selectionBackground,
+.taomni-diff-host .cm-focused .cm-selectionBackground {
+  background: var(--taomni-editor-selection-bg) !important;
+}
+
+.taomni-diff-host .cm-merge-a .cm-changedLine {
+  background-color: var(--taomni-diff-deleted-bg) !important;
+}
+
 .taomni-diff-host .cm-merge-a .cm-changedText {
-  background-color: var(--intellij-diff-deleted-word) !important;
-  background-image: none !important; /* Remove CodeMirror default underline */
+  background: var(--taomni-diff-deleted-word) !important;
   border-radius: 2px;
 }
 
 .taomni-diff-host .cm-merge-b .cm-changedLine {
-  background-color: var(--intellij-diff-added-bg) !important;
+  background-color: var(--taomni-diff-added-bg) !important;
 }
+
 .taomni-diff-host .cm-merge-b .cm-changedText {
-  background-color: var(--intellij-diff-added-word) !important;
-  background-image: none !important; /* Remove CodeMirror default underline */
+  background: var(--taomni-diff-added-word) !important;
   border-radius: 2px;
 }
 
-/* Changed lines and word highlights in unified view */
 .taomni-diff-host .cm-deletedChunk {
-  background-color: var(--intellij-diff-deleted-bg) !important;
-  border-left: 3px solid #ef4444 !important;
+  background: var(--taomni-diff-deleted-bg) !important;
+  border-left: 3px solid #e04f5f !important;
   padding-left: 8px !important;
 }
+
 .taomni-diff-host .cm-deletedLine {
-  background-color: transparent !important;
+  background: transparent !important;
 }
+
 .taomni-diff-host .cm-deletedChunk .cm-deletedText {
-  background-color: var(--intellij-diff-deleted-word) !important;
-  background-image: none !important;
+  background: var(--taomni-diff-deleted-word) !important;
   border-radius: 2px;
 }
+
 .taomni-diff-host .cm-inlineChangedLine {
-  background-color: var(--intellij-diff-modified-bg) !important;
+  background: var(--taomni-diff-modified-bg) !important;
 }
 
-/* Line number gutters of changed lines match the line background */
-.taomni-diff-host .cm-merge-a .cm-changedLineGutter {
-  background-color: var(--intellij-diff-deleted-bg) !important;
-  color: var(--taomni-text) !important;
-}
-.taomni-diff-host .cm-merge-b .cm-changedLineGutter {
-  background-color: var(--intellij-diff-added-bg) !important;
-  color: var(--taomni-text) !important;
-}
+.taomni-diff-host .cm-merge-a .cm-changedLineGutter,
 .taomni-diff-host .cm-deletedLineGutter {
-  background-color: var(--intellij-diff-deleted-bg) !important;
-  color: var(--taomni-text) !important;
+  background: var(--taomni-diff-deleted-bg) !important;
+  color: var(--taomni-diff-text) !important;
 }
+
+.taomni-diff-host .cm-merge-b .cm-changedLineGutter {
+  background: var(--taomni-diff-added-bg) !important;
+  color: var(--taomni-diff-text) !important;
+}
+
 .taomni-diff-host .cm-inlineChangedLineGutter {
-  background-color: var(--intellij-diff-modified-bg) !important;
-  color: var(--taomni-text) !important;
+  background: var(--taomni-diff-modified-bg) !important;
+  color: var(--taomni-diff-text) !important;
 }
 
-/* Spacers (empty line fillers) */
 .taomni-diff-host .cm-mergeSpacer {
-  background-color: var(--intellij-diff-spacer-bg) !important;
-  background-image: none !important; /* Remove default hatch pattern */
+  background: color-mix(in srgb, var(--taomni-diff-border) 28%, transparent) !important;
+  background-image: none !important;
 }
 
-/* Revert column / middle gutter - Make it seamless and transparent like IntelliJ */
-.taomni-diff-host .cm-merge-revert {
-  background-color: transparent !important;
-  border: none !important;
-  width: 20px !important;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
+.taomni-diff-host .taomni-diff-connector {
+  position: relative;
+  flex: 0 0 ${CONNECTOR_WIDTH}px;
+  width: ${CONNECTOR_WIDTH}px;
+  min-width: ${CONNECTOR_WIDTH}px;
+  height: 100%;
+  overflow: hidden;
+  background:
+    linear-gradient(to right, transparent 0, color-mix(in srgb, var(--taomni-diff-border) 55%, transparent) 50%, transparent 100%),
+    var(--taomni-diff-gutter-bg);
+  border-left: 1px solid var(--taomni-diff-border);
+  border-right: 1px solid var(--taomni-diff-border);
+  pointer-events: none;
 }
 
-.taomni-diff-host .cm-merge-revert button {
-  color: var(--intellij-diff-revert-color) !important;
-  font-weight: bold !important;
-  font-size: 14px !important;
-  line-height: 1 !important;
-  height: 18px !important;
-  width: 18px !important;
-  border-radius: 4px !important;
-  display: inline-flex !important;
-  align-items: center !important;
-  justify-content: center !important;
-  transition: var(--taomni-transition) !important;
-  opacity: 0; /* Hidden by default, show on hover like IntelliJ */
-  background-color: transparent !important;
+.taomni-diff-host .taomni-diff-connector svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 
-/* Show the revert button when hovering over the revert column or the button itself */
-.taomni-diff-host .cm-merge-revert:hover button,
-.taomni-diff-host .cm-merge-revert button:hover {
-  opacity: 1;
+.taomni-diff-host .taomni-diff-connector-path {
+  stroke: var(--taomni-diff-connector-stroke);
+  stroke-width: 1;
 }
 
-.taomni-diff-host .cm-merge-revert button:hover {
-  background-color: var(--intellij-diff-revert-hover) !important;
+.taomni-diff-host .taomni-diff-connector-path.is-added {
+  fill: var(--taomni-diff-connector-added);
 }
 
-/* Collapsed lines widget */
-.taomni-diff-host .cm-collapsedLines {
-  font-size: 11px !important;
-  font-family: var(--taomni-ui-font-family) !important;
-  border: 1px solid var(--intellij-diff-divider) !important;
-  border-radius: 4px !important;
-  margin: 4px 8px !important;
-  text-align: center !important;
-  padding: 4px !important;
-  transition: var(--taomni-transition) !important;
+.taomni-diff-host .taomni-diff-connector-path.is-deleted {
+  fill: var(--taomni-diff-connector-deleted);
 }
 
-.taomni-diff-host .cm-collapsedLines:hover {
-  background-color: var(--taomni-hover) !important;
-  border-color: var(--taomni-accent) !important;
+.taomni-diff-host .taomni-diff-connector-path.is-modified {
+  fill: var(--taomni-diff-connector-modified);
+}
+
+.taomni-diff-host .cm-scroller {
+  scrollbar-color: var(--taomni-diff-scroll-thumb) var(--taomni-diff-scroll-track);
+  scrollbar-width: thin;
+}
+
+.taomni-diff-host .cm-scroller::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+.taomni-diff-host .cm-scroller::-webkit-scrollbar-track {
+  background: var(--taomni-diff-scroll-track);
+}
+
+.taomni-diff-host .cm-scroller::-webkit-scrollbar-thumb {
+  background: var(--taomni-diff-scroll-thumb);
+  border: 3px solid var(--taomni-diff-scroll-track);
+  border-radius: 6px;
+}
+
+.taomni-diff-host .cm-scroller::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--taomni-diff-scroll-thumb) 78%, var(--taomni-diff-text));
 }
 `;
   document.head.appendChild(style);
@@ -259,6 +315,163 @@ function imageDataUrl(path: string, b64: string | null): string | null {
   return `data:${mime};base64,${b64}`;
 }
 
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function chunkKind(chunk: Chunk): "added" | "deleted" | "modified" {
+  if (chunk.fromA === chunk.toA) return "added";
+  if (chunk.fromB === chunk.toB) return "deleted";
+  return "modified";
+}
+
+function sideRange(view: EditorView, chunk: Chunk, side: "a" | "b"): { top: number; bottom: number } {
+  const docLength = view.state.doc.length;
+  const from = side === "a" ? chunk.fromA : chunk.fromB;
+  const to = side === "a" ? chunk.toA : chunk.toB;
+  const end = side === "a" ? chunk.endA : chunk.endB;
+  const empty = from === to;
+  const startPos = clampNumber(from, 0, docLength);
+  const startBlock = view.lineBlockAt(startPos);
+  const top = startBlock.top - view.scrollDOM.scrollTop;
+  if (empty) {
+    const markerHeight = clampNumber(startBlock.height * 0.25, 4, 8);
+    return { top, bottom: top + markerHeight };
+  }
+  const endPos = clampNumber(Math.max(startPos, end - 1), 0, docLength);
+  const endBlock = view.lineBlockAt(endPos);
+  return { top, bottom: endBlock.bottom - view.scrollDOM.scrollTop };
+}
+
+function connectorPath(left: { top: number; bottom: number }, right: { top: number; bottom: number }, width: number): string {
+  const leftTop = Math.round(left.top * 10) / 10;
+  const rightTop = Math.round(right.top * 10) / 10;
+  const leftBottom = Math.max(leftTop + 3, Math.round(left.bottom * 10) / 10);
+  const rightBottom = Math.max(rightTop + 3, Math.round(right.bottom * 10) / 10);
+  const c1 = Math.round(width * 0.42);
+  const c2 = Math.round(width * 0.58);
+  return [
+    `M 0 ${leftTop}`,
+    `C ${c1} ${leftTop}, ${c2} ${rightTop}, ${width} ${rightTop}`,
+    `L ${width} ${rightBottom}`,
+    `C ${c2} ${rightBottom}, ${c1} ${leftBottom}, 0 ${leftBottom}`,
+    "Z",
+  ].join(" ");
+}
+
+function mappedScrollTop(source: HTMLElement, target: HTMLElement): number {
+  const sourceMax = Math.max(0, source.scrollHeight - source.clientHeight);
+  const targetMax = Math.max(0, target.scrollHeight - target.clientHeight);
+  if (sourceMax === 0 || targetMax === 0) return 0;
+  return (source.scrollTop / sourceMax) * targetMax;
+}
+
+function setupSplitDiffInteractions(mv: MergeView, isSyncEnabled: () => boolean): () => void {
+  const editorDom = mv.dom.querySelector<HTMLElement>(".cm-mergeViewEditors");
+  const editorWraps = editorDom
+    ? Array.from(editorDom.children).filter((child): child is HTMLElement =>
+        child instanceof HTMLElement && child.classList.contains("cm-mergeViewEditor"),
+      )
+    : [];
+  const leftWrap = editorWraps[0];
+  const rightWrap = editorWraps[1];
+  if (!editorDom || !leftWrap || !rightWrap) return () => {};
+
+  const connector = document.createElement("div");
+  connector.className = "taomni-diff-connector";
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("aria-hidden", "true");
+  const pathLayer = document.createElementNS("http://www.w3.org/2000/svg", "g");
+  svg.appendChild(pathLayer);
+  connector.appendChild(svg);
+  editorDom.insertBefore(connector, rightWrap);
+
+  const aScroll = mv.a.scrollDOM;
+  const bScroll = mv.b.scrollDOM;
+  let ignoreNextScroll: HTMLElement | null = null;
+  let renderFrame = 0;
+  let deferredRender = 0;
+
+  const renderConnectors = () => {
+    renderFrame = 0;
+    if (!connector.isConnected) return;
+    const width = connector.clientWidth || CONNECTOR_WIDTH;
+    const height = connector.clientHeight;
+    svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+    svg.setAttribute("width", String(width));
+    svg.setAttribute("height", String(height));
+
+    const fragment = document.createDocumentFragment();
+    for (const chunk of mv.chunks) {
+      const left = sideRange(mv.a, chunk, "a");
+      const right = sideRange(mv.b, chunk, "b");
+      if (Math.max(left.bottom, right.bottom) < -24 || Math.min(left.top, right.top) > height + 24) {
+        continue;
+      }
+      const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      path.setAttribute("class", `taomni-diff-connector-path is-${chunkKind(chunk)}`);
+      path.setAttribute("d", connectorPath(left, right, width));
+      fragment.appendChild(path);
+    }
+    pathLayer.replaceChildren(fragment);
+  };
+
+  const queueRender = () => {
+    if (renderFrame === 0) {
+      renderFrame = window.requestAnimationFrame(renderConnectors);
+    }
+  };
+
+  const handleScroll = (source: HTMLElement, target: HTMLElement) => {
+    if (ignoreNextScroll === source) {
+      ignoreNextScroll = null;
+      queueRender();
+      return;
+    }
+    if (isSyncEnabled()) {
+      ignoreNextScroll = target;
+      target.scrollTop = mappedScrollTop(source, target);
+    }
+    queueRender();
+  };
+
+  const onAScroll = () => handleScroll(aScroll, bScroll);
+  const onBScroll = () => handleScroll(bScroll, aScroll);
+  aScroll.addEventListener("scroll", onAScroll, { passive: true });
+  bScroll.addEventListener("scroll", onBScroll, { passive: true });
+
+  const resizeObserver = typeof ResizeObserver !== "undefined" ? new ResizeObserver(queueRender) : null;
+  resizeObserver?.observe(connector);
+  resizeObserver?.observe(aScroll);
+  resizeObserver?.observe(bScroll);
+  window.addEventListener("resize", queueRender);
+
+  queueRender();
+  deferredRender = window.setTimeout(queueRender, 80);
+
+  return () => {
+    aScroll.removeEventListener("scroll", onAScroll);
+    bScroll.removeEventListener("scroll", onBScroll);
+    window.removeEventListener("resize", queueRender);
+    resizeObserver?.disconnect();
+    if (renderFrame !== 0) window.cancelAnimationFrame(renderFrame);
+    if (deferredRender !== 0) window.clearTimeout(deferredRender);
+    connector.remove();
+  };
+}
+
+function scrollChunkIntoView(view: EditorView, chunk: Chunk, side: "a" | "b") {
+  const docLength = view.state.doc.length;
+  const from = side === "a" ? chunk.fromA : chunk.fromB;
+  const end = side === "a" ? chunk.endA : chunk.endB;
+  const anchor = clampNumber(from, 0, docLength);
+  const scrollPos = clampNumber(Math.max(anchor, end - 1), 0, docLength);
+  view.dispatch({
+    selection: { anchor },
+    effects: EditorView.scrollIntoView(scrollPos, { y: "center", x: "nearest" }),
+  });
+}
+
 function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
@@ -268,6 +481,9 @@ function formatBytes(n: number): string {
 export function DiffViewer({ pair, loading, emptyLabel }: DiffViewerProps) {
   const [view, setView] = useState<ViewMode>(() => readPref<ViewMode>(VIEW_KEY, "split"));
   const [whitespace, setWhitespace] = useState<WhitespaceMode>(() => readPref<WhitespaceMode>(WS_KEY, "none"));
+  const [syncScrolling, setSyncScrolling] = useState(
+    () => readPref<"true" | "false">(SYNC_SCROLL_KEY, "true") !== "false",
+  );
   const [highlightWords, setHighlightWords] = useState(true);
   const [diffCount, setDiffCount] = useState(0);
   const [forceRenderLargeDiffKey, setForceRenderLargeDiffKey] = useState("");
@@ -275,7 +491,9 @@ export function DiffViewer({ pair, loading, emptyLabel }: DiffViewerProps) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const mergeRef = useRef<MergeView | null>(null);
   const unifiedRef = useRef<EditorView | null>(null);
-  const navRef = useRef<EditorView | null>(null);
+  const scrollCleanupRef = useRef<(() => void) | null>(null);
+  const syncScrollingRef = useRef(syncScrolling);
+  const activeChunkIndexRef = useRef(-1);
   const pairKey = pair
     ? `${pair.path}\0${pair.oldPath ?? ""}\0${pair.oldSize}\0${pair.newSize}\0${pair.oldText?.length ?? -1}\0${pair.newText?.length ?? -1}`
     : "";
@@ -295,19 +513,25 @@ export function DiffViewer({ pair, loading, emptyLabel }: DiffViewerProps) {
 
   useEffect(() => writePref(VIEW_KEY, view), [view]);
   useEffect(() => writePref(WS_KEY, whitespace), [whitespace]);
+  useEffect(() => writePref(SYNC_SCROLL_KEY, String(syncScrolling)), [syncScrolling]);
+  useEffect(() => {
+    syncScrollingRef.current = syncScrolling;
+  }, [syncScrolling]);
 
   // BUILD_EFFECT
   useEffect(() => {
     let cancelled = false;
     const teardown = () => {
+      scrollCleanupRef.current?.();
+      scrollCleanupRef.current = null;
       mergeRef.current?.destroy();
       mergeRef.current = null;
       unifiedRef.current?.destroy();
       unifiedRef.current = null;
-      navRef.current = null;
     };
     teardown();
     setDiffCount(0);
+    activeChunkIndexRef.current = -1;
     const host = hostRef.current;
     if (!host || !renderable || !pair) {
       return () => {
@@ -332,11 +556,10 @@ export function DiffViewer({ pair, loading, emptyLabel }: DiffViewerProps) {
             orientation: "a-b",
             highlightChanges: highlightWords,
             gutter: true,
-            collapseUnchanged: { margin: 6, minSize: 8 },
             diffConfig,
           });
           mergeRef.current = mv;
-          navRef.current = mv.b;
+          scrollCleanupRef.current = setupSplitDiffInteractions(mv, () => syncScrollingRef.current);
           setDiffCount(mv.chunks.length);
         } else {
           const uv = new EditorView({
@@ -349,13 +572,11 @@ export function DiffViewer({ pair, loading, emptyLabel }: DiffViewerProps) {
                 mergeControls: false,
                 highlightChanges: highlightWords,
                 gutter: true,
-                collapseUnchanged: { margin: 6, minSize: 8 },
                 diffConfig,
               }),
             ],
           });
           unifiedRef.current = uv;
-          navRef.current = uv;
           setDiffCount(getChunks(uv.state)?.chunks.length ?? 0);
         }
       })
@@ -369,20 +590,36 @@ export function DiffViewer({ pair, loading, emptyLabel }: DiffViewerProps) {
     };
   }, [pair, renderable, view, whitespace, highlightWords]);
 
-  const goNext = useCallback(() => {
-    const v = navRef.current;
-    if (v) {
-      goToNextChunk(v);
-      v.focus();
+  const goToChunk = useCallback((direction: 1 | -1) => {
+    const mv = mergeRef.current;
+    const uv = unifiedRef.current;
+    const chunks = mv?.chunks ?? (uv ? getChunks(uv.state)?.chunks : null) ?? [];
+    if (chunks.length === 0) return;
+
+    const current = activeChunkIndexRef.current;
+    const next =
+      current < 0 || current >= chunks.length
+        ? direction < 0
+          ? chunks.length - 1
+          : 0
+        : (current + direction + chunks.length) % chunks.length;
+    activeChunkIndexRef.current = next;
+    const chunk = chunks[next];
+
+    if (mv) {
+      scrollChunkIntoView(mv.a, chunk, "a");
+      scrollChunkIntoView(mv.b, chunk, "b");
+      mv.b.focus();
+      return;
+    }
+
+    if (uv) {
+      scrollChunkIntoView(uv, chunk, "b");
+      uv.focus();
     }
   }, []);
-  const goPrev = useCallback(() => {
-    const v = navRef.current;
-    if (v) {
-      goToPreviousChunk(v);
-      v.focus();
-    }
-  }, []);
+  const goNext = useCallback(() => goToChunk(1), [goToChunk]);
+  const goPrev = useCallback(() => goToChunk(-1), [goToChunk]);
 
   // RENDER
   if (loading) {
@@ -448,6 +685,23 @@ export function DiffViewer({ pair, loading, emptyLabel }: DiffViewerProps) {
 
         <div className="h-4 w-[1px] bg-[var(--taomni-divider)] mx-1" />
 
+        {view === "split" && (
+          <button
+            type="button"
+            title={syncScrolling ? "Synchronize scrolling: on" : "Synchronize scrolling: off"}
+            aria-pressed={syncScrolling}
+            className={`h-7 w-7 rounded-md inline-flex items-center justify-center border transition-all duration-150 cursor-pointer ${
+              syncScrolling
+                ? "border-[var(--taomni-accent-soft)] bg-[color-mix(in_srgb,var(--taomni-accent)_15%,transparent)] text-[var(--taomni-accent)]"
+                : "border-[var(--taomni-divider)] bg-[var(--taomni-card-bg)] text-[var(--taomni-text-muted)] hover:text-[var(--taomni-text)] hover:bg-[var(--taomni-hover)]"
+            }`}
+            onClick={() => setSyncScrolling((current) => !current)}
+          >
+            <RefreshCw className="w-3.5 h-3.5" />
+            <span className="sr-only">Synchronize scrolling</span>
+          </button>
+        )}
+
         <select
           className="h-7 bg-[var(--taomni-input-bg)] border border-[var(--taomni-input-border)] rounded-md px-2 text-[11px] text-[var(--taomni-text)] hover:border-[var(--taomni-accent-soft)] focus:outline-none transition-all duration-150 cursor-pointer"
           value={whitespace}
@@ -496,7 +750,7 @@ export function DiffViewer({ pair, loading, emptyLabel }: DiffViewerProps) {
           </button>
         </div>
       </div>
-      <div ref={hostRef} className="taomni-diff-host flex-1 min-h-0 overflow-hidden" />
+      <div ref={hostRef} data-testid="git-diff-viewer" className="taomni-diff-host flex-1 min-h-0 overflow-hidden" />
     </div>
   );
 }


### PR DESCRIPTION
Update the CodeMirror-based Git diff viewer to better match an IDE side-by-side diff experience.

- remove unchanged-code collapsing so the full file remains scrollable

- add a persisted synchronized scrolling toggle for split diffs

- navigate diff chunks by index and scroll both panes together from toolbar buttons

- render a middle connector band between left and right changed ranges

- tune diff backgrounds, gutters, word highlights, fonts, and scrollbars for dark-theme readability

- keep unrelated repository changes out of this commit