### PR TITLE
feat(database): add native PanWeiDB engine

### DIFF
--- a/qa-ui-auto-tests/feature-list.md
+++ b/qa-ui-auto-tests/feature-list.md
@@ -1220,6 +1220,10 @@ controls:
     selector: '[data-testid="session-proto-postgresql"]'
     kind: interactive
     optional: true        # DB session type — form body owned by F-DB-1
+  - id: proto-panweidb
+    selector: '[data-testid="session-proto-panweidb"]'
+    kind: interactive
+    optional: true        # DB session type — form body owned by F-DB-1
   - id: proto-clickhouse
     selector: '[data-testid="session-proto-clickhouse"]'
     kind: interactive
@@ -3220,7 +3224,7 @@ controls:
 
 ---
 
-## 23. 数据库客户端 — SQL（MySQL / PostgreSQL / ClickHouse）
+## 23. 数据库客户端 — SQL（MySQL / PostgreSQL / PanWeiDB / ClickHouse）
 
 ### 23.1 SQL 客户端 `DbClientTab` ✅
 
@@ -3263,7 +3267,7 @@ controls:
   - id: db-name
     selector: 'input[aria-label="Database name"]'
     kind: interactive
-    optional: true       # hidden for Redis; present for MySQL/PostgreSQL/ClickHouse
+    optional: true       # hidden for Redis; present for MySQL/PostgreSQL/PanWeiDB/ClickHouse
   - id: db-save-in-vault
     selector: '[data-testid="db-save-in-vault"]'
     kind: interactive
@@ -3404,14 +3408,14 @@ controls:
   # Format/History/Save) use title= only — no stable testid yet; promote when covered.
 -->
 
-- DB 会话（MySQL/PostgreSQL/ClickHouse）经 `SessionEditor` 创建（proto 选择器 + database section 由 F6.3 拥有），打开后 `MainLayout.openDbTab` 挂载 `DbClientTab`（`type:"database"`），与 SFTP/VNC 一样常驻挂载以便查询跨标签存活
+- DB 会话（MySQL/PostgreSQL/PanWeiDB/ClickHouse）经 `SessionEditor` 创建（proto 选择器 + database section 由 F6.3 拥有），打开后 `MainLayout.openDbTab` 挂载 `DbClientTab`（`type:"database"`），与 SFTP/VNC 一样常驻挂载以便查询跨标签存活
 - 左侧 `SchemaTree`：懒加载 schema→table→column/index 展开（`db-schema-drawer-handle` 抽屉折叠）；右侧查询工作区为多 query 面板（最多 4 个）的 tab 布局
 - `SqlEditorPanel` 封装 CodeMirror 6：按引擎选 dialect、schema-aware 自动补全（`SQLNamespace`），暴露命令式 `SqlEditorHandle`；工具条 Run (F5) / Run selection / Cancel / Format / History / Save / Rows / Sheets / Schema 选择；执行时按 SQL 语句范围拆分并给每个 result sheet 绑定 `sourceRef`
 - SQL 历史持久化到 SQLite `sql_history`，按 workspace/session + engine 查询；History 面板支持 Run / Select / +Tab / JSON / Ask AI / Refresh / Clear / Delete；当前 editor 语句面板用 cursor/selection 定位多 SQL 文档中的单条语句，并提供同一套 Run / Select / +Tab / JSON / Ask AI 交互
 - `QueryResultGrid` 为手写虚拟化网格（行高 24 + overscan）：NULL 徽标、数值右对齐、排序、CSV/单元格复制、完整值查看（Ctrl+Enter / 右键菜单，保留长文本和换行）、列显隐、聚合统计、行筛选、Table/List/Chart 视图、增删改行 + 提交/撤销；过滤/排序会生成包裹源 SQL 的 derived SQL，自动创建/复用 `Generated SQL` query 面板并支持显式替换仍匹配的来源语句
 - 查询工作区跨会话持久化（`queryRegistry` + `ef0b686`），结果可经 Export Grid 对话框导出
 - 浮动工具条复用共享 `FloatingToolbar`（F10.1，`db-floating-toolbar`）：Chat 入口 / 最大化 / 分离到独立窗口（`db-detach`，分离/重挂载行为属 F-Detach-1）
-- **e2e 测试限制**：实际查询需活的 MySQL/PostgreSQL/ClickHouse fixture，浏览器冒烟无法连接；smoke 只覆盖「SessionEditor 选 DB proto → 填 host/port → 保存 → 打开标签 → schema-tree / sql-editor / query-result-grid 挂载」的路由路径（参照 TC-111 RDP scaffold 模式），真实查询/编辑留待配置 DB fixture 的手动/native 回归
+- **e2e 测试限制**：实际查询需活的 MySQL/PostgreSQL/PanWeiDB/ClickHouse fixture，浏览器冒烟无法连接；smoke 只覆盖「SessionEditor 选 DB proto → 填 host/port → 保存 → 打开标签 → schema-tree / sql-editor / query-result-grid 挂载」的路由路径（参照 TC-111 RDP scaffold 模式），真实查询/编辑留待配置 DB fixture 的手动/native 回归
 
 ---
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation",
- "parking_lot",
+ "parking_lot 0.12.5",
  "percent-encoding",
  "windows-sys 0.60.2",
  "x11rb",
@@ -324,7 +324,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.18",
- "time",
+ "time 0.3.51",
 ]
 
 [[package]]
@@ -944,6 +944,15 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -1462,7 +1471,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.18",
 ]
 
 [[package]]
@@ -1548,7 +1557,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
- "time",
+ "time 0.3.51",
  "version_check",
 ]
 
@@ -1932,7 +1941,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.13.1",
  "smallvec",
 ]
 
@@ -2062,7 +2071,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
 ]
 
 [[package]]
@@ -2280,6 +2289,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
 dependencies = [
  "cipher 0.5.2",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2778,6 +2796,12 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
@@ -2918,7 +2942,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3033,6 +3057,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3088,7 +3118,7 @@ checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -3179,6 +3209,12 @@ checksum = "c13a5f2acc785d8fb6bf6b7ab6bfb0ef5dad4f4d97e8e70bb8e470722312f76f"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "gdk"
@@ -3319,7 +3355,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -3576,7 +3612,7 @@ dependencies = [
  "indexmap 2.14.0",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.18",
  "tracing",
 ]
 
@@ -3696,7 +3732,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version",
- "spin",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -3761,6 +3797,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
  "hmac 0.13.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -3929,7 +3975,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4200,6 +4246,15 @@ checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "block-padding 0.4.2",
  "hybrid-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -4918,7 +4973,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -4946,7 +5001,7 @@ dependencies = [
  "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
- "socket2",
+ "socket2 0.6.4",
  "tokio",
  "url",
 ]
@@ -5236,7 +5291,7 @@ dependencies = [
  "log",
  "objc2",
  "objc2-foundation",
- "time",
+ "time 0.3.51",
  "uuid",
 ]
 
@@ -5287,6 +5342,17 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
@@ -5332,7 +5398,7 @@ dependencies = [
  "log",
  "mio",
  "socket-pktinfo",
- "socket2",
+ "socket2 0.6.4",
 ]
 
 [[package]]
@@ -5420,7 +5486,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -6333,6 +6399,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "opengauss-protocol"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ff8153f68e8ed50b85d9a9660c071640cc6cea13fd819b4e5a5ba3d9eb34431"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac 0.11.0",
+ "lazy_static",
+ "md-5 0.9.1",
+ "memchr",
+ "rand 0.8.6",
+ "ring 0.16.20",
+ "rust-crypto",
+ "sha2 0.9.9",
+ "stringprep",
+]
+
+[[package]]
+name = "opengauss-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6218724e916b203f3bfc5b47fd0750af9552a0b763d574f046c7a2292d1f412d"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "opengauss-protocol",
+]
+
+[[package]]
 name = "openh264"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6554,12 +6652,37 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if 1.0.4",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -6570,7 +6693,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -6705,12 +6828,21 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
 ]
 
@@ -6721,7 +6853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -6731,7 +6863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -6741,10 +6873,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -6753,7 +6894,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
- "siphasher",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
@@ -6810,7 +6951,7 @@ dependencies = [
  "oid",
  "serde",
  "serde_bytes",
- "time",
+ "time 0.3.51",
  "zeroize",
 ]
 
@@ -7013,7 +7154,7 @@ dependencies = [
  "indexmap 2.14.0",
  "quick-xml 0.39.4",
  "serde",
- "time",
+ "time 0.3.51",
 ]
 
 [[package]]
@@ -7420,7 +7561,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
- "socket2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7438,7 +7579,7 @@ dependencies = [
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.4",
- "ring",
+ "ring 0.17.14",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
  "rustls-pki-types",
@@ -7458,7 +7599,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7495,6 +7636,29 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+dependencies = [
+ "libc",
+ "rand 0.4.6",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
 
 [[package]]
 name = "rand"
@@ -7547,6 +7711,21 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -7605,11 +7784,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
- "ring",
+ "ring 0.17.14",
  "rustls-pki-types",
- "time",
+ "time 0.3.51",
  "x509-parser",
  "yasna",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -7630,12 +7818,21 @@ dependencies = [
  "rustls 0.23.41",
  "rustls-native-certs 0.8.4",
  "ryu",
- "socket2",
+ "socket2 0.6.4",
  "tokio",
  "tokio-rustls 0.26.4",
- "tokio-util",
+ "tokio-util 0.7.18",
  "url",
  "xxhash-rust",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -7793,7 +7990,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
- "tokio-util",
+ "tokio-util 0.7.18",
  "tower",
  "tower-http",
  "tower-service",
@@ -7889,6 +8086,21 @@ dependencies = [
 
 [[package]]
 name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -7956,7 +8168,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.18",
  "tower-service",
  "tracing",
  "uuid",
@@ -8031,7 +8243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags 2.13.0",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink 0.12.0",
  "libsqlite3-sys",
@@ -8140,7 +8352,7 @@ dependencies = [
  "serde_bytes",
  "thiserror 2.0.18",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.18",
  "wasm-bindgen-futures",
 ]
 
@@ -8154,6 +8366,19 @@ dependencies = [
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "rust-crypto"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
+dependencies = [
+ "gcc",
+ "libc",
+ "rand 0.3.23",
+ "rustc-serialize",
+ "time 0.1.45",
 ]
 
 [[package]]
@@ -8184,6 +8409,12 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "rustc_version"
@@ -8274,7 +8505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.14",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -8288,7 +8519,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
+ "ring 0.17.14",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "subtle",
@@ -8380,7 +8611,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
+ "ring 0.17.14",
  "untrusted 0.9.0",
 ]
 
@@ -8391,7 +8622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
- "ring",
+ "ring 0.17.14",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -8559,7 +8790,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
+ "ring 0.17.14",
  "untrusted 0.9.0",
 ]
 
@@ -8658,7 +8889,7 @@ dependencies = [
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash 2.1.2",
@@ -8827,7 +9058,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_with_macros",
- "time",
+ "time 0.3.51",
 ]
 
 [[package]]
@@ -8924,6 +9155,19 @@ dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.4",
+ "cpufeatures 0.2.17",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -9090,6 +9334,12 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
@@ -9113,8 +9363,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
 dependencies = [
  "libc",
- "socket2",
+ "socket2 0.6.4",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -9142,7 +9402,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -9204,6 +9464,12 @@ checksum = "a16f73dcebb4e44f93258cc9712d57f3c076f67b91163d6ded5a675577f5cdc5"
 dependencies = [
  "linkme",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -9471,7 +9737,7 @@ dependencies = [
  "sha1 0.11.0",
  "sha2 0.11.0",
  "signature 3.0.0",
- "time",
+ "time 0.3.51",
  "tokio",
  "tracing",
  "url",
@@ -9502,8 +9768,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
- "parking_lot",
- "phf_shared",
+ "parking_lot 0.12.5",
+ "phf_shared 0.13.1",
  "precomputed-hash",
 ]
 
@@ -9514,7 +9780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -9698,7 +9964,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-ui-kit",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.5",
  "percent-encoding",
  "raw-window-handle",
  "tao-macros",
@@ -9802,7 +10068,7 @@ dependencies = [
  "sha1 0.11.0",
  "sha2 0.11.0",
  "shellexpand",
- "socket2",
+ "socket2 0.6.4",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -9819,9 +10085,10 @@ dependencies = [
  "thrift",
  "tiberius",
  "tokio",
+ "tokio-opengauss",
  "tokio-rustls 0.26.4",
  "tokio-tungstenite",
- "tokio-util",
+ "tokio-util 0.7.18",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
@@ -9962,7 +10229,7 @@ dependencies = [
  "syn 2.0.118",
  "tauri-utils",
  "thiserror 2.0.18",
- "time",
+ "time 0.3.51",
  "url",
  "uuid",
  "walkdir",
@@ -10059,7 +10326,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
- "time",
+ "time 0.3.51",
 ]
 
 [[package]]
@@ -10077,7 +10344,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
- "time",
+ "time 0.3.51",
  "url",
 ]
 
@@ -10138,7 +10405,7 @@ dependencies = [
  "tauri-plugin",
  "tempfile",
  "thiserror 2.0.18",
- "time",
+ "time 0.3.51",
  "tokio",
  "url",
  "windows-sys 0.60.2",
@@ -10212,7 +10479,7 @@ dependencies = [
  "json-patch",
  "log",
  "memchr",
- "phf",
+ "phf 0.13.1",
  "plist",
  "proc-macro2",
  "quote",
@@ -10373,7 +10640,7 @@ dependencies = [
  "rustls-pemfile 1.0.4",
  "thiserror 1.0.69",
  "tokio-rustls 0.24.1",
- "tokio-util",
+ "tokio-util 0.7.18",
  "tracing",
  "uuid",
 ]
@@ -10390,6 +10657,17 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -10480,10 +10758,10 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -10497,6 +10775,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tokio-opengauss"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0cbaece592af0ca1d7f54faba4fda9c1e7a67b662a2e3f9549807093236f05"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures",
+ "log",
+ "opengauss-protocol",
+ "opengauss-types",
+ "parking_lot 0.11.2",
+ "percent-encoding",
+ "phf 0.10.1",
+ "pin-project-lite",
+ "socket2 0.4.10",
+ "tokio",
+ "tokio-util 0.6.10",
 ]
 
 [[package]]
@@ -10540,6 +10841,20 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -11142,6 +11457,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
@@ -11350,7 +11671,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -12070,7 +12391,7 @@ dependencies = [
  "picky-asn1-x509",
  "rsa 0.10.0-rc.18",
  "sha1 0.11.0",
- "time",
+ "time 0.3.51",
  "tracing",
  "uuid",
 ]
@@ -12222,10 +12543,10 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "oid-registry",
- "ring",
+ "ring 0.17.14",
  "rusticata-macros",
  "thiserror 2.0.18",
- "time",
+ "time 0.3.51",
 ]
 
 [[package]]
@@ -12316,7 +12637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
  "bit-vec 0.9.1",
- "time",
+ "time 0.3.51",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -125,13 +125,15 @@ nokhwa = { version = "0.10", optional = true, default-features = false, features
 ash = { version = "0.38", optional = true }
 llama-cpp-2 = { version = "0.1", optional = true }
 plist = "1.9"
-# Database client backends (MySQL / StarRocks / PostgreSQL via sqlx, SQL Server
-# via tiberius, Redis via redis-rs, ClickHouse via the existing reqwest HTTP
-# client). Values are decoded to frontend strings while preserving common
-# database-native numeric, UUID, JSON and time types.
+# Database client backends (MySQL / StarRocks / PostgreSQL via sqlx, PanWeiDB
+# via the native openGauss connector, SQL Server via tiberius, Redis via
+# redis-rs, ClickHouse via the existing reqwest HTTP client). Values are decoded
+# to frontend strings while preserving common database-native numeric, UUID,
+# JSON and time types where the driver exposes them.
 sqlx-core = { version = "0.9", default-features = false, features = ["_rt-tokio", "_tls-rustls-ring-webpki", "chrono", "bigdecimal", "uuid", "json"] }
 sqlx-mysql = { version = "0.9", default-features = false, features = ["chrono", "bigdecimal", "uuid", "json"] }
 sqlx-postgres = { version = "0.9", default-features = false, features = ["chrono", "bigdecimal", "uuid", "json"] }
+tokio-opengauss = "0.1"
 tiberius = { version = "0.12", default-features = false, features = ["tds73", "rustls", "chrono", "bigdecimal"] }
 redis = { version = "1.2", default-features = false, features = ["tokio-comp", "tokio-rustls-comp", "streams"] }
 # Native HBase RPC client (hbase/native): protobuf wire types via prost,

--- a/src-tauri/src/agent/cc_bridge/mcp_control.rs
+++ b/src-tauri/src/agent/cc_bridge/mcp_control.rs
@@ -349,6 +349,7 @@ fn parse_session_type(s: &str) -> Result<SessionType, String> {
         "Mosh",
         "MySQL",
         "PostgreSQL",
+        "PanWeiDB",
         "SQLServer",
         "StarRocks",
         "ClickHouse",

--- a/src-tauri/src/agent/cc_bridge/mcp_http.rs
+++ b/src-tauri/src/agent/cc_bridge/mcp_http.rs
@@ -109,14 +109,16 @@ impl Flavor {
     }
 
     /// Pick the MCP flavor for a thread from its bound session's type: SQL DB
-    /// engines (MySQL/PG/SQL Server/StarRocks/ClickHouse/Presto) → `Sql`, Redis → `Redis`, anything
-    /// else (SSH/terminal/local/unbound) → `Shell`.
+    /// engines (MySQL/PG/PanWeiDB/SQL Server/StarRocks/ClickHouse/Presto) →
+    /// `Sql`, Redis → `Redis`, anything else (SSH/terminal/local/unbound) →
+    /// `Shell`.
     pub fn for_session_type(t: Option<&crate::session::models::SessionType>) -> Flavor {
         use crate::session::models::SessionType;
         match t {
             Some(
                 SessionType::MySQL
                 | SessionType::PostgreSQL
+                | SessionType::PanWeiDB
                 | SessionType::SQLServer
                 | SessionType::StarRocks
                 | SessionType::ClickHouse
@@ -1850,6 +1852,7 @@ mod tests {
         let sql = [
             SessionType::MySQL,
             SessionType::PostgreSQL,
+            SessionType::PanWeiDB,
             SessionType::SQLServer,
             SessionType::StarRocks,
             SessionType::ClickHouse,

--- a/src-tauri/src/agent/cc_bridge/session_card.rs
+++ b/src-tauri/src/agent/cc_bridge/session_card.rs
@@ -74,7 +74,8 @@ fn is_remote(t: &SessionType) -> bool {
 /// so a DB thread is steered to its SQL/Redis tools, not the terminal tools its
 /// `.mcp.json` doesn't even expose (Phase 6).
 enum DbRouting {
-    /// MySQL / PostgreSQL / SQL Server / StarRocks / ClickHouse / Presto — the `taomni_sql` tools.
+    /// MySQL / PostgreSQL / PanWeiDB / SQL Server / StarRocks / ClickHouse /
+    /// Presto — the `taomni_sql` tools.
     Sql,
     /// Redis — the `taomni_redis` tools.
     Redis,
@@ -86,6 +87,7 @@ fn db_routing(t: &SessionType) -> DbRouting {
     match t {
         SessionType::MySQL
         | SessionType::PostgreSQL
+        | SessionType::PanWeiDB
         | SessionType::SQLServer
         | SessionType::StarRocks
         | SessionType::ClickHouse
@@ -576,6 +578,7 @@ mod tests {
         for engine in [
             SessionType::MySQL,
             SessionType::PostgreSQL,
+            SessionType::PanWeiDB,
             SessionType::SQLServer,
             SessionType::StarRocks,
             SessionType::ClickHouse,

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -1,6 +1,7 @@
-//! Database client backend: MySQL / PostgreSQL / StarRocks (via `sqlx`), SQL
-//! Server (via `tiberius`), ClickHouse and Presto (via the existing `reqwest`
-//! HTTP client), and Redis (via `redis-rs`).
+//! Database client backend: MySQL / PostgreSQL / StarRocks (via `sqlx`),
+//! PanWeiDB (via the native openGauss connector), SQL Server (via `tiberius`),
+//! ClickHouse and Presto (via the existing `reqwest` HTTP client), and Redis
+//! (via `redis-rs`).
 //!
 //! SQL engines surface a single Tauri command surface (`db_*`, with
 //! `redis_*` for Redis). Live connections are cached in
@@ -10,6 +11,7 @@
 
 pub mod clickhouse;
 pub mod forward;
+pub mod panwei;
 pub mod presto;
 pub mod redis_ops;
 pub mod sql;
@@ -39,7 +41,7 @@ use crate::state::AppState;
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DbConfig {
-    /// Backend engine: "MySQL" | "PostgreSQL" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto" | "Redis".
+    /// Backend engine: "MySQL" | "PostgreSQL" | "PanWeiDB" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto" | "Redis".
     pub engine: String,
     pub host: String,
     pub port: u16,
@@ -226,6 +228,7 @@ pub struct DbObject {
 pub enum DbHandle {
     MySql(Pool<MySql>),
     Postgres(Pool<Postgres>),
+    PanWeiDB(panwei::PanWeiClient),
     SqlServer(Arc<AsyncMutex<sql::SqlServerClient>>),
     StarRocks(Pool<MySql>),
     ClickHouse(clickhouse::ClickHouseClient),
@@ -320,6 +323,22 @@ fn start_keepalive(handle: &DbHandle, shutdown: CancellationToken) -> Option<Joi
                 }
             }))
         }
+        DbHandle::PanWeiDB(client) => {
+            let client = client.clone();
+            Some(tokio::spawn(async move {
+                let mut interval =
+                    tokio::time::interval(Duration::from_secs(KEEPALIVE_INTERVAL_SECS));
+                interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                loop {
+                    tokio::select! {
+                        _ = shutdown.cancelled() => break,
+                        _ = interval.tick() => {
+                            let _ = panwei::ping(&client).await;
+                        }
+                    }
+                }
+            }))
+        }
         DbHandle::SqlServer(client) => {
             let client = client.clone();
             Some(tokio::spawn(async move {
@@ -385,7 +404,8 @@ async fn close_session(session: Arc<DbSession>) {
         DbHandle::MySql(pool) => pool.close().await,
         DbHandle::StarRocks(pool) => pool.close().await,
         DbHandle::Postgres(pool) => pool.close().await,
-        DbHandle::SqlServer(_)
+        DbHandle::PanWeiDB(_)
+        | DbHandle::SqlServer(_)
         | DbHandle::ClickHouse(_)
         | DbHandle::Presto(_)
         | DbHandle::Redis(_) => {}
@@ -447,6 +467,7 @@ pub async fn db_connect(
     let handle = match config.engine.as_str() {
         "MySQL" => sql::connect_mysql(&config, password.as_deref()).await?,
         "PostgreSQL" => sql::connect_postgres(&config, password.as_deref()).await?,
+        "PanWeiDB" => panwei::connect(&config, password.as_deref()).await?,
         "SQLServer" => sql::connect_sqlserver(&config, password.as_deref()).await?,
         "StarRocks" => sql::connect_starrocks(&config, password.as_deref()).await?,
         "ClickHouse" => clickhouse::connect(&config, password.as_deref()).await?,
@@ -526,6 +547,7 @@ pub async fn db_ping(state: State<'_, AppState>, session_id: String) -> Result<S
     match &session.handle {
         DbHandle::MySql(pool) => sql::ping_mysql(pool).await,
         DbHandle::Postgres(pool) => sql::ping_postgres(pool).await,
+        DbHandle::PanWeiDB(client) => panwei::ping(client).await,
         DbHandle::SqlServer(client) => sql::ping_sqlserver(client).await,
         DbHandle::StarRocks(pool) => sql::ping_starrocks(pool).await,
         DbHandle::ClickHouse(client) => clickhouse::ping(client).await,
@@ -560,6 +582,7 @@ pub async fn db_list_catalogs(
         DbHandle::Presto(client) => presto::list_catalogs(client).await,
         DbHandle::MySql(_)
         | DbHandle::Postgres(_)
+        | DbHandle::PanWeiDB(_)
         | DbHandle::SqlServer(_)
         | DbHandle::StarRocks(_)
         | DbHandle::ClickHouse(_)
@@ -578,6 +601,7 @@ pub async fn db_list_schemas(
         DbHandle::MySql(pool) => sql::list_schemas_mysql(pool).await,
         DbHandle::StarRocks(pool) => sql::list_schemas_mysql(pool).await,
         DbHandle::Postgres(pool) => sql::list_schemas_postgres(pool).await,
+        DbHandle::PanWeiDB(client) => panwei::list_schemas(client).await,
         DbHandle::SqlServer(client) => sql::list_schemas_sqlserver(client).await,
         DbHandle::ClickHouse(client) => clickhouse::list_schemas(client).await,
         DbHandle::Presto(client) => presto::list_schemas(client, catalog.as_deref()).await,
@@ -597,6 +621,7 @@ pub async fn db_list_tables(
         DbHandle::MySql(pool) => sql::list_tables_mysql(pool, schema.as_deref()).await,
         DbHandle::StarRocks(pool) => sql::list_tables_mysql(pool, schema.as_deref()).await,
         DbHandle::Postgres(pool) => sql::list_tables_postgres(pool, schema.as_deref()).await,
+        DbHandle::PanWeiDB(client) => panwei::list_tables(client, schema.as_deref()).await,
         DbHandle::SqlServer(client) => sql::list_tables_sqlserver(client, schema.as_deref()).await,
         DbHandle::ClickHouse(client) => clickhouse::list_tables(client, schema.as_deref()).await,
         DbHandle::Presto(client) => {
@@ -622,6 +647,9 @@ pub async fn db_describe_table(
         }
         DbHandle::Postgres(pool) => {
             sql::describe_table_postgres(pool, schema.as_deref(), &table).await
+        }
+        DbHandle::PanWeiDB(client) => {
+            panwei::describe_table(client, schema.as_deref(), &table).await
         }
         DbHandle::SqlServer(client) => {
             sql::describe_table_sqlserver(client, schema.as_deref(), &table).await
@@ -650,6 +678,9 @@ pub async fn db_list_indexes(
         DbHandle::Postgres(pool) => {
             sql::list_indexes_postgres(pool, schema.as_deref(), &table).await
         }
+        DbHandle::PanWeiDB(client) => {
+            panwei::list_indexes(client, schema.as_deref(), &table).await
+        }
         DbHandle::SqlServer(client) => {
             sql::list_indexes_sqlserver(client, schema.as_deref(), &table).await
         }
@@ -672,6 +703,9 @@ pub async fn db_list_objects(
         DbHandle::StarRocks(_) => Ok(Vec::new()),
         DbHandle::Postgres(pool) => {
             sql::list_objects_postgres(pool, schema.as_deref(), &kind).await
+        }
+        DbHandle::PanWeiDB(client) => {
+            panwei::list_objects(client, schema.as_deref(), &kind).await
         }
         DbHandle::SqlServer(client) => {
             sql::list_objects_sqlserver(client, schema.as_deref(), &kind).await
@@ -701,6 +735,9 @@ pub async fn db_object_ddl(
         DbHandle::Postgres(pool) => {
             sql::object_ddl_postgres(pool, schema.as_deref(), &kind, &name).await
         }
+        DbHandle::PanWeiDB(client) => {
+            panwei::object_ddl(client, schema.as_deref(), &kind, &name).await
+        }
         DbHandle::SqlServer(client) => {
             sql::object_ddl_sqlserver(client, schema.as_deref(), &kind, &name).await
         }
@@ -728,6 +765,7 @@ pub async fn db_table_stats(
         DbHandle::Postgres(pool) => {
             sql::table_stats_postgres(pool, schema.as_deref(), &table).await
         }
+        DbHandle::PanWeiDB(client) => panwei::table_stats(client, schema.as_deref(), &table).await,
         DbHandle::SqlServer(client) => {
             sql::table_stats_sqlserver(client, schema.as_deref(), &table).await
         }
@@ -775,6 +813,7 @@ pub async fn db_execute(
         DbHandle::MySql(pool) => sql::execute_mysql(pool, &sql, &token).await,
         DbHandle::StarRocks(pool) => sql::execute_mysql(pool, &sql, &token).await,
         DbHandle::Postgres(pool) => sql::execute_postgres(pool, &sql, &token).await,
+        DbHandle::PanWeiDB(client) => panwei::execute(client, &sql, &token).await,
         DbHandle::SqlServer(client) => sql::execute_sqlserver(client, &sql, &token).await,
         DbHandle::ClickHouse(client) => clickhouse::execute(client, &sql, &token).await,
         DbHandle::Presto(client) => presto::execute(client, &sql, &token).await,
@@ -801,6 +840,9 @@ pub async fn db_execute_stream(
         }
         DbHandle::Postgres(pool) => {
             sql::execute_postgres_stream(pool, &sql, max_rows, &token, &on_event).await
+        }
+        DbHandle::PanWeiDB(client) => {
+            panwei::execute_stream(client, &sql, max_rows, &token, &on_event).await
         }
         DbHandle::SqlServer(client) => {
             sql::execute_sqlserver_stream(client, &sql, max_rows, &token, &on_event).await

--- a/src-tauri/src/database/panwei.rs
+++ b/src-tauri/src/database/panwei.rs
@@ -1,0 +1,534 @@
+//! PanWeiDB / openGauss-compatible backend via the native `tokio-opengauss`
+//! connector. This is intentionally separate from the PostgreSQL `sqlx`
+//! backend because PanWeiDB deployments can require openGauss SHA256
+//! authentication that regular PostgreSQL clients do not implement.
+
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use tokio::sync::Mutex as AsyncMutex;
+use tokio::task::JoinHandle;
+use tokio_opengauss::{
+    Client as OgClient, Config as OgConfig, NoTls, Row as OgRow, SimpleQueryMessage,
+    config::SslMode, types::ToSql,
+};
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    ColumnDescription, ColumnInfo, DbConfig, DbHandle, DbObject, IndexInfo, QueryResult,
+    QueryStreamChannel, SchemaInfo, TableInfo, emit_query_result_stream,
+};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 15;
+
+#[derive(Clone)]
+pub struct PanWeiClient {
+    inner: Arc<PanWeiInner>,
+}
+
+struct PanWeiInner {
+    client: AsyncMutex<OgClient>,
+    connection_task: JoinHandle<()>,
+}
+
+impl Drop for PanWeiInner {
+    fn drop(&mut self) {
+        self.connection_task.abort();
+    }
+}
+
+impl PanWeiClient {
+    fn new(client: OgClient, connection_task: JoinHandle<()>) -> Self {
+        Self {
+            inner: Arc::new(PanWeiInner {
+                client: AsyncMutex::new(client),
+                connection_task,
+            }),
+        }
+    }
+}
+
+fn timeout(config: &DbConfig) -> Duration {
+    Duration::from_secs(match config.timeout_secs {
+        Some(s) if s > 0 => s,
+        _ => DEFAULT_TIMEOUT_SECS,
+    })
+}
+
+pub async fn connect(config: &DbConfig, password: Option<&str>) -> Result<DbHandle, String> {
+    if config.ssl {
+        return Err(
+            "PanWeiDB SSL connections are not supported by the native openGauss connector yet."
+                .into(),
+        );
+    }
+
+    let mut opts = OgConfig::new();
+    opts.host(&config.host)
+        .port(config.port)
+        .ssl_mode(SslMode::Disable)
+        .connect_timeout(timeout(config))
+        .application_name("Taomni");
+    if let Some(user) = config.username.as_deref().filter(|u| !u.is_empty()) {
+        opts.user(user);
+    }
+    if let Some(pw) = password {
+        opts.password(pw);
+    }
+    if let Some(db) = config.database.as_deref().filter(|d| !d.is_empty()) {
+        opts.dbname(db);
+    }
+
+    let (client, connection) = tokio::time::timeout(timeout(config), opts.connect(NoTls))
+        .await
+        .map_err(|_| "PanWeiDB connect timed out".to_string())?
+        .map_err(|e| format!("PanWeiDB connect failed: {e}"))?;
+    let connection_task = tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            log::debug!("PanWeiDB connection task ended: {e}");
+        }
+    });
+
+    Ok(DbHandle::PanWeiDB(PanWeiClient::new(
+        client,
+        connection_task,
+    )))
+}
+
+pub async fn ping(client: &PanWeiClient) -> Result<String, String> {
+    let guard = client.inner.client.lock().await;
+    guard
+        .execute("SELECT 1", &[])
+        .await
+        .map_err(|e| format!("PanWeiDB ping failed: {e}"))?;
+    Ok("PanWeiDB connection OK".into())
+}
+
+fn simple_messages_to_result(messages: Vec<SimpleQueryMessage>, start: Instant) -> QueryResult {
+    let mut columns = Vec::new();
+    let mut rows = Vec::new();
+    let mut rows_affected = 0;
+    let mut warnings = Vec::new();
+
+    for message in messages {
+        match message {
+            SimpleQueryMessage::Row(row) => {
+                let row_columns: Vec<ColumnInfo> = row
+                    .columns()
+                    .iter()
+                    .map(|c| ColumnInfo {
+                        name: c.name().to_string(),
+                        type_name: "text".to_string(),
+                    })
+                    .collect();
+                if columns.is_empty() {
+                    columns = row_columns;
+                } else if columns.len() != row_columns.len()
+                    || columns
+                        .iter()
+                        .zip(&row_columns)
+                        .any(|(a, b)| a.name != b.name)
+                {
+                    warnings.push(
+                        "Multiple result sets with different columns were flattened into one grid."
+                            .to_string(),
+                    );
+                }
+
+                let values = (0..row.len())
+                    .map(|index| {
+                        row.try_get(index)
+                            .ok()
+                            .flatten()
+                            .map(|value| value.to_string())
+                    })
+                    .collect();
+                rows.push(values);
+            }
+            SimpleQueryMessage::CommandComplete(count) => {
+                rows_affected += count;
+            }
+            _ => {}
+        }
+    }
+
+    QueryResult {
+        rows_affected: if columns.is_empty() { rows_affected } else { 0 },
+        columns,
+        rows,
+        duration_ms: start.elapsed().as_millis() as u64,
+        warnings,
+    }
+}
+
+async fn fetch(
+    client: &PanWeiClient,
+    sql: &str,
+    params: &[&(dyn ToSql + Sync)],
+) -> Result<Vec<OgRow>, String> {
+    let guard = client.inner.client.lock().await;
+    guard
+        .query(sql, params)
+        .await
+        .map_err(|e| format!("Query failed: {e}"))
+}
+
+async fn fetch_optional(
+    client: &PanWeiClient,
+    sql: &str,
+    params: &[&(dyn ToSql + Sync)],
+) -> Result<Option<OgRow>, String> {
+    let guard = client.inner.client.lock().await;
+    guard
+        .query_opt(sql, params)
+        .await
+        .map_err(|e| format!("Query failed: {e}"))
+}
+
+pub async fn execute(
+    client: &PanWeiClient,
+    sql: &str,
+    token: &CancellationToken,
+) -> Result<QueryResult, String> {
+    let start = Instant::now();
+    let guard = client.inner.client.lock().await;
+    let cancel = guard.cancel_token();
+    let run = guard.simple_query(sql);
+    tokio::pin!(run);
+    let messages = tokio::select! {
+        _ = token.cancelled() => {
+            let _ = cancel.cancel_query(NoTls).await;
+            return Err("Query cancelled".into());
+        }
+        r = &mut run => r.map_err(|e| format!("Query failed: {e}"))?,
+    };
+    Ok(simple_messages_to_result(messages, start))
+}
+
+pub async fn execute_stream(
+    client: &PanWeiClient,
+    sql: &str,
+    max_rows: Option<u64>,
+    token: &CancellationToken,
+    on_event: &QueryStreamChannel,
+) -> Result<(), String> {
+    let mut result = execute(client, sql, token).await?;
+    if let Some(limit) = max_rows.filter(|value| *value > 0) {
+        if result.rows.len() as u64 > limit {
+            result.rows.truncate(limit as usize);
+            result
+                .warnings
+                .push(format!("Result limited to {limit} rows"));
+        }
+    }
+    emit_query_result_stream(on_event, result)
+}
+
+pub async fn list_schemas(client: &PanWeiClient) -> Result<Vec<SchemaInfo>, String> {
+    let rows = fetch(
+        client,
+        "SELECT schema_name FROM information_schema.schemata \
+         WHERE schema_name NOT LIKE 'pg_%' AND schema_name <> 'information_schema' \
+         ORDER BY schema_name",
+        &[],
+    )
+    .await
+    .map_err(|e| format!("list schemas failed: {e}"))?;
+    Ok(rows
+        .iter()
+        .filter_map(|row| row.try_get::<usize, String>(0).ok())
+        .map(|name| SchemaInfo { name })
+        .collect())
+}
+
+pub async fn list_tables(
+    client: &PanWeiClient,
+    schema: Option<&str>,
+) -> Result<Vec<TableInfo>, String> {
+    let schema = schema.unwrap_or("public");
+    let rows = fetch(
+        client,
+        "SELECT t.table_name, t.table_type, \
+                CASE WHEN c.reltuples >= 0 THEN c.reltuples::bigint ELSE NULL END AS row_count \
+         FROM information_schema.tables t \
+         LEFT JOIN pg_namespace n ON n.nspname = t.table_schema \
+         LEFT JOIN pg_class c ON c.relname = t.table_name AND c.relnamespace = n.oid \
+         WHERE t.table_schema = $1 ORDER BY t.table_name",
+        &[&schema],
+    )
+    .await
+    .map_err(|e| format!("list tables failed: {e}"))?;
+
+    let mut out: Vec<TableInfo> = rows
+        .iter()
+        .filter_map(|row| {
+            let name: String = row.try_get(0).ok()?;
+            let table_type: String = row.try_get(1).unwrap_or_default();
+            let row_count: Option<i64> = row.try_get(2).ok().flatten();
+            Some(TableInfo {
+                name,
+                kind: if table_type.eq_ignore_ascii_case("VIEW") {
+                    "view"
+                } else {
+                    "table"
+                }
+                .to_string(),
+                row_count,
+            })
+        })
+        .collect();
+
+    if let Ok(mvs) = fetch(
+        client,
+        "SELECT matviewname FROM pg_matviews WHERE schemaname = $1",
+        &[&schema],
+    )
+    .await
+    {
+        for row in &mvs {
+            if let Ok(name) = row.try_get::<usize, String>(0) {
+                out.push(TableInfo {
+                    name,
+                    kind: "materialized_view".to_string(),
+                    row_count: None,
+                });
+            }
+        }
+    }
+
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
+pub async fn describe_table(
+    client: &PanWeiClient,
+    schema: Option<&str>,
+    table: &str,
+) -> Result<Vec<ColumnDescription>, String> {
+    let schema = schema.unwrap_or("public");
+    let rows = fetch(
+        client,
+        "SELECT c.column_name, c.data_type, c.is_nullable, c.column_default, \
+            COALESCE(pk.is_pk, false) AS is_pk \
+         FROM information_schema.columns c \
+         LEFT JOIN ( \
+            SELECT kcu.column_name, true AS is_pk \
+            FROM information_schema.table_constraints tc \
+            JOIN information_schema.key_column_usage kcu \
+              ON tc.constraint_name = kcu.constraint_name \
+             AND tc.table_schema = kcu.table_schema \
+            WHERE tc.constraint_type = 'PRIMARY KEY' \
+              AND tc.table_schema = $1 AND tc.table_name = $2 \
+         ) pk ON pk.column_name = c.column_name \
+         WHERE c.table_schema = $1 AND c.table_name = $2 \
+         ORDER BY c.ordinal_position",
+        &[&schema, &table],
+    )
+    .await
+    .map_err(|e| format!("describe table failed: {e}"))?;
+    Ok(rows
+        .iter()
+        .filter_map(|row| {
+            let name: String = row.try_get(0).ok()?;
+            let type_name: String = row.try_get(1).unwrap_or_default();
+            let nullable: String = row.try_get(2).unwrap_or_default();
+            let default: Option<String> = row.try_get(3).ok().flatten();
+            let primary_key: bool = row.try_get(4).unwrap_or(false);
+            Some(ColumnDescription {
+                name,
+                type_name,
+                nullable: nullable.eq_ignore_ascii_case("YES"),
+                default,
+                primary_key,
+            })
+        })
+        .collect())
+}
+
+pub async fn list_indexes(
+    client: &PanWeiClient,
+    schema: Option<&str>,
+    table: &str,
+) -> Result<Vec<IndexInfo>, String> {
+    let schema = schema.unwrap_or("public");
+    let rows = fetch(
+        client,
+        "SELECT i.relname AS index_name, a.attname AS column_name, ix.indisunique AS is_unique \
+         FROM pg_class t \
+         JOIN pg_namespace n ON n.oid = t.relnamespace \
+         JOIN pg_index ix ON t.oid = ix.indrelid \
+         JOIN pg_class i ON i.oid = ix.indexrelid \
+         JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey) \
+         WHERE n.nspname = $1 AND t.relname = $2 \
+         ORDER BY i.relname, array_position(ix.indkey, a.attnum)",
+        &[&schema, &table],
+    )
+    .await
+    .map_err(|e| format!("list indexes failed: {e}"))?;
+
+    let mut grouped: Vec<IndexInfo> = Vec::new();
+    for row in &rows {
+        let name: String = match row.try_get(0) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        let column: String = row.try_get(1).unwrap_or_default();
+        let unique: bool = row.try_get(2).unwrap_or(false);
+        match grouped.iter_mut().find(|idx| idx.name == name) {
+            Some(index) => index.columns.push(column),
+            None => grouped.push(IndexInfo {
+                name,
+                columns: vec![column],
+                unique,
+            }),
+        }
+    }
+    Ok(grouped)
+}
+
+pub async fn list_objects(
+    client: &PanWeiClient,
+    schema: Option<&str>,
+    kind: &str,
+) -> Result<Vec<DbObject>, String> {
+    let schema = schema.unwrap_or("public");
+    let sql = match kind {
+        "function" => {
+            "SELECT DISTINCT p.proname FROM pg_catalog.pg_proc p \
+             JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace \
+             WHERE n.nspname = $1 ORDER BY p.proname"
+        }
+        "sequence" => {
+            "SELECT sequence_name FROM information_schema.sequences \
+             WHERE sequence_schema = $1 ORDER BY sequence_name"
+        }
+        _ => return Ok(Vec::new()),
+    };
+    let rows = fetch(client, sql, &[&schema])
+        .await
+        .map_err(|e| format!("list {kind} failed: {e}"))?;
+    Ok(rows
+        .iter()
+        .filter_map(|row| {
+            let name: String = row.try_get(0).ok()?;
+            Some(DbObject {
+                name,
+                kind: kind.to_string(),
+                owner: None,
+            })
+        })
+        .collect())
+}
+
+pub async fn object_ddl(
+    client: &PanWeiClient,
+    schema: Option<&str>,
+    kind: &str,
+    name: &str,
+) -> Result<String, String> {
+    let schema = schema.unwrap_or("public");
+    match kind {
+        "view" | "materialized_view" => {
+            let row = fetch_optional(
+                client,
+                "SELECT pg_get_viewdef(c.oid, true) FROM pg_class c \
+                 JOIN pg_namespace n ON n.oid = c.relnamespace \
+                 WHERE n.nspname = $1 AND c.relname = $2",
+                &[&schema, &name],
+            )
+            .await
+            .map_err(|e| format!("view definition failed: {e}"))?;
+            let def: String = row
+                .and_then(|row| row.try_get::<usize, String>(0).ok())
+                .ok_or_else(|| format!("View {name} not found"))?;
+            let kw = if kind == "materialized_view" {
+                "MATERIALIZED VIEW"
+            } else {
+                "VIEW"
+            };
+            Ok(format!(
+                "CREATE OR REPLACE {kw} \"{schema}\".\"{name}\" AS\n{def}"
+            ))
+        }
+        "function" => {
+            let row = fetch_optional(
+                client,
+                "SELECT pg_get_functiondef(p.oid) FROM pg_proc p \
+                 JOIN pg_namespace n ON n.oid = p.pronamespace \
+                 WHERE n.nspname = $1 AND p.proname = $2 LIMIT 1",
+                &[&schema, &name],
+            )
+            .await
+            .map_err(|e| format!("function definition failed: {e}"))?;
+            row.and_then(|row| row.try_get::<usize, String>(0).ok())
+                .ok_or_else(|| format!("Function {name} not found"))
+        }
+        "sequence" => Ok(format!("CREATE SEQUENCE \"{schema}\".\"{name}\";")),
+        _ => {
+            let cols = describe_table(client, Some(schema), name).await?;
+            if cols.is_empty() {
+                return Err(format!("Table {name} not found"));
+            }
+            let mut lines: Vec<String> = cols
+                .iter()
+                .map(|column| {
+                    let mut line = format!("  \"{}\" {}", column.name, column.type_name);
+                    if !column.nullable {
+                        line.push_str(" NOT NULL");
+                    }
+                    if let Some(default) = &column.default {
+                        line.push_str(" DEFAULT ");
+                        line.push_str(default);
+                    }
+                    line
+                })
+                .collect();
+            let pks: Vec<String> = cols
+                .iter()
+                .filter(|column| column.primary_key)
+                .map(|column| format!("\"{}\"", column.name))
+                .collect();
+            if !pks.is_empty() {
+                lines.push(format!("  PRIMARY KEY ({})", pks.join(", ")));
+            }
+            Ok(format!(
+                "CREATE TABLE \"{schema}\".\"{name}\" (\n{}\n);",
+                lines.join(",\n")
+            ))
+        }
+    }
+}
+
+pub async fn table_stats(
+    client: &PanWeiClient,
+    schema: Option<&str>,
+    table: &str,
+) -> Result<QueryResult, String> {
+    let schema = schema.unwrap_or("public");
+    let row = fetch_optional(
+        client,
+        "SELECT pg_total_relation_size(c.oid), pg_relation_size(c.oid), \
+                pg_indexes_size(c.oid), s.n_live_tup \
+         FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace \
+         LEFT JOIN pg_stat_user_tables s ON s.relid = c.oid \
+         WHERE n.nspname = $1 AND c.relname = $2",
+        &[&schema, &table],
+    )
+    .await
+    .map_err(|e| format!("table stats failed: {e}"))?
+    .ok_or_else(|| format!("Table {table} not found"))?;
+    let num = |idx: usize| {
+        row.try_get::<usize, Option<i64>>(idx)
+            .ok()
+            .flatten()
+            .map(|v| v.to_string())
+    };
+    Ok(super::metric_result(vec![
+        ("Total size (bytes)", num(0)),
+        ("Table size (bytes)", num(1)),
+        ("Indexes size (bytes)", num(2)),
+        ("Live rows (estimate)", num(3)),
+    ]))
+}

--- a/src-tauri/src/session/models.rs
+++ b/src-tauri/src/session/models.rs
@@ -39,6 +39,7 @@ pub enum SessionType {
     Mosh,
     MySQL,
     PostgreSQL,
+    PanWeiDB,
     SQLServer,
     StarRocks,
     ClickHouse,
@@ -78,6 +79,7 @@ impl SessionType {
             Self::Mosh => "Mosh",
             Self::MySQL => "MySQL",
             Self::PostgreSQL => "PostgreSQL",
+            Self::PanWeiDB => "PanWeiDB",
             Self::SQLServer => "SQLServer",
             Self::StarRocks => "StarRocks",
             Self::ClickHouse => "ClickHouse",
@@ -107,6 +109,7 @@ impl SessionType {
             "Mosh" => Self::Mosh,
             "MySQL" => Self::MySQL,
             "PostgreSQL" => Self::PostgreSQL,
+            "PanWeiDB" | "PanWei" | "openGauss" | "OpenGauss" => Self::PanWeiDB,
             "SQLServer" | "SQL Server" | "MSSQL" => Self::SQLServer,
             "StarRocks" | "StarRocksDB" => Self::StarRocks,
             "ClickHouse" => Self::ClickHouse,
@@ -132,6 +135,7 @@ impl SessionType {
             Self::Mosh => 60001,
             Self::MySQL => 3306,
             Self::PostgreSQL => 5432,
+            Self::PanWeiDB => 5432,
             Self::SQLServer => 1433,
             Self::StarRocks => 9030,
             Self::ClickHouse => 9000,
@@ -200,11 +204,35 @@ mod tests {
             ("Mosh", 60001),
             ("Browser", 0),
             ("Mail", 993),
+            ("PanWeiDB", 5432),
         ] {
             let ty = SessionType::from_str(raw);
             assert_eq!(ty.as_str(), raw);
             assert_eq!(ty.default_port(), expected_port);
         }
+    }
+
+    #[test]
+    fn session_config_deserializes_panweidb_type() {
+        let json = r#"{
+            "id": "pw",
+            "name": "PanWei 192.168.152.250",
+            "session_type": "PanWeiDB",
+            "group_path": null,
+            "host": "192.168.152.250",
+            "port": 17700,
+            "username": "panwei_omm",
+            "auth_method": "Password",
+            "options_json": "{\"dbDatabase\":\"panweidb\"}",
+            "created_at": 0,
+            "updated_at": 0,
+            "last_connected_at": null,
+            "sort_order": 0
+        }"#;
+        let config: SessionConfig =
+            serde_json::from_str(json).expect("PanWeiDB session_type must deserialize");
+        assert_eq!(config.session_type, SessionType::PanWeiDB);
+        assert_eq!(config.session_type.as_str(), "PanWeiDB");
     }
 
     #[test]

--- a/src/components/database/QueryResultGrid.tsx
+++ b/src/components/database/QueryResultGrid.tsx
@@ -439,6 +439,7 @@ function sqlTextExpression(engine: SqlEngine, expression: string): string {
     case "StarRocks":
       return `CAST(${expression} AS CHAR)`;
     case "PostgreSQL":
+    case "PanWeiDB":
       return `${expression}::text`;
     case "SQLServer":
       return `CAST(${expression} AS NVARCHAR(MAX))`;

--- a/src/components/database/SqlEditorPanel.tsx
+++ b/src/components/database/SqlEditorPanel.tsx
@@ -128,6 +128,7 @@ function dialectFor(engine: string): SQLDialect {
     case "StarRocks":
       return MySQL;
     case "PostgreSQL":
+    case "PanWeiDB":
       return PostgreSQL;
     case "SQLServer":
       return StandardSQL;

--- a/src/components/session/SessionEditor.test.tsx
+++ b/src/components/session/SessionEditor.test.tsx
@@ -693,6 +693,36 @@ describe("SessionEditor SSH settings tabs", { timeout: 15_000 }, () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("persists PanWeiDB database settings through the session store save path", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderEditor(undefined, { initialProto: "PanWeiDB" });
+
+    await waitFor(() => expect(screen.getByTestId("session-database-section")).toBeInTheDocument());
+    await user.type(screen.getByLabelText("Remote host"), "192.168.152.250");
+    await user.clear(screen.getByLabelText("Port"));
+    await user.type(screen.getByLabelText("Port"), "17700");
+    await user.type(screen.getByLabelText("Database username"), "panwei_omm");
+    await user.type(screen.getByLabelText("Database name"), "panweidb");
+
+    await user.click(screen.getByRole("button", { name: "OK" }));
+
+    expect(ipcMocks.saveSession).toHaveBeenCalledTimes(1);
+    const savedConfig = ipcMocks.saveSession.mock.calls[0][0];
+    const savedOptions = JSON.parse(savedConfig.options_json);
+    expect(savedConfig).toMatchObject({
+      session_type: "PanWeiDB",
+      host: "192.168.152.250",
+      port: 17700,
+      username: "panwei_omm",
+    });
+    expect(savedOptions).toMatchObject({
+      dbDatabase: "panweidb",
+      dbSsl: false,
+      dbTimeout: "15",
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it("persists StarRocks database settings with the FE query port", async () => {
     const user = userEvent.setup();
     const { onClose } = renderEditor(undefined, { initialProto: "StarRocks" });

--- a/src/components/session/SessionEditor.tsx
+++ b/src/components/session/SessionEditor.tsx
@@ -118,7 +118,7 @@ import type { SftpPathMapping } from "../../types";
 type Proto =
   | "SSH" | "Telnet" | "Rlogin" | "RDP" | "VNC" | "FTP" | "SFTP"
   | "Serial" | "File" | "Shell" | "Browser" | "Mosh" | "S3" | "WSL"
-  | "MySQL" | "PostgreSQL" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto" | "Redis" | "HBaseShell"
+  | "MySQL" | "PostgreSQL" | "PanWeiDB" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto" | "Redis" | "HBaseShell"
   | "Proxy" | "Mail";
 
 type SectionTab = "advanced" | "terminal" | "appearance" | "network" | "bookmark" | "rdp" | "database" | "mappings" | "proxy" | "objectstorage" | "mail";
@@ -141,6 +141,7 @@ const PROTOS: { id: Proto; icon: React.ReactNode; color: string }[] = [
   { id: "WSL",     icon: <TerminalIcon className="w-7 h-7" />, color: "#0078d4" },
   { id: "MySQL",      icon: <Database className="w-7 h-7" />, color: "#00758f" },
   { id: "PostgreSQL", icon: <Database className="w-7 h-7" />, color: "#336791" },
+  { id: "PanWeiDB",   icon: <Database className="w-7 h-7" />, color: "#0b8f6a" },
   { id: "SQLServer",  icon: <Database className="w-7 h-7" />, color: "#cc2927" },
   { id: "StarRocks",  icon: <Database className="w-7 h-7" />, color: "#0f8f8c" },
   { id: "ClickHouse", icon: <Database className="w-7 h-7" />, color: "#e6a817" },
@@ -155,11 +156,11 @@ const DEFAULT_PORTS: Record<string, number> = {
   SSH: 22, Telnet: 23, Rlogin: 513, RDP: 3389, VNC: 5900,
   FTP: 21, SFTP: 22, Serial: 0, File: 0, Shell: 0,
   Browser: 0, Mosh: 60001, S3: 443, WSL: 0,
-  MySQL: 3306, PostgreSQL: 5432, SQLServer: 1433, StarRocks: 9030, ClickHouse: 9000, Presto: 8080, Redis: 6379,
+  MySQL: 3306, PostgreSQL: 5432, PanWeiDB: 5432, SQLServer: 1433, StarRocks: 9030, ClickHouse: 9000, Presto: 8080, Redis: 6379,
   HBaseShell: 8080, Proxy: 3128, Mail: 993,
 };
 
-const DB_PROTOS: Proto[] = ["MySQL", "PostgreSQL", "SQLServer", "StarRocks", "ClickHouse", "Presto", "Redis"];
+const DB_PROTOS: Proto[] = ["MySQL", "PostgreSQL", "PanWeiDB", "SQLServer", "StarRocks", "ClickHouse", "Presto", "Redis"];
 const PLANNED_CLIENT_PROTOS = new Set<Proto>();
 
 /** Map UI proto to the backend session_type string. Object storage ("S3"
@@ -2151,7 +2152,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
   const [fileEmbedInTab, setFileEmbedInTab] = useState(() => optionBoolean(initialOptions, "fileEmbedInTab", true));
   const [fileExtraArgs, setFileExtraArgs] = useState(() => optionString(initialOptions, "fileExtraArgs", ""));
 
-  /* --- database session options (MySQL/PostgreSQL/SQLServer/StarRocks/ClickHouse/Presto/Redis) --- */
+  /* --- database session options (MySQL/PostgreSQL/PanWeiDB/SQLServer/StarRocks/ClickHouse/Presto/Redis) --- */
   const [dbCatalog, setDbCatalog] = useState(() => optionString(initialOptions, "dbCatalog", ""));
   const [dbDatabase, setDbDatabase] = useState(() => optionString(initialOptions, "dbDatabase", ""));
   const [dbSsl, setDbSsl] = useState(() => optionBoolean(initialOptions, "dbSsl", false));
@@ -2868,12 +2869,16 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
       }),
     });
 
-    if (isEdit) {
-      await updateSession(config);
-    } else {
-      await addSession(config);
+    try {
+      if (isEdit) {
+        await updateSession(config);
+      } else {
+        await addSession(config);
+      }
+      onClose();
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : String(err));
     }
-    onClose();
   };
 
   const handleSaveTemplate = async () => {

--- a/src/components/sidebar/SessionTree.tsx
+++ b/src/components/sidebar/SessionTree.tsx
@@ -1792,6 +1792,8 @@ function sessionIcon(type: string) {
       return <Database className="w-3.5 h-3.5" style={{ color: "#00758f" }} />;
     case "PostgreSQL":
       return <Database className="w-3.5 h-3.5" style={{ color: "#336791" }} />;
+    case "PanWeiDB":
+      return <Database className="w-3.5 h-3.5" style={{ color: "#0b8f6a" }} />;
     case "SQLServer":
       return <Database className="w-3.5 h-3.5" style={{ color: "#cc2927" }} />;
     case "StarRocks":

--- a/src/components/tabbar/TabBar.tsx
+++ b/src/components/tabbar/TabBar.tsx
@@ -575,6 +575,8 @@ function dbEngineColor(engine?: string): string {
       return "#00758f";
     case "PostgreSQL":
       return "#336791";
+    case "PanWeiDB":
+      return "#0b8f6a";
     case "SQLServer":
       return "#cc2927";
     case "StarRocks":

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1867,6 +1867,7 @@ export function MainLayout() {
     } else if (
       session.session_type === "MySQL" ||
       session.session_type === "PostgreSQL" ||
+      session.session_type === "PanWeiDB" ||
       session.session_type === "SQLServer" ||
       session.session_type === "StarRocks" ||
       session.session_type === "ClickHouse" ||

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -885,7 +885,7 @@ export async function secureCrtDecryptPasswords(
   });
 }
 
-// --- Database client (MySQL / PostgreSQL / SQL Server / StarRocks / ClickHouse / Presto / Redis) ---
+// --- Database client (MySQL / PostgreSQL / PanWeiDB / SQL Server / StarRocks / ClickHouse / Presto / Redis) ---
 
 /** Strip the frontend-only `sessionId` to build the Rust `DbConfig` payload. */
 function toDbConfigPayload(info: DbConnectInfo): Record<string, unknown> {

--- a/src/lib/sessionImportExport.test.ts
+++ b/src/lib/sessionImportExport.test.ts
@@ -466,6 +466,14 @@ describe("DBeaver session import", () => {
             url: "redis://:redis-pass@redis.example.com:6380/2",
           },
         },
+        panwei: {
+          driver: "panweidb",
+          name: "PanWei Warehouse",
+          configuration: {
+            url: "jdbc:postgresql://pw.example.com:5432/pwdb?sslmode=disable",
+            user: "pwuser",
+          },
+        },
         oracle: {
           driver: "oracle",
           name: "Skipped Oracle",
@@ -487,6 +495,7 @@ describe("DBeaver session import", () => {
       "ClickHouse",
       "Presto",
       "Redis",
+      "PanWeiDB",
     ]);
     expect(result.skipped).toBe(1);
     expect(result.secrets).toHaveLength(2);
@@ -551,6 +560,17 @@ describe("DBeaver session import", () => {
     });
     expect(JSON.parse(result.sessions[6].options_json)).toMatchObject({
       dbRedisIndex: "2",
+    });
+    expect(result.sessions[7]).toMatchObject({
+      name: "PanWei Warehouse",
+      session_type: "PanWeiDB",
+      host: "pw.example.com",
+      port: 5432,
+      username: "pwuser",
+    });
+    expect(JSON.parse(result.sessions[7].options_json)).toMatchObject({
+      dbDatabase: "pwdb",
+      dbSsl: false,
     });
   });
 

--- a/src/lib/sessionImportExport.ts
+++ b/src/lib/sessionImportExport.ts
@@ -63,6 +63,7 @@ const DEFAULT_PORTS: Record<string, number> = {
   Mosh: 60001,
   MySQL: 3306,
   PostgreSQL: 5432,
+  PanWeiDB: 5432,
   SQLServer: 1433,
   StarRocks: 9030,
   ClickHouse: 9000,
@@ -84,6 +85,7 @@ const CSV_PASSWORD_SESSION_TYPES = new Set([
   "Mosh",
   "MySQL",
   "PostgreSQL",
+  "PanWeiDB",
   "SQLServer",
   "StarRocks",
   "ClickHouse",
@@ -884,6 +886,7 @@ function navicatSessionType(value: string): string | null {
   const key = value.toLowerCase().replace(/[^a-z0-9]+/g, " ");
   if (/\b(starrocks|starrocksdb|star rocks)\b/.test(key)) return "StarRocks";
   if (/\b(mysql|mariadb|tidb|oceanbase|polardb)\b/.test(key)) return "MySQL";
+  if (/\b(panwei|panweidb|open gauss|opengauss)\b/.test(key)) return "PanWeiDB";
   if (/\b(postgresql|postgres|pgsql)\b/.test(key)) return "PostgreSQL";
   if (/\b(sqlserver|sql server|mssql|azure sql)\b/.test(key)) return "SQLServer";
   if (/\b(clickhouse|click house)\b/.test(key)) return "ClickHouse";
@@ -1167,6 +1170,7 @@ function dbeaverSessionType(value: string): string | null {
   const key = value.toLowerCase().replace(/[^a-z0-9]+/g, " ");
   if (/\b(starrocks|starrocksdb|star rocks)\b/.test(key)) return "StarRocks";
   if (/\b(mysql|mariadb|tidb|oceanbase|polardb)\b/.test(key)) return "MySQL";
+  if (/\b(panwei|panweidb|open gauss|opengauss)\b/.test(key)) return "PanWeiDB";
   if (/\b(postgresql|postgres|cockroach|yugabyte)\b/.test(key)) return "PostgreSQL";
   if (/\b(sqlserver|sql server|mssql|jtds|azure sql)\b/.test(key)) return "SQLServer";
   if (/\b(clickhouse|click house|chjdbc)\b/.test(key)) return "ClickHouse";

--- a/src/lib/sessionImportSecrets.ts
+++ b/src/lib/sessionImportSecrets.ts
@@ -8,6 +8,7 @@ type TranslateFn = (key: string, vars?: Record<string, string | number>) => stri
 const DB_PASSWORD_SESSION_TYPES = new Set([
   "MySQL",
   "PostgreSQL",
+  "PanWeiDB",
   "SQLServer",
   "StarRocks",
   "ClickHouse",

--- a/src/lib/sqlDialect.test.ts
+++ b/src/lib/sqlDialect.test.ts
@@ -33,6 +33,7 @@ describe("sqlDialect identifiers", () => {
     expect(quoteIdent("MySQL", "a`b")).toBe("`a``b`");
     expect(quoteIdent("ClickHouse", "x")).toBe("`x`");
     expect(quoteIdent("PostgreSQL", 'a"b')).toBe('"a""b"');
+    expect(quoteIdent("PanWeiDB", 'a"b')).toBe('"a""b"');
     expect(quoteIdent("Presto", "x")).toBe('"x"');
     expect(quoteIdent("SQLServer", "a]b")).toBe("[a]]b]");
   });
@@ -56,6 +57,7 @@ describe("sqlDialect identifiers", () => {
 
   it("narrows engine strings", () => {
     expect(asSqlEngine("PostgreSQL")).toBe("PostgreSQL");
+    expect(asSqlEngine("PanWeiDB")).toBe("PanWeiDB");
     expect(asSqlEngine("SQLServer")).toBe("SQLServer");
     expect(asSqlEngine("StarRocks")).toBe("StarRocks");
     expect(asSqlEngine("nonsense")).toBe("MySQL");
@@ -63,6 +65,7 @@ describe("sqlDialect identifiers", () => {
 
   it("emits the right set-default statement", () => {
     expect(setDefaultSchemaSql("PostgreSQL", "s")).toBe('SET search_path TO "s"');
+    expect(setDefaultSchemaSql("PanWeiDB", "s")).toBe('SET search_path TO "s"');
     expect(setDefaultSchemaSql("Presto", "s", "c")).toBe('USE "c"."s"');
     expect(setDefaultSchemaSql("MySQL", "s")).toBe("USE `s`");
     expect(setDefaultSchemaSql("StarRocks", "s")).toBe("USE `s`");
@@ -74,6 +77,7 @@ describe("sqlDialect capabilities", () => {
   it("exposes per-engine folder categories", () => {
     expect(categoriesForEngine("MySQL")).toContain("trigger");
     expect(categoriesForEngine("PostgreSQL")).toContain("sequence");
+    expect(categoriesForEngine("PanWeiDB")).toContain("sequence");
     expect(categoriesForEngine("SQLServer")).toContain("procedure");
     expect(categoriesForEngine("StarRocks")).toEqual(["table", "view"]);
     expect(categoriesForEngine("ClickHouse")).toContain("dictionary");
@@ -86,6 +90,7 @@ describe("sqlDialect capabilities", () => {
     expect(supportsInlineEdit("StarRocks")).toBe(false);
     expect(supportsInlineEdit("ClickHouse")).toBe(false);
     expect(supportsIndexes("PostgreSQL")).toBe(true);
+    expect(supportsIndexes("PanWeiDB")).toBe(true);
     expect(supportsIndexes("SQLServer")).toBe(true);
     expect(supportsIndexes("StarRocks")).toBe(false);
     expect(supportsIndexes("Presto")).toBe(false);
@@ -96,6 +101,7 @@ describe("sqlDialect capabilities", () => {
     expect(actionMode("MySQL", "renameDatabase")).toBe("disabled");
     expect(actionMode("PostgreSQL", "renameDatabase")).toBe("execute");
     expect(actionMode("PostgreSQL", "disableTrigger")).toBe("execute");
+    expect(actionMode("PanWeiDB", "disableTrigger")).toBe("execute");
     expect(actionMode("SQLServer", "disableTrigger")).toBe("execute");
     expect(actionMode("SQLServer", "renameDatabase")).toBe("disabled");
     expect(actionMode("MySQL", "disableTrigger")).toBe("disabled");

--- a/src/lib/sqlDialect.ts
+++ b/src/lib/sqlDialect.ts
@@ -6,7 +6,7 @@
  * menus, and the query editor all agree on how to talk to each engine.
  */
 
-export type SqlEngine = "MySQL" | "PostgreSQL" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto";
+export type SqlEngine = "MySQL" | "PostgreSQL" | "PanWeiDB" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto";
 
 /** Canonical object kinds surfaced as tree folders / context menus. */
 export type ObjectKind =
@@ -42,11 +42,15 @@ export type DialectAction =
   | "renameDatabase"
   | "disableTrigger";
 
-const DOUBLE_QUOTE_ENGINES: SqlEngine[] = ["PostgreSQL", "Presto"];
+const DOUBLE_QUOTE_ENGINES: SqlEngine[] = ["PostgreSQL", "PanWeiDB", "Presto"];
+
+function isPostgresLike(engine: SqlEngine): boolean {
+  return engine === "PostgreSQL" || engine === "PanWeiDB";
+}
 
 /** Narrow an arbitrary engine string to a known `SqlEngine` (else MySQL). */
 export function asSqlEngine(engine: string): SqlEngine {
-  return engine === "PostgreSQL" || engine === "SQLServer" || engine === "StarRocks" || engine === "ClickHouse" || engine === "Presto"
+  return engine === "PostgreSQL" || engine === "PanWeiDB" || engine === "SQLServer" || engine === "StarRocks" || engine === "ClickHouse" || engine === "Presto"
     ? engine
     : "MySQL";
 }
@@ -85,7 +89,7 @@ export function setDefaultSchemaSql(
   schema: string,
   catalog?: string | null,
 ): string {
-  if (engine === "PostgreSQL") return `SET search_path TO ${quoteIdent(engine, schema)}`;
+  if (isPostgresLike(engine)) return `SET search_path TO ${quoteIdent(engine, schema)}`;
   if (engine === "SQLServer") return `-- SQL Server schemas are selected by using two-part names such as ${quoteIdent(engine, schema)}.${quoteIdent(engine, "table_name")}`;
   if (engine === "Presto" && catalog) {
     return `USE ${quoteIdent(engine, catalog)}.${quoteIdent(engine, schema)}`;
@@ -100,6 +104,7 @@ export function setDefaultSchemaSql(
 const ENGINE_CATEGORIES: Record<SqlEngine, ObjectKind[]> = {
   MySQL: ["table", "view", "procedure", "function", "trigger", "event"],
   PostgreSQL: ["table", "view", "materialized_view", "function", "sequence"],
+  PanWeiDB: ["table", "view", "materialized_view", "function", "sequence"],
   SQLServer: ["table", "view", "procedure", "function", "trigger", "sequence"],
   StarRocks: ["table", "view"],
   ClickHouse: ["table", "view", "materialized_view", "dictionary"],
@@ -113,12 +118,12 @@ export function categoriesForEngine(engine: SqlEngine): ObjectKind[] {
 
 /** Inline grid write-back (UPDATE/DELETE/INSERT) is only safe on row stores. */
 export function supportsInlineEdit(engine: SqlEngine): boolean {
-  return engine === "MySQL" || engine === "PostgreSQL" || engine === "SQLServer";
+  return engine === "MySQL" || isPostgresLike(engine) || engine === "SQLServer";
 }
 
 /** Index introspection is only meaningful for the row-store engines. */
 export function supportsIndexes(engine: SqlEngine): boolean {
-  return engine === "MySQL" || engine === "PostgreSQL" || engine === "SQLServer";
+  return engine === "MySQL" || isPostgresLike(engine) || engine === "SQLServer";
 }
 
 /** ClickHouse mutates rows via `ALTER TABLE … UPDATE/DELETE`, not DML. */
@@ -147,8 +152,8 @@ export function actionMode(engine: SqlEngine, action: DialectAction): ActionMode
       // MySQL and StarRocks have no safe RENAME DATABASE; SQL Server has no direct schema rename.
       return engine === "MySQL" || engine === "StarRocks" || engine === "SQLServer" ? "disabled" : "execute";
     case "disableTrigger":
-      // PostgreSQL and SQL Server support per-trigger enable/disable.
-      return engine === "PostgreSQL" || engine === "SQLServer" ? "execute" : "disabled";
+      // PostgreSQL-compatible engines and SQL Server support per-trigger enable/disable.
+      return isPostgresLike(engine) || engine === "SQLServer" ? "execute" : "disabled";
     default:
       return "execute";
   }
@@ -276,7 +281,7 @@ export function dropStatement(
     case "view":
       return `DROP VIEW ${obj};`;
     case "materialized_view":
-      return engine === "PostgreSQL"
+      return isPostgresLike(engine)
         ? `DROP MATERIALIZED VIEW ${obj};`
         : `DROP VIEW ${obj};`;
     case "procedure":
@@ -323,7 +328,7 @@ export function alterColumnStatement(
   const newCol = quoteIdent(engine, change.newName || change.oldName);
   const nullSuffix =
     change.nullable === undefined ? "" : change.nullable ? " NULL" : " NOT NULL";
-  if (engine === "PostgreSQL") {
+  if (isPostgresLike(engine)) {
     const lines = [`ALTER TABLE ${tbl} ALTER COLUMN ${oldCol} TYPE ${change.type};`];
     if (change.nullable !== undefined) {
       lines.push(
@@ -373,7 +378,7 @@ export function dropIndexStatement(
 
 export function dropDatabaseStatement(engine: SqlEngine, db: string): string {
   const name = quoteIdent(engine, db);
-  return engine === "PostgreSQL" || engine === "Presto" || engine === "SQLServer"
+  return isPostgresLike(engine) || engine === "Presto" || engine === "SQLServer"
     ? `DROP SCHEMA ${name};`
     : `DROP DATABASE ${name};`;
 }
@@ -397,7 +402,7 @@ export function dropTriggerStatement(
   trigger: string,
   table?: string | null,
 ): string {
-  if (engine === "PostgreSQL" && table) {
+  if (isPostgresLike(engine) && table) {
     return `DROP TRIGGER ${quoteIdent(engine, trigger)} ON ${qualifiedName(engine, {
       schema,
       name: table,
@@ -448,7 +453,7 @@ export function createTemplate(
   const q = (name: string) => qualifiedName(engine, { schema, name });
   switch (kind) {
     case "table":
-      if (engine === "PostgreSQL") {
+      if (isPostgresLike(engine)) {
         return `CREATE TABLE ${q("new_table")} (\n  "id" serial PRIMARY KEY\n);`;
       }
       if (engine === "ClickHouse") {
@@ -467,7 +472,7 @@ export function createTemplate(
       return `CREATE ${kw} ${q("new_view")} AS\nSELECT 1;`;
     }
     case "procedure":
-      if (engine === "PostgreSQL") {
+      if (isPostgresLike(engine)) {
         return `CREATE PROCEDURE ${q("new_procedure")}()\nLANGUAGE plpgsql\nAS $$\nBEGIN\n  -- body\nEND;\n$$;`;
       }
       if (engine === "SQLServer") {
@@ -475,7 +480,7 @@ export function createTemplate(
       }
       return `DELIMITER //\nCREATE PROCEDURE ${q("new_procedure")}()\nBEGIN\n  -- body\nEND //\nDELIMITER ;`;
     case "function":
-      if (engine === "PostgreSQL") {
+      if (isPostgresLike(engine)) {
         return `CREATE FUNCTION ${q("new_function")}()\nRETURNS integer\nLANGUAGE plpgsql\nAS $$\nBEGIN\n  RETURN 0;\nEND;\n$$;`;
       }
       if (engine === "SQLServer") {
@@ -483,7 +488,7 @@ export function createTemplate(
       }
       return `DELIMITER //\nCREATE FUNCTION ${q("new_function")}()\nRETURNS INT DETERMINISTIC\nBEGIN\n  RETURN 0;\nEND //\nDELIMITER ;`;
     case "trigger":
-      if (engine === "PostgreSQL") {
+      if (isPostgresLike(engine)) {
         return `CREATE TRIGGER new_trigger\nBEFORE INSERT ON ${q("table_name")}\nFOR EACH ROW EXECUTE FUNCTION trigger_function();`;
       }
       if (engine === "SQLServer") {

--- a/src/lib/sqlStatements.test.ts
+++ b/src/lib/sqlStatements.test.ts
@@ -71,6 +71,9 @@ describe("splitSqlStatements", () => {
     expect(sqlStatementsForExecution("PostgreSQL", "select 1; select 2;")).toEqual([
       "select 1; select 2;",
     ]);
+    expect(sqlStatementsForExecution("PanWeiDB", "select 1; select 2;")).toEqual([
+      "select 1; select 2;",
+    ]);
   });
 
   it("returns source ranges for executable statements", () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -146,14 +146,14 @@ export interface VncConnectInfo {
 
 /**
  * Connection parameters for a database client tab (MySQL / PostgreSQL /
- * SQL Server / StarRocks / ClickHouse / Presto / Redis). Mirrors the Rust `DbConfig` (camelCase). The password
+ * PanWeiDB / SQL Server / StarRocks / ClickHouse / Presto / Redis). Mirrors the Rust `DbConfig` (camelCase). The password
  * may be a `vault:<id>` reference resolved server-side.
  */
 export interface DbConnectInfo {
   sessionId: string;
   /** Stable saved-session id used for restoring query workspace files. */
   workspaceSessionId?: string;
-  engine: "MySQL" | "PostgreSQL" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto" | "Redis";
+  engine: "MySQL" | "PostgreSQL" | "PanWeiDB" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto" | "Redis";
   host: string;
   port: number;
   username?: string | null;


### PR DESCRIPTION
Add a dedicated PanWeiDB session engine backed by tokio-opengauss instead of routing PanWeiDB-compatible connections through sqlx-postgres. This matches the DBeaver setup from the issue where a PostgreSQL JDBC URL is used with a PanWei/openGauss driver and supports openGauss-style authentication that regular PostgreSQL clients may not implement.

Issue analysis:
- DBeaver can connect because it uses a PostgreSQL-style JDBC URL together with the PanWei/openGauss JDBC driver.
- Taomni's existing PostgreSQL path uses sqlx-postgres, so a PanWeiDB server that requires openGauss/PanWei authentication behavior can fail even though the TCP endpoint is reachable.
- The user-provided endpoint 192.168.152.250:17700 accepts TCP connections and answers PostgreSQL/openGauss startup packets with MD5 password authentication, confirming that 17700 is a JDBC/wire-protocol endpoint rather than an SSH or HTTP endpoint.

Backend changes:
- add a PanWeiDB/openGauss client wrapper with connection lifecycle management, ping, query execution, streaming result emission, and cancellation
- wire DbHandle::PanWeiDB through db_connect, db_ping, schema/table/index/object metadata, object DDL, table stats, execute, execute_stream, keepalive, and close-session handling
- add tokio-opengauss to the Tauri backend dependencies and lockfile
- add PanWeiDB to the persisted SessionType enum so newly created PanWeiDB sessions can be saved and reopened
- route PanWeiDB database sessions to SQL MCP tooling instead of terminal tooling
- return an explicit unsupported error for PanWeiDB SSL until a native TLS connector is added

Frontend changes:
- add PanWeiDB as a database protocol/session type with default port 5432
- route PanWeiDB sessions into DbClientTab and show distinct tab/tree coloring
- map PanWeiDB to PostgreSQL-compatible CodeMirror SQL mode and SQL dialect behavior
- use PostgreSQL-compatible text casts for generated result-grid SQL
- surface save_session/add_session/update_session failures in SessionEditor instead of closing silently only on success

Import and coverage:
- recognize panwei, panweidb, open gauss, and opengauss in DBeaver/Navicat imports
- preserve password handling/default port behavior for imported PanWeiDB sessions
- cover PanWeiDB dialect behavior, statement execution semantics, DBeaver import mapping, and SessionEditor save payload behavior in tests
- update the UI automation feature catalog for the new protocol control

Verification:
- nc -vz -w 5 192.168.152.250 17700
- PostgreSQL/openGauss startup-packet probe to 192.168.152.250:17700 returned AuthenticationMD5Password
- pnpm test src/lib/sqlDialect.test.ts src/lib/sqlStatements.test.ts src/lib/sessionImportExport.test.ts
- pnpm test src/components/session/SessionEditor.test.tsx
- cargo test session_config_deserializes_panweidb_type
- cargo test flavor_for_session_type_maps_db_engines
- cargo test card_sql_session_routes_to_sql_tools_not_terminal
- cargo test --lib planned_client_session_types_round_trip
- pnpm build
- cd src-tauri && cargo check

Refs #276, #277