### PR TITLE
fix(ai): remember chat provider selection

### DIFF
--- a/src/components/chat/ChatDrawer.test.tsx
+++ b/src/components/chat/ChatDrawer.test.tsx
@@ -86,6 +86,7 @@ function makeConfig(): AiConfig {
 describe("ChatDrawer provider and echo controls", () => {
   beforeEach(() => {
     Element.prototype.scrollIntoView = vi.fn();
+    window.localStorage.clear();
     invokeMock.mockReset();
     invokeMock.mockImplementation((command: string) => {
       if (command === "chat_list_threads") return Promise.resolve([]);
@@ -143,17 +144,18 @@ describe("ChatDrawer provider and echo controls", () => {
 
   afterEach(() => {
     cleanup();
+    window.localStorage.clear();
     vi.clearAllMocks();
   });
 
-  it("puts Claude Code before the active LLM provider", () => {
+  it("puts the active LLM provider before local agents", () => {
     render(<ChatDrawer />);
 
     const provider = screen.getByLabelText("Thread LLM provider") as HTMLSelectElement;
     expect(Array.from(provider.options).map((option) => option.value)).toEqual([
-      "claude-code",
       "deepseek",
       "local",
+      "claude-code",
     ]);
   });
 
@@ -172,12 +174,27 @@ describe("ChatDrawer provider and echo controls", () => {
 
     const provider = screen.getByLabelText("Thread LLM provider") as HTMLSelectElement;
     expect(Array.from(provider.options).map((option) => option.value)).toEqual([
-      "claude-code",
-      "group:balanced",
       "deepseek",
       "local",
+      "group:balanced",
+      "claude-code",
     ]);
     expect(Array.from(provider.options).map((option) => option.textContent)).toContain("Group: Balanced");
+  });
+
+  it("remembers provider changes from the thread picker", () => {
+    render(<ChatDrawer />);
+
+    const provider = screen.getByLabelText("Thread LLM provider") as HTMLSelectElement;
+    fireEvent.change(provider, { target: { value: "deepseek" } });
+
+    expect(JSON.parse(window.localStorage.getItem("taomni.chatDrawer.provider.v1") ?? "{}")).toMatchObject({
+      chat: "deepseek",
+    });
+    expect(invokeMock).toHaveBeenCalledWith("chat_set_thread_provider", {
+      threadId: "thread-1",
+      providerId: "deepseek",
+    });
   });
 
   it("renders terminal echo as the same compact button style as echo toggles", () => {

--- a/src/components/chat/ChatDrawer.tsx
+++ b/src/components/chat/ChatDrawer.tsx
@@ -31,6 +31,7 @@ import {
   DEFAULT_CLAUDE_CODE_MODEL,
   DEFAULT_CODEX_MODEL,
   providerGroupIdFromRoute,
+  rememberChatDrawerProviderPreference,
   useAiStore,
   type AiConfig,
   type LlmProviderCapability,
@@ -258,6 +259,10 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
     const ids = chatDrawerProviderIds(aiConfig, capabilityForMode(mode));
     if (preferredProviderId && ids.includes(preferredProviderId)) return preferredProviderId;
     return ids[0] ?? null;
+  };
+
+  const rememberProviderForMode = (mode: ChatThreadMode, providerId: string) => {
+    rememberChatDrawerProviderPreference(providerId, capabilityForMode(mode));
   };
 
   const handleNewThread = async () => {
@@ -751,10 +756,11 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
               value={selectedProviderId}
               aria-label={t("chat.threadProviderAria")}
               onChange={(e) => {
+                const providerId = e.target.value;
+                rememberProviderForMode(currentMode, providerId);
+                setDraftProviderId(providerId);
                 if (activeThread) {
-                  void setThreadProvider(activeThread.id, e.target.value);
-                } else {
-                  setDraftProviderId(e.target.value);
+                  void setThreadProvider(activeThread.id, providerId);
                 }
               }}
             >

--- a/src/stores/aiStore.ts
+++ b/src/stores/aiStore.ts
@@ -162,12 +162,11 @@ export function isCodexAvailableForChat(config: AiConfig | null | undefined): bo
 }
 
 export function defaultChatProviderId(config: AiConfig | null | undefined): string | undefined {
-  if (isClaudeCodeAvailableForChat(config)) return "claude-code";
-  if (isCodexAvailableForChat(config)) return "codex";
-  return undefined;
+  return chatDrawerProviderIds(config, "chat")[0];
 }
 
 export const PROVIDER_GROUP_PREFIX = "group:";
+const CHAT_DRAWER_PROVIDER_PREF_STORAGE_KEY = "taomni.chatDrawer.provider.v1";
 
 export function providerGroupRouteId(groupId: string): string {
   return groupId.startsWith(PROVIDER_GROUP_PREFIX) ? groupId : `${PROVIDER_GROUP_PREFIX}${groupId}`;
@@ -180,6 +179,40 @@ export function providerGroupIdFromRoute(routeId: string): string | null {
 }
 
 export type LlmProviderCapability = "chat" | "image_generation" | "video_generation";
+
+type ChatDrawerProviderPreference = Partial<Record<LlmProviderCapability, string>>;
+
+export function readChatDrawerProviderPreference(
+  capability: LlmProviderCapability = "chat",
+): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(CHAT_DRAWER_PROVIDER_PREF_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as ChatDrawerProviderPreference;
+    const providerId = parsed?.[capability];
+    return typeof providerId === "string" && providerId.trim() ? providerId : null;
+  } catch {
+    return null;
+  }
+}
+
+export function rememberChatDrawerProviderPreference(
+  providerId: string,
+  capability: LlmProviderCapability = "chat",
+) {
+  if (typeof window === "undefined" || !providerId.trim()) return;
+  try {
+    const raw = window.localStorage.getItem(CHAT_DRAWER_PROVIDER_PREF_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) as ChatDrawerProviderPreference : {};
+    window.localStorage.setItem(
+      CHAT_DRAWER_PROVIDER_PREF_STORAGE_KEY,
+      JSON.stringify({ ...parsed, [capability]: providerId }),
+    );
+  } catch {
+    // Best-effort UI preference persistence.
+  }
+}
 
 export function llmProviderSupports(provider: LlmProviderConfig | null | undefined, capability: LlmProviderCapability): boolean {
   if (!provider) return false;
@@ -209,7 +242,13 @@ export function chatDrawerProviderIds(
   const localAgentIds: string[] = [];
   if (capability === "chat" && isClaudeCodeAvailableForChat(config)) localAgentIds.push("claude-code");
   if (capability === "chat" && isCodexAvailableForChat(config)) localAgentIds.push("codex");
-  return [...localAgentIds, ...groups, ...orderedLlmIds];
+  const orderedIds = [...orderedLlmIds, ...groups, ...localAgentIds];
+  const preferred = readChatDrawerProviderPreference(capability);
+  return Array.from(new Set(
+    preferred && orderedIds.includes(preferred)
+      ? [preferred, ...orderedIds]
+      : orderedIds,
+  ));
 }
 
 interface AiStore {

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "./appStore";
 import { useChatStore, type ChatThread } from "./chatStore";
-import { DEFAULT_CLAUDE_CODE_MODEL, DEFAULT_CODEX_MODEL, useAiStore, type AiConfig } from "./aiStore";
+import {
+  DEFAULT_CLAUDE_CODE_MODEL,
+  DEFAULT_CODEX_MODEL,
+  rememberChatDrawerProviderPreference,
+  useAiStore,
+  type AiConfig,
+} from "./aiStore";
 import type { Tab } from "../types";
 
 const invokeMock = vi.hoisted(() => vi.fn());
@@ -102,6 +108,7 @@ function makeThread(overrides: Partial<ChatThread> = {}): ChatThread {
 describe("chatStore new thread provider selection", () => {
   beforeEach(() => {
     invokeMock.mockReset();
+    window.localStorage.clear();
     useAiStore.setState({
       config: makeConfig(),
       loading: false,
@@ -142,14 +149,27 @@ describe("chatStore new thread provider selection", () => {
   });
 
   afterEach(() => {
+    window.localStorage.clear();
     vi.clearAllMocks();
   });
 
-  it("uses Claude Code as the default provider when it is enabled", async () => {
+  it("uses the active LLM provider as the default even when Claude Code is enabled", async () => {
     await useChatStore.getState().newThread(undefined, "term-1");
 
     expect(invokeMock).toHaveBeenCalledWith("chat_new_thread", {
-      providerId: "claude-code",
+      providerId: "deepseek",
+      linkedSessionId: "term-1",
+      mode: "chat",
+    });
+  });
+
+  it("uses the remembered chat provider before the active LLM provider", async () => {
+    rememberChatDrawerProviderPreference("local", "chat");
+
+    await useChatStore.getState().newThread(undefined, "term-1");
+
+    expect(invokeMock).toHaveBeenCalledWith("chat_new_thread", {
+      providerId: "local",
       linkedSessionId: "term-1",
       mode: "chat",
     });


### PR DESCRIPTION
Persist the chat drawer provider preference in localStorage per capability so a user-selected provider is reused for future AI threads.

Update chat provider ordering to prefer the remembered provider first, then the configured active LLM provider, then other configured providers and local agents. This prevents Claude/Codex local agents from overriding a user's DeepSeek preference by default.

Wire the provider picker to save explicit thread provider changes and add focused tests for active-provider ordering, remembered-provider defaults, and picker persistence.

Tests: .\\node_modules\\.bin\\vitest.CMD run src\\components\\chat\\ChatDrawer.test.tsx src\\stores\\chatStore.test.ts

Tests: .\\node_modules\\.bin\\tsc.CMD -b