### PR TITLE
fix(mail): keep background sync running

### DIFF
--- a/src/components/mail/MailClientTab.test.tsx
+++ b/src/components/mail/MailClientTab.test.tsx
@@ -199,6 +199,7 @@ describe("MailClientTab", () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
   });
 
   it("keeps the loaded body when double-click opens the message in a tab", async () => {
@@ -362,5 +363,62 @@ describe("MailClientTab", () => {
       51,
       0,
     ));
+  });
+
+  it("keeps periodic sync running while hidden and refreshes from cache when visible", async () => {
+    vi.useFakeTimers();
+    const intervalInfo: MailTabInfo = {
+      ...info,
+      sync: { ...info.sync, onOpen: false, intervalMinutes: 1 },
+    };
+    const freshFolder: MailFolder = {
+      ...folder,
+      total: 2,
+      unread: 1,
+      updatedAt: 2,
+    };
+    const freshMessage: MailMessageHeader = {
+      ...uncachedMessage,
+      flags: [],
+    };
+    mailMocks.mailSyncAllFolders.mockResolvedValue({
+      accountId: info.sessionId,
+      folders: [freshFolder],
+      fetchedMessages: 1,
+      cachedBodies: 0,
+      syncedAt: 2,
+    });
+    mailMocks.mailListCachedFolders.mockResolvedValue([freshFolder]);
+    mailMocks.mailListCachedMessages.mockResolvedValue([freshMessage]);
+
+    const view = render(<MailClientTab tabId="mail-tab" info={intervalInfo} visible={false} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(mailMocks.mailSyncAllFolders).toHaveBeenCalledWith(
+      intervalInfo,
+      { limit: 50, includeBodies: false },
+    );
+    expect(mailMocks.mailListCachedFolders).not.toHaveBeenCalled();
+    expect(mailMocks.mailListCachedMessages).not.toHaveBeenCalled();
+
+    view.rerender(<MailClientTab tabId="mail-tab" info={intervalInfo} visible />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mailMocks.mailListCachedFolders).toHaveBeenCalledWith(info.sessionId);
+    expect(mailMocks.mailListCachedMessages).toHaveBeenCalledWith(
+      info.sessionId,
+      "INBOX",
+      51,
+      0,
+    );
+    expect(screen.getAllByText(/Header arrived before the body cache is warm/).length).toBeGreaterThan(0);
   });
 });

--- a/src/components/mail/MailClientTab.tsx
+++ b/src/components/mail/MailClientTab.tsx
@@ -1582,17 +1582,17 @@ export function MailClientTab({ tabId, info, visible }: MailClientTabProps) {
   }, [batchSize, info.sync.onOpen, selectedFolder, syncFolder, visible]);
 
   useEffect(() => {
-    if (!visible || info.sync.intervalMinutes <= 0) return;
+    if (info.sync.intervalMinutes <= 0) return;
     const intervalMs = Math.max(1, info.sync.intervalMinutes) * 60 * 1000;
     const id = window.setInterval(() => {
-      void syncFolder(selectedFolder, true, {
+      void syncAllFolders(true, {
         limit: batchSize,
         includeBodies: false,
         indicator: "none",
       });
     }, intervalMs);
     return () => window.clearInterval(id);
-  }, [batchSize, info.sync.intervalMinutes, selectedFolder, syncFolder, visible]);
+  }, [batchSize, info.sync.intervalMinutes, syncAllFolders]);
 
   useEffect(() => {
     if (messages.length === 0) {


### PR DESCRIPTION
Run the periodic mail sync even when the mail tab is hidden so cached headers continue refreshing in the background.

Use the same all-folder incremental sync path as the manual Sync button instead of only syncing the currently selected folder.

Keep hidden tabs from mutating UI state during background sync; they mark the cache as stale and refresh folders/messages from cache when shown again.

Add a focused MailClientTab regression test that verifies hidden periodic sync still runs and visible tabs reload the refreshed cache.