### PR TITLE
feat(database): add Oracle database support

### DIFF
--- a/qa-ui-auto-tests/feature-list.md
+++ b/qa-ui-auto-tests/feature-list.md
@@ -3224,7 +3224,7 @@ controls:
 
 ---
 
-## 23. 数据库客户端 — SQL（MySQL / PostgreSQL / PanWeiDB / ClickHouse）
+## 23. 数据库客户端 — SQL（MySQL / PostgreSQL / PanWeiDB / Oracle / SQLServer / StarRocks / ClickHouse / Presto）
 
 ### 23.1 SQL 客户端 `DbClientTab` ✅
 
@@ -3267,7 +3267,7 @@ controls:
   - id: db-name
     selector: 'input[aria-label="Database name"]'
     kind: interactive
-    optional: true       # hidden for Redis; present for MySQL/PostgreSQL/PanWeiDB/ClickHouse
+    optional: true       # hidden for Redis; present for MySQL/PostgreSQL/PanWeiDB/Oracle/SQLServer/StarRocks/ClickHouse/Presto
   - id: db-save-in-vault
     selector: '[data-testid="db-save-in-vault"]'
     kind: interactive
@@ -3408,14 +3408,14 @@ controls:
   # Format/History/Save) use title= only — no stable testid yet; promote when covered.
 -->
 
-- DB 会话（MySQL/PostgreSQL/PanWeiDB/ClickHouse）经 `SessionEditor` 创建（proto 选择器 + database section 由 F6.3 拥有），打开后 `MainLayout.openDbTab` 挂载 `DbClientTab`（`type:"database"`），与 SFTP/VNC 一样常驻挂载以便查询跨标签存活
+- DB 会话（MySQL/PostgreSQL/PanWeiDB/Oracle/SQLServer/StarRocks/ClickHouse/Presto）经 `SessionEditor` 创建（proto 选择器 + database section 由 F6.3 拥有），打开后 `MainLayout.openDbTab` 挂载 `DbClientTab`（`type:"database"`），与 SFTP/VNC 一样常驻挂载以便查询跨标签存活
 - 左侧 `SchemaTree`：懒加载 schema→table→column/index 展开（`db-schema-drawer-handle` 抽屉折叠）；右侧查询工作区为多 query 面板（最多 4 个）的 tab 布局
 - `SqlEditorPanel` 封装 CodeMirror 6：按引擎选 dialect、schema-aware 自动补全（`SQLNamespace`），暴露命令式 `SqlEditorHandle`；工具条 Run (F5) / Run selection / Cancel / Format / History / Save / Rows / Sheets / Schema 选择；执行时按 SQL 语句范围拆分并给每个 result sheet 绑定 `sourceRef`
 - SQL 历史持久化到 SQLite `sql_history`，按 workspace/session + engine 查询；History 面板支持 Run / Select / +Tab / JSON / Ask AI / Refresh / Clear / Delete；当前 editor 语句面板用 cursor/selection 定位多 SQL 文档中的单条语句，并提供同一套 Run / Select / +Tab / JSON / Ask AI 交互
 - `QueryResultGrid` 为手写虚拟化网格（行高 24 + overscan）：NULL 徽标、数值右对齐、排序、CSV/单元格复制、完整值查看（Ctrl+Enter / 右键菜单，保留长文本和换行）、列显隐、聚合统计、行筛选、Table/List/Chart 视图、增删改行 + 提交/撤销；过滤/排序会生成包裹源 SQL 的 derived SQL，自动创建/复用 `Generated SQL` query 面板并支持显式替换仍匹配的来源语句
 - 查询工作区跨会话持久化（`queryRegistry` + `ef0b686`），结果可经 Export Grid 对话框导出
 - 浮动工具条复用共享 `FloatingToolbar`（F10.1，`db-floating-toolbar`）：Chat 入口 / 最大化 / 分离到独立窗口（`db-detach`，分离/重挂载行为属 F-Detach-1）
-- **e2e 测试限制**：实际查询需活的 MySQL/PostgreSQL/PanWeiDB/ClickHouse fixture，浏览器冒烟无法连接；smoke 只覆盖「SessionEditor 选 DB proto → 填 host/port → 保存 → 打开标签 → schema-tree / sql-editor / query-result-grid 挂载」的路由路径（参照 TC-111 RDP scaffold 模式），真实查询/编辑留待配置 DB fixture 的手动/native 回归
+- **e2e 测试限制**：实际查询需活的 MySQL/PostgreSQL/PanWeiDB/Oracle/SQLServer/StarRocks/ClickHouse/Presto fixture，浏览器冒烟无法连接；smoke 只覆盖「SessionEditor 选 DB proto → 填 host/port → 保存 → 打开标签 → schema-tree / sql-editor / query-result-grid 挂载」的路由路径（参照 TC-111 RDP scaffold 模式），真实查询/编辑留待配置 DB fixture 的手动/native 回归
 
 ---
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2028,12 +2028,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2051,11 +2075,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.118",
 ]
@@ -6357,6 +6392,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "odpic-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "920b5474a5128a9f0232df5a0ffc50aaa5b077b29b8b06ab0131985ac82793ed"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "oid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6505,6 +6549,33 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "oracle"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db40fe6e4df881b683691ade5ef1f7b1afd52aefa115581f7b92855524d7ec0"
+dependencies = [
+ "cc",
+ "chrono",
+ "odpic-sys",
+ "once_cell",
+ "oracle_procmacro",
+ "paste",
+ "rustversion",
+]
+
+[[package]]
+name = "oracle_procmacro"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad247f3421d57de56a0d0408d3249d4b1048a522be2013656d92f022c3d8af27"
+dependencies = [
+ "darling 0.13.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "ordered-float"
@@ -8180,7 +8251,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -9067,7 +9138,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10041,6 +10112,7 @@ dependencies = [
  "native-tls",
  "nokhwa",
  "openh264",
+ "oracle",
  "pbkdf2",
  "plist",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -127,14 +127,16 @@ ash = { version = "0.38", optional = true }
 llama-cpp-2 = { version = "0.1", optional = true }
 plist = "1.9"
 # Database client backends (MySQL / StarRocks / PostgreSQL via sqlx, PanWeiDB
-# via the native openGauss connector, SQL Server via tiberius, Redis via
-# redis-rs, ClickHouse via the existing reqwest HTTP client). Values are decoded
-# to frontend strings while preserving common database-native numeric, UUID,
-# JSON and time types where the driver exposes them.
+# via the native openGauss connector, Oracle via rust-oracle/ODPI-C, SQL Server
+# via tiberius, Redis via redis-rs, ClickHouse via the existing reqwest HTTP
+# client). Values are decoded to frontend strings while preserving common
+# database-native numeric, UUID, JSON and time types where the driver exposes
+# them.
 sqlx-core = { version = "0.9", default-features = false, features = ["_rt-tokio", "_tls-rustls-ring-webpki", "chrono", "bigdecimal", "uuid", "json"] }
 sqlx-mysql = { version = "0.9", default-features = false, features = ["chrono", "bigdecimal", "uuid", "json"] }
 sqlx-postgres = { version = "0.9", default-features = false, features = ["chrono", "bigdecimal", "uuid", "json"] }
 tokio-opengauss = "0.1"
+oracle = { version = "0.6.3", features = ["chrono"] }
 tiberius = { version = "0.12", default-features = false, features = ["tds73", "rustls", "chrono", "bigdecimal"] }
 redis = { version = "1.2", default-features = false, features = ["tokio-comp", "tokio-rustls-comp", "streams"] }
 # Native HBase RPC client (hbase/native): protobuf wire types via prost,

--- a/src-tauri/src/agent/cc_bridge/mcp_control.rs
+++ b/src-tauri/src/agent/cc_bridge/mcp_control.rs
@@ -350,6 +350,7 @@ fn parse_session_type(s: &str) -> Result<SessionType, String> {
         "MySQL",
         "PostgreSQL",
         "PanWeiDB",
+        "Oracle",
         "SQLServer",
         "StarRocks",
         "ClickHouse",

--- a/src-tauri/src/agent/cc_bridge/mcp_http.rs
+++ b/src-tauri/src/agent/cc_bridge/mcp_http.rs
@@ -63,7 +63,7 @@ const CAPTURE_TIMEOUT_SECS: u64 = 900;
 
 /// Which tool surface a CC thread's MCP endpoint exposes. Selected at spawn
 /// from the bound session's type (E): a terminal/SSH/local thread gets `Shell`;
-/// a SQL DB session (MySQL/PG/SQL Server/ClickHouse/Presto) gets `Sql`; a Redis session
+/// a SQL DB session (MySQL/PG/PanWeiDB/Oracle/SQL Server/ClickHouse/Presto) gets `Sql`; a Redis session
 /// gets `Redis`. One listener serves all three at distinct nest paths, and a
 /// thread's `.mcp.json` lists *only* its flavor's server — so a DB thread never
 /// sees shell tools, and vice-versa (reduces cross-surface confusion).
@@ -109,7 +109,7 @@ impl Flavor {
     }
 
     /// Pick the MCP flavor for a thread from its bound session's type: SQL DB
-    /// engines (MySQL/PG/PanWeiDB/SQL Server/StarRocks/ClickHouse/Presto) →
+    /// engines (MySQL/PG/PanWeiDB/Oracle/SQL Server/StarRocks/ClickHouse/Presto) →
     /// `Sql`, Redis → `Redis`, anything else (SSH/terminal/local/unbound) →
     /// `Shell`.
     pub fn for_session_type(t: Option<&crate::session::models::SessionType>) -> Flavor {
@@ -119,6 +119,7 @@ impl Flavor {
                 SessionType::MySQL
                 | SessionType::PostgreSQL
                 | SessionType::PanWeiDB
+                | SessionType::Oracle
                 | SessionType::SQLServer
                 | SessionType::StarRocks
                 | SessionType::ClickHouse
@@ -235,7 +236,7 @@ pub async fn ensure_started(app: &AppHandle) -> Result<SocketAddr, String> {
             Default::default(),
         )
     };
-    // SQL flavor (`/mcp/sql`) — MySQL/PG/SQL Server/StarRocks/ClickHouse/Presto.
+    // SQL flavor (`/mcp/sql`) — MySQL/PG/PanWeiDB/Oracle/SQL Server/StarRocks/ClickHouse/Presto.
     let sql_service = {
         let app = app.clone();
         let toks = tokens.clone();
@@ -1853,6 +1854,7 @@ mod tests {
             SessionType::MySQL,
             SessionType::PostgreSQL,
             SessionType::PanWeiDB,
+            SessionType::Oracle,
             SessionType::SQLServer,
             SessionType::StarRocks,
             SessionType::ClickHouse,

--- a/src-tauri/src/agent/cc_bridge/mcp_sql.rs
+++ b/src-tauri/src/agent/cc_bridge/mcp_sql.rs
@@ -1,5 +1,5 @@
 //! Phase 6 — the `taomni_sql` MCP flavor: the tool surface a Claude Code thread
-//! bound to a SQL DB session (MySQL / PostgreSQL / SQL Server / StarRocks / ClickHouse / Presto) sees.
+//! bound to a SQL DB session (MySQL / PostgreSQL / Oracle / SQL Server / StarRocks / ClickHouse / Presto) sees.
 //!
 //! Unlike the shell flavor (which routes side-effects back through the frontend
 //! terminal), every tool here runs **backend-direct**: it resolves the thread's
@@ -948,7 +948,7 @@ impl ServerHandler for SqlHandler {
         info.capabilities = ServerCapabilities::builder().enable_tools().build();
         info.instructions = Some(
             "Taomni SQL database tools. You operate on the chat thread's bound DB connection \
-             (MySQL/PostgreSQL/SQL Server/StarRocks/ClickHouse/Presto). Use these tools, not local Bash/Read. \
+             (MySQL/PostgreSQL/Oracle/SQL Server/StarRocks/ClickHouse/Presto). Use these tools, not local Bash/Read. \
              When the user says selected/current/multiple tables or objects, call selected_objects first; \
              for SELECT workflows pass selectable_only=true to filter out non-queryable objects. \
              Mutating statements route through human confirmation."

--- a/src-tauri/src/agent/cc_bridge/session_card.rs
+++ b/src-tauri/src/agent/cc_bridge/session_card.rs
@@ -74,8 +74,8 @@ fn is_remote(t: &SessionType) -> bool {
 /// so a DB thread is steered to its SQL/Redis tools, not the terminal tools its
 /// `.mcp.json` doesn't even expose (Phase 6).
 enum DbRouting {
-    /// MySQL / PostgreSQL / PanWeiDB / SQL Server / StarRocks / ClickHouse /
-    /// Presto — the `taomni_sql` tools.
+    /// MySQL / PostgreSQL / PanWeiDB / Oracle / SQL Server / StarRocks /
+    /// ClickHouse / Presto — the `taomni_sql` tools.
     Sql,
     /// Redis — the `taomni_redis` tools.
     Redis,
@@ -88,6 +88,7 @@ fn db_routing(t: &SessionType) -> DbRouting {
         SessionType::MySQL
         | SessionType::PostgreSQL
         | SessionType::PanWeiDB
+        | SessionType::Oracle
         | SessionType::SQLServer
         | SessionType::StarRocks
         | SessionType::ClickHouse
@@ -579,6 +580,7 @@ mod tests {
             SessionType::MySQL,
             SessionType::PostgreSQL,
             SessionType::PanWeiDB,
+            SessionType::Oracle,
             SessionType::SQLServer,
             SessionType::StarRocks,
             SessionType::ClickHouse,

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -1,7 +1,7 @@
 //! Database client backend: MySQL / PostgreSQL / StarRocks (via `sqlx`),
-//! PanWeiDB (via the native openGauss connector), SQL Server (via `tiberius`),
-//! ClickHouse and Presto (via the existing `reqwest` HTTP client), and Redis
-//! (via `redis-rs`).
+//! PanWeiDB (via the native openGauss connector), Oracle (via `rust-oracle`),
+//! SQL Server (via `tiberius`), ClickHouse and Presto (via the existing
+//! `reqwest` HTTP client), and Redis (via `redis-rs`).
 //!
 //! SQL engines surface a single Tauri command surface (`db_*`, with
 //! `redis_*` for Redis). Live connections are cached in
@@ -11,6 +11,7 @@
 
 pub mod clickhouse;
 pub mod forward;
+pub mod oracle;
 pub mod panwei;
 pub mod presto;
 pub mod redis_ops;
@@ -41,7 +42,7 @@ use crate::state::AppState;
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DbConfig {
-    /// Backend engine: "MySQL" | "PostgreSQL" | "PanWeiDB" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto" | "Redis".
+    /// Backend engine: "MySQL" | "PostgreSQL" | "PanWeiDB" | "Oracle" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto" | "Redis".
     pub engine: String,
     pub host: String,
     pub port: u16,
@@ -229,6 +230,7 @@ pub enum DbHandle {
     MySql(Pool<MySql>),
     Postgres(Pool<Postgres>),
     PanWeiDB(panwei::PanWeiClient),
+    Oracle(oracle::OracleClient),
     SqlServer(Arc<AsyncMutex<sql::SqlServerClient>>),
     StarRocks(Pool<MySql>),
     ClickHouse(clickhouse::ClickHouseClient),
@@ -339,6 +341,22 @@ fn start_keepalive(handle: &DbHandle, shutdown: CancellationToken) -> Option<Joi
                 }
             }))
         }
+        DbHandle::Oracle(client) => {
+            let client = client.clone();
+            Some(tokio::spawn(async move {
+                let mut interval =
+                    tokio::time::interval(Duration::from_secs(KEEPALIVE_INTERVAL_SECS));
+                interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                loop {
+                    tokio::select! {
+                        _ = shutdown.cancelled() => break,
+                        _ = interval.tick() => {
+                            let _ = oracle::ping(&client).await;
+                        }
+                    }
+                }
+            }))
+        }
         DbHandle::SqlServer(client) => {
             let client = client.clone();
             Some(tokio::spawn(async move {
@@ -405,6 +423,7 @@ async fn close_session(session: Arc<DbSession>) {
         DbHandle::StarRocks(pool) => pool.close().await,
         DbHandle::Postgres(pool) => pool.close().await,
         DbHandle::PanWeiDB(_)
+        | DbHandle::Oracle(_)
         | DbHandle::SqlServer(_)
         | DbHandle::ClickHouse(_)
         | DbHandle::Presto(_)
@@ -468,6 +487,7 @@ pub async fn db_connect(
         "MySQL" => sql::connect_mysql(&config, password.as_deref()).await?,
         "PostgreSQL" => sql::connect_postgres(&config, password.as_deref()).await?,
         "PanWeiDB" => panwei::connect(&config, password.as_deref()).await?,
+        "Oracle" => oracle::connect(&config, password.as_deref()).await?,
         "SQLServer" => sql::connect_sqlserver(&config, password.as_deref()).await?,
         "StarRocks" => sql::connect_starrocks(&config, password.as_deref()).await?,
         "ClickHouse" => clickhouse::connect(&config, password.as_deref()).await?,
@@ -548,6 +568,7 @@ pub async fn db_ping(state: State<'_, AppState>, session_id: String) -> Result<S
         DbHandle::MySql(pool) => sql::ping_mysql(pool).await,
         DbHandle::Postgres(pool) => sql::ping_postgres(pool).await,
         DbHandle::PanWeiDB(client) => panwei::ping(client).await,
+        DbHandle::Oracle(client) => oracle::ping(client).await,
         DbHandle::SqlServer(client) => sql::ping_sqlserver(client).await,
         DbHandle::StarRocks(pool) => sql::ping_starrocks(pool).await,
         DbHandle::ClickHouse(client) => clickhouse::ping(client).await,
@@ -583,6 +604,7 @@ pub async fn db_list_catalogs(
         DbHandle::MySql(_)
         | DbHandle::Postgres(_)
         | DbHandle::PanWeiDB(_)
+        | DbHandle::Oracle(_)
         | DbHandle::SqlServer(_)
         | DbHandle::StarRocks(_)
         | DbHandle::ClickHouse(_)
@@ -602,6 +624,7 @@ pub async fn db_list_schemas(
         DbHandle::StarRocks(pool) => sql::list_schemas_mysql(pool).await,
         DbHandle::Postgres(pool) => sql::list_schemas_postgres(pool).await,
         DbHandle::PanWeiDB(client) => panwei::list_schemas(client).await,
+        DbHandle::Oracle(client) => oracle::list_schemas(client).await,
         DbHandle::SqlServer(client) => sql::list_schemas_sqlserver(client).await,
         DbHandle::ClickHouse(client) => clickhouse::list_schemas(client).await,
         DbHandle::Presto(client) => presto::list_schemas(client, catalog.as_deref()).await,
@@ -622,6 +645,7 @@ pub async fn db_list_tables(
         DbHandle::StarRocks(pool) => sql::list_tables_mysql(pool, schema.as_deref()).await,
         DbHandle::Postgres(pool) => sql::list_tables_postgres(pool, schema.as_deref()).await,
         DbHandle::PanWeiDB(client) => panwei::list_tables(client, schema.as_deref()).await,
+        DbHandle::Oracle(client) => oracle::list_tables(client, schema.as_deref()).await,
         DbHandle::SqlServer(client) => sql::list_tables_sqlserver(client, schema.as_deref()).await,
         DbHandle::ClickHouse(client) => clickhouse::list_tables(client, schema.as_deref()).await,
         DbHandle::Presto(client) => {
@@ -650,6 +674,9 @@ pub async fn db_describe_table(
         }
         DbHandle::PanWeiDB(client) => {
             panwei::describe_table(client, schema.as_deref(), &table).await
+        }
+        DbHandle::Oracle(client) => {
+            oracle::describe_table(client, schema.as_deref(), &table).await
         }
         DbHandle::SqlServer(client) => {
             sql::describe_table_sqlserver(client, schema.as_deref(), &table).await
@@ -681,6 +708,9 @@ pub async fn db_list_indexes(
         DbHandle::PanWeiDB(client) => {
             panwei::list_indexes(client, schema.as_deref(), &table).await
         }
+        DbHandle::Oracle(client) => {
+            oracle::list_indexes(client, schema.as_deref(), &table).await
+        }
         DbHandle::SqlServer(client) => {
             sql::list_indexes_sqlserver(client, schema.as_deref(), &table).await
         }
@@ -707,6 +737,7 @@ pub async fn db_list_objects(
         DbHandle::PanWeiDB(client) => {
             panwei::list_objects(client, schema.as_deref(), &kind).await
         }
+        DbHandle::Oracle(client) => oracle::list_objects(client, schema.as_deref(), &kind).await,
         DbHandle::SqlServer(client) => {
             sql::list_objects_sqlserver(client, schema.as_deref(), &kind).await
         }
@@ -738,6 +769,9 @@ pub async fn db_object_ddl(
         DbHandle::PanWeiDB(client) => {
             panwei::object_ddl(client, schema.as_deref(), &kind, &name).await
         }
+        DbHandle::Oracle(client) => {
+            oracle::object_ddl(client, schema.as_deref(), &kind, &name).await
+        }
         DbHandle::SqlServer(client) => {
             sql::object_ddl_sqlserver(client, schema.as_deref(), &kind, &name).await
         }
@@ -766,6 +800,7 @@ pub async fn db_table_stats(
             sql::table_stats_postgres(pool, schema.as_deref(), &table).await
         }
         DbHandle::PanWeiDB(client) => panwei::table_stats(client, schema.as_deref(), &table).await,
+        DbHandle::Oracle(client) => oracle::table_stats(client, schema.as_deref(), &table).await,
         DbHandle::SqlServer(client) => {
             sql::table_stats_sqlserver(client, schema.as_deref(), &table).await
         }
@@ -814,6 +849,7 @@ pub async fn db_execute(
         DbHandle::StarRocks(pool) => sql::execute_mysql(pool, &sql, &token).await,
         DbHandle::Postgres(pool) => sql::execute_postgres(pool, &sql, &token).await,
         DbHandle::PanWeiDB(client) => panwei::execute(client, &sql, &token).await,
+        DbHandle::Oracle(client) => oracle::execute(client, &sql, &token).await,
         DbHandle::SqlServer(client) => sql::execute_sqlserver(client, &sql, &token).await,
         DbHandle::ClickHouse(client) => clickhouse::execute(client, &sql, &token).await,
         DbHandle::Presto(client) => presto::execute(client, &sql, &token).await,
@@ -843,6 +879,9 @@ pub async fn db_execute_stream(
         }
         DbHandle::PanWeiDB(client) => {
             panwei::execute_stream(client, &sql, max_rows, &token, &on_event).await
+        }
+        DbHandle::Oracle(client) => {
+            oracle::execute_stream(client, &sql, max_rows, &token, &on_event).await
         }
         DbHandle::SqlServer(client) => {
             sql::execute_sqlserver_stream(client, &sql, max_rows, &token, &on_event).await

--- a/src-tauri/src/database/oracle.rs
+++ b/src-tauri/src/database/oracle.rs
@@ -1,0 +1,582 @@
+//! Oracle backend via `rust-oracle` (ODPI-C).
+//!
+//! The driver is synchronous, so every database operation runs inside
+//! `spawn_blocking` while the async command layer keeps its normal shape.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use oracle::{Connection, Row, SqlValue, StatementType};
+use tokio::task::JoinError;
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    send_query_stream_event, ColumnDescription, ColumnInfo, DbConfig, DbHandle, DbObject,
+    IndexInfo, QueryResult, QueryStreamChannel, QueryStreamEvent, SchemaInfo, TableInfo,
+};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 15;
+const STREAM_BATCH_ROWS: usize = 100;
+const STREAM_BATCH_ROWS_U32: u32 = 100;
+
+pub type OracleClient = Arc<Connection>;
+
+fn timeout(config: &DbConfig) -> Duration {
+    Duration::from_secs(match config.timeout_secs {
+        Some(s) if s > 0 => s,
+        _ => DEFAULT_TIMEOUT_SECS,
+    })
+}
+
+fn oracle_connect_string(config: &DbConfig) -> String {
+    let service = config.database.as_deref().map(str::trim).unwrap_or("");
+    if service.starts_with("//")
+        || service.to_ascii_lowercase().starts_with("tcps://")
+        || service.starts_with('(')
+    {
+        return service.to_string();
+    }
+    let scheme = if config.ssl { "tcps://" } else { "//" };
+    if service.is_empty() {
+        format!("{scheme}{}:{}", config.host, config.port)
+    } else if service.starts_with('/') || service.starts_with('?') {
+        format!("{scheme}{}:{}{}", config.host, config.port, service)
+    } else {
+        format!("{scheme}{}:{}/{}", config.host, config.port, service)
+    }
+}
+
+fn join_blocking_error(err: JoinError) -> String {
+    if err.is_panic() {
+        "Oracle operation panicked".to_string()
+    } else {
+        format!("Oracle operation failed: {err}")
+    }
+}
+
+async fn oracle_blocking<T, F>(
+    client: OracleClient,
+    token: Option<&CancellationToken>,
+    op: F,
+) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce(OracleClient) -> Result<T, String> + Send + 'static,
+{
+    let cancel_client = client.clone();
+    let mut task = tokio::task::spawn_blocking(move || op(client));
+    if let Some(token) = token {
+        tokio::select! {
+            res = &mut task => res.map_err(join_blocking_error)?,
+            _ = token.cancelled() => {
+                let _ = tokio::task::spawn_blocking(move || cancel_client.break_execution()).await;
+                match task.await {
+                    Ok(_) => Err("Query cancelled".into()),
+                    Err(err) => Err(join_blocking_error(err)),
+                }
+            }
+        }
+    } else {
+        task.await.map_err(join_blocking_error)?
+    }
+}
+
+pub async fn connect(config: &DbConfig, password: Option<&str>) -> Result<DbHandle, String> {
+    let username = config.username.clone().unwrap_or_default();
+    let password = password.unwrap_or("").to_string();
+    let connect_string = oracle_connect_string(config);
+    let timeout = timeout(config);
+    let connect = tokio::task::spawn_blocking(move || {
+        let mut conn = Connection::connect(username, password, connect_string)
+            .map_err(|e| format!("Oracle connect failed: {e}"))?;
+        conn.set_autocommit(true);
+        Ok::<_, String>(Arc::new(conn))
+    });
+    let client = tokio::time::timeout(timeout, connect)
+        .await
+        .map_err(|_| "Oracle connect timed out".to_string())?
+        .map_err(join_blocking_error)??;
+    Ok(DbHandle::Oracle(client))
+}
+
+pub async fn ping(client: &OracleClient) -> Result<String, String> {
+    oracle_blocking(client.clone(), None, |conn| {
+        conn.ping()
+            .map_err(|e| format!("Oracle ping failed: {e}"))?;
+        Ok("Oracle connection OK".into())
+    })
+    .await
+}
+
+fn oracle_owner_sql(schema: Option<&str>) -> String {
+    match schema.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(schema) => format!("'{}'", schema.replace('\'', "''").to_uppercase()),
+        None => "SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')".to_string(),
+    }
+}
+
+fn oracle_object_type(kind: &str) -> Option<&'static str> {
+    match kind {
+        "table" => Some("TABLE"),
+        "view" => Some("VIEW"),
+        "materialized_view" => Some("MATERIALIZED VIEW"),
+        "procedure" => Some("PROCEDURE"),
+        "function" => Some("FUNCTION"),
+        "trigger" => Some("TRIGGER"),
+        "sequence" => Some("SEQUENCE"),
+        _ => None,
+    }
+}
+
+fn dbms_metadata_object_type(kind: &str) -> Option<&'static str> {
+    match kind {
+        "table" => Some("TABLE"),
+        "view" => Some("VIEW"),
+        "materialized_view" => Some("MATERIALIZED_VIEW"),
+        "procedure" => Some("PROCEDURE"),
+        "function" => Some("FUNCTION"),
+        "trigger" => Some("TRIGGER"),
+        "sequence" => Some("SEQUENCE"),
+        _ => None,
+    }
+}
+
+fn oracle_table_kind(object_type: &str) -> String {
+    match object_type {
+        "VIEW" => "view",
+        "MATERIALIZED VIEW" => "materialized_view",
+        _ => "table",
+    }
+    .to_string()
+}
+
+fn oracle_value_to_string(value: &SqlValue<'_>) -> Option<String> {
+    match value.is_null() {
+        Ok(true) => None,
+        _ => Some(value.to_string()),
+    }
+}
+
+fn row_value(row: &Row, index: usize) -> Option<String> {
+    row.sql_values().get(index).and_then(oracle_value_to_string)
+}
+
+fn row_bool(row: &Row, index: usize) -> bool {
+    row_value(row, index)
+        .map(|v| matches!(v.as_str(), "1" | "Y" | "YES" | "TRUE"))
+        .unwrap_or(false)
+}
+
+fn oracle_rows(
+    client: &OracleClient,
+    sql: &str,
+    max_rows: Option<u64>,
+) -> Result<(Vec<ColumnInfo>, Vec<Vec<Option<String>>>, bool), String> {
+    let mut stmt = client
+        .statement(sql)
+        .fetch_array_size(STREAM_BATCH_ROWS_U32)
+        .prefetch_rows(STREAM_BATCH_ROWS_U32 + 1)
+        .build()
+        .map_err(|e| format!("Query failed: {e}"))?;
+    let rows = stmt.query(&[]).map_err(|e| format!("Query failed: {e}"))?;
+    let columns = rows
+        .column_info()
+        .iter()
+        .map(|info| ColumnInfo {
+            name: info.name().to_string(),
+            type_name: info.oracle_type().to_string(),
+        })
+        .collect();
+    let max_rows = max_rows.filter(|value| *value > 0);
+    let mut out_rows = Vec::new();
+    let mut limit_reached = false;
+    for row_result in rows {
+        if max_rows.is_some_and(|limit| out_rows.len() as u64 >= limit) {
+            limit_reached = true;
+            break;
+        }
+        let row = row_result.map_err(|e| format!("Query failed: {e}"))?;
+        let values = row
+            .sql_values()
+            .iter()
+            .map(oracle_value_to_string)
+            .collect();
+        out_rows.push(values);
+    }
+    Ok((columns, out_rows, limit_reached))
+}
+
+pub async fn execute(
+    client: &OracleClient,
+    sql: &str,
+    token: &CancellationToken,
+) -> Result<QueryResult, String> {
+    let sql = sql.to_string();
+    oracle_blocking(client.clone(), Some(token), move |conn| {
+        let start = Instant::now();
+        let mut stmt = conn
+            .statement(&sql)
+            .build()
+            .map_err(|e| format!("Statement failed: {e}"))?;
+        if stmt.statement_type() == StatementType::Select {
+            let (columns, rows, _) = oracle_rows(&conn, &sql, None)?;
+            Ok(QueryResult {
+                columns,
+                rows,
+                rows_affected: 0,
+                duration_ms: start.elapsed().as_millis() as u64,
+                warnings: Vec::new(),
+            })
+        } else {
+            stmt.execute(&[])
+                .map_err(|e| format!("Statement failed: {e}"))?;
+            let rows_affected = stmt.row_count().unwrap_or(0);
+            Ok(QueryResult {
+                columns: Vec::new(),
+                rows: Vec::new(),
+                rows_affected,
+                duration_ms: start.elapsed().as_millis() as u64,
+                warnings: Vec::new(),
+            })
+        }
+    })
+    .await
+}
+
+pub async fn execute_stream(
+    client: &OracleClient,
+    sql: &str,
+    max_rows: Option<u64>,
+    token: &CancellationToken,
+    on_event: &QueryStreamChannel,
+) -> Result<(), String> {
+    let sql = sql.to_string();
+    let start = Instant::now();
+    let result = oracle_blocking(client.clone(), Some(token), move |conn| {
+        let mut stmt = conn
+            .statement(&sql)
+            .build()
+            .map_err(|e| format!("Statement failed: {e}"))?;
+        if stmt.statement_type() == StatementType::Select {
+            let (columns, rows, limit_reached) = oracle_rows(&conn, &sql, max_rows)?;
+            Ok((Some((columns, rows, limit_reached)), 0_u64))
+        } else {
+            stmt.execute(&[])
+                .map_err(|e| format!("Statement failed: {e}"))?;
+            Ok((None, stmt.row_count().unwrap_or(0)))
+        }
+    })
+    .await?;
+
+    match result {
+        (Some((columns, rows, limit_reached)), _) => {
+            if !columns.is_empty() {
+                send_query_stream_event(on_event, QueryStreamEvent::Columns { columns })?;
+            }
+            for batch in rows.chunks(STREAM_BATCH_ROWS) {
+                send_query_stream_event(
+                    on_event,
+                    QueryStreamEvent::Rows {
+                        rows: batch.to_vec(),
+                    },
+                )?;
+            }
+            send_query_stream_event(
+                on_event,
+                QueryStreamEvent::Done {
+                    rows_affected: 0,
+                    duration_ms: start.elapsed().as_millis() as u64,
+                    warnings: match (limit_reached, max_rows.filter(|value| *value > 0)) {
+                        (true, Some(limit)) => vec![format!("Result limited to {limit} rows")],
+                        _ => Vec::new(),
+                    },
+                },
+            )
+        }
+        (None, rows_affected) => send_query_stream_event(
+            on_event,
+            QueryStreamEvent::Done {
+                rows_affected,
+                duration_ms: start.elapsed().as_millis() as u64,
+                warnings: Vec::new(),
+            },
+        ),
+    }
+}
+
+pub async fn list_schemas(client: &OracleClient) -> Result<Vec<SchemaInfo>, String> {
+    oracle_blocking(client.clone(), None, |conn| {
+        let sql = "SELECT DISTINCT owner \
+                   FROM all_objects \
+                   WHERE object_type IN ('TABLE','VIEW','MATERIALIZED VIEW','SEQUENCE','PROCEDURE','FUNCTION','TRIGGER') \
+                   UNION SELECT SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA') FROM dual \
+                   ORDER BY 1";
+        let (columns, rows, _) = oracle_rows(&conn, sql, None)?;
+        let _ = columns;
+        Ok(rows
+            .into_iter()
+            .filter_map(|row| row.into_iter().next().flatten())
+            .map(|name| SchemaInfo { name })
+            .collect())
+    })
+    .await
+}
+
+pub async fn list_tables(
+    client: &OracleClient,
+    schema: Option<&str>,
+) -> Result<Vec<TableInfo>, String> {
+    let owner = oracle_owner_sql(schema);
+    let sql = format!(
+        "SELECT o.object_name, o.object_type, t.num_rows \
+         FROM all_objects o \
+         LEFT JOIN all_tables t ON t.owner = o.owner AND t.table_name = o.object_name \
+         WHERE o.owner = {owner} \
+           AND o.object_type IN ('TABLE','VIEW','MATERIALIZED VIEW') \
+           AND o.object_name NOT LIKE 'BIN$%' \
+         ORDER BY o.object_name"
+    );
+    oracle_blocking(client.clone(), None, move |conn| {
+        let (_, rows, _) = oracle_rows(&conn, &sql, None)?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|row| {
+                let name = row.first().and_then(Clone::clone)?;
+                let object_type = row.get(1).and_then(Clone::clone).unwrap_or_default();
+                let row_count = row
+                    .get(2)
+                    .and_then(Clone::clone)
+                    .and_then(|value| value.parse::<i64>().ok());
+                Some(TableInfo {
+                    name,
+                    kind: oracle_table_kind(&object_type),
+                    row_count,
+                })
+            })
+            .collect())
+    })
+    .await
+}
+
+pub async fn describe_table(
+    client: &OracleClient,
+    schema: Option<&str>,
+    table: &str,
+) -> Result<Vec<ColumnDescription>, String> {
+    let owner = oracle_owner_sql(schema);
+    let table = table.replace('\'', "''").to_uppercase();
+    let sql = format!(
+        "SELECT c.column_name, \
+                c.data_type || \
+                CASE \
+                  WHEN c.data_type IN ('VARCHAR2','NVARCHAR2','CHAR','NCHAR','RAW') THEN '(' || c.data_length || ')' \
+                  WHEN c.data_type = 'NUMBER' AND c.data_precision IS NOT NULL THEN '(' || c.data_precision || CASE WHEN c.data_scale IS NOT NULL THEN ',' || c.data_scale ELSE '' END || ')' \
+                  WHEN c.data_type LIKE 'TIMESTAMP%' AND c.data_scale IS NOT NULL THEN '(' || c.data_scale || ')' \
+                  ELSE '' \
+                END AS type_name, \
+                c.nullable, c.data_default, \
+                CASE WHEN pk.column_name IS NULL THEN 0 ELSE 1 END AS is_pk \
+         FROM all_tab_columns c \
+         LEFT JOIN ( \
+           SELECT acc.owner, acc.table_name, acc.column_name \
+           FROM all_constraints ac \
+           JOIN all_cons_columns acc ON acc.owner = ac.owner AND acc.constraint_name = ac.constraint_name \
+           WHERE ac.constraint_type = 'P' \
+         ) pk ON pk.owner = c.owner AND pk.table_name = c.table_name AND pk.column_name = c.column_name \
+         WHERE c.owner = {owner} AND c.table_name = '{table}' \
+         ORDER BY c.column_id"
+    );
+    oracle_blocking(client.clone(), None, move |conn| {
+        let (_, rows, _) = oracle_rows(&conn, &sql, None)?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|row| {
+                Some(ColumnDescription {
+                    name: row.first().and_then(Clone::clone)?,
+                    type_name: row.get(1).and_then(Clone::clone).unwrap_or_default(),
+                    nullable: row
+                        .get(2)
+                        .and_then(Clone::clone)
+                        .map(|value| value.eq_ignore_ascii_case("Y"))
+                        .unwrap_or(true),
+                    default: row.get(3).and_then(Clone::clone),
+                    primary_key: row
+                        .get(4)
+                        .and_then(Clone::clone)
+                        .map(|value| value == "1")
+                        .unwrap_or(false),
+                })
+            })
+            .collect())
+    })
+    .await
+}
+
+pub async fn list_indexes(
+    client: &OracleClient,
+    schema: Option<&str>,
+    table: &str,
+) -> Result<Vec<IndexInfo>, String> {
+    let owner = oracle_owner_sql(schema);
+    let table = table.replace('\'', "''").to_uppercase();
+    let sql = format!(
+        "SELECT i.index_name, c.column_name, CASE WHEN i.uniqueness = 'UNIQUE' THEN 1 ELSE 0 END \
+         FROM all_indexes i \
+         JOIN all_ind_columns c ON c.index_owner = i.owner AND c.index_name = i.index_name \
+         WHERE i.owner = {owner} AND i.table_name = '{table}' \
+         ORDER BY i.index_name, c.column_position"
+    );
+    oracle_blocking(client.clone(), None, move |conn| {
+        let mut grouped: Vec<IndexInfo> = Vec::new();
+        let rows = conn
+            .query(&sql, &[])
+            .map_err(|e| format!("list indexes failed: {e}"))?;
+        for row_result in rows {
+            let row = row_result.map_err(|e| format!("list indexes failed: {e}"))?;
+            let Some(name) = row_value(&row, 0) else {
+                continue;
+            };
+            let column = row_value(&row, 1).unwrap_or_default();
+            let unique = row_bool(&row, 2);
+            if let Some(last) = grouped.last_mut().filter(|item| item.name == name) {
+                last.columns.push(column);
+                last.unique = last.unique || unique;
+            } else {
+                grouped.push(IndexInfo {
+                    name,
+                    columns: vec![column],
+                    unique,
+                });
+            }
+        }
+        Ok(grouped)
+    })
+    .await
+}
+
+pub async fn list_objects(
+    client: &OracleClient,
+    schema: Option<&str>,
+    kind: &str,
+) -> Result<Vec<DbObject>, String> {
+    let Some(object_type) = oracle_object_type(kind) else {
+        return Ok(Vec::new());
+    };
+    let owner = oracle_owner_sql(schema);
+    let (sql, owner_col) = if kind == "trigger" {
+        (
+            format!(
+                "SELECT trigger_name, table_name \
+                 FROM all_triggers \
+                 WHERE owner = {owner} \
+                 ORDER BY trigger_name"
+            ),
+            true,
+        )
+    } else if kind == "sequence" {
+        (
+            format!(
+                "SELECT sequence_name, CAST(NULL AS VARCHAR2(128)) \
+                 FROM all_sequences \
+                 WHERE sequence_owner = {owner} \
+                 ORDER BY sequence_name"
+            ),
+            false,
+        )
+    } else {
+        (
+            format!(
+                "SELECT object_name, CAST(NULL AS VARCHAR2(128)) \
+                 FROM all_objects \
+                 WHERE owner = {owner} \
+                   AND object_type = '{object_type}' \
+                   AND object_name NOT LIKE 'BIN$%' \
+                 ORDER BY object_name"
+            ),
+            false,
+        )
+    };
+    let kind = kind.to_string();
+    oracle_blocking(client.clone(), None, move |conn| {
+        let (_, rows, _) = oracle_rows(&conn, &sql, None)?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|row| {
+                let name = row.first().and_then(Clone::clone)?;
+                let owner = if owner_col {
+                    row.get(1).and_then(Clone::clone)
+                } else {
+                    None
+                };
+                Some(DbObject {
+                    name,
+                    kind: kind.clone(),
+                    owner,
+                })
+            })
+            .collect())
+    })
+    .await
+}
+
+pub async fn object_ddl(
+    client: &OracleClient,
+    schema: Option<&str>,
+    kind: &str,
+    name: &str,
+) -> Result<String, String> {
+    let object_type = dbms_metadata_object_type(kind).unwrap_or("TABLE");
+    let owner = oracle_owner_sql(schema);
+    let name = name.replace('\'', "''").to_uppercase();
+    let sql = format!("SELECT DBMS_METADATA.GET_DDL('{object_type}', '{name}', {owner}) FROM dual");
+    oracle_blocking(client.clone(), None, move |conn| {
+        let (_, rows, _) = oracle_rows(&conn, &sql, Some(1))?;
+        rows.first()
+            .and_then(|row| row.first().cloned().flatten())
+            .filter(|ddl| !ddl.trim().is_empty())
+            .ok_or_else(|| format!("No DDL returned for {name}"))
+    })
+    .await
+}
+
+pub async fn table_stats(
+    client: &OracleClient,
+    schema: Option<&str>,
+    table: &str,
+) -> Result<QueryResult, String> {
+    let owner = oracle_owner_sql(schema);
+    let table = table.replace('\'', "''").to_uppercase();
+    let sql = format!(
+        "SELECT t.num_rows, \
+                t.blocks, \
+                t.avg_row_len, \
+                t.tablespace_name, \
+                TO_CHAR(t.last_analyzed, 'YYYY-MM-DD HH24:MI:SS'), \
+                (SELECT SUM(s.bytes) \
+                   FROM all_segments s \
+                  WHERE s.owner = t.owner AND s.segment_name = t.table_name), \
+                (SELECT SUM(s.bytes) \
+                   FROM all_indexes i \
+                   JOIN all_segments s ON s.owner = i.owner AND s.segment_name = i.index_name \
+                  WHERE i.table_owner = t.owner AND i.table_name = t.table_name) \
+         FROM all_tables t \
+         WHERE t.owner = {owner} AND t.table_name = '{table}'"
+    );
+    oracle_blocking(client.clone(), None, move |conn| {
+        let (_, rows, _) = oracle_rows(&conn, &sql, Some(1))?;
+        let row = rows
+            .first()
+            .ok_or_else(|| format!("Table {table} not found"))?;
+        let get = |index: usize| row.get(index).cloned().flatten();
+        Ok(super::metric_result(vec![
+            ("Estimated rows", get(0)),
+            ("Blocks", get(1)),
+            ("Average row length", get(2)),
+            ("Tablespace", get(3)),
+            ("Last analyzed", get(4)),
+            ("Data bytes", get(5)),
+            ("Index bytes", get(6)),
+        ]))
+    })
+    .await
+}

--- a/src-tauri/src/session/models.rs
+++ b/src-tauri/src/session/models.rs
@@ -40,6 +40,7 @@ pub enum SessionType {
     MySQL,
     PostgreSQL,
     PanWeiDB,
+    Oracle,
     SQLServer,
     StarRocks,
     ClickHouse,
@@ -80,6 +81,7 @@ impl SessionType {
             Self::MySQL => "MySQL",
             Self::PostgreSQL => "PostgreSQL",
             Self::PanWeiDB => "PanWeiDB",
+            Self::Oracle => "Oracle",
             Self::SQLServer => "SQLServer",
             Self::StarRocks => "StarRocks",
             Self::ClickHouse => "ClickHouse",
@@ -110,6 +112,7 @@ impl SessionType {
             "MySQL" => Self::MySQL,
             "PostgreSQL" => Self::PostgreSQL,
             "PanWeiDB" | "PanWei" | "openGauss" | "OpenGauss" => Self::PanWeiDB,
+            "Oracle" | "OracleDB" | "Oracle Database" => Self::Oracle,
             "SQLServer" | "SQL Server" | "MSSQL" => Self::SQLServer,
             "StarRocks" | "StarRocksDB" => Self::StarRocks,
             "ClickHouse" => Self::ClickHouse,
@@ -136,6 +139,7 @@ impl SessionType {
             Self::MySQL => 3306,
             Self::PostgreSQL => 5432,
             Self::PanWeiDB => 5432,
+            Self::Oracle => 1521,
             Self::SQLServer => 1433,
             Self::StarRocks => 9030,
             Self::ClickHouse => 9000,
@@ -205,6 +209,7 @@ mod tests {
             ("Browser", 0),
             ("Mail", 993),
             ("PanWeiDB", 5432),
+            ("Oracle", 1521),
         ] {
             let ty = SessionType::from_str(raw);
             assert_eq!(ty.as_str(), raw);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -77,7 +77,7 @@ pub struct AppState {
     pub servers: Arc<ServerRegistry>,
     pub vnc_sessions: Arc<RwLock<HashMap<String, VncSession>>>,
     pub rdp_sessions: Arc<RwLock<HashMap<String, RdpSession>>>,
-    /// Live database client connections (MySQL/PostgreSQL/SQL Server/StarRocks/ClickHouse/Redis),
+    /// Live database client connections (MySQL/PostgreSQL/Oracle/SQL Server/StarRocks/ClickHouse/Redis),
     /// keyed by session id. Each `DbSession` wraps the per-engine connection
     /// handle plus a cancellation token for in-flight queries.
     pub db_connections: Arc<RwLock<HashMap<String, Arc<DbSession>>>>,

--- a/src/components/chat/CodeBlockToolbar.tsx
+++ b/src/components/chat/CodeBlockToolbar.tsx
@@ -325,7 +325,7 @@ const SLASH_COMMENT_LANGS = new Set([
   "less",
 ]);
 
-const SQL_COMMENT_LANGS = new Set(["sql", "mysql", "postgres", "postgresql", "sqlite", "lua", "haskell", "hs"]);
+const SQL_COMMENT_LANGS = new Set(["sql", "mysql", "oracle", "postgres", "postgresql", "sqlite", "lua", "haskell", "hs"]);
 const HTML_COMMENT_LANGS = new Set(["", "html", "xml", "md", "markdown"]);
 const BATCH_COMMENT_LANGS = new Set(["bat", "batch", "cmd"]);
 

--- a/src/components/database/DbClientTab.tsx
+++ b/src/components/database/DbClientTab.tsx
@@ -89,6 +89,7 @@ import {
   qualifiedName as dialectQualifiedName,
   sqlLiteral as dialectSqlLiteral,
   setDefaultSchemaSql,
+  selectStatement as dialectSelectStatement,
 } from "../../lib/sqlDialect";
 
 interface DbClientTabProps {
@@ -1452,8 +1453,12 @@ export default function DbClientTab({
 
   const quickSelect = useCallback(
     (schema: string | null, table: string) => {
-      const qualified = qualifiedName(info.engine, schema ?? activeSchema, table, info.catalog);
-      const sql = `SELECT * FROM ${qualified} LIMIT ${rowLimit}`;
+      const sql = dialectSelectStatement(
+        asSqlEngine(info.engine),
+        { catalog: info.catalog, schema: schema ?? activeSchema, name: table },
+        [],
+        rowLimit,
+      );
       editorHandles.current[activePanelId]?.setValue(sql);
       void runQuery(activePanelId, sql);
     },

--- a/src/components/database/QueryResultGrid.tsx
+++ b/src/components/database/QueryResultGrid.tsx
@@ -441,6 +441,8 @@ function sqlTextExpression(engine: SqlEngine, expression: string): string {
     case "PostgreSQL":
     case "PanWeiDB":
       return `${expression}::text`;
+    case "Oracle":
+      return `CAST(${expression} AS VARCHAR2(4000))`;
     case "SQLServer":
       return `CAST(${expression} AS NVARCHAR(MAX))`;
     case "ClickHouse":
@@ -522,7 +524,8 @@ function buildGeneratedResultSql({
   }
   const orderBy = sortCol !== null && sortDir ? `ORDER BY ${columnSql(sortCol)} ${sortDir.toUpperCase()}` : "";
   if (whereClauses.length === 0 && !orderBy) return null;
-  const lines = ["SELECT *", "FROM (", indentSql(baseSql), ") AS taomni_result"];
+  const alias = engine === "Oracle" ? ") taomni_result" : ") AS taomni_result";
+  const lines = ["SELECT *", "FROM (", indentSql(baseSql), alias];
   if (whereClauses.length > 0) lines.push(`WHERE ${whereClauses.join("\n  AND ")}`);
   if (orderBy) lines.push(orderBy);
   return `${lines.join("\n")};`;

--- a/src/components/database/SqlEditorPanel.tsx
+++ b/src/components/database/SqlEditorPanel.tsx
@@ -130,6 +130,7 @@ function dialectFor(engine: string): SQLDialect {
     case "PostgreSQL":
     case "PanWeiDB":
       return PostgreSQL;
+    case "Oracle":
     case "SQLServer":
       return StandardSQL;
     default:

--- a/src/components/session/SessionEditor.test.tsx
+++ b/src/components/session/SessionEditor.test.tsx
@@ -693,6 +693,33 @@ describe("SessionEditor SSH settings tabs", { timeout: 15_000 }, () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("persists Oracle database settings with the default port", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderEditor(undefined, { initialProto: "Oracle" });
+
+    await waitFor(() => expect(screen.getByTestId("session-database-section")).toBeInTheDocument());
+    await user.type(screen.getByLabelText("Remote host"), "oracle.example.com");
+    await user.type(screen.getByLabelText("Database username"), "billing");
+    await user.type(screen.getByLabelText("Oracle service or schema"), "ORCLPDB1");
+
+    await user.click(screen.getByRole("button", { name: "OK" }));
+
+    expect(ipcMocks.saveSession).toHaveBeenCalledTimes(1);
+    const savedConfig = ipcMocks.saveSession.mock.calls[0][0];
+    const savedOptions = JSON.parse(savedConfig.options_json);
+    expect(savedConfig).toMatchObject({
+      session_type: "Oracle",
+      host: "oracle.example.com",
+      port: 1521,
+      username: "billing",
+    });
+    expect(savedOptions).toMatchObject({
+      dbDatabase: "ORCLPDB1",
+      dbTimeout: "15",
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it("persists PanWeiDB database settings through the session store save path", async () => {
     const user = userEvent.setup();
     const { onClose } = renderEditor(undefined, { initialProto: "PanWeiDB" });

--- a/src/components/session/SessionEditor.tsx
+++ b/src/components/session/SessionEditor.tsx
@@ -118,7 +118,7 @@ import type { SftpPathMapping } from "../../types";
 type Proto =
   | "SSH" | "Telnet" | "Rlogin" | "RDP" | "VNC" | "FTP" | "SFTP"
   | "Serial" | "File" | "Shell" | "Browser" | "Mosh" | "S3" | "WSL"
-  | "MySQL" | "PostgreSQL" | "PanWeiDB" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto" | "Redis" | "HBaseShell"
+  | "MySQL" | "PostgreSQL" | "PanWeiDB" | "Oracle" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto" | "Redis" | "HBaseShell"
   | "Proxy" | "Mail";
 
 type SectionTab = "advanced" | "terminal" | "appearance" | "network" | "bookmark" | "rdp" | "database" | "mappings" | "proxy" | "objectstorage" | "mail";
@@ -142,6 +142,7 @@ const PROTOS: { id: Proto; icon: React.ReactNode; color: string }[] = [
   { id: "MySQL",      icon: <Database className="w-7 h-7" />, color: "#00758f" },
   { id: "PostgreSQL", icon: <Database className="w-7 h-7" />, color: "#336791" },
   { id: "PanWeiDB",   icon: <Database className="w-7 h-7" />, color: "#0b8f6a" },
+  { id: "Oracle",     icon: <Database className="w-7 h-7" />, color: "#c74634" },
   { id: "SQLServer",  icon: <Database className="w-7 h-7" />, color: "#cc2927" },
   { id: "StarRocks",  icon: <Database className="w-7 h-7" />, color: "#0f8f8c" },
   { id: "ClickHouse", icon: <Database className="w-7 h-7" />, color: "#e6a817" },
@@ -156,11 +157,11 @@ const DEFAULT_PORTS: Record<string, number> = {
   SSH: 22, Telnet: 23, Rlogin: 513, RDP: 3389, VNC: 5900,
   FTP: 21, SFTP: 22, Serial: 0, File: 0, Shell: 0,
   Browser: 0, Mosh: 60001, S3: 443, WSL: 0,
-  MySQL: 3306, PostgreSQL: 5432, PanWeiDB: 5432, SQLServer: 1433, StarRocks: 9030, ClickHouse: 9000, Presto: 8080, Redis: 6379,
+  MySQL: 3306, PostgreSQL: 5432, PanWeiDB: 5432, Oracle: 1521, SQLServer: 1433, StarRocks: 9030, ClickHouse: 9000, Presto: 8080, Redis: 6379,
   HBaseShell: 8080, Proxy: 3128, Mail: 993,
 };
 
-const DB_PROTOS: Proto[] = ["MySQL", "PostgreSQL", "PanWeiDB", "SQLServer", "StarRocks", "ClickHouse", "Presto", "Redis"];
+const DB_PROTOS: Proto[] = ["MySQL", "PostgreSQL", "PanWeiDB", "Oracle", "SQLServer", "StarRocks", "ClickHouse", "Presto", "Redis"];
 const PLANNED_CLIENT_PROTOS = new Set<Proto>();
 
 /** Map UI proto to the backend session_type string. Object storage ("S3"
@@ -1527,6 +1528,7 @@ function DatabaseSettings({
   const isRedis = proto === "Redis";
   const isClickHouse = proto === "ClickHouse";
   const isPresto = proto === "Presto";
+  const isOracle = proto === "Oracle";
   return (
     <div data-testid="database-settings" className="grid grid-cols-12 gap-x-3 gap-y-2.5 text-[12px]">
       <Field label="Username">
@@ -1582,12 +1584,12 @@ function DatabaseSettings({
       )}
 
       {!isRedis && (
-        <Field label={isPresto ? "Schema" : "Database"}>
+        <Field label={isPresto ? "Schema" : isOracle ? "Service / Schema" : "Database"}>
           <input
             className="taomni-input w-64"
             value={database}
-            aria-label={isPresto ? "Presto schema" : "Database name"}
-            placeholder={isPresto ? "(optional) default schema" : "database / schema name"}
+            aria-label={isPresto ? "Presto schema" : isOracle ? "Oracle service or schema" : "Database name"}
+            placeholder={isPresto ? "(optional) default schema" : isOracle ? "service name (e.g. ORCLPDB1)" : "database / schema name"}
             onChange={(e) => setDatabase(e.target.value)}
           />
         </Field>
@@ -2152,7 +2154,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
   const [fileEmbedInTab, setFileEmbedInTab] = useState(() => optionBoolean(initialOptions, "fileEmbedInTab", true));
   const [fileExtraArgs, setFileExtraArgs] = useState(() => optionString(initialOptions, "fileExtraArgs", ""));
 
-  /* --- database session options (MySQL/PostgreSQL/PanWeiDB/SQLServer/StarRocks/ClickHouse/Presto/Redis) --- */
+  /* --- database session options (MySQL/PostgreSQL/PanWeiDB/Oracle/SQLServer/StarRocks/ClickHouse/Presto/Redis) --- */
   const [dbCatalog, setDbCatalog] = useState(() => optionString(initialOptions, "dbCatalog", ""));
   const [dbDatabase, setDbDatabase] = useState(() => optionString(initialOptions, "dbDatabase", ""));
   const [dbSsl, setDbSsl] = useState(() => optionBoolean(initialOptions, "dbSsl", false));

--- a/src/components/sidebar/SessionTree.tsx
+++ b/src/components/sidebar/SessionTree.tsx
@@ -1794,6 +1794,8 @@ function sessionIcon(type: string) {
       return <Database className="w-3.5 h-3.5" style={{ color: "#336791" }} />;
     case "PanWeiDB":
       return <Database className="w-3.5 h-3.5" style={{ color: "#0b8f6a" }} />;
+    case "Oracle":
+      return <Database className="w-3.5 h-3.5" style={{ color: "#c74634" }} />;
     case "SQLServer":
       return <Database className="w-3.5 h-3.5" style={{ color: "#cc2927" }} />;
     case "StarRocks":

--- a/src/components/tabbar/TabBar.tsx
+++ b/src/components/tabbar/TabBar.tsx
@@ -577,6 +577,8 @@ function dbEngineColor(engine?: string): string {
       return "#336791";
     case "PanWeiDB":
       return "#0b8f6a";
+    case "Oracle":
+      return "#c74634";
     case "SQLServer":
       return "#cc2927";
     case "StarRocks":

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1868,6 +1868,7 @@ export function MainLayout() {
       session.session_type === "MySQL" ||
       session.session_type === "PostgreSQL" ||
       session.session_type === "PanWeiDB" ||
+      session.session_type === "Oracle" ||
       session.session_type === "SQLServer" ||
       session.session_type === "StarRocks" ||
       session.session_type === "ClickHouse" ||

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -885,7 +885,7 @@ export async function secureCrtDecryptPasswords(
   });
 }
 
-// --- Database client (MySQL / PostgreSQL / PanWeiDB / SQL Server / StarRocks / ClickHouse / Presto / Redis) ---
+// --- Database client (MySQL / PostgreSQL / PanWeiDB / Oracle / SQL Server / StarRocks / ClickHouse / Presto / Redis) ---
 
 /** Strip the frontend-only `sessionId` to build the Rust `DbConfig` payload. */
 function toDbConfigPayload(info: DbConnectInfo): Record<string, unknown> {

--- a/src/lib/sessionImportExport.test.ts
+++ b/src/lib/sessionImportExport.test.ts
@@ -476,10 +476,10 @@ describe("DBeaver session import", () => {
         },
         oracle: {
           driver: "oracle",
-          name: "Skipped Oracle",
+          name: "Billing Oracle",
           configuration: {
-            host: "oracle.example.com",
-            port: "1521",
+            url: "jdbc:oracle:thin:@//oracle.example.com:1522/ORCLPDB1",
+            user: "billing",
           },
         },
       },
@@ -496,8 +496,9 @@ describe("DBeaver session import", () => {
       "Presto",
       "Redis",
       "PanWeiDB",
+      "Oracle",
     ]);
-    expect(result.skipped).toBe(1);
+    expect(result.skipped).toBe(0);
     expect(result.secrets).toHaveLength(2);
     expect(result.sessions[0]).toMatchObject({
       name: "Maria Prod",
@@ -570,6 +571,17 @@ describe("DBeaver session import", () => {
     });
     expect(JSON.parse(result.sessions[7].options_json)).toMatchObject({
       dbDatabase: "pwdb",
+      dbSsl: false,
+    });
+    expect(result.sessions[8]).toMatchObject({
+      name: "Billing Oracle",
+      session_type: "Oracle",
+      host: "oracle.example.com",
+      port: 1522,
+      username: "billing",
+    });
+    expect(JSON.parse(result.sessions[8].options_json)).toMatchObject({
+      dbDatabase: "ORCLPDB1",
       dbSsl: false,
     });
   });
@@ -721,14 +733,14 @@ describe("Navicat session import", () => {
       '    <Connection ConnectionName="StarRocks FE" ConnType="STARROCKS" Host="sr.example.com" UserName="reader" Database="warehouse" />',
       "  </Group>",
       '  <Connection ConnectionName="Cache" ConnType="REDIS" Host="redis.example.com" Port="6380" UserName="default" Database="2" />',
-      '  <Connection ConnectionName="Skipped Oracle" ConnType="ORACLE" Host="oracle.example.com" Port="1521" />',
+      '  <Connection ConnectionName="Billing Oracle" ConnType="ORACLE" Host="oracle.example.com" Port="1521" UserName="billing" Database="ORCLPDB1" />',
       "</Connections>",
     ].join("\n");
 
     const result = await parseNavicatSessions(text, { targetFolder: "Imported", now: 6060 });
 
-    expect(result.sessions.map((s) => s.session_type)).toEqual(["MySQL", "StarRocks", "Redis"]);
-    expect(result.skipped).toBe(1);
+    expect(result.sessions.map((s) => s.session_type)).toEqual(["MySQL", "StarRocks", "Redis", "Oracle"]);
+    expect(result.skipped).toBe(0);
     expect(result.sessions[0]).toMatchObject({
       name: "Prod MySQL",
       group_path: "User sessions / Imported / Navicat / Production",
@@ -760,6 +772,18 @@ describe("Navicat session import", () => {
     expect(JSON.parse(result.sessions[2].options_json)).toMatchObject({
       dbRedisIndex: "2",
     });
+    expect(result.sessions[3]).toMatchObject({
+      name: "Billing Oracle",
+      session_type: "Oracle",
+      host: "oracle.example.com",
+      port: 1521,
+      username: "billing",
+    });
+    expect(JSON.parse(result.sessions[3].options_json)).toMatchObject({
+      dbDatabase: "ORCLPDB1",
+      dbSsl: false,
+      dbTimeout: "15",
+    });
     expect(result.secrets).toEqual([
       {
         sessionId: result.sessions[0].id,
@@ -769,7 +793,7 @@ describe("Navicat session import", () => {
         attachment: "session",
       },
     ]);
-    expect(result.warnings).toContain('Skipped Navicat connection "Skipped Oracle" because its database type is not supported by Taomni.');
+    expect(result.warnings).not.toContain('Skipped Navicat connection "Billing Oracle" because its database type is not supported by Taomni.');
   });
 
   it("keeps Navicat Pwd_2 local credential recovery as a phase 2 warning", async () => {

--- a/src/lib/sessionImportExport.ts
+++ b/src/lib/sessionImportExport.ts
@@ -64,6 +64,7 @@ const DEFAULT_PORTS: Record<string, number> = {
   MySQL: 3306,
   PostgreSQL: 5432,
   PanWeiDB: 5432,
+  Oracle: 1521,
   SQLServer: 1433,
   StarRocks: 9030,
   ClickHouse: 9000,
@@ -86,6 +87,7 @@ const CSV_PASSWORD_SESSION_TYPES = new Set([
   "MySQL",
   "PostgreSQL",
   "PanWeiDB",
+  "Oracle",
   "SQLServer",
   "StarRocks",
   "ClickHouse",
@@ -887,6 +889,7 @@ function navicatSessionType(value: string): string | null {
   if (/\b(starrocks|starrocksdb|star rocks)\b/.test(key)) return "StarRocks";
   if (/\b(mysql|mariadb|tidb|oceanbase|polardb)\b/.test(key)) return "MySQL";
   if (/\b(panwei|panweidb|open gauss|opengauss)\b/.test(key)) return "PanWeiDB";
+  if (/\b(oracle|oracledb|oci)\b/.test(key)) return "Oracle";
   if (/\b(postgresql|postgres|pgsql)\b/.test(key)) return "PostgreSQL";
   if (/\b(sqlserver|sql server|mssql|azure sql)\b/.test(key)) return "SQLServer";
   if (/\b(clickhouse|click house)\b/.test(key)) return "ClickHouse";
@@ -1171,6 +1174,7 @@ function dbeaverSessionType(value: string): string | null {
   if (/\b(starrocks|starrocksdb|star rocks)\b/.test(key)) return "StarRocks";
   if (/\b(mysql|mariadb|tidb|oceanbase|polardb)\b/.test(key)) return "MySQL";
   if (/\b(panwei|panweidb|open gauss|opengauss)\b/.test(key)) return "PanWeiDB";
+  if (/\b(oracle|oracledb|oci|ojdbc)\b/.test(key)) return "Oracle";
   if (/\b(postgresql|postgres|cockroach|yugabyte)\b/.test(key)) return "PostgreSQL";
   if (/\b(sqlserver|sql server|mssql|jtds|azure sql)\b/.test(key)) return "SQLServer";
   if (/\b(clickhouse|click house|chjdbc)\b/.test(key)) return "ClickHouse";
@@ -1185,6 +1189,9 @@ function parseDbeaverJdbcUrl(rawUrl: string): DbeaverUrlInfo {
   let url = raw.replace(/^jdbc:/i, "");
   if (url.toLowerCase().startsWith("jtds:")) {
     url = url.slice(5);
+  }
+  if (/^oracle:/i.test(url)) {
+    return parseOracleJdbcUrl(url);
   }
   if (/^sqlserver:/i.test(url)) {
     return parseSqlServerJdbcUrl(url);
@@ -1216,6 +1223,41 @@ function parseDbeaverJdbcUrl(rawUrl: string): DbeaverUrlInfo {
   } catch {
     return { driverKey };
   }
+}
+
+function parseOracleJdbcUrl(url: string): DbeaverUrlInfo {
+  const info: DbeaverUrlInfo = { driverKey: "oracle" };
+  const atIndex = url.indexOf("@");
+  if (atIndex < 0) return info;
+  const connect = url.slice(atIndex + 1).trim();
+  if (connect.startsWith("//")) {
+    try {
+      const parsed = new URL(`oracle:${connect}`);
+      const service = parsed.pathname.replace(/^\/+/, "");
+      return {
+        ...info,
+        host: parsed.hostname,
+        port: parsed.port ? sanitizePort(parsed.port, DEFAULT_PORTS.Oracle) : undefined,
+        database: service ? decodeURIComponent(service) : undefined,
+      };
+    } catch {
+      return info;
+    }
+  }
+  if (connect.startsWith("(")) {
+    return { ...info, database: connect };
+  }
+  const parts = connect.split(":");
+  if (parts.length >= 3) {
+    return {
+      ...info,
+      host: parts[0],
+      port: sanitizePort(parts[1], DEFAULT_PORTS.Oracle),
+      database: parts.slice(2).join(":") || undefined,
+    };
+  }
+  const hostPort = parseHostPort(connect);
+  return { ...info, host: hostPort.host, port: hostPort.port };
 }
 
 function parseSqlServerJdbcUrl(url: string): DbeaverUrlInfo {

--- a/src/lib/sessionImportSecrets.ts
+++ b/src/lib/sessionImportSecrets.ts
@@ -9,6 +9,7 @@ const DB_PASSWORD_SESSION_TYPES = new Set([
   "MySQL",
   "PostgreSQL",
   "PanWeiDB",
+  "Oracle",
   "SQLServer",
   "StarRocks",
   "ClickHouse",

--- a/src/lib/sqlDialect.test.ts
+++ b/src/lib/sqlDialect.test.ts
@@ -34,6 +34,7 @@ describe("sqlDialect identifiers", () => {
     expect(quoteIdent("ClickHouse", "x")).toBe("`x`");
     expect(quoteIdent("PostgreSQL", 'a"b')).toBe('"a""b"');
     expect(quoteIdent("PanWeiDB", 'a"b')).toBe('"a""b"');
+    expect(quoteIdent("Oracle", 'a"b')).toBe('"a""b"');
     expect(quoteIdent("Presto", "x")).toBe('"x"');
     expect(quoteIdent("SQLServer", "a]b")).toBe("[a]]b]");
   });
@@ -45,6 +46,9 @@ describe("sqlDialect identifiers", () => {
       '"c"."s"."t"',
     );
     expect(qualifiedName("Presto", { schema: "s", name: "t" })).toBe('"s"."t"');
+    expect(qualifiedName("Oracle", { schema: "APP", name: "ORDERS" })).toBe(
+      '"APP"."ORDERS"',
+    );
     expect(qualifiedName("SQLServer", { schema: "dbo", name: "orders" })).toBe(
       "[dbo].[orders]",
     );
@@ -58,6 +62,7 @@ describe("sqlDialect identifiers", () => {
   it("narrows engine strings", () => {
     expect(asSqlEngine("PostgreSQL")).toBe("PostgreSQL");
     expect(asSqlEngine("PanWeiDB")).toBe("PanWeiDB");
+    expect(asSqlEngine("Oracle")).toBe("Oracle");
     expect(asSqlEngine("SQLServer")).toBe("SQLServer");
     expect(asSqlEngine("StarRocks")).toBe("StarRocks");
     expect(asSqlEngine("nonsense")).toBe("MySQL");
@@ -66,6 +71,7 @@ describe("sqlDialect identifiers", () => {
   it("emits the right set-default statement", () => {
     expect(setDefaultSchemaSql("PostgreSQL", "s")).toBe('SET search_path TO "s"');
     expect(setDefaultSchemaSql("PanWeiDB", "s")).toBe('SET search_path TO "s"');
+    expect(setDefaultSchemaSql("Oracle", "APP")).toBe('ALTER SESSION SET CURRENT_SCHEMA = "APP"');
     expect(setDefaultSchemaSql("Presto", "s", "c")).toBe('USE "c"."s"');
     expect(setDefaultSchemaSql("MySQL", "s")).toBe("USE `s`");
     expect(setDefaultSchemaSql("StarRocks", "s")).toBe("USE `s`");
@@ -78,6 +84,7 @@ describe("sqlDialect capabilities", () => {
     expect(categoriesForEngine("MySQL")).toContain("trigger");
     expect(categoriesForEngine("PostgreSQL")).toContain("sequence");
     expect(categoriesForEngine("PanWeiDB")).toContain("sequence");
+    expect(categoriesForEngine("Oracle")).toContain("trigger");
     expect(categoriesForEngine("SQLServer")).toContain("procedure");
     expect(categoriesForEngine("StarRocks")).toEqual(["table", "view"]);
     expect(categoriesForEngine("ClickHouse")).toContain("dictionary");
@@ -86,11 +93,13 @@ describe("sqlDialect capabilities", () => {
 
   it("gates inline edit / indexes to row stores", () => {
     expect(supportsInlineEdit("MySQL")).toBe(true);
+    expect(supportsInlineEdit("Oracle")).toBe(true);
     expect(supportsInlineEdit("SQLServer")).toBe(true);
     expect(supportsInlineEdit("StarRocks")).toBe(false);
     expect(supportsInlineEdit("ClickHouse")).toBe(false);
     expect(supportsIndexes("PostgreSQL")).toBe(true);
     expect(supportsIndexes("PanWeiDB")).toBe(true);
+    expect(supportsIndexes("Oracle")).toBe(true);
     expect(supportsIndexes("SQLServer")).toBe(true);
     expect(supportsIndexes("StarRocks")).toBe(false);
     expect(supportsIndexes("Presto")).toBe(false);
@@ -102,6 +111,9 @@ describe("sqlDialect capabilities", () => {
     expect(actionMode("PostgreSQL", "renameDatabase")).toBe("execute");
     expect(actionMode("PostgreSQL", "disableTrigger")).toBe("execute");
     expect(actionMode("PanWeiDB", "disableTrigger")).toBe("execute");
+    expect(actionMode("Oracle", "disableTrigger")).toBe("execute");
+    expect(actionMode("Oracle", "dropDatabase")).toBe("editor");
+    expect(actionMode("Oracle", "renameDatabase")).toBe("disabled");
     expect(actionMode("SQLServer", "disableTrigger")).toBe("execute");
     expect(actionMode("SQLServer", "renameDatabase")).toBe("disabled");
     expect(actionMode("MySQL", "disableTrigger")).toBe("disabled");
@@ -122,6 +134,9 @@ describe("sqlDialect DML templates", () => {
     expect(selectStatement("MySQL", t, [], 50)).toContain("SELECT *\nFROM `db`.`orders`");
     expect(selectStatement("SQLServer", t, ["id"], 25)).toContain(
       "SELECT TOP (25) [id]\nFROM [db].[orders];",
+    );
+    expect(selectStatement("Oracle", { schema: "APP", name: "ORDERS" }, ["ID"], 25)).toContain(
+      'SELECT "ID"\nFROM "APP"."ORDERS"\nFETCH FIRST 25 ROWS ONLY;',
     );
   });
 
@@ -197,12 +212,20 @@ describe("sqlDialect destructive builders", () => {
         nullable: false,
       }),
     ).toContain('ALTER TABLE "s"."t" ALTER COLUMN "a" TYPE text;');
+    expect(
+      alterColumnStatement("Oracle", { schema: "APP", name: "ORDERS" }, {
+        oldName: "TOTAL",
+        newName: "AMOUNT",
+        type: "NUMBER(12,2)",
+      }),
+    ).toContain('ALTER TABLE "APP"."ORDERS" RENAME COLUMN "TOTAL" TO "AMOUNT";');
   });
 
   it("database drop/rename and triggers", () => {
     expect(dropDatabaseStatement("MySQL", "db")).toBe("DROP DATABASE `db`;");
     expect(dropDatabaseStatement("PostgreSQL", "s")).toBe('DROP SCHEMA "s";');
     expect(renameDatabaseStatement("ClickHouse", "a", "b")).toBe("RENAME DATABASE `a` TO `b`;");
+    expect(dropDatabaseStatement("Oracle", "APP")).toBe('DROP USER "APP" CASCADE;');
     expect(renameDatabaseStatement("PostgreSQL", "a", "b")).toBe('ALTER SCHEMA "a" RENAME TO "b";');
     expect(dropTriggerStatement("PostgreSQL", "s", "trg", "t")).toBe(
       'DROP TRIGGER "trg" ON "s"."t";',
@@ -210,6 +233,9 @@ describe("sqlDialect destructive builders", () => {
     expect(dropTriggerStatement("MySQL", "db", "trg")).toBe("DROP TRIGGER `db`.`trg`;");
     expect(disableTriggerStatement("PostgreSQL", "s", "trg", "t")).toBe(
       'ALTER TABLE "s"."t" DISABLE TRIGGER "trg";',
+    );
+    expect(disableTriggerStatement("Oracle", "APP", "TRG", "ORDERS")).toBe(
+      'ALTER TRIGGER "APP"."TRG" DISABLE;',
     );
   });
 });
@@ -219,8 +245,14 @@ describe("sqlDialect routine invocation + templates", () => {
     expect(callStatement("MySQL", { schema: "db", name: "p" })).toBe(
       "CALL `db`.`p`(/* params */);",
     );
+    expect(callStatement("Oracle", { schema: "APP", name: "P" })).toContain(
+      '  "APP"."P"(/* params */);',
+    );
     expect(functionCallStatement("PostgreSQL", { schema: "s", name: "f" })).toBe(
       'SELECT "s"."f"(/* params */);',
+    );
+    expect(functionCallStatement("Oracle", { schema: "APP", name: "F" })).toBe(
+      'SELECT "APP"."F"(/* params */) FROM dual;',
     );
   });
 
@@ -228,6 +260,7 @@ describe("sqlDialect routine invocation + templates", () => {
     expect(createTemplate("MySQL", "table", "db")).toContain("CREATE TABLE `db`.`new_table`");
     expect(createTemplate("ClickHouse", "table", "db")).toContain("ENGINE = MergeTree()");
     expect(createTemplate("PostgreSQL", "function", "s")).toContain("LANGUAGE plpgsql");
+    expect(createTemplate("Oracle", "procedure", "APP")).toContain("CREATE OR REPLACE PROCEDURE");
     expect(createTemplate("MySQL", "view", "db")).toContain("CREATE VIEW `db`.`new_view`");
   });
 });

--- a/src/lib/sqlDialect.ts
+++ b/src/lib/sqlDialect.ts
@@ -6,7 +6,7 @@
  * menus, and the query editor all agree on how to talk to each engine.
  */
 
-export type SqlEngine = "MySQL" | "PostgreSQL" | "PanWeiDB" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto";
+export type SqlEngine = "MySQL" | "PostgreSQL" | "PanWeiDB" | "Oracle" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto";
 
 /** Canonical object kinds surfaced as tree folders / context menus. */
 export type ObjectKind =
@@ -42,7 +42,7 @@ export type DialectAction =
   | "renameDatabase"
   | "disableTrigger";
 
-const DOUBLE_QUOTE_ENGINES: SqlEngine[] = ["PostgreSQL", "PanWeiDB", "Presto"];
+const DOUBLE_QUOTE_ENGINES: SqlEngine[] = ["PostgreSQL", "PanWeiDB", "Oracle", "Presto"];
 
 function isPostgresLike(engine: SqlEngine): boolean {
   return engine === "PostgreSQL" || engine === "PanWeiDB";
@@ -50,7 +50,7 @@ function isPostgresLike(engine: SqlEngine): boolean {
 
 /** Narrow an arbitrary engine string to a known `SqlEngine` (else MySQL). */
 export function asSqlEngine(engine: string): SqlEngine {
-  return engine === "PostgreSQL" || engine === "PanWeiDB" || engine === "SQLServer" || engine === "StarRocks" || engine === "ClickHouse" || engine === "Presto"
+  return engine === "PostgreSQL" || engine === "PanWeiDB" || engine === "Oracle" || engine === "SQLServer" || engine === "StarRocks" || engine === "ClickHouse" || engine === "Presto"
     ? engine
     : "MySQL";
 }
@@ -90,6 +90,7 @@ export function setDefaultSchemaSql(
   catalog?: string | null,
 ): string {
   if (isPostgresLike(engine)) return `SET search_path TO ${quoteIdent(engine, schema)}`;
+  if (engine === "Oracle") return `ALTER SESSION SET CURRENT_SCHEMA = ${quoteIdent(engine, schema)}`;
   if (engine === "SQLServer") return `-- SQL Server schemas are selected by using two-part names such as ${quoteIdent(engine, schema)}.${quoteIdent(engine, "table_name")}`;
   if (engine === "Presto" && catalog) {
     return `USE ${quoteIdent(engine, catalog)}.${quoteIdent(engine, schema)}`;
@@ -105,6 +106,7 @@ const ENGINE_CATEGORIES: Record<SqlEngine, ObjectKind[]> = {
   MySQL: ["table", "view", "procedure", "function", "trigger", "event"],
   PostgreSQL: ["table", "view", "materialized_view", "function", "sequence"],
   PanWeiDB: ["table", "view", "materialized_view", "function", "sequence"],
+  Oracle: ["table", "view", "materialized_view", "procedure", "function", "trigger", "sequence"],
   SQLServer: ["table", "view", "procedure", "function", "trigger", "sequence"],
   StarRocks: ["table", "view"],
   ClickHouse: ["table", "view", "materialized_view", "dictionary"],
@@ -118,12 +120,12 @@ export function categoriesForEngine(engine: SqlEngine): ObjectKind[] {
 
 /** Inline grid write-back (UPDATE/DELETE/INSERT) is only safe on row stores. */
 export function supportsInlineEdit(engine: SqlEngine): boolean {
-  return engine === "MySQL" || isPostgresLike(engine) || engine === "SQLServer";
+  return engine === "MySQL" || isPostgresLike(engine) || engine === "Oracle" || engine === "SQLServer";
 }
 
 /** Index introspection is only meaningful for the row-store engines. */
 export function supportsIndexes(engine: SqlEngine): boolean {
-  return engine === "MySQL" || isPostgresLike(engine) || engine === "SQLServer";
+  return engine === "MySQL" || isPostgresLike(engine) || engine === "Oracle" || engine === "SQLServer";
 }
 
 /** ClickHouse mutates rows via `ALTER TABLE … UPDATE/DELETE`, not DML. */
@@ -147,13 +149,17 @@ export function actionMode(engine: SqlEngine, action: DialectAction): ActionMode
     // Connector write-support is unknown; never auto-execute mutations.
     return action === "disableTrigger" ? "disabled" : "editor";
   }
+  if (engine === "Oracle") {
+    if (action === "renameDatabase") return "disabled";
+    if (action === "dropDatabase") return "editor";
+  }
   switch (action) {
     case "renameDatabase":
       // MySQL and StarRocks have no safe RENAME DATABASE; SQL Server has no direct schema rename.
       return engine === "MySQL" || engine === "StarRocks" || engine === "SQLServer" ? "disabled" : "execute";
     case "disableTrigger":
-      // PostgreSQL-compatible engines and SQL Server support per-trigger enable/disable.
-      return isPostgresLike(engine) || engine === "SQLServer" ? "execute" : "disabled";
+      // PostgreSQL-compatible engines, Oracle, and SQL Server support per-trigger enable/disable.
+      return isPostgresLike(engine) || engine === "Oracle" || engine === "SQLServer" ? "execute" : "disabled";
     default:
       return "execute";
   }
@@ -176,6 +182,9 @@ export function selectStatement(
     columns.length > 0 ? columns.map((c) => quoteIdent(engine, c)).join(", ") : "*";
   if (engine === "SQLServer") {
     return `SELECT TOP (${limit}) ${cols}\nFROM ${qualifiedName(engine, target)};`;
+  }
+  if (engine === "Oracle") {
+    return `SELECT ${cols}\nFROM ${qualifiedName(engine, target)}\nFETCH FIRST ${limit} ROWS ONLY;`;
   }
   return `SELECT ${cols}\nFROM ${qualifiedName(engine, target)}\nLIMIT ${limit};`;
 }
@@ -266,7 +275,7 @@ export function renameTableStatement(
   if (engine === "SQLServer") {
     return `EXEC sp_rename ${sqlLiteral(oldName)}, ${sqlLiteral(newName)};`;
   }
-  // PostgreSQL / Presto: rename target is unqualified.
+  // PostgreSQL / Oracle / Presto: rename target is unqualified.
   return `ALTER TABLE ${oldName} RENAME TO ${quoteIdent(engine, newName)};`;
 }
 
@@ -281,7 +290,7 @@ export function dropStatement(
     case "view":
       return `DROP VIEW ${obj};`;
     case "materialized_view":
-      return isPostgresLike(engine)
+      return isPostgresLike(engine) || engine === "Oracle"
         ? `DROP MATERIALIZED VIEW ${obj};`
         : `DROP VIEW ${obj};`;
     case "procedure":
@@ -349,6 +358,13 @@ export function alterColumnStatement(
     }
     return lines.join("\n");
   }
+  if (engine === "Oracle") {
+    const lines = [`ALTER TABLE ${tbl} MODIFY (${oldCol} ${change.type}${nullSuffix});`];
+    if (change.newName && change.newName !== change.oldName) {
+      lines.push(`ALTER TABLE ${tbl} RENAME COLUMN ${oldCol} TO ${newCol};`);
+    }
+    return lines.join("\n");
+  }
   // MySQL / StarRocks / ClickHouse: CHANGE renames, MODIFY keeps the name.
   if ((engine === "MySQL" || engine === "StarRocks") && change.newName && change.newName !== change.oldName) {
     return `ALTER TABLE ${tbl} CHANGE COLUMN ${oldCol} ${newCol} ${change.type}${nullSuffix};`;
@@ -372,12 +388,13 @@ export function dropIndexStatement(
   if (engine === "SQLServer") {
     return `DROP INDEX ${quoteIdent(engine, index)} ON ${tbl};`;
   }
-  // PostgreSQL: indexes live in the schema namespace.
+  // PostgreSQL / Oracle: indexes live in the schema namespace.
   return `DROP INDEX ${qualifiedName(engine, { schema, name: index })};`;
 }
 
 export function dropDatabaseStatement(engine: SqlEngine, db: string): string {
   const name = quoteIdent(engine, db);
+  if (engine === "Oracle") return `DROP USER ${name} CASCADE;`;
   return isPostgresLike(engine) || engine === "Presto" || engine === "SQLServer"
     ? `DROP SCHEMA ${name};`
     : `DROP DATABASE ${name};`;
@@ -391,6 +408,7 @@ export function renameDatabaseStatement(
   const from = quoteIdent(engine, db);
   const to = quoteIdent(engine, newName);
   if (engine === "ClickHouse") return `RENAME DATABASE ${from} TO ${to};`;
+  if (engine === "Oracle") return `-- Oracle schemas are users and cannot be renamed directly. Create ${to}, transfer objects from ${from}, then drop ${from}.`;
   if (engine === "SQLServer") return `-- SQL Server does not support direct schema rename. Create ${to}, transfer objects from ${from}, then drop ${from}.`;
   // PostgreSQL / Presto operate on schemas.
   return `ALTER SCHEMA ${from} RENAME TO ${to};`;
@@ -423,6 +441,9 @@ export function disableTriggerStatement(
   if (engine === "SQLServer") {
     return `DISABLE TRIGGER ${quoteIdent(engine, trigger)} ON ${qualifiedName(engine, { schema, name: table })};`;
   }
+  if (engine === "Oracle") {
+    return `ALTER TRIGGER ${qualifiedName(engine, { schema, name: trigger })} DISABLE;`;
+  }
   return `ALTER TABLE ${qualifiedName(engine, { schema, name: table })} DISABLE TRIGGER ${quoteIdent(
     engine,
     trigger,
@@ -436,11 +457,13 @@ export function disableTriggerStatement(
 /** `CALL <proc>(...)` for stored procedures. */
 export function callStatement(engine: SqlEngine, target: ObjectTarget): string {
   if (engine === "SQLServer") return `EXEC ${qualifiedName(engine, target)} /* params */;`;
+  if (engine === "Oracle") return `BEGIN\n  ${qualifiedName(engine, target)}(/* params */);\nEND;`;
   return `CALL ${qualifiedName(engine, target)}(/* params */);`;
 }
 
 /** `SELECT <fn>(...)` to invoke / test a function. */
 export function functionCallStatement(engine: SqlEngine, target: ObjectTarget): string {
+  if (engine === "Oracle") return `SELECT ${qualifiedName(engine, target)}(/* params */) FROM dual;`;
   return `SELECT ${qualifiedName(engine, target)}(/* params */);`;
 }
 
@@ -465,6 +488,9 @@ export function createTemplate(
       if (engine === "SQLServer") {
         return `CREATE TABLE ${q("new_table")} (\n  [id] int IDENTITY(1,1) NOT NULL PRIMARY KEY\n);`;
       }
+      if (engine === "Oracle") {
+        return `CREATE TABLE ${q("new_table")} (\n  "id" NUMBER GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY\n);`;
+      }
       return `CREATE TABLE ${q("new_table")} (\n  \`id\` INT NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (\`id\`)\n);`;
     case "view":
     case "materialized_view": {
@@ -478,6 +504,9 @@ export function createTemplate(
       if (engine === "SQLServer") {
         return `CREATE OR ALTER PROCEDURE ${q("new_procedure")}\nAS\nBEGIN\n  SET NOCOUNT ON;\n  -- body\nEND;`;
       }
+      if (engine === "Oracle") {
+        return `CREATE OR REPLACE PROCEDURE ${q("new_procedure")} AS\nBEGIN\n  -- body\n  NULL;\nEND;`;
+      }
       return `DELIMITER //\nCREATE PROCEDURE ${q("new_procedure")}()\nBEGIN\n  -- body\nEND //\nDELIMITER ;`;
     case "function":
       if (isPostgresLike(engine)) {
@@ -486,6 +515,9 @@ export function createTemplate(
       if (engine === "SQLServer") {
         return `CREATE OR ALTER FUNCTION ${q("new_function")}()\nRETURNS int\nAS\nBEGIN\n  RETURN 0;\nEND;`;
       }
+      if (engine === "Oracle") {
+        return `CREATE OR REPLACE FUNCTION ${q("new_function")}\nRETURN NUMBER AS\nBEGIN\n  RETURN 0;\nEND;`;
+      }
       return `DELIMITER //\nCREATE FUNCTION ${q("new_function")}()\nRETURNS INT DETERMINISTIC\nBEGIN\n  RETURN 0;\nEND //\nDELIMITER ;`;
     case "trigger":
       if (isPostgresLike(engine)) {
@@ -493,6 +525,9 @@ export function createTemplate(
       }
       if (engine === "SQLServer") {
         return `CREATE OR ALTER TRIGGER ${q("new_trigger")}\nON ${q("table_name")}\nAFTER INSERT\nAS\nBEGIN\n  SET NOCOUNT ON;\n  -- body\nEND;`;
+      }
+      if (engine === "Oracle") {
+        return `CREATE OR REPLACE TRIGGER ${q("new_trigger")}\nBEFORE INSERT ON ${q("table_name")}\nFOR EACH ROW\nBEGIN\n  -- body\n  NULL;\nEND;`;
       }
       return `CREATE TRIGGER ${q("new_trigger")}\nBEFORE INSERT ON ${q("table_name")}\nFOR EACH ROW\nBEGIN\n  -- body\nEND;`;
     case "event":

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -146,14 +146,14 @@ export interface VncConnectInfo {
 
 /**
  * Connection parameters for a database client tab (MySQL / PostgreSQL /
- * PanWeiDB / SQL Server / StarRocks / ClickHouse / Presto / Redis). Mirrors the Rust `DbConfig` (camelCase). The password
+ * PanWeiDB / Oracle / SQL Server / StarRocks / ClickHouse / Presto / Redis). Mirrors the Rust `DbConfig` (camelCase). The password
  * may be a `vault:<id>` reference resolved server-side.
  */
 export interface DbConnectInfo {
   sessionId: string;
   /** Stable saved-session id used for restoring query workspace files. */
   workspaceSessionId?: string;
-  engine: "MySQL" | "PostgreSQL" | "PanWeiDB" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto" | "Redis";
+  engine: "MySQL" | "PostgreSQL" | "PanWeiDB" | "Oracle" | "SQLServer" | "StarRocks" | "ClickHouse" | "Presto" | "Redis";
   host: string;
   port: number;
   username?: string | null;


### PR DESCRIPTION
Add Oracle as a first-class database engine across the Rust backend, session model, React connection UI, SQL dialect helpers, query result SQL generation, import/export detection, and password handling.

Wire Oracle into the AI chat and Claude Code MCP SQL routing so list, describe, execute, object metadata, DDL, and table statistics flows match the MySQL-backed database session path.

Implement the Oracle backend with rust-oracle/ODPI-C, including connection and ping, synchronous execution wrapped in spawn_blocking, streamed query events, schema/table/column/index browsing, object listing, DBMS_METADATA DDL retrieval, and catalog-driven table statistics.

Add focused coverage for Oracle SQL dialect behavior, Oracle session import/export from Navicat and DBeaver JDBC URLs, and SessionEditor Oracle defaults.

Verification: pnpm test src/lib/sqlDialect.test.ts src/lib/sessionImportExport.test.ts src/components/session/SessionEditor.test.tsx; pnpm build; CARGO_TARGET_DIR=/tmp/taomni-cargo-check CARGO_INCREMENTAL=0 cargo check --manifest-path src-tauri/Cargo.toml --no-default-features.