### PR TITLE
feat(ui): refine dark theme and git typography

### DIFF
--- a/src/components/git/DiffViewer.tsx
+++ b/src/components/git/DiffViewer.tsx
@@ -48,7 +48,7 @@ const diffTheme = EditorView.theme({
   "&": { backgroundColor: "transparent", color: "var(--taomni-text)", height: "100%" },
   ".cm-scroller": {
     fontFamily: '"JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
-    fontSize: "13px",
+    fontSize: "var(--taomni-git-diff-font-size)",
     lineHeight: "1.6",
   },
   ".cm-gutters": {
@@ -78,6 +78,7 @@ if (typeof document !== "undefined" && !document.getElementById(STYLE_ID)) {
   style.id = STYLE_ID;
   style.textContent = `
 .taomni-diff-host {
+  --taomni-git-diff-font-size: calc(var(--taomni-ui-font-size) + 1px);
   --taomni-diff-editor-bg: #fbfdff;
   --taomni-diff-gutter-bg: #f4f7fb;
   --taomni-diff-text: #142033;
@@ -153,7 +154,7 @@ html[data-app-theme="dark"] .taomni-diff-host {
 .taomni-diff-host .cm-mergeView,
 .taomni-diff-host .cm-deletedChunk {
   font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace !important;
-  font-size: 13px !important;
+  font-size: var(--taomni-git-diff-font-size) !important;
   line-height: 1.58 !important;
 }
 

--- a/src/components/git/GitPanel.test.tsx
+++ b/src/components/git/GitPanel.test.tsx
@@ -1,0 +1,142 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "../../stores/appStore";
+import { GitPanel } from "./GitPanel";
+import type { GitOperationState, GitSnapshot } from "../../lib/git";
+
+const gitMocks = vi.hoisted(() => {
+  const settings = {
+    userName: null,
+    userEmail: null,
+    httpProxy: null,
+    httpsProxy: null,
+    pullRebase: null,
+    pushDefault: null,
+    coreAutocrlf: null,
+    coreFilemode: null,
+    commitGpgsign: null,
+  };
+
+  const snapshot: GitSnapshot = {
+    repoRoot: "D:\\repo",
+    currentBranch: "main",
+    headOid: "abc123",
+    detached: false,
+    upstream: null,
+    ahead: 0,
+    behind: 0,
+    changes: [],
+    remotes: [],
+    branches: [
+      {
+        name: "main",
+        fullName: "main",
+        current: true,
+        remote: false,
+        upstream: null,
+        oid: "abc123",
+        subject: "Initial commit",
+      },
+    ],
+    stashes: [],
+    tags: [],
+    settings,
+  };
+
+  return {
+    gitSnapshot: vi.fn(async () => snapshot),
+    gitOperationState: vi.fn(async (): Promise<GitOperationState> => ({ kind: "none", conflictedPaths: [] })),
+    gitRepoName: vi.fn(() => "repo"),
+    gitChangeLabel: vi.fn((change: { status: string }) => change.status),
+    selectedRemote: vi.fn(() => null),
+    gitBlobPair: vi.fn(),
+    gitCheckoutBranch: vi.fn(),
+    gitCherryPick: vi.fn(),
+    gitOperationContinue: vi.fn(),
+    gitOperationAbort: vi.fn(),
+    gitRebaseSkip: vi.fn(),
+    gitResolveConflict: vi.fn(),
+    gitCleanUntracked: vi.fn(),
+    gitCommit: vi.fn(),
+    gitCreateBranch: vi.fn(),
+    gitDeleteBranch: vi.fn(),
+    gitDeleteRemote: vi.fn(),
+    gitDiscard: vi.fn(),
+    gitFetch: vi.fn(),
+    gitMergeBranch: vi.fn(),
+    gitRenameBranch: vi.fn(),
+    gitSetUpstream: vi.fn(),
+    gitCreateTag: vi.fn(),
+    gitDeleteTag: vi.fn(),
+    gitPushTag: vi.fn(),
+    gitCheckoutTag: vi.fn(),
+    gitPull: vi.fn(),
+    gitPush: vi.fn(),
+    gitReset: vi.fn(),
+    gitRevert: vi.fn(),
+    gitSaveRemoteAuth: vi.fn(),
+    gitSaveSettings: vi.fn(),
+    gitSetRemote: vi.fn(),
+    gitStage: vi.fn(),
+    gitStashApply: vi.fn(),
+    gitStashDrop: vi.fn(),
+    gitStashSave: vi.fn(),
+    gitStashShow: vi.fn(),
+    gitUnstage: vi.fn(),
+  };
+});
+
+vi.mock("../../lib/git", () => ({
+  ...gitMocks,
+  GIT_REF_WORKTREE: ":WORKTREE",
+}));
+
+describe("GitPanel", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useAppStore.setState({
+      uiFontFamily: "Inter",
+      uiFontSize: 12,
+      statusMessage: "Ready",
+    });
+    gitMocks.gitSnapshot.mockClear();
+    gitMocks.gitOperationState.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses Ctrl plus/minus/zero to adjust global UI font size while the Git panel is active", async () => {
+    render(<GitPanel repoRoot="D:\\repo" />);
+
+    await waitFor(() => expect(gitMocks.gitSnapshot).toHaveBeenCalled());
+
+    fireEvent.keyDown(window, { key: "=", code: "Equal", ctrlKey: true });
+    expect(useAppStore.getState().uiFontSize).toBe(13);
+    expect(window.localStorage.getItem("taomni.uiFontSize")).toBe("13");
+
+    fireEvent.keyDown(window, { key: "-", code: "Minus", ctrlKey: true });
+    expect(useAppStore.getState().uiFontSize).toBe(12);
+
+    fireEvent.keyDown(window, { key: "+", code: "Equal", ctrlKey: true });
+    expect(useAppStore.getState().uiFontSize).toBe(13);
+
+    fireEvent.keyDown(window, { key: "0", code: "Digit0", ctrlKey: true });
+    expect(useAppStore.getState().uiFontSize).toBe(12);
+    expect(window.localStorage.getItem("taomni.uiFontSize")).toBe("12");
+  });
+
+  it("uses Ctrl wheel to adjust global UI font size inside the Git panel", async () => {
+    render(<GitPanel repoRoot="D:\\repo" />);
+
+    await waitFor(() => expect(gitMocks.gitSnapshot).toHaveBeenCalled());
+    const panel = screen.getByTestId("git-panel");
+
+    fireEvent.wheel(panel, { ctrlKey: true, deltaY: -100 });
+    expect(useAppStore.getState().uiFontSize).toBe(13);
+
+    fireEvent.wheel(panel, { ctrlKey: true, deltaY: 100 });
+    expect(useAppStore.getState().uiFontSize).toBe(12);
+  });
+});

--- a/src/components/git/GitPanel.tsx
+++ b/src/components/git/GitPanel.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 import {
   AlertTriangle,
   GitBranch,
@@ -97,6 +104,7 @@ const EMPTY_SETTINGS: GitRepoSettings = {
 
 export function GitPanel({ repoRoot }: GitPanelProps) {
   const setStatusMessage = useAppStore((s) => s.setStatusMessage);
+  const setUiFontSize = useAppStore((s) => s.setUiFontSize);
   const [view, setView] = useState<GitView>("changes");
   const [snapshot, setSnapshot] = useState<GitSnapshot | null>(null);
   const [loading, setLoading] = useState(false);
@@ -127,6 +135,7 @@ export function GitPanel({ repoRoot }: GitPanelProps) {
   const [amendChecked, setAmendChecked] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number; path: string } | null>(null);
   const [commitMenu, setCommitMenu] = useState<{ x: number; y: number; entry: GitLogEntry } | null>(null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
   const anchorRef = useRef<string | null>(null);
   const [operation, setOperation] = useState<GitOperationState | null>(null);
   const [compare, setCompare] = useState<{ refA: string; refB: string; title: string } | null>(null);
@@ -146,6 +155,72 @@ export function GitPanel({ repoRoot }: GitPanelProps) {
     [selectedPath, snapshot],
   );
   const hasConflicts = !!snapshot?.changes.some((change) => change.conflict);
+  const setGitUiFontSize = useCallback(
+    (size: number) => {
+      const next = Math.min(18, Math.max(10, Math.round(size)));
+      setUiFontSize(next);
+      setStatusMessage(`UI font size ${next}px`);
+    },
+    [setStatusMessage, setUiFontSize],
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!event.ctrlKey || event.altKey || event.metaKey) return;
+
+      const increase =
+        event.key === "+" ||
+        event.key === "=" ||
+        event.code === "NumpadAdd";
+      const decrease =
+        event.key === "-" ||
+        event.key === "_" ||
+        event.code === "NumpadSubtract";
+      const reset =
+        event.key === "0" ||
+        event.code === "Digit0" ||
+        event.code === "Numpad0";
+
+      if (!increase && !decrease && !reset) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+
+      const current = useAppStore.getState().uiFontSize;
+      if (increase) {
+        setGitUiFontSize(current + 1);
+      } else if (decrease) {
+        setGitUiFontSize(current - 1);
+      } else {
+        setGitUiFontSize(12);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [setGitUiFontSize]);
+
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+
+    const handleWheel = (event: WheelEvent) => {
+      if (!event.ctrlKey) return;
+      event.preventDefault();
+      event.stopPropagation();
+
+      const current = useAppStore.getState().uiFontSize;
+      if (event.deltaY < 0) {
+        setGitUiFontSize(current + 1);
+      } else if (event.deltaY > 0) {
+        setGitUiFontSize(current - 1);
+      }
+    };
+
+    el.addEventListener("wheel", handleWheel, { capture: true, passive: false });
+    return () => el.removeEventListener("wheel", handleWheel, { capture: true });
+  }, [setGitUiFontSize]);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -369,7 +444,11 @@ export function GitPanel({ repoRoot }: GitPanelProps) {
   };
 
   return (
-    <div data-testid="git-panel" className="h-full w-full min-h-0 flex flex-col bg-[var(--taomni-bg)] text-[var(--taomni-text)]">
+    <div
+      ref={rootRef}
+      data-testid="git-panel"
+      className="h-full w-full min-h-0 flex flex-col bg-[var(--taomni-bg)] text-[var(--taomni-text)]"
+    >
       <header className="h-10 shrink-0 flex items-center gap-2 px-3 border-b border-[var(--taomni-divider)] bg-[var(--taomni-quick-bg)]">
         <GitBranch className="w-4 h-4 text-[var(--taomni-accent)]" />
         <div className="min-w-0">

--- a/src/index.css
+++ b/src/index.css
@@ -125,62 +125,66 @@ button, input, select, textarea, optgroup {
 }
 
 html[data-app-theme="dark"] {
-  --taomni-bg: #0b0f19; /*星空暗夜深蓝色调和底色*/
-  --taomni-chrome-bg: #0f172a; 
-  --taomni-chrome-border: #1e293b;
-  --taomni-titlebar-from: #1e293b;
-  --taomni-titlebar-to: #0f172a;
-  --taomni-menubar-bg: #0b0f19;
-  --taomni-quick-bg: #1e293b;
-  --taomni-accent: #60a5fa;
-  --taomni-accent-soft: #93c5fd;
-  --taomni-tab-active: #0b0f19;
-  --taomni-tab-inactive: #1e293b;
-  --taomni-tab-border: #334155;
-  --taomni-sidebar-bg: #0b0f19;
-  --taomni-sidebar-border: #1e293b;
-  --taomni-panel-bg: #0f172a;
-  --taomni-card-bg: #1e293b;
-  --taomni-card-border: #334155;
-  --taomni-status-bg: #0b0f19;
-  --taomni-status-text: #cbd5e1;
-  --taomni-text: #f8fafc;
-  --taomni-text-muted: #94a3b8;
-  --taomni-divider: #1e293b;
-  --taomni-hover: #1e293b;
-  --taomni-selected: #1e3a8a;
-  --taomni-selected-border: #3b82f6;
-  --taomni-editor-selection-bg: rgba(96, 165, 250, 0.46);
-  --taomni-editor-selection-text: #f8fafc;
-  --taomni-editor-selection-match-bg: rgba(250, 204, 21, 0.28);
-  --taomni-editor-selection-match-border: rgba(250, 204, 21, 0.72);
-  --taomni-control-hover: rgba(255, 255, 255, 0.05);
-  --taomni-input-bg: #0b0f19;
-  --taomni-input-border: #334155;
-  --taomni-button-from: #1e293b;
-  --taomni-button-to: #0f172a;
-  --taomni-button-hover-from: #334155;
-  --taomni-button-hover-to: #1e293b;
-  --taomni-button-disabled: #0f172a;
-  --taomni-scrollbar-track: #0b0f19;
-  --taomni-scrollbar-thumb: #334155;
-  --taomni-scrollbar-thumb-hover: #475569;
-  --taomni-db-syntax-keyword: #93c5fd;
-  --taomni-db-syntax-name: #f8fafc;
-  --taomni-db-syntax-function: #67e8f9;
-  --taomni-db-syntax-string: #86efac;
-  --taomni-db-syntax-atom: #fcd34d;
-  --taomni-db-syntax-comment: #94a3b8;
-  --taomni-db-syntax-operator: #cbd5e1;
-  --taomni-db-syntax-punctuation: #cbd5e1;
-  --taomni-link: #60a5fa;
-  --taomni-ribbon-from: #0f172a;
-  --taomni-ribbon-to: #0b0f19;
-  --taomni-ribbon-border: #1e293b;
-  --taomni-tao-ribbon-bg: #20384a;
-  --taomni-tao-ribbon-text: #d8f3ef;
-  --taomni-tao-ribbon-border: #4f8f9d;
-  --taomni-tao-ribbon-shadow: 0 8px 22px rgba(79, 143, 157, 0.24);
+  --taomni-bg: #1e1f22;
+  --taomni-chrome-bg: #191a1c;
+  --taomni-chrome-border: #303238;
+  --taomni-titlebar-from: #202124;
+  --taomni-titlebar-to: #191a1c;
+  --taomni-menubar-bg: #191a1c;
+  --taomni-quick-bg: #26282e;
+  --taomni-accent: #6aa6f8;
+  --taomni-accent-soft: #8bbcff;
+  --taomni-tab-active: #1e1f22;
+  --taomni-tab-inactive: #26282e;
+  --taomni-tab-border: #35383f;
+  --taomni-sidebar-bg: #1e1f22;
+  --taomni-sidebar-border: #303238;
+  --taomni-panel-bg: #1e1f22;
+  --taomni-card-bg: #26282e;
+  --taomni-card-border: #35383f;
+  --taomni-status-bg: #191a1c;
+  --taomni-status-text: #c6ccd6;
+  --taomni-text: #e6eaf0;
+  --taomni-text-muted: #9ca3ad;
+  --taomni-divider: #303238;
+  --taomni-hover: #282a30;
+  --taomni-selected: #293b55;
+  --taomni-selected-border: #5c8fd6;
+  --taomni-editor-selection-bg: rgba(92, 143, 214, 0.4);
+  --taomni-editor-selection-text: #eef2f7;
+  --taomni-editor-selection-match-bg: rgba(225, 177, 75, 0.3);
+  --taomni-editor-selection-match-border: rgba(225, 177, 75, 0.72);
+  --taomni-control-hover: rgba(255, 255, 255, 0.06);
+  --taomni-input-bg: #191a1c;
+  --taomni-input-border: #35383f;
+  --taomni-button-from: #2b2d33;
+  --taomni-button-to: #24262b;
+  --taomni-button-hover-from: #35383f;
+  --taomni-button-hover-to: #2b2d33;
+  --taomni-button-disabled: #202124;
+  --taomni-scrollbar-track: #1e1f22;
+  --taomni-scrollbar-thumb: #3a3d44;
+  --taomni-scrollbar-thumb-hover: #4b4f58;
+  --taomni-term-bg: #1e1f22;
+  --taomni-term-text: #e6eaf0;
+  --taomni-term-prompt: #5fd58a;
+  --taomni-term-path: #6aa6f8;
+  --taomni-db-syntax-keyword: #8bbcff;
+  --taomni-db-syntax-name: #e6eaf0;
+  --taomni-db-syntax-function: #78d6e8;
+  --taomni-db-syntax-string: #9bd68f;
+  --taomni-db-syntax-atom: #e5c07b;
+  --taomni-db-syntax-comment: #8b929d;
+  --taomni-db-syntax-operator: #c6ccd6;
+  --taomni-db-syntax-punctuation: #c6ccd6;
+  --taomni-link: #78a8f8;
+  --taomni-ribbon-from: #24262b;
+  --taomni-ribbon-to: #1e1f22;
+  --taomni-ribbon-border: #303238;
+  --taomni-tao-ribbon-bg: #24363b;
+  --taomni-tao-ribbon-text: #d9f0ec;
+  --taomni-tao-ribbon-border: #5aa3a3;
+  --taomni-tao-ribbon-shadow: 0 8px 22px rgba(90, 163, 163, 0.2);
 
   /* Warning banner tokens — readable on the dark panel surface */
   --taomni-warning-bg: rgba(245, 158, 11, 0.18);
@@ -200,9 +204,9 @@ html[data-app-theme="dark"] {
   --taomni-badge-warning-border: #b45309;
 
   /* Ambient shadows optimized for night theme */
-  --taomni-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.2);
-  --taomni-shadow-md: 0 4px 16px -2px rgba(0, 0, 0, 0.4), 0 2px 4px -1px rgba(0, 0, 0, 0.15);
-  --taomni-shadow-lg: 0 16px 24px -4px rgba(0, 0, 0, 0.5), 0 4px 8px -2px rgba(0, 0, 0, 0.25);
+  --taomni-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.24);
+  --taomni-shadow-md: 0 4px 16px -2px rgba(0, 0, 0, 0.36), 0 2px 4px -1px rgba(0, 0, 0, 0.18);
+  --taomni-shadow-lg: 0 16px 24px -4px rgba(0, 0, 0, 0.46), 0 4px 8px -2px rgba(0, 0, 0, 0.24);
 }
 
 body {
@@ -469,54 +473,63 @@ body {
 
 [data-testid="sftp-browser"],
 [data-testid="sftp-detached-window"],
+[data-testid="git-panel"],
 [role="dialog"] {
   font-family: var(--taomni-ui-font-family) !important;
 }
 
 [data-testid="sftp-browser"] *:not(.taomni-mono):not(.font-mono),
 [data-testid="sftp-detached-window"] *:not(.taomni-mono):not(.font-mono),
+[data-testid="git-panel"] *:not(.taomni-mono):not(.font-mono):not(.taomni-diff-host):not(.taomni-diff-host *),
 [role="dialog"] *:not(.taomni-mono):not(.font-mono) {
   font-family: inherit;
 }
 
 [data-testid="sftp-browser"] .text-\[12px\],
 [data-testid="sftp-detached-window"] .text-\[12px\],
+[data-testid="git-panel"] .text-\[12px\]:not(.taomni-diff-host *),
 [role="dialog"] .text-\[12px\] {
   font-size: var(--taomni-ui-font-size) !important;
 }
 
 [data-testid="sftp-browser"] .text-\[11px\],
 [data-testid="sftp-detached-window"] .text-\[11px\],
+[data-testid="git-panel"] .text-\[11px\]:not(.taomni-diff-host *),
 [role="dialog"] .text-\[11px\] {
   font-size: calc(var(--taomni-ui-font-size) - 1px) !important;
 }
 
 [data-testid="sftp-browser"] .text-\[10px\],
 [data-testid="sftp-detached-window"] .text-\[10px\],
+[data-testid="git-panel"] .text-\[10px\]:not(.taomni-diff-host *),
 [role="dialog"] .text-\[10px\] {
   font-size: calc(var(--taomni-ui-font-size) - 2px) !important;
 }
 
 [data-testid="sftp-browser"] .text-xs,
 [data-testid="sftp-detached-window"] .text-xs,
+[data-testid="git-panel"] .text-xs:not(.taomni-diff-host *),
 [role="dialog"] .text-xs {
   font-size: var(--taomni-ui-font-size) !important;
 }
 
 [data-testid="sftp-browser"] .text-sm,
 [data-testid="sftp-detached-window"] .text-sm,
+[data-testid="git-panel"] .text-sm:not(.taomni-diff-host *),
 [role="dialog"] .text-sm {
   font-size: calc(var(--taomni-ui-font-size) + 2px) !important;
 }
 
 [data-testid="sftp-browser"] .text-\[14px\],
 [data-testid="sftp-detached-window"] .text-\[14px\],
+[data-testid="git-panel"] .text-\[14px\]:not(.taomni-diff-host *),
 [role="dialog"] .text-\[14px\] {
   font-size: calc(var(--taomni-ui-font-size) + 2px) !important;
 }
 
 [data-testid="sftp-browser"] .text-base,
 [data-testid="sftp-detached-window"] .text-base,
+[data-testid="git-panel"] .text-base:not(.taomni-diff-host *),
 [role="dialog"] .text-base {
   font-size: calc(var(--taomni-ui-font-size) + 4px) !important;
 }

--- a/src/stores/appStore.test.ts
+++ b/src/stores/appStore.test.ts
@@ -192,6 +192,16 @@ describe("appStore.uiAppearance", () => {
     expect(window.localStorage.getItem("taomni.uiFontSize")).toBe("14");
   });
 
+  it("clamps uiFontSize to the supported settings range", () => {
+    useAppStore.getState().setUiFontSize(99);
+    expect(useAppStore.getState().uiFontSize).toBe(18);
+    expect(window.localStorage.getItem("taomni.uiFontSize")).toBe("18");
+
+    useAppStore.getState().setUiFontSize(3);
+    expect(useAppStore.getState().uiFontSize).toBe(10);
+    expect(window.localStorage.getItem("taomni.uiFontSize")).toBe("10");
+  });
+
   it("allows setting and persisting the welcome recent session limit", () => {
     useAppStore.getState().setWelcomeRecentSessionLimit(35);
     expect(useAppStore.getState().welcomeRecentSessionLimit).toBe(35);

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -35,6 +35,8 @@ const WELCOME_RECENT_SESSION_LIMIT_KEY = "taomni.welcomeRecentSessionLimit";
 const DEFAULT_WELCOME_RECENT_SESSION_LIMIT = 20;
 const MIN_WELCOME_RECENT_SESSION_LIMIT = 1;
 const MAX_WELCOME_RECENT_SESSION_LIMIT = 100;
+const MIN_UI_FONT_SIZE = 10;
+const MAX_UI_FONT_SIZE = 18;
 
 interface AppState {
   tabs: Tab[];
@@ -178,7 +180,7 @@ function readUiFontSize(): number {
     const val = window.localStorage.getItem(UI_FONT_SIZE_KEY);
     if (val) {
       const parsed = parseInt(val, 10);
-      if (!isNaN(parsed) && parsed >= 10 && parsed <= 18) {
+      if (!isNaN(parsed) && parsed >= MIN_UI_FONT_SIZE && parsed <= MAX_UI_FONT_SIZE) {
         return parsed;
       }
     }
@@ -194,6 +196,11 @@ function writeUiFontSize(size: number) {
   } catch {
     // Ignore storage failures
   }
+}
+
+function clampUiFontSize(size: number): number {
+  if (!Number.isFinite(size)) return 12;
+  return Math.min(MAX_UI_FONT_SIZE, Math.max(MIN_UI_FONT_SIZE, Math.round(size)));
 }
 
 function readTerminalSplitLayout(): TerminalSplitLayout {
@@ -678,8 +685,9 @@ export const useAppStore = create<AppState>((set) => ({
 
   setUiFontSize: (size) =>
     set(() => {
-      writeUiFontSize(size);
-      return { uiFontSize: size };
+      const next = clampUiFontSize(size);
+      writeUiFontSize(next);
+      return { uiFontSize: next };
     }),
 
   setWelcomeRecentSessionLimit: (limit) =>


### PR DESCRIPTION
Update the dark application palette to use the screenshot-matched neutral charcoal surfaces instead of the previous blue-black tones. Refresh related text, border, hover, selection, scrollbar, terminal, database syntax, and ribbon tokens so the theme stays visually consistent.

Make the Git panel participate in global UI typography settings by mapping its fixed Tailwind text sizes back to --taomni-ui-font-size. Keep diff content monospace, but derive its font size from the global UI size so code preview scales with the surrounding Git controls.

Add Git panel keyboard zoom support for Ctrl++ / Ctrl+- / Ctrl+0, backed by the existing persisted UI font-size store. Clamp UI font-size updates to the settings-supported 10-18px range.

Tests: pnpm vitest run src/components/git/GitPanel.test.tsx src/stores/appStore.test.ts

Tests: pnpm build