### PR TITLE
fix(terminal): sync appearance context menu state

### DIFF
--- a/src/components/sidebar/SessionTree.test.tsx
+++ b/src/components/sidebar/SessionTree.test.tsx
@@ -291,4 +291,26 @@ describe("SessionTree multi-select batch operations", () => {
       expect.stringContaining("JetBrains Mono"),
     ]);
   });
+
+  it("keeps the session appearance menu draft current for repeated font size changes", async () => {
+    render(<SessionTree />);
+    selectBothIpySessions();
+
+    fireEvent.contextMenu(sessionRow("ipy-145"));
+    const item = screen.getByTestId("context-menu-item-set-terminal-theme");
+    fireEvent.mouseEnter(item.parentElement!);
+
+    const fontSizeInput = await screen.findByTestId("session-terminal-font-size");
+    const increase = await screen.findByLabelText("Increase text size");
+    fireEvent.click(increase);
+    expect(fontSizeInput).toHaveValue("15");
+    fireEvent.click(increase);
+    expect(fontSizeInput).toHaveValue("16");
+
+    await waitFor(() => expect(ipcMocks.saveSession).toHaveBeenCalledTimes(4));
+    const savedFontSizes = ipcMocks.saveSession.mock.calls.map(([cfg]) => (
+      JSON.parse(cfg.options_json).terminalProfile.fontSize
+    ));
+    expect(savedFontSizes.filter((size) => size === 16)).toHaveLength(2);
+  });
 });

--- a/src/components/terminal/TerminalAppearanceMenuPanel.tsx
+++ b/src/components/terminal/TerminalAppearanceMenuPanel.tsx
@@ -61,8 +61,11 @@ export function TerminalAppearanceMenuPanel({
   fontSizeTestId?: string;
 }) {
   const fontOptions = useTerminalFontOptions(fonts.length > 0 ? fonts : SAFE_TERMINAL_FONT_FALLBACKS);
-  const selectedFont = fontFamily ? resolveSelectedFontName(fontFamily, fontOptions) : MIXED_FONT_VALUE;
-  const [fontSizeText, setFontSizeText] = useState(fontSize === null ? "" : String(fontSize));
+  const [draftThemeValue, setDraftThemeValue] = useState(themeValue);
+  const [draftFontFamily, setDraftFontFamily] = useState<string | null>(fontFamily);
+  const [draftFontSize, setDraftFontSize] = useState<number | null>(fontSize);
+  const selectedFont = draftFontFamily ? resolveSelectedFontName(draftFontFamily, fontOptions) : MIXED_FONT_VALUE;
+  const [fontSizeText, setFontSizeText] = useState(draftFontSize === null ? "" : String(draftFontSize));
   const partitionedFonts = useMemo(() => {
     const mono: string[] = [];
     const prop: string[] = [];
@@ -77,22 +80,40 @@ export function TerminalAppearanceMenuPanel({
   }, [fontOptions]);
 
   useEffect(() => {
-    setFontSizeText(fontSize === null ? "" : String(fontSize));
+    setDraftThemeValue(themeValue);
+  }, [themeValue]);
+
+  useEffect(() => {
+    setDraftFontFamily(fontFamily);
+  }, [fontFamily]);
+
+  useEffect(() => {
+    setDraftFontSize(fontSize);
   }, [fontSize]);
+
+  useEffect(() => {
+    setFontSizeText(draftFontSize === null ? "" : String(draftFontSize));
+  }, [draftFontSize]);
 
   const updateFontSize = (next: number) => {
     if (!Number.isFinite(next)) return;
-    onChangeFontSize(Math.max(8, Math.min(32, Math.round(next))));
+    const clamped = Math.max(8, Math.min(32, Math.round(next)));
+    setDraftFontSize(clamped);
+    setFontSizeText(String(clamped));
+    onChangeFontSize(clamped);
   };
 
   return (
     <div className="w-[380px] max-w-[calc(100vw-24px)] max-h-[min(420px,calc(100vh-24px))] overflow-hidden rounded-md border border-[var(--taomni-divider)] bg-[var(--taomni-panel-bg)] shadow-lg">
       <ThemePreviewList
-        value={themeValue}
+        value={draftThemeValue}
         options={themeOptions}
         testId={themeListTestId}
         className="max-h-[min(270px,calc(100vh-170px))] overflow-y-auto overscroll-contain p-1"
-        onChange={onChangeTheme}
+        onChange={(nextTheme) => {
+          setDraftThemeValue(nextTheme);
+          onChangeTheme(nextTheme);
+        }}
       />
       <div className="border-t border-[var(--taomni-divider)] p-2 space-y-2">
         <label className="block">
@@ -103,9 +124,13 @@ export function TerminalAppearanceMenuPanel({
             data-testid={fontSelectTestId}
             value={selectedFont}
             disabled={fontOptions.length === 0}
-            onChange={(event) => onChangeFontFamily(makeTerminalFontFamily(event.target.value))}
+            onChange={(event) => {
+              const nextFontFamily = makeTerminalFontFamily(event.target.value);
+              setDraftFontFamily(nextFontFamily);
+              onChangeFontFamily(nextFontFamily);
+            }}
           >
-            {!fontFamily && (
+            {!draftFontFamily && (
               <option value={MIXED_FONT_VALUE} disabled>
                 {labels.mixedFont}
               </option>
@@ -137,8 +162,8 @@ export function TerminalAppearanceMenuPanel({
               type="button"
               className="taomni-btn h-7 w-7 p-0 inline-flex items-center justify-center"
               aria-label={labels.decreaseTextSize}
-              disabled={fontSize === null}
-              onClick={() => fontSize !== null && updateFontSize(fontSize - 1)}
+              disabled={draftFontSize === null}
+              onClick={() => draftFontSize !== null && updateFontSize(draftFontSize - 1)}
             >
               <Minus className="w-3.5 h-3.5" />
             </button>
@@ -147,7 +172,7 @@ export function TerminalAppearanceMenuPanel({
               aria-label={labels.fontSize}
               data-testid={fontSizeTestId}
               inputMode="numeric"
-              placeholder={fontSize === null ? "-" : undefined}
+              placeholder={draftFontSize === null ? "-" : undefined}
               value={fontSizeText}
               onChange={(event) => {
                 const next = event.target.value;
@@ -160,14 +185,13 @@ export function TerminalAppearanceMenuPanel({
               }}
               onBlur={() => {
                 if (!fontSizeText) {
-                  setFontSizeText(fontSize === null ? "" : String(fontSize));
+                  setFontSizeText(draftFontSize === null ? "" : String(draftFontSize));
                   return;
                 }
                 const parsed = Number(fontSizeText);
                 if (Number.isFinite(parsed) && parsed > 0) {
                   const clamped = Math.max(8, Math.min(32, Math.round(parsed)));
-                  setFontSizeText(String(clamped));
-                  onChangeFontSize(clamped);
+                  updateFontSize(clamped);
                 }
               }}
             />
@@ -175,8 +199,8 @@ export function TerminalAppearanceMenuPanel({
               type="button"
               className="taomni-btn h-7 w-7 p-0 inline-flex items-center justify-center"
               aria-label={labels.increaseTextSize}
-              disabled={fontSize === null}
-              onClick={() => fontSize !== null && updateFontSize(fontSize + 1)}
+              disabled={draftFontSize === null}
+              onClick={() => draftFontSize !== null && updateFontSize(draftFontSize + 1)}
             >
               <Plus className="w-3.5 h-3.5" />
             </button>

--- a/src/components/terminal/TerminalPanel.test.tsx
+++ b/src/components/terminal/TerminalPanel.test.tsx
@@ -1298,6 +1298,41 @@ describe("TerminalPanel focus behavior", () => {
     }));
   });
 
+  it("keeps the open terminal appearance menu in sync while changing theme and font size", async () => {
+    const onProfileChange = vi.fn();
+    render(
+      <TerminalPanel
+        visible
+        terminalProfile={{ ...DEFAULT_TERMINAL_PROFILE, theme: "classic", fontSize: 14 }}
+        onTerminalProfileChange={onProfileChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(terminalMocks.terminalCtor).toHaveBeenCalled();
+    });
+
+    fireEvent.contextMenu(screen.getByTestId("terminal-pane"));
+    fireEvent.mouseEnter(await screen.findByTestId("context-menu-item-theme"));
+
+    const kanagawa = await screen.findByTestId("terminal-context-theme-option-kanagawa-wave");
+    fireEvent.click(kanagawa);
+
+    expect(kanagawa).toHaveAttribute("aria-selected", "true");
+
+    const sizeInput = screen.getByTestId("terminal-context-font-size");
+    const increase = screen.getByLabelText("Increase terminal font size");
+    fireEvent.click(increase);
+    expect(sizeInput).toHaveValue("15");
+    fireEvent.click(increase);
+    expect(sizeInput).toHaveValue("16");
+
+    expect(onProfileChange).toHaveBeenLastCalledWith(expect.objectContaining({
+      theme: "kanagawa-wave",
+      fontSize: 16,
+    }));
+  });
+
   it("does not render the Git rail button inside the terminal pane", async () => {
     const onOpen = vi.fn();
     const onSessionReady = vi.fn();
@@ -1363,6 +1398,36 @@ describe("TerminalPanel focus behavior", () => {
 
     const stored = JSON.parse(window.localStorage.getItem("taomni.localTerminalProfile.v1") ?? "{}");
     expect(stored.theme).toBe("kanagawa-wave");
+  });
+
+  it("saves appearance changes made in the open context menu as the local terminal default", async () => {
+    const onSessionReady = vi.fn();
+
+    render(
+      <TerminalPanel
+        visible
+        onSessionReady={onSessionReady}
+        terminalProfile={{
+          ...DEFAULT_TERMINAL_PROFILE,
+          theme: "classic",
+          fontSize: 14,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onSessionReady).toHaveBeenCalledWith("terminal-session");
+    });
+
+    fireEvent.contextMenu(screen.getByTestId("terminal-pane"));
+    fireEvent.mouseEnter(await screen.findByTestId("context-menu-item-theme"));
+    fireEvent.click(await screen.findByTestId("terminal-context-theme-option-kanagawa-wave"));
+    fireEvent.click(screen.getByLabelText("Increase terminal font size"));
+    fireEvent.click(await screen.findByTestId("terminal-context-set-local-default-theme"));
+
+    const stored = JSON.parse(window.localStorage.getItem("taomni.localTerminalProfile.v1") ?? "{}");
+    expect(stored.theme).toBe("kanagawa-wave");
+    expect(stored.fontSize).toBe(15);
   });
 
   it("auto-saves local terminal appearance changes for future local terminals", async () => {

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -1785,12 +1785,13 @@ export function TerminalPanel({
             testId: "terminal-context-set-local-default-theme",
             onClick: () => {
               const currentDefault = loadLocalTerminalDefaultProfile();
+              const currentProfile = currentTerminalProfileRef.current;
               saveLocalTerminalDefaultProfile({
                 ...currentDefault,
-                theme: themeName,
-                fontFamily,
-                fontSize,
-                fontLigatures,
+                theme: currentProfile.theme,
+                fontFamily: currentProfile.fontFamily,
+                fontSize: currentProfile.fontSize,
+                fontLigatures: currentProfile.fontLigatures,
               });
               setStatusMessage("Default appearance for new local terminals updated");
             },


### PR DESCRIPTION
The terminal and saved-session appearance flyouts previously rendered with the props captured when the right-click menu opened. Applying a theme or font-size change updated the live terminal/session profile, but the still-open menu kept showing and calculating from stale values. This made the selected theme and font-size input refresh only after reopening the menu, and repeated + font-size clicks reused the old size.

Keep a local draft for the appearance menu's theme, font family, and font size so the open flyout reflects changes immediately while still accepting external prop updates. Use the latest live terminal profile ref when saving the current appearance as the default for new local terminals, so changes made in the open menu are persisted correctly.

Add regression coverage for terminal context-menu theme/font-size sync, local-default persistence after in-menu edits, and repeated saved-session font-size changes.

Tests: pnpm test -- src/components/terminal/TerminalPanel.test.tsx src/components/sidebar/SessionTree.test.tsx

Tests: pnpm build