### PR TITLE
feat(mail): align compose toolbar and sync flow with Thunderbird

### DIFF
--- a/.agents/skills/qa-ui-auto/references/testid-catalog.md
+++ b/.agents/skills/qa-ui-auto/references/testid-catalog.md
@@ -148,12 +148,22 @@
 - `[data-testid="mail-compose-align-center"]` — interactive — F-MAIL-2.align-center
 - `[data-testid="mail-compose-align-right"]` — interactive — F-MAIL-2.align-right
 - `[data-testid="mail-compose-link"]` — interactive [optional] — F-MAIL-2.link
+- `[data-testid="mail-compose-insert-menu"]` — interactive — F-MAIL-2.insert-menu
+- `[data-testid="mail-compose-insert-image"]` — interactive — F-MAIL-2.insert-image
+- `[data-testid="mail-compose-insert-hr"]` — interactive [optional] — F-MAIL-2.insert-hr
+- `[data-testid="mail-compose-insert-table"]` — interactive [optional] — F-MAIL-2.insert-table
 - `[data-testid="mail-compose-emoji"]` — interactive — F-MAIL-2.emoji
+- `[data-testid="mail-compose-emoji-laugh"]` — interactive — F-MAIL-2.emoji-laugh
 - `[data-testid="mail-compose-editor"]` — interactive — F-MAIL-2.compose-editor
 - `[data-testid="mail-compose-attach"]` — interactive — F-MAIL-2.compose-attach
 - `[data-testid="mail-compose-attachments"]` — display — F-MAIL-2.compose-attachments
 - `[data-testid="mail-compose-attachment-chip"]` — display — F-MAIL-2.compose-attachment-chip
 - `[data-testid="mail-compose-save-draft"]` — interactive — F-MAIL-2.compose-save-draft
+
+## mail/sync (F-MAIL-3)
+
+- `[data-testid="mail-sync-button"]` — interactive — F-MAIL-3.sync-button
+- `[data-testid="mail-body-warming-progress"]` — display [optional] — F-MAIL-3.body-warming-progress
 
 ## main (F1.2)
 

--- a/qa-ui-auto-tests/cases/TC-115-mail-rich-compose-draft-and-attachment.testcase.yaml
+++ b/qa-ui-auto-tests/cases/TC-115-mail-rich-compose-draft-and-attachment.testcase.yaml
@@ -60,6 +60,18 @@ steps:
   - click: '[data-testid="mail-compose-align-right"]'
   - click: '[data-testid="mail-compose-align-left"]'
   - click: '[data-testid="mail-compose-emoji"]'
+  - click: '[data-testid="mail-compose-emoji-laugh"]'
+  - click: '[data-testid="mail-compose-insert-menu"]'
+  - click: '[data-testid="mail-compose-insert-image"]'
+  - wait_for: '[data-testid="text-input-dialog"]'
+  - fill:
+      selector: '[data-testid="text-input-dialog-input"]'
+      value: '/workspace/inline-logo.png'
+  - click: '[data-testid="text-input-dialog-confirm"]'
+  - wait_for: '[data-testid="mail-compose-attachment-chip"]'
+  - assert_text:
+      selector: '[data-testid="mail-compose-attachments"]'
+      contains: 'Inline inline-logo.png'
   - click: '[data-testid="mail-compose-attach"]'
   - wait_for: '[data-testid="text-input-dialog"]'
   - fill:
@@ -70,6 +82,9 @@ steps:
   - assert_text:
       selector: '[data-testid="mail-compose-attachments"]'
       contains: 'quarterly-brief.pdf'
+  - assert_text:
+      selector: '[data-testid="mail-compose-attachments"]'
+      contains: 'inline-logo.png'
   - click: '[data-testid="mail-compose-save-draft"]'
   - assert_text:
       selector: '[data-testid="mail-compose-menu-bar"]'

--- a/qa-ui-auto-tests/cases/TC-116-mail-sync-headers-first.testcase.yaml
+++ b/qa-ui-auto-tests/cases/TC-116-mail-sync-headers-first.testcase.yaml
@@ -1,0 +1,29 @@
+id: TC-116
+title: Mail sync headers-first refresh
+description: |
+  Opens a browser-stub Mail tab and runs the mailbox Sync action. The browser
+  stub verifies the visible headers-first refresh path; body warming progress is
+  optional because the stub messages already include cached bodies.
+covers: [F-MAIL-3]
+tags: [mail, smoke, p1]
+modes: [browser]
+fixtures: [reset_db]
+timeout_sec: 45
+steps:
+  - open: ${cfg.app.base_url}
+  - wait_for: '[data-testid="status-bar"]'
+  - click: '[data-testid="app-main-menu"]'
+  - hover: '[data-testid="context-menu-item-view"]'
+  - click: '[data-testid="context-menu-item-toggle-quick-connect"]'
+  - wait_for: '[data-testid="quick-connect"]'
+  - fill:
+      selector: '[data-testid="qc-input"]'
+      value: 'mail://san.zhang%40yourmail.com@imap.yourmail.com:993'
+  - click: '[data-testid="qc-submit"]'
+  - wait_for: '[data-testid="mail-client-tab"]'
+  - click: '[data-testid="mail-sync-button"]'
+  - assert_text:
+      selector: '[data-testid="mail-client-tab"]'
+      contains: 'Synced'
+      timeout_sec: 10
+  - screenshot: mail-116-sync-headers-first.png

--- a/qa-ui-auto-tests/feature-list.md
+++ b/qa-ui-auto-tests/feature-list.md
@@ -3646,8 +3646,25 @@ controls:
     selector: '[data-testid="mail-compose-link"]'
     kind: interactive
     optional: true       # opens a URL prompt; covered by component tests to avoid prompt timing in smoke
+  - id: insert-menu
+    selector: '[data-testid="mail-compose-insert-menu"]'
+    kind: interactive
+  - id: insert-image
+    selector: '[data-testid="mail-compose-insert-image"]'
+    kind: interactive
+  - id: insert-hr
+    selector: '[data-testid="mail-compose-insert-hr"]'
+    kind: interactive
+    optional: true
+  - id: insert-table
+    selector: '[data-testid="mail-compose-insert-table"]'
+    kind: interactive
+    optional: true       # opens a table-size prompt; covered by component tests
   - id: emoji
     selector: '[data-testid="mail-compose-emoji"]'
+    kind: interactive
+  - id: emoji-laugh
+    selector: '[data-testid="mail-compose-emoji-laugh"]'
     kind: interactive
   - id: compose-editor
     selector: '[data-testid="mail-compose-editor"]'
@@ -3667,11 +3684,39 @@ controls:
 -->
 
 - 写信窗口改为 HTML + 纯文本 fallback 双轨草稿，默认发送模式为 `auto`：只有使用富文本格式或检测到富文本结构时才发送 HTML body。
-- 正文使用 `RichMailEditor` contenteditable 编辑器，提供段落、字体、字号、颜色、加粗/斜体/下划线、清除格式、列表、缩进、对齐、链接、表情和附件入口。
+- 正文使用 `RichMailEditor` contenteditable 编辑器，提供段落、字体、字号、颜色、加粗/斜体/下划线、清除格式、列表、缩进、对齐、链接、Thunderbird 式表情菜单、插入菜单和附件入口。
+- 插入菜单第一期支持本地图片内联 CID：正文写入 `<img src="cid:...">`，附件元数据保存 `inline/contentId`，发送时生成 `multipart/related`；普通附件同时存在时外层使用 `multipart/mixed`。
 - 展示和编辑都经过 `mailHtml` 清洗；远程图片默认阻断，用户显式加载后才显示。
 - 回复和转发保留原始 HTML 内容，回复按 Thunderbird 风格生成 `blockquote type="cite"` 引用和纯文本引用 fallback。
-- 附件元数据随本地草稿保存，发送时后端以 multipart/mixed MIME 附加本地文件。
+- 附件元数据随本地草稿保存，发送时后端按普通附件和内联 CID 图片分别生成 MIME。
 - 本地草稿存入邮件缓存库（浏览器模式用 localStorage stub），支持手动保存、自动保存、Drafts 列表重开、丢弃和发送后删除。
+
+---
+
+### 13.3 邮箱刷新与正文预热 ✅
+
+<!-- feature
+id: F-MAIL-3
+status: done
+area: mail/sync
+components: [MailClientTab]
+files:
+  - src/components/mail/MailClientTab.tsx
+  - src/lib/mail.ts
+  - src-tauri/src/mail/mod.rs
+controls:
+  - id: sync-button
+    selector: '[data-testid="mail-sync-button"]'
+    kind: interactive
+  - id: body-warming-progress
+    selector: '[data-testid="mail-body-warming-progress"]'
+    kind: display
+    optional: true       # only visible while recent uncached bodies are warming
+-->
+
+- 手工刷新、打开自动刷新和定时刷新默认只同步 headers；headers 写入缓存并重新加载列表后界面即可继续操作。
+- 最近正文缓存改为前端后台 warming：按 `bodyRecentLimit` 遍历已缓存 headers，逐封调用 `mail_get_message_body`，并用独立进度显示。
+- 邮件正文读取按 `folder:uid` 缓存在前端内存中；点击已缓存正文优先使用内存/SQLite，自动标记已读不再等待正文加载完成。
 
 ---
 

--- a/src-tauri/src/mail/mod.rs
+++ b/src-tauri/src/mail/mod.rs
@@ -327,6 +327,10 @@ pub struct MailSendAttachment {
     pub name: Option<String>,
     #[serde(default)]
     pub content_type: Option<String>,
+    #[serde(default)]
+    pub inline: bool,
+    #[serde(default)]
+    pub content_id: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -344,6 +348,10 @@ pub struct MailDraftAttachment {
     pub name: Option<String>,
     #[serde(default)]
     pub content_type: Option<String>,
+    #[serde(default)]
+    pub inline: bool,
+    #[serde(default)]
+    pub content_id: Option<String>,
     #[serde(default)]
     pub size: Option<u64>,
     #[serde(default)]
@@ -761,7 +769,7 @@ pub async fn mail_sync_headers(
         .unwrap_or(account.config.sync.max_fetch_per_sync)
         .max(1)
         .min(2000);
-    let include_bodies = include_bodies.unwrap_or(true);
+    let include_bodies = include_bodies.unwrap_or(false);
 
     let mut result = tokio::task::spawn_blocking(move || {
         let mut imap = connect_imap(&account)?;
@@ -821,7 +829,7 @@ pub async fn mail_sync_all_folders(
         .unwrap_or(account.config.sync.max_fetch_per_sync)
         .max(1)
         .min(2000);
-    let include_bodies = include_bodies.unwrap_or(true);
+    let include_bodies = include_bodies.unwrap_or(false);
     let sync_states = if cache_enabled {
         let db = state.db.lock().map_err(|e| e.to_string())?;
         init_mail_tables(&db).map_err(|e| e.to_string())?;
@@ -2420,40 +2428,46 @@ fn build_send_message(
         builder = builder.bcc(parse_mailbox(bcc)?);
     }
 
-    if !request.attachments.is_empty() {
-        let attachments = read_send_attachments(&request.attachments)?;
-        let mut mixed = match (&request.text_body, &request.html_body) {
-            (Some(text), Some(html)) => MultiPart::mixed().multipart(
-                MultiPart::alternative_plain_html(text.clone(), html.clone()),
-            ),
-            (Some(text), None) => MultiPart::mixed().singlepart(SinglePart::plain(text.clone())),
-            (None, Some(html)) => MultiPart::mixed().singlepart(SinglePart::html(html.clone())),
-            (None, None) => return Err("email body is required".into()),
-        };
-        for attachment in attachments {
-            mixed = mixed.singlepart(
-                Attachment::new(attachment.name).body(attachment.bytes, attachment.content_type),
-            );
-        }
-        return builder
-            .multipart(mixed)
-            .map_err(|e| format!("failed to build email body: {e}"));
-    }
+    let body = build_send_body_part(request)?;
+    let attachments = read_send_attachments(&request.attachments)?;
+    let has_inline = attachments.iter().any(|attachment| attachment.inline);
+    let has_regular = attachments.iter().any(|attachment| !attachment.inline);
 
-    match (&request.text_body, &request.html_body) {
-        (Some(text), Some(html)) => builder
-            .multipart(MultiPart::alternative_plain_html(
-                text.clone(),
-                html.clone(),
-            ))
-            .map_err(|e| format!("failed to build email body: {e}")),
-        (Some(text), None) => builder
-            .singlepart(SinglePart::plain(text.clone()))
-            .map_err(|e| format!("failed to build email body: {e}")),
-        (None, Some(html)) => builder
-            .singlepart(SinglePart::html(html.clone()))
-            .map_err(|e| format!("failed to build email body: {e}")),
-        (None, None) => Err("email body is required".into()),
+    if has_inline {
+        let related = build_related_body(
+            body,
+            attachments.iter().filter(|attachment| attachment.inline),
+        )?;
+        if has_regular {
+            let mut mixed = MultiPart::mixed().multipart(related);
+            for attachment in attachments.iter().filter(|attachment| !attachment.inline) {
+                mixed = mixed.singlepart(regular_attachment_part(attachment));
+            }
+            builder
+                .multipart(mixed)
+                .map_err(|e| format!("failed to build email body: {e}"))
+        } else {
+            builder
+                .multipart(related)
+                .map_err(|e| format!("failed to build email body: {e}"))
+        }
+    } else if has_regular {
+        let mut mixed = add_body_part_to_multipart(MultiPart::mixed().build(), body);
+        for attachment in &attachments {
+            mixed = mixed.singlepart(regular_attachment_part(attachment));
+        }
+        builder
+            .multipart(mixed)
+            .map_err(|e| format!("failed to build email body: {e}"))
+    } else {
+        match body {
+            SendBodyPart::Single(part) => builder
+                .singlepart(part)
+                .map_err(|e| format!("failed to build email body: {e}")),
+            SendBodyPart::Multi(part) => builder
+                .multipart(part)
+                .map_err(|e| format!("failed to build email body: {e}")),
+        }
     }
 }
 
@@ -2461,6 +2475,57 @@ struct ResolvedSendAttachment {
     name: String,
     content_type: ContentType,
     bytes: Vec<u8>,
+    inline: bool,
+    content_id: Option<String>,
+}
+
+enum SendBodyPart {
+    Single(SinglePart),
+    Multi(MultiPart),
+}
+
+fn build_send_body_part(request: &MailSendRequest) -> Result<SendBodyPart, String> {
+    match (&request.text_body, &request.html_body) {
+        (Some(text), Some(html)) => Ok(SendBodyPart::Multi(MultiPart::alternative_plain_html(
+            text.clone(),
+            html.clone(),
+        ))),
+        (Some(text), None) => Ok(SendBodyPart::Single(SinglePart::plain(text.clone()))),
+        (None, Some(html)) => Ok(SendBodyPart::Single(SinglePart::html(html.clone()))),
+        (None, None) => Err("email body is required".into()),
+    }
+}
+
+fn add_body_part_to_multipart(multipart: MultiPart, body: SendBodyPart) -> MultiPart {
+    match body {
+        SendBodyPart::Single(part) => multipart.singlepart(part),
+        SendBodyPart::Multi(part) => multipart.multipart(part),
+    }
+}
+
+fn build_related_body<'a>(
+    body: SendBodyPart,
+    inline_attachments: impl Iterator<Item = &'a ResolvedSendAttachment>,
+) -> Result<MultiPart, String> {
+    let mut related = add_body_part_to_multipart(MultiPart::related().build(), body);
+    for attachment in inline_attachments {
+        let content_id = attachment.content_id.as_deref().ok_or_else(|| {
+            format!(
+                "inline attachment {} is missing a Content-ID",
+                attachment.name
+            )
+        })?;
+        related = related.singlepart(
+            Attachment::new_inline_with_name(content_id.to_string(), attachment.name.clone())
+                .body(attachment.bytes.clone(), attachment.content_type.clone()),
+        );
+    }
+    Ok(related)
+}
+
+fn regular_attachment_part(attachment: &ResolvedSendAttachment) -> SinglePart {
+    Attachment::new(attachment.name.clone())
+        .body(attachment.bytes.clone(), attachment.content_type.clone())
 }
 
 fn read_send_attachments(
@@ -2493,6 +2558,13 @@ fn read_send_attachments(
                 name,
                 content_type: attachment_content_type(attachment.content_type.as_deref()),
                 bytes,
+                inline: attachment.inline,
+                content_id: attachment
+                    .content_id
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned),
             })
         })
         .collect()
@@ -2541,6 +2613,43 @@ fn validate_send_request(request: &MailSendRequest) -> Result<(), String> {
     for (index, attachment) in request.attachments.iter().enumerate() {
         if attachment.path.trim().is_empty() {
             return Err(format!("attachment #{} path is required", index + 1));
+        }
+        if attachment.inline {
+            let content_id = attachment
+                .content_id
+                .as_deref()
+                .map(str::trim)
+                .unwrap_or("");
+            if content_id.is_empty() {
+                return Err(format!(
+                    "inline attachment #{} Content-ID is required",
+                    index + 1
+                ));
+            }
+            if content_id
+                .chars()
+                .any(|ch| matches!(ch, '<' | '>' | '\r' | '\n' | '\0'))
+            {
+                return Err(format!(
+                    "inline attachment #{} Content-ID contains invalid characters",
+                    index + 1
+                ));
+            }
+            let content_type = attachment
+                .content_type
+                .as_deref()
+                .map(str::trim)
+                .unwrap_or("");
+            if !content_type
+                .get(..content_type.len().min(6))
+                .unwrap_or("")
+                .eq_ignore_ascii_case("image/")
+            {
+                return Err(format!(
+                    "inline attachment #{} must have an image/* content type",
+                    index + 1
+                ));
+            }
         }
     }
     Ok(())
@@ -3823,6 +3932,8 @@ mod tests {
                 path: path.to_string_lossy().into_owned(),
                 name: Some("report.txt".into()),
                 content_type: Some("text/plain".into()),
+                inline: false,
+                content_id: None,
             }],
         };
 
@@ -3831,6 +3942,78 @@ mod tests {
 
         assert!(raw.contains("multipart/mixed"));
         assert!(raw.contains("multipart/alternative"));
+        assert!(raw.contains("filename=\"report.txt\""));
+    }
+
+    #[test]
+    fn build_send_message_embeds_inline_images_in_related_mime() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("logo.png");
+        std::fs::write(&path, b"png body").unwrap();
+        let request = MailSendRequest {
+            to: vec!["Receiver <receiver@example.com>".into()],
+            cc: vec![],
+            bcc: vec![],
+            subject: "Hello".into(),
+            text_body: Some("Plain body".into()),
+            html_body: Some("<p><img src=\"cid:logo-1@inline.local\"></p>".into()),
+            attachments: vec![MailSendAttachment {
+                path: path.to_string_lossy().into_owned(),
+                name: Some("logo.png".into()),
+                content_type: Some("image/png".into()),
+                inline: true,
+                content_id: Some("logo-1@inline.local".into()),
+            }],
+        };
+
+        let message = build_send_message(&sample_resolved_account(), &request).unwrap();
+        let raw = String::from_utf8(message.formatted()).unwrap();
+
+        assert!(raw.contains("multipart/related"));
+        assert!(raw.contains("multipart/alternative"));
+        assert!(raw.contains("Content-ID: <logo-1@inline.local>"));
+        assert!(raw.contains("Content-Disposition: inline; filename=\"logo.png\""));
+    }
+
+    #[test]
+    fn build_send_message_nests_related_body_inside_mixed_when_inline_and_regular_attachments_exist(
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let image_path = dir.path().join("logo.png");
+        let report_path = dir.path().join("report.txt");
+        std::fs::write(&image_path, b"png body").unwrap();
+        std::fs::write(&report_path, b"report body").unwrap();
+        let request = MailSendRequest {
+            to: vec!["Receiver <receiver@example.com>".into()],
+            cc: vec![],
+            bcc: vec![],
+            subject: "Hello".into(),
+            text_body: Some("Plain body".into()),
+            html_body: Some("<p><img src=\"cid:logo-1@inline.local\"></p>".into()),
+            attachments: vec![
+                MailSendAttachment {
+                    path: image_path.to_string_lossy().into_owned(),
+                    name: Some("logo.png".into()),
+                    content_type: Some("image/png".into()),
+                    inline: true,
+                    content_id: Some("logo-1@inline.local".into()),
+                },
+                MailSendAttachment {
+                    path: report_path.to_string_lossy().into_owned(),
+                    name: Some("report.txt".into()),
+                    content_type: Some("text/plain".into()),
+                    inline: false,
+                    content_id: None,
+                },
+            ],
+        };
+
+        let message = build_send_message(&sample_resolved_account(), &request).unwrap();
+        let raw = String::from_utf8(message.formatted()).unwrap();
+
+        assert!(raw.contains("multipart/mixed"));
+        assert!(raw.contains("multipart/related"));
+        assert!(raw.contains("Content-ID: <logo-1@inline.local>"));
         assert!(raw.contains("filename=\"report.txt\""));
     }
 
@@ -3853,6 +4036,8 @@ mod tests {
                     path: "/tmp/report.txt".into(),
                     name: Some("report.txt".into()),
                     content_type: Some("text/plain".into()),
+                    inline: false,
+                    content_id: None,
                     size: Some(12),
                     modified_at: Some(123),
                 }],

--- a/src/components/mail/MailClientTab.test.tsx
+++ b/src/components/mail/MailClientTab.test.tsx
@@ -141,6 +141,15 @@ const messageBody: MailMessageBody = {
   source: "cache",
 };
 
+const uncachedMessage: MailMessageHeader = {
+  ...message,
+  uid: 102,
+  messageId: "message-102@example.com",
+  subject: "Fresh header",
+  snippet: "Header arrived before the body cache is warm.",
+  bodyCached: false,
+};
+
 function renderMailbox() {
   return render(<MailClientTab tabId="mail-tab" info={info} visible />);
 }
@@ -258,5 +267,44 @@ describe("MailClientTab", () => {
     expect(html.className).not.toContain("_td]:border");
     expect(html.className).not.toContain("_td]:px");
     expect(html.className).not.toContain("_td]:py");
+  });
+
+  it("syncs headers first and shows body warming as separate progress", async () => {
+    let resolveWarmBody!: (body: MailMessageBody) => void;
+    const warmBodyPromise = new Promise<MailMessageBody>((resolve) => {
+      resolveWarmBody = resolve;
+    });
+    mailMocks.mailListCachedMessages.mockReset();
+    mailMocks.mailListCachedMessages
+      .mockResolvedValueOnce([message])
+      .mockResolvedValueOnce([uncachedMessage])
+      .mockResolvedValueOnce([uncachedMessage]);
+    mailMocks.mailGetMessageBody.mockImplementation((_config: MailTabInfo, _folder: string, uid: number) => {
+      if (uid === uncachedMessage.uid) return warmBodyPromise;
+      return Promise.resolve(messageBody);
+    });
+
+    renderMailbox();
+
+    await screen.findByText(/Second line stays visible/);
+    fireEvent.click(screen.getByTestId("mail-sync-button"));
+
+    await waitFor(() => expect(mailMocks.mailSyncAllFolders).toHaveBeenCalledWith(
+      info,
+      { limit: 50, includeBodies: false },
+    ));
+    expect(await screen.findByText(/Header arrived before the body cache is warm/)).toBeInTheDocument();
+    expect(await screen.findByTestId("mail-body-warming-progress")).toHaveTextContent("Bodies 0/1");
+
+    resolveWarmBody({
+      ...messageBody,
+      uid: uncachedMessage.uid,
+      messageId: uncachedMessage.messageId,
+      subject: uncachedMessage.subject,
+      snippet: uncachedMessage.snippet,
+      source: "remote",
+    });
+
+    await waitFor(() => expect(screen.queryByTestId("mail-body-warming-progress")).not.toBeInTheDocument());
   });
 });

--- a/src/components/mail/MailClientTab.tsx
+++ b/src/components/mail/MailClientTab.tsx
@@ -24,6 +24,7 @@ import {
   FolderSymlink,
   FolderX,
   Forward,
+  Image as ImageIcon,
   ImageOff,
   Inbox,
   Link as LinkIcon,
@@ -146,6 +147,13 @@ interface RecipientSearchState {
 interface OpenMailMessageTab {
   key: string;
   message: MailMessageHeader;
+}
+
+interface BodyWarmState {
+  active: boolean;
+  done: number;
+  total: number;
+  folder?: string | null;
 }
 
 interface MailDraggableDialogProps {
@@ -615,6 +623,21 @@ function basename(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() || path || "attachment";
 }
 
+function makeInlineImageContentId(name: string): string {
+  const stem = name
+    .replace(/\.[^.]+$/, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32) || "image";
+  const random = Math.random().toString(36).slice(2, 10);
+  return `taomni-${stem}-${Date.now()}-${random}@inline.local`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function guessContentType(name: string): string {
   const ext = name.split(".").pop()?.toLowerCase() ?? "";
   if (["jpg", "jpeg"].includes(ext)) return "image/jpeg";
@@ -725,7 +748,9 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
   const [loadingFolders, setLoadingFolders] = useState(false);
   const [loadingMessages, setLoadingMessages] = useState(false);
   const [syncing, setSyncing] = useState(false);
-  const [bodyLoading, setBodyLoading] = useState(false);
+  const [bodyCache, setBodyCache] = useState<Map<string, MailMessageBody>>(() => new Map());
+  const [bodyLoadingKey, setBodyLoadingKey] = useState<string | null>(null);
+  const [bodyWarming, setBodyWarming] = useState<BodyWarmState>({ active: false, done: 0, total: 0 });
   const [hasMoreMessages, setHasMoreMessages] = useState(false);
   const [loadingMoreMessages, setLoadingMoreMessages] = useState(false);
   const [testing, setTesting] = useState(false);
@@ -749,6 +774,10 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
   const initialSyncDoneRef = useRef(false);
   const contactIndexAccountRef = useRef<string | null>(null);
   const contactSearchSeqRef = useRef(0);
+  const bodyCacheRef = useRef<Map<string, MailMessageBody>>(new Map());
+  const bodyRequestsRef = useRef<Map<string, Promise<MailMessageBody>>>(new Map());
+  const bodyLoadSeqRef = useRef(0);
+  const bodyWarmSeqRef = useRef(0);
   const autoSaveTimerRef = useRef<number | null>(null);
   const lastSavedDraftJsonRef = useRef("");
   const foldersRef = useRef<MailFolder[]>([]);
@@ -832,10 +861,12 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
   }, [messages, query]);
   const allFilteredMessagesChecked = filteredMessages.length > 0
     && filteredMessages.every((message) => checkedMessageKeys.has(messageKey(message)));
-  const selectedBody = useMemo(
-    () => (bodyMatchesMessage(body, selectedMessage) ? body : null),
-    [body, selectedMessage],
-  );
+  const selectedBody = useMemo(() => {
+    if (!selectedMessage) return null;
+    const cached = bodyCache.get(messageKey(selectedMessage));
+    if (cached && bodyMatchesMessage(cached, selectedMessage)) return cached;
+    return bodyMatchesMessage(body, selectedMessage) ? body : null;
+  }, [body, bodyCache, selectedMessage]);
 
   const readerHtml = useMemo(() => {
     if (!selectedBody?.html) return null;
@@ -1025,7 +1056,7 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
     if (append) {
       setLoadingMoreMessages(true);
     } else {
-      setLoadingMessages(true);
+      if (!quiet) setLoadingMessages(true);
       setHasMoreMessages(false);
     }
     setError(null);
@@ -1051,10 +1082,128 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
       if (append) {
         setLoadingMoreMessages(false);
       } else {
-        setLoadingMessages(false);
+        if (!quiet) setLoadingMessages(false);
       }
     }
   }, [info.sessionId, pageSize]);
+
+  const rememberBody = useCallback((nextBody: MailMessageBody) => {
+    const key = `${nextBody.folder}:${nextBody.uid}`;
+    const nextCache = new Map(bodyCacheRef.current);
+    nextCache.set(key, nextBody);
+    bodyCacheRef.current = nextCache;
+    setBodyCache(nextCache);
+    setBody(nextBody);
+
+    const enrichHeader = (message: MailMessageHeader): MailMessageHeader => {
+      if (messageKey(message) !== key) return message;
+      const attachmentCount = nextBody.attachments.length;
+      return {
+        ...message,
+        messageId: nextBody.messageId ?? message.messageId,
+        subject: nextBody.subject || message.subject,
+        snippet: nextBody.snippet ?? message.snippet,
+        rawSize: nextBody.rawSize ?? message.rawSize,
+        bodyCached: true,
+        hasAttachments: message.hasAttachments || attachmentCount > 0,
+        attachmentCount: Math.max(message.attachmentCount, attachmentCount),
+        attachments: attachmentCount > 0 ? nextBody.attachments : message.attachments,
+      };
+    };
+
+    setMessages((current) => current.map(enrichHeader));
+    setMessageTabs((current) => current.map((tab) => ({
+      ...tab,
+      message: enrichHeader(tab.message),
+    })));
+  }, []);
+
+  const fetchBodyForMessage = useCallback((message: MailMessageHeader): Promise<MailMessageBody> => {
+    const key = messageKey(message);
+    const cached = bodyCacheRef.current.get(key);
+    if (cached && bodyMatchesMessage(cached, message)) {
+      rememberBody(cached);
+      return Promise.resolve(cached);
+    }
+    const inflight = bodyRequestsRef.current.get(key);
+    if (inflight) return inflight;
+
+    const request = mailGetMessageBody(info, message.folder, message.uid)
+      .then((nextBody) => {
+        rememberBody(nextBody);
+        return nextBody;
+      })
+      .finally(() => {
+        bodyRequestsRef.current.delete(key);
+      });
+    bodyRequestsRef.current.set(key, request);
+    return request;
+  }, [info, rememberBody]);
+
+  const warmRecentBodies = useCallback(async (foldersToWarm: MailFolder[], preferredFolder: string) => {
+    if (!info.cache.enabled || info.cache.bodyRecentLimit <= 0) {
+      setBodyWarming({ active: false, done: 0, total: 0 });
+      return;
+    }
+    const seq = bodyWarmSeqRef.current + 1;
+    bodyWarmSeqRef.current = seq;
+    const limit = Math.max(1, Math.min(1000, info.cache.bodyRecentLimit));
+    const orderedFolders = foldersToWarm.slice().sort((a, b) => {
+      if (a.name === preferredFolder) return -1;
+      if (b.name === preferredFolder) return 1;
+      return 0;
+    });
+    const seen = new Set<string>();
+    const candidates: MailMessageHeader[] = [];
+    setBodyWarming({ active: true, done: 0, total: 0 });
+
+    try {
+      for (const folder of orderedFolders) {
+        if (bodyWarmSeqRef.current !== seq) return;
+        const page = await mailListCachedMessages(info.sessionId, folder.name, limit, 0);
+        for (const message of page) {
+          const key = messageKey(message);
+          if (seen.has(key) || message.bodyCached || bodyCacheRef.current.has(key)) continue;
+          seen.add(key);
+          candidates.push(message);
+        }
+      }
+
+      if (bodyWarmSeqRef.current !== seq) return;
+      if (candidates.length === 0) {
+        setBodyWarming({ active: false, done: 0, total: 0 });
+        return;
+      }
+
+      setBodyWarming({ active: true, done: 0, total: candidates.length, folder: candidates[0]?.folder ?? null });
+      let done = 0;
+      for (const message of candidates) {
+        if (bodyWarmSeqRef.current !== seq) return;
+        try {
+          await fetchBodyForMessage(message);
+        } catch {
+          // Body warming is opportunistic; direct message open still reports errors.
+        }
+        done += 1;
+        if (bodyWarmSeqRef.current !== seq) return;
+        setBodyWarming({
+          active: done < candidates.length,
+          done,
+          total: candidates.length,
+          folder: message.folder,
+        });
+      }
+    } finally {
+      if (bodyWarmSeqRef.current === seq) {
+        setBodyWarming((current) => ({
+          active: false,
+          done: current.total > 0 ? current.done : 0,
+          total: current.total,
+          folder: current.folder,
+        }));
+      }
+    }
+  }, [fetchBodyForMessage, info.cache.bodyRecentLimit, info.cache.enabled, info.sessionId]);
 
   const syncFolder = useCallback(async (
     folder = selectedFolder,
@@ -1065,7 +1214,7 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
     const append = options.append ?? false;
     const offset = Math.max(0, options.offset ?? 0);
     const limit = Math.max(1, options.limit ?? (offset > 0 ? pageSize : batchSize));
-    const includeBodies = options.includeBodies ?? offset === 0;
+    const includeBodies = options.includeBodies ?? false;
 
     if (indicator === "more") {
       setLoadingMoreMessages(true);
@@ -1092,7 +1241,7 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
         setStatus(
           append
             ? result.fetchedMessages > 0 ? `Loaded ${result.fetchedMessages} older messages` : "No more messages"
-            : `Synced ${result.fetchedMessages} messages, cached ${result.cachedBodies} bodies`,
+            : `Synced ${result.fetchedMessages} headers`,
         );
       }
       return result;
@@ -1114,7 +1263,7 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
   ) => {
     const indicator = options.indicator ?? "sync";
     const limit = Math.max(1, options.limit ?? batchSize);
-    const includeBodies = options.includeBodies ?? true;
+    const includeBodies = options.includeBodies ?? false;
     const activeBeforeSync = selectedFolder;
 
     if (indicator === "sync") {
@@ -1136,9 +1285,10 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
       await loadCachedMessages(nextFolder, 0, false, quiet || indicator === "none");
       if (indicator !== "none") {
         setStatus(
-          `Synced ${result.fetchedMessages} new messages across ${result.folders.length} folders, cached ${result.cachedBodies} bodies`,
+          `Synced ${result.fetchedMessages} new headers across ${result.folders.length} folders`,
         );
       }
+      void warmRecentBodies(result.folders, nextFolder);
       return result;
     } catch (e) {
       if (indicator !== "none") setError(String(e));
@@ -1148,23 +1298,32 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
         setSyncing(false);
       }
     }
-  }, [batchSize, info, loadCachedMessages, selectedFolder]);
+  }, [batchSize, info, loadCachedMessages, selectedFolder, warmRecentBodies]);
 
   const loadBody = useCallback(async (message: MailMessageHeader) => {
-    setBodyLoading(true);
+    const key = messageKey(message);
+    const cached = bodyCacheRef.current.get(key);
+    if (cached && bodyMatchesMessage(cached, message)) {
+      rememberBody(cached);
+      return cached;
+    }
+    const seq = bodyLoadSeqRef.current + 1;
+    bodyLoadSeqRef.current = seq;
+    setBodyLoadingKey(key);
     setError(null);
     try {
-      const nextBody = await mailGetMessageBody(info, message.folder, message.uid);
-      setBody(nextBody);
-      setStatus(nextBody.source === "cache" ? "Loaded body from cache" : "Loaded body from server");
+      const nextBody = await fetchBodyForMessage(message);
+      if (bodyLoadSeqRef.current === seq) {
+        setStatus(nextBody.source === "cache" ? "Loaded body from cache" : "Loaded body from server");
+      }
       return nextBody;
     } catch (e) {
       setError(String(e));
       return null;
     } finally {
-      setBodyLoading(false);
+      setBodyLoadingKey((current) => (current === key ? null : current));
     }
-  }, [info]);
+  }, [fetchBodyForMessage, rememberBody]);
 
   const markMessagesReadLocally = useCallback((folder: string, uids: number[] | null, markedCount: number) => {
     if (markedCount <= 0) return;
@@ -1266,7 +1425,12 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
     setSelectedFolder(message.folder);
     setSelectedMessageKey(key);
     setMailViewKey(viewKey);
-    setBody((current) => (bodyMatchesMessage(current, message) ? current : null));
+    const cached = bodyCacheRef.current.get(key);
+    setBody((current) => (
+      cached && bodyMatchesMessage(cached, message)
+        ? cached
+        : bodyMatchesMessage(current, message) ? current : null
+    ));
   }, []);
 
   const openMessageTab = useCallback((message: MailMessageHeader) => {
@@ -1319,6 +1483,10 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
   useEffect(() => {
     initialSyncDoneRef.current = false;
     foldersRef.current = [];
+    bodyWarmSeqRef.current += 1;
+    bodyLoadSeqRef.current += 1;
+    bodyCacheRef.current = new Map();
+    bodyRequestsRef.current.clear();
     setFolders([]);
     setMessages([]);
     setSelectedMessageKey(null);
@@ -1327,6 +1495,9 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
     setPopupMessageKey(null);
     setCheckedMessageKeys(new Set());
     setBody(null);
+    setBodyCache(new Map());
+    setBodyLoadingKey(null);
+    setBodyWarming({ active: false, done: 0, total: 0 });
     setHasMoreMessages(false);
     setLoadingMoreMessages(false);
     setDownloadingAttachmentIndex(null);
@@ -1343,7 +1514,7 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
     initialSyncDoneRef.current = true;
     void syncAllFolders(true, {
       limit: batchSize,
-      includeBodies: true,
+      includeBodies: false,
       indicator: "sync",
     });
   }, [batchSize, info.sync.onOpen, syncAllFolders, visible]);
@@ -1354,7 +1525,7 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
     const id = window.setInterval(() => {
       void syncAllFolders(true, {
         limit: batchSize,
-        includeBodies: true,
+        includeBodies: false,
         indicator: "none",
       });
     }, intervalMs);
@@ -1391,10 +1562,16 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
       remoteImagesMessageKeyRef.current = key;
       setAllowRemoteImages(false);
     }
+    if (!selectedBody) {
+      void loadBody(selectedMessage);
+    }
+    if (autoReadKeyRef.current === key || !isUnread(selectedMessage)) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    autoReadKeyRef.current = key;
     void (async () => {
-      const currentBody = selectedBody ?? await loadBody(selectedMessage);
-      if (cancelled || !currentBody || autoReadKeyRef.current === key || !isUnread(selectedMessage)) return;
-      autoReadKeyRef.current = key;
       try {
         const result = await mailMarkRead(info, selectedMessage.folder, [selectedMessage.uid], false);
         if (!cancelled && result.marked > 0) {
@@ -1446,9 +1623,16 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
     setError(null);
     try {
       await mailClearCache(info.sessionId);
+      bodyWarmSeqRef.current += 1;
+      bodyLoadSeqRef.current += 1;
+      bodyCacheRef.current = new Map();
+      bodyRequestsRef.current.clear();
       setFolders([]);
       setMessages([]);
       setBody(null);
+      setBodyCache(new Map());
+      setBodyLoadingKey(null);
+      setBodyWarming({ active: false, done: 0, total: 0 });
       setSelectedMessageKey(null);
       setMailViewKey("mailbox");
       setMessageTabs([]);
@@ -1657,6 +1841,8 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
         path: attachment.path,
         name: attachment.name ?? null,
         contentType: attachment.contentType ?? null,
+        inline: attachment.inline ?? false,
+        contentId: attachment.contentId ?? null,
       })),
     };
     const recipients = [...draft.to, ...draft.cc, ...draft.bcc];
@@ -1712,11 +1898,58 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
     }
   };
 
+  const handleInsertInlineImage = async (): Promise<string | null> => {
+    try {
+      const paths = await selectUploadFile();
+      const path = paths[0];
+      if (!path) return null;
+      const name = basename(path);
+      const contentType = guessContentType(name);
+      if (!contentType.toLowerCase().startsWith("image/")) {
+        setError("Inline image must be a local image file.");
+        return null;
+      }
+      const contentId = makeInlineImageContentId(name);
+      const attachment: MailDraftAttachment = {
+        path,
+        name,
+        contentType,
+        inline: true,
+        contentId,
+        size: null,
+        modifiedAt: null,
+      };
+      setDraft((current) => ({
+        ...current,
+        richFormatUsed: true,
+        attachments: [...current.attachments, attachment],
+      }));
+      return `<img src="cid:${escapeHtml(contentId)}" alt="${escapeHtml(name)}">`;
+    } catch (e) {
+      setError(String(e));
+      return null;
+    }
+  };
+
   const removeDraftAttachment = (index: number) => {
-    setDraft((current) => ({
-      ...current,
-      attachments: current.attachments.filter((_, i) => i !== index),
-    }));
+    setDraft((current) => {
+      const removed = current.attachments[index];
+      const attachments = current.attachments.filter((_, i) => i !== index);
+      if (!removed?.inline || !removed.contentId) {
+        return { ...current, attachments };
+      }
+      const cid = escapeRegExp(removed.contentId);
+      const htmlBody = current.htmlBody.replace(
+        new RegExp(`<img\\b[^>]*\\bsrc=["']cid:${cid}["'][^>]*>`, "gi"),
+        "",
+      );
+      return {
+        ...current,
+        attachments,
+        htmlBody,
+        textBody: mailHtmlToPlainText(htmlBody),
+      };
+    });
   };
 
   const discardCurrentDraft = async () => {
@@ -2321,7 +2554,7 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
         label: "Sync all folders",
         icon: <RefreshCw className="w-3.5 h-3.5" />,
         disabled: syncing,
-        onClick: () => void syncAllFolders(false, { limit: batchSize, includeBodies: true, indicator: "sync" }),
+        onClick: () => void syncAllFolders(false, { limit: batchSize, includeBodies: false, indicator: "sync" }),
       },
       {
         label: "Mark folder read",
@@ -2351,7 +2584,7 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
       disabled: syncing,
       onClick: () => void syncAllFolders(false, {
         limit: batchSize,
-        includeBodies: true,
+        includeBodies: false,
         indicator: "sync",
       }),
     },
@@ -2405,10 +2638,12 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
     ? `${info.cache.headerRetentionDays}d headers, ${info.cache.bodyRecentLimit} recent bodies`
     : "cache off";
   const renderReaderSurface = (message: MailMessageHeader | null, popup = false) => {
-    const currentBody = bodyMatchesMessage(body, message) ? body : null;
+    const currentBody = message
+      ? bodyCache.get(messageKey(message)) ?? (bodyMatchesMessage(body, message) ? body : null)
+      : null;
     const currentHtml = currentBody?.html ? sanitizeMailHtml(currentBody.html, allowRemoteImages) : null;
     const currentAttachments = currentBody?.attachments.length ? currentBody.attachments : message?.attachments ?? [];
-    const loadingThisBody = !!message && bodyLoading && selectedMessageKey === messageKey(message);
+    const loadingThisBody = !!message && bodyLoadingKey === messageKey(message);
 
     return (
       <main
@@ -2596,7 +2831,7 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
           className="taomni-btn h-7 px-2 inline-flex items-center gap-1.5"
           onClick={() => void syncAllFolders(false, {
             limit: batchSize,
-            includeBodies: true,
+            includeBodies: false,
             indicator: "sync",
           })}
           disabled={syncing}
@@ -2605,6 +2840,16 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
           {syncing ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <RefreshCw className="w-3.5 h-3.5" />}
           Sync
         </button>
+        {bodyWarming.active && (
+          <span
+            className="h-7 px-2 inline-flex items-center gap-1.5 rounded border border-[var(--taomni-divider)] text-[11px] text-[var(--taomni-text-muted)]"
+            data-testid="mail-body-warming-progress"
+            title={bodyWarming.folder ? `Warming ${bodyWarming.folder}` : "Warming recent message bodies"}
+          >
+            <Loader2 className="w-3 h-3 animate-spin" />
+            Bodies {bodyWarming.total > 0 ? `${bodyWarming.done}/${bodyWarming.total}` : "warming"}
+          </span>
+        )}
         <button
           type="button"
           className="taomni-btn h-7 px-2 inline-flex items-center gap-1.5"
@@ -2929,7 +3174,9 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
                 <span className="text-[12px] font-semibold min-w-0 truncate">
                   {selectedMessage?.subject || "Message"}
                 </span>
-                {bodyLoading && <Loader2 className="w-3.5 h-3.5 animate-spin text-[var(--taomni-text-muted)]" />}
+                {selectedMessage && bodyLoadingKey === messageKey(selectedMessage) && (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin text-[var(--taomni-text-muted)]" />
+                )}
                 <div className="ml-auto flex items-center gap-1">
                   <button
                     type="button"
@@ -3080,7 +3327,7 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
                   </div>
 
                   <div className="p-4 text-[13px] leading-6">
-                    {bodyLoading && !selectedBody ? (
+                    {selectedMessage && bodyLoadingKey === messageKey(selectedMessage) && !selectedBody ? (
                       <div className="h-32 flex items-center justify-center text-[12px] text-[var(--taomni-text-muted)]">
                         <Loader2 className="w-4 h-4 mr-2 animate-spin" />
                         Loading message body
@@ -3297,6 +3544,7 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
               html={draft.htmlBody}
               disabled={sending}
               onAttach={() => void handleAddDraftAttachments()}
+              onInlineImage={() => handleInsertInlineImage()}
               onRichFormatUsed={() => setDraft((current) => ({ ...current, richFormatUsed: true }))}
               onChange={(htmlBody, textBody) => setDraft((current) => ({ ...current, htmlBody, textBody }))}
             />
@@ -3309,8 +3557,10 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
                     data-testid="mail-compose-attachment-chip"
                     title={attachment.path}
                   >
-                    <Paperclip className="w-3 h-3" />
-                    <span className="max-w-[280px] truncate">{attachment.name || basename(attachment.path)}</span>
+                    {attachment.inline ? <ImageIcon className="w-3 h-3" /> : <Paperclip className="w-3 h-3" />}
+                    <span className="max-w-[280px] truncate">
+                      {attachment.inline ? "Inline " : ""}{attachment.name || basename(attachment.path)}
+                    </span>
                     <button
                       type="button"
                       className="ml-1 text-[var(--taomni-text-muted)] hover:text-[var(--taomni-text)]"

--- a/src/components/mail/RichMailEditor.test.tsx
+++ b/src/components/mail/RichMailEditor.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RichMailEditor } from "./RichMailEditor";
 
@@ -60,5 +60,47 @@ describe("RichMailEditor", () => {
     expect(execCommand).toHaveBeenCalledWith("bold", false, undefined);
     expect(onRichFormatUsed).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith("<p>Hello</p>", "Hello");
+  });
+
+  it("opens the Thunderbird-style emoticon menu and inserts the selected emoticon", async () => {
+    const execCommand = vi.fn();
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(<RichMailEditor html="<p>Hello</p>" onChange={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId("mail-compose-emoji"));
+    fireEvent.click(await screen.findByTestId("mail-compose-emoji-laugh"));
+
+    expect(execCommand).toHaveBeenCalledWith("insertHTML", false, "😂");
+  });
+
+  it("inserts inline CID image HTML returned by the parent compose window", async () => {
+    const execCommand = vi.fn();
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(
+      <RichMailEditor
+        html="<p>Hello</p>"
+        onChange={vi.fn()}
+        onInlineImage={vi.fn(async () => "<img src=\"cid:logo-1@inline.local\" alt=\"logo\">")}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("mail-compose-insert-menu"));
+    fireEvent.click(await screen.findByTestId("mail-compose-insert-image"));
+
+    await waitFor(() => {
+      expect(execCommand).toHaveBeenCalledWith(
+        "insertHTML",
+        false,
+        "<img src=\"cid:logo-1@inline.local\" alt=\"logo\">",
+      );
+    });
   });
 });

--- a/src/components/mail/RichMailEditor.tsx
+++ b/src/components/mail/RichMailEditor.tsx
@@ -1,20 +1,26 @@
-import { useEffect, useRef, useState, type ClipboardEvent, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ClipboardEvent, type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
 import {
   AlignCenter,
   AlignLeft,
   AlignRight,
+  Anchor,
   Bold,
+  ChevronDown,
   Eraser,
+  Image as ImageIcon,
   IndentDecrease,
   IndentIncrease,
   Italic,
   Link as LinkIcon,
   List,
   ListOrdered,
+  Minus,
+  Table2,
   Smile,
   Underline,
 } from "lucide-react";
 import { mailHtmlToPlainText, sanitizeMailComposeHtml } from "../../lib/mailHtml";
+import { useContextMenu, type MenuItem } from "../ContextMenu";
 
 interface RichMailEditorProps {
   html: string;
@@ -22,6 +28,7 @@ interface RichMailEditorProps {
   onChange: (html: string, text: string) => void;
   onRichFormatUsed?: () => void;
   onAttach?: () => void;
+  onInlineImage?: () => string | null | Promise<string | null>;
 }
 
 const PARAGRAPH_OPTIONS = [
@@ -47,15 +54,36 @@ const SIZE_OPTIONS = [
   { value: "5", label: "24" },
 ];
 
+const EMOJI_OPTIONS = [
+  { id: "smile", label: "微笑", value: "🙂" },
+  { id: "frown", label: "皱眉", value: "🙁" },
+  { id: "wink", label: "眨眼", value: "😉" },
+  { id: "tongue", label: "吐舌", value: "😛" },
+  { id: "laugh", label: "大笑", value: "😂" },
+  { id: "blush", label: "窘迫", value: "😳" },
+  { id: "unsure", label: "迟疑", value: "😕" },
+  { id: "surprise", label: "惊讶", value: "😮" },
+  { id: "kiss", label: "亲吻", value: "😘" },
+  { id: "shout", label: "大叫", value: "😱" },
+  { id: "cool", label: "酷", value: "😎" },
+  { id: "money", label: "爱财", value: "🤑" },
+  { id: "sealed", label: "失言", value: "😶" },
+  { id: "innocent", label: "无辜", value: "😇" },
+  { id: "cry", label: "哭泣", value: "😭" },
+  { id: "silent", label: "缄默", value: "🤐" },
+];
+
 export function RichMailEditor({
   html,
   disabled = false,
   onChange,
   onRichFormatUsed,
   onAttach,
+  onInlineImage,
 }: RichMailEditorProps) {
   const editorRef = useRef<HTMLDivElement>(null);
   const [color, setColor] = useState("#1f2937");
+  const editorMenu = useContextMenu();
 
   useEffect(() => {
     const editor = editorRef.current;
@@ -107,6 +135,76 @@ export function RichMailEditor({
     if (!href?.trim()) return;
     exec("createLink", href.trim());
   };
+
+  const handleAnchor = () => {
+    const name = window.prompt("Anchor name");
+    const cleaned = name?.trim().replace(/\s+/g, "-");
+    if (!cleaned) return;
+    insertHtml(`<a name="${escapeHtml(cleaned)}"></a>`, true);
+  };
+
+  const handleInlineImage = async () => {
+    const imageHtml = await onInlineImage?.();
+    if (!imageHtml) return;
+    insertHtml(imageHtml, true);
+  };
+
+  const handleTable = () => {
+    const raw = window.prompt("Table size (columns x rows)", "2x2");
+    if (!raw) return;
+    const match = /^\s*(\d{1,2})\s*[x*,]\s*(\d{1,2})\s*$/i.exec(raw);
+    const cols = Math.max(1, Math.min(12, Number(match?.[1] ?? 2)));
+    const rows = Math.max(1, Math.min(20, Number(match?.[2] ?? 2)));
+    insertHtml(buildTableHtml(cols, rows), true);
+  };
+
+  const showMenu = (event: ReactMouseEvent<HTMLButtonElement>, items: MenuItem[]) => {
+    if (disabled) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const rect = event.currentTarget.getBoundingClientRect();
+    editorMenu.showAt(rect.left, rect.bottom + 4, items);
+  };
+
+  const emojiMenuItems = (): MenuItem[] => EMOJI_OPTIONS.map((emoji) => ({
+    label: `${emoji.value} ${emoji.label}`,
+    testId: `mail-compose-emoji-${emoji.id}`,
+    onClick: () => insertHtml(emoji.value, false),
+  }));
+
+  const insertMenuItems = (): MenuItem[] => [
+    {
+      label: "链接",
+      testId: "mail-compose-insert-link",
+      icon: <LinkIcon className="w-3.5 h-3.5" />,
+      onClick: handleLink,
+    },
+    {
+      label: "锚标",
+      testId: "mail-compose-insert-anchor",
+      icon: <Anchor className="w-3.5 h-3.5" />,
+      onClick: handleAnchor,
+    },
+    {
+      label: "图像",
+      testId: "mail-compose-insert-image",
+      icon: <ImageIcon className="w-3.5 h-3.5" />,
+      disabled: !onInlineImage,
+      onClick: () => void handleInlineImage(),
+    },
+    {
+      label: "水平线",
+      testId: "mail-compose-insert-hr",
+      icon: <Minus className="w-3.5 h-3.5" />,
+      onClick: () => insertHtml("<hr>", true),
+    },
+    {
+      label: "表格",
+      testId: "mail-compose-insert-table",
+      icon: <Table2 className="w-3.5 h-3.5" />,
+      onClick: handleTable,
+    },
+  ];
 
   return (
     <div className="mx-3 mb-3 min-h-0 flex-1 flex flex-col border border-[var(--taomni-input-border)] rounded-md overflow-hidden bg-[var(--taomni-input-bg)]">
@@ -172,7 +270,12 @@ export function RichMailEditor({
         <ToolbarButton label="Align center" testId="mail-compose-align-center" disabled={disabled} onClick={() => exec("justifyCenter")}><AlignCenter className="w-3.5 h-3.5" /></ToolbarButton>
         <ToolbarButton label="Align right" testId="mail-compose-align-right" disabled={disabled} onClick={() => exec("justifyRight")}><AlignRight className="w-3.5 h-3.5" /></ToolbarButton>
         <ToolbarButton label="Insert link" testId="mail-compose-link" disabled={disabled} onClick={handleLink}><LinkIcon className="w-3.5 h-3.5" /></ToolbarButton>
-        <ToolbarButton label="Insert smile" testId="mail-compose-emoji" disabled={disabled} onClick={() => insertHtml("🙂", false)}><Smile className="w-3.5 h-3.5" /></ToolbarButton>
+        <MenuButton label="Insert" testId="mail-compose-insert-menu" disabled={disabled} onClick={(event) => showMenu(event, insertMenuItems())}>
+          <ImageIcon className="w-3.5 h-3.5" />
+        </MenuButton>
+        <MenuButton label="Insert emoticon" testId="mail-compose-emoji" disabled={disabled} onClick={(event) => showMenu(event, emojiMenuItems())}>
+          <Smile className="w-3.5 h-3.5" />
+        </MenuButton>
         {onAttach && (
           <button
             type="button"
@@ -186,6 +289,7 @@ export function RichMailEditor({
           </button>
         )}
       </div>
+      {editorMenu.render}
       <div
         ref={editorRef}
         className="flex-1 min-h-[240px] overflow-auto px-3 py-2 text-[13px] leading-6 outline-none bg-[var(--taomni-input-bg)] empty:before:content-['']"
@@ -227,6 +331,43 @@ function ToolbarButton({
       {children}
     </button>
   );
+}
+
+function MenuButton({
+  label,
+  testId,
+  disabled,
+  onClick,
+  children,
+}: {
+  label: string;
+  testId: string;
+  disabled?: boolean;
+  onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      className="taomni-btn h-7 px-1.5 inline-flex items-center justify-center gap-0.5"
+      aria-label={label}
+      title={label}
+      data-testid={testId}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+      <ChevronDown className="w-3 h-3" />
+    </button>
+  );
+}
+
+function buildTableHtml(cols: number, rows: number): string {
+  const cells = Array.from({ length: cols }, () => (
+    '<td style="border: 1px solid #9ca3af; padding: 4px 8px;">&nbsp;</td>'
+  )).join("");
+  const body = Array.from({ length: rows }, () => `<tr>${cells}</tr>`).join("");
+  return `<table style="border-collapse: collapse;"><tbody>${body}</tbody></table><p><br></p>`;
 }
 
 function escapeHtml(value: string): string {

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -128,6 +128,8 @@ export interface MailSendAttachment {
   path: string;
   name?: string | null;
   contentType?: string | null;
+  inline?: boolean;
+  contentId?: string | null;
 }
 
 export interface MailSendResult {
@@ -154,6 +156,8 @@ export interface MailDraftAttachment {
   path: string;
   name?: string | null;
   contentType?: string | null;
+  inline?: boolean;
+  contentId?: string | null;
   size?: number | null;
   modifiedAt?: number | null;
 }

--- a/src/lib/mailHtml.test.ts
+++ b/src/lib/mailHtml.test.ts
@@ -38,6 +38,22 @@ describe("mailHtml", () => {
     expect(allowed).toContain("https://example.com/a.png");
   });
 
+  it("preserves compose CID images and safe inserted table styles", () => {
+    const html = sanitizeMailComposeHtml(`
+      <p><img src="cid:logo-1@inline.local" alt="logo"></p>
+      <table style="border-collapse: collapse; position: fixed">
+        <tbody><tr><td style="border: 1px solid #9ca3af; padding: 4px 8px; background-image: url(javascript:alert(1))">Cell</td></tr></tbody>
+      </table>
+    `);
+
+    expect(html).toContain("src=\"cid:logo-1@inline.local\"");
+    expect(html).toContain("border-collapse: collapse");
+    expect(html).toContain("border: 1px solid #9ca3af");
+    expect(html).toContain("padding: 4px 8px");
+    expect(html).not.toContain("position");
+    expect(html).not.toContain("background-image");
+  });
+
   it("round-trips plain text through mail HTML and extracts readable text from lists and paragraphs", () => {
     expect(plainTextToMailHtml("Hello\nWorld")).toBe("<p>Hello<br>World</p>");
 

--- a/src/lib/mailHtml.ts
+++ b/src/lib/mailHtml.ts
@@ -21,16 +21,20 @@ const MAIL_PURIFY_CONFIG: DomPurifyConfig = {
   FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover", "onfocus"],
   ALLOW_DATA_ATTR: false,
   ADD_ATTR: ["target"],
+  ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|cid):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
 };
 
 const SAFE_STYLE_PROPS = new Set([
   "background-color",
+  "border",
+  "border-collapse",
   "color",
   "font-family",
   "font-size",
   "font-style",
   "font-weight",
   "margin-left",
+  "padding",
   "text-align",
   "text-decoration",
   "text-decoration-line",
@@ -88,6 +92,13 @@ function isSafeStyleValue(prop: string, value: string): boolean {
   if (prop === "font-family") return /^[\w\s,"'-]+$/.test(value);
   if (prop === "font-size" || prop === "margin-left") {
     return /^-?\d+(\.\d+)?(px|pt|em|rem|%)$/.test(lower);
+  }
+  if (prop === "padding") {
+    return /^\d+(\.\d+)?(px|pt|em|rem|%)(\s+\d+(\.\d+)?(px|pt|em|rem|%)){0,3}$/.test(lower);
+  }
+  if (prop === "border-collapse") return /^(collapse|separate)$/.test(lower);
+  if (prop === "border") {
+    return /^(\d+(\.\d+)?(px|pt|em|rem)\s+)?(solid|dashed|dotted|double)\s+(#[0-9a-f]{3,8}|[a-z]+|rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}(\s*,\s*(0|1|0?\.\d+))?\s*\))$/.test(lower);
   }
   if (prop === "color" || prop === "background-color") return isSafeCssColor(value);
   return false;

--- a/src/stubs/tauri-core.ts
+++ b/src/stubs/tauri-core.ts
@@ -873,6 +873,8 @@ interface StubMailDraft {
     path: string;
     name?: string | null;
     contentType?: string | null;
+    inline?: boolean;
+    contentId?: string | null;
     size?: number | null;
     modifiedAt?: number | null;
   }>;
@@ -911,6 +913,8 @@ function stubSaveMailDraft(accountId: string, draft: Record<string, unknown>): S
           path: String(item.path),
           name: typeof item.name === "string" ? item.name : null,
           contentType: typeof item.contentType === "string" ? item.contentType : null,
+          inline: item.inline === true,
+          contentId: typeof item.contentId === "string" ? item.contentId : null,
           size: typeof item.size === "number" ? item.size : null,
           modifiedAt: typeof item.modifiedAt === "number" ? item.modifiedAt : null,
         }))


### PR DESCRIPTION
Add Thunderbird-style compose toolbar menus for emoji and insert actions, including inline image, horizontal rule, and table insertion.

Support local inline image insertion using CID-backed draft attachments and emit multipart/related MIME when sending, nesting it with multipart/mixed when regular attachments are also present.

Switch mail refresh paths to headers-first syncing and run body warming as a separate progress-tracked background task so cached headers become usable before body fetches finish.

Preserve inline attachment metadata through frontend types, browser stubs, local drafts, send validation, and MIME construction; allow safe cid: image rendering in sanitized mail HTML.

Update mail UI tests, Rust MIME tests, qa-ui-auto cases, feature coverage, and the testid catalog for the new compose and sync behavior.