### PR TITLE
Add custom SQL syntax highlighting, theme tokens, and minor UI fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@codemirror/view": "^6.43.0",
     "@fontsource/inter": "^5.2.8",
     "@fontsource/outfit": "^5.2.8",
+    "@lezer/highlight": "1.2.3",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-notification": "^2.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@fontsource/outfit':
         specifier: ^5.2.8
         version: 5.2.8
+      '@lezer/highlight':
+        specifier: 1.2.3
+        version: 1.2.3
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0

--- a/src/components/database/SqlEditorPanel.tsx
+++ b/src/components/database/SqlEditorPanel.tsx
@@ -33,7 +33,8 @@ import {
   closeBracketsKeymap,
   type CompletionSource,
 } from "@codemirror/autocomplete";
-import { bracketMatching, syntaxHighlighting, defaultHighlightStyle } from "@codemirror/language";
+import { bracketMatching, HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { tags } from "@lezer/highlight";
 import type { DbMetadataCache } from "../../lib/dbMetadataCache";
 import { createSqlMetadataCompletionSource } from "../../lib/sqlMetadataCompletions";
 
@@ -78,6 +79,48 @@ function autocompleteFor(
   }
   return autocompletion();
 }
+
+const sqlHighlightStyle = HighlightStyle.define([
+  {
+    tag: tags.keyword,
+    color: "var(--taomni-db-syntax-keyword, #1d4ed8)",
+    fontWeight: "600",
+  },
+  {
+    tag: [tags.definitionKeyword, tags.modifier, tags.operatorKeyword],
+    color: "var(--taomni-db-syntax-keyword, #1d4ed8)",
+    fontWeight: "600",
+  },
+  {
+    tag: [tags.name, tags.variableName, tags.propertyName],
+    color: "var(--taomni-db-syntax-name, var(--taomni-text))",
+  },
+  {
+    tag: [tags.function(tags.variableName), tags.function(tags.propertyName)],
+    color: "var(--taomni-db-syntax-function, #0f766e)",
+  },
+  {
+    tag: [tags.string, tags.special(tags.string)],
+    color: "var(--taomni-db-syntax-string, #047857)",
+  },
+  {
+    tag: [tags.number, tags.integer, tags.float, tags.bool, tags.atom],
+    color: "var(--taomni-db-syntax-atom, #b45309)",
+  },
+  {
+    tag: [tags.comment, tags.lineComment, tags.blockComment],
+    color: "var(--taomni-db-syntax-comment, var(--taomni-text-muted))",
+    fontStyle: "italic",
+  },
+  {
+    tag: [tags.operator, tags.compareOperator, tags.logicOperator, tags.arithmeticOperator],
+    color: "var(--taomni-db-syntax-operator, var(--taomni-text-muted))",
+  },
+  {
+    tag: [tags.punctuation, tags.separator],
+    color: "var(--taomni-db-syntax-punctuation, var(--taomni-text-muted))",
+  },
+]);
 
 function dialectFor(engine: string): SQLDialect {
   switch (engine) {
@@ -202,7 +245,7 @@ export function SqlEditorPanel({
         bracketMatching(),
         closeBrackets(),
         autocompleteCompartment.current.of(autocompleteFor(completionSources, defaultSources)),
-        syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+        syntaxHighlighting(sqlHighlightStyle),
         langCompartment.current.of(
           sql({ dialect: dialectFor(engine), upperCaseKeywords: true }),
         ),
@@ -267,6 +310,24 @@ export function SqlEditorPanel({
           },
           ".cm-cursor": {
             borderLeftColor: "var(--taomni-accent)",
+          },
+          ".cm-tooltip, .cm-tooltip-autocomplete": {
+            backgroundColor: "var(--taomni-panel-bg)",
+            color: "var(--taomni-text)",
+            border: "1px solid var(--taomni-divider)",
+            boxShadow: "var(--taomni-shadow-md)",
+          },
+          ".cm-tooltip-autocomplete ul li[aria-selected]": {
+            backgroundColor: "var(--taomni-selected)",
+            color: "var(--taomni-text)",
+          },
+          ".cm-completionIcon": {
+            color: "var(--taomni-text-muted)",
+          },
+          ".cm-completionMatchedText": {
+            color: "var(--taomni-accent-soft)",
+            textDecoration: "none",
+            fontWeight: "600",
           },
           "&.cm-focused": { outline: "none" },
         }),

--- a/src/components/git/DiffViewer.tsx
+++ b/src/components/git/DiffViewer.tsx
@@ -792,7 +792,7 @@ function ImageDiff({ pair }: { pair: GitBlobPair }) {
   const oldUrl = imageDataUrl(pair.oldPath ?? pair.path, pair.oldImageB64);
   const newUrl = imageDataUrl(pair.path, pair.newImageB64);
   return (
-    <div className="h-full min-h-0 grid grid-cols-2 gap-2 p-3 overflow-auto bg-[var(--taomni-terminal-bg,#111827)]">
+    <div className="h-full min-h-0 grid grid-cols-2 gap-2 p-3 overflow-auto bg-[var(--taomni-term-bg,#111827)]">
       <ImageSide label={`Before · ${formatBytes(pair.oldSize)}`} url={oldUrl} missing="Not present" />
       <ImageSide label={`After · ${formatBytes(pair.newSize)}`} url={newUrl} missing="Deleted" />
     </div>

--- a/src/components/git/GitPanel.tsx
+++ b/src/components/git/GitPanel.tsx
@@ -1106,7 +1106,7 @@ function SettingInput({ label, value, onChange }: { label: string; value: string
 
 function DiffPane({ diff, loading }: { diff: string; loading: boolean }) {
   return (
-    <div className="flex-1 min-h-0 overflow-auto bg-[var(--taomni-terminal-bg,#111827)]">
+    <div className="flex-1 min-h-0 overflow-auto bg-[var(--taomni-term-bg,#111827)]">
       {loading ? (
         <div className="h-full flex items-center justify-center text-[var(--taomni-text-muted)]">
           <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading diff

--- a/src/index.css
+++ b/src/index.css
@@ -57,6 +57,14 @@
   --taomni-term-text: #f8fafc;
   --taomni-term-prompt: #10b981;
   --taomni-term-path: #3b82f6;
+  --taomni-db-syntax-keyword: #1d4ed8;
+  --taomni-db-syntax-name: #0f172a;
+  --taomni-db-syntax-function: #0f766e;
+  --taomni-db-syntax-string: #047857;
+  --taomni-db-syntax-atom: #b45309;
+  --taomni-db-syntax-comment: #64748b;
+  --taomni-db-syntax-operator: #475569;
+  --taomni-db-syntax-punctuation: #475569;
   --taomni-link: #2563eb;
   --taomni-ribbon-from: #f8fafc;
   --taomni-ribbon-to: #e2e8f0;
@@ -157,6 +165,14 @@ html[data-app-theme="dark"] {
   --taomni-scrollbar-track: #0b0f19;
   --taomni-scrollbar-thumb: #334155;
   --taomni-scrollbar-thumb-hover: #475569;
+  --taomni-db-syntax-keyword: #93c5fd;
+  --taomni-db-syntax-name: #f8fafc;
+  --taomni-db-syntax-function: #67e8f9;
+  --taomni-db-syntax-string: #86efac;
+  --taomni-db-syntax-atom: #fcd34d;
+  --taomni-db-syntax-comment: #94a3b8;
+  --taomni-db-syntax-operator: #cbd5e1;
+  --taomni-db-syntax-punctuation: #cbd5e1;
   --taomni-link: #60a5fa;
   --taomni-ribbon-from: #0f172a;
   --taomni-ribbon-to: #0b0f19;
@@ -824,18 +840,24 @@ html[data-app-theme="dark"] .bg-white {
 html[data-app-theme="dark"] .bg-white\/90 {
   background-color: color-mix(in srgb, var(--taomni-panel-bg) 90%, transparent) !important;
 }
-html[data-app-theme="dark"] .bg-slate-100 {
+html[data-app-theme="dark"] .bg-slate-100,
+html[data-app-theme="dark"] .bg-slate-200 {
   background-color: var(--taomni-quick-bg) !important;
 }
 html[data-app-theme="dark"] .border-slate-100,
+html[data-app-theme="dark"] .border-slate-200,
+html[data-app-theme="dark"] .border-slate-300,
 html[data-app-theme="dark"] .border-slate-400,
 html[data-app-theme="dark"] .border-slate-500 {
   border-color: var(--taomni-divider) !important;
 }
-html[data-app-theme="dark"] .text-slate-300,
-html[data-app-theme="dark"] .text-slate-500,
-html[data-app-theme="dark"] .text-slate-600,
 html[data-app-theme="dark"] .text-slate-700 {
+  color: var(--taomni-text) !important;
+}
+html[data-app-theme="dark"] .text-slate-300,
+html[data-app-theme="dark"] .text-slate-400,
+html[data-app-theme="dark"] .text-slate-500,
+html[data-app-theme="dark"] .text-slate-600 {
   color: var(--taomni-text-muted) !important;
 }
 html[data-app-theme="dark"] .hover\:bg-white\/15:hover,


### PR DESCRIPTION
### Motivation

- Provide a tailored SQL color theme and improve completion tooltip styling for the SQL editor to match app tokens and make database code more readable. 
- Centralize DB-syntax color tokens in `index.css` so light/dark themes can use consistent semantic variables. 
- Fix incorrect CSS variable usage for terminal background in a couple of panes.

### Description

- Added `@lezer/highlight` as a dependency and updated the lockfile to enable use of lezer tagging. 
- Implemented a custom `sqlHighlightStyle` in `src/components/database/SqlEditorPanel.tsx` (using `HighlightStyle.define` and `tags`) and replaced the previous `syntaxHighlighting` call to use this style. 
- Added editor/autocomplete tooltip styling and completion match/icon rules inside the editor `EditorView.theme` in `SqlEditorPanel.tsx`. 
- Introduced new CSS variables for DB syntax colors in `src/index.css` and wired light/dark variants plus a few dark-mode text/color class overrides. 
- Fixed background variable name typos from `--taomni-terminal-bg` to `--taomni-term-bg` in `src/components/git/DiffViewer.tsx` and `src/components/git/GitPanel.tsx`.

### Testing

- Ran `pnpm install` which updated the lockfile and completed successfully. 
- Built the frontend with `pnpm run build` and the build completed without errors. 
- Executed the test suite with `pnpm test` and the automated tests passed (no regressions reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a431cec4f48833391ab9a01f6684d74)