### PR TITLE
fix(ui): preserve chat and settings tab state

### DIFF
--- a/src/components/chat/ChatDrawer.test.tsx
+++ b/src/components/chat/ChatDrawer.test.tsx
@@ -146,6 +146,7 @@ describe("ChatDrawer provider and echo controls", () => {
       drawerPosition: "right",
       drawerPinned: true,
       pendingComposerText: "",
+      composerDrafts: {},
     });
   });
 
@@ -305,6 +306,7 @@ describe("ChatDrawer layout resizing", () => {
       drawerHeight: 420,
       drawerPinned: false,
       pendingComposerText: "",
+      composerDrafts: {},
     });
   });
 

--- a/src/components/chat/ChatDrawer.tsx
+++ b/src/components/chat/ChatDrawer.tsx
@@ -576,6 +576,11 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
     : currentMode === "video"
       ? t("chat.videoPromptPlaceholder")
       : undefined;
+  const composerDraftKey = activeThreadId
+    ? `thread:${activeThreadId}`
+    : (drawerTabId ?? activeChatTabId)
+      ? `tab:${drawerTabId ?? activeChatTabId}`
+      : null;
   const sendingLabel = currentMode === "image"
     ? t("chat.imageGenerating")
     : currentMode === "video"
@@ -1027,6 +1032,8 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
 
         {/* Composer */}
         <Composer
+          key={composerDraftKey ?? "global"}
+          draftKey={composerDraftKey}
           onSend={handleSend}
           sending={sending}
           disabled={false}

--- a/src/components/chat/Composer.test.tsx
+++ b/src/components/chat/Composer.test.tsx
@@ -34,6 +34,7 @@ describe("Composer attachments", () => {
     dialogOpenMock.mockReset();
     useChatStore.setState({
       pendingComposerText: "",
+      composerDrafts: {},
       consumePendingComposerText: () => "",
     });
     invokeMock.mockImplementation((command: string, args: { paths?: string[] }) => {
@@ -87,6 +88,31 @@ describe("Composer attachments", () => {
     fireEvent.click(sendButton);
     fireEvent.keyDown(textarea, { key: "Enter", ctrlKey: true });
     expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("restores an unsent draft for the same draft key", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    const { unmount } = render(<Composer draftKey="thread:draft-1" onSend={onSend} sending={false} />);
+
+    const textarea = screen.getByPlaceholderText(/Type a message/) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "unfinished question" } });
+
+    await waitFor(() => {
+      expect(useChatStore.getState().composerDrafts["thread:draft-1"]?.text).toBe("unfinished question");
+    });
+
+    unmount();
+    render(<Composer draftKey="thread:draft-1" onSend={onSend} sending={false} />);
+
+    const restored = screen.getByPlaceholderText(/Type a message/) as HTMLTextAreaElement;
+    expect(restored.value).toBe("unfinished question");
+
+    fireEvent.click(screen.getByTitle("Send (Ctrl+Enter)"));
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith("unfinished question", undefined, []));
+    await waitFor(() => {
+      expect(useChatStore.getState().composerDrafts["thread:draft-1"]).toBeUndefined();
+    });
   });
 
   it("attaches OS-dropped file paths to the composer", async () => {

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -35,6 +35,7 @@ interface ComposerProps {
   disabled?: boolean;
   attachmentsEnabled?: boolean;
   placeholder?: string;
+  draftKey?: string | null;
   /**
    * Optional resolver: turns AttachmentRefs into LLM-ready text before send.
    * Currently only `terminal` refs surface to the existing terminal_context
@@ -54,11 +55,15 @@ export function Composer({
   disabled,
   attachmentsEnabled = true,
   placeholder,
+  draftKey,
   resolveTerminalContext,
 }: ComposerProps) {
   const t = useT();
-  const [text, setText] = useState("");
-  const [selectedAttachments, setSelectedAttachments] = useState<ChatAttachment[]>([]);
+  const initialDraft = draftKey ? useChatStore.getState().composerDrafts[draftKey] : undefined;
+  const [text, setText] = useState(() => initialDraft?.text ?? "");
+  const [selectedAttachments, setSelectedAttachments] = useState<ChatAttachment[]>(
+    () => initialDraft?.selectedAttachments ?? [],
+  );
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [draggingFiles, setDraggingFiles] = useState(false);
   const [composerHeight, setComposerHeight] = useState(readComposerHeight);
@@ -66,7 +71,18 @@ export function Composer({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const pending = useChatStore((s) => s.pendingComposerText);
   const consumePending = useChatStore((s) => s.consumePendingComposerText);
+  const setComposerDraft = useChatStore((s) => s.setComposerDraft);
+  const clearComposerDraft = useChatStore((s) => s.clearComposerDraft);
   const draftDisabled = disabled === true;
+
+  useEffect(() => {
+    if (!draftKey) return;
+    if (text.length > 0 || selectedAttachments.length > 0) {
+      setComposerDraft(draftKey, { text, selectedAttachments });
+    } else {
+      clearComposerDraft(draftKey);
+    }
+  }, [clearComposerDraft, draftKey, selectedAttachments, setComposerDraft, text]);
 
   // Pick up text staged by the SelectionToolbar's "Send to AI".
   useEffect(() => {

--- a/src/layouts/MainLayout.test.tsx
+++ b/src/layouts/MainLayout.test.tsx
@@ -538,6 +538,39 @@ describe("MainLayout attached SFTP sidebar", () => {
     expect(useAppStore.getState().activeTabId).toBe("settings");
   });
 
+  it("keeps the settings tab mounted when switching away", async () => {
+    useAppStore.setState({
+      tabs: [
+        ...useAppStore.getState().tabs,
+        { id: "settings", type: "settings", title: "Settings", closable: true },
+      ],
+      activeTabId: "settings",
+    });
+
+    render(<MainLayout />);
+
+    const wrapper = screen.getByTestId("settings-tab-panel") as HTMLElement;
+    const panel = screen.getByTestId("settings-panel");
+    expect(wrapper.style.display).toBe("block");
+
+    act(() => {
+      useAppStore.getState().setActiveTab("ssh-tab");
+    });
+
+    await waitFor(() => {
+      expect(wrapper.style.display).toBe("none");
+    });
+    expect(panel).toBeInTheDocument();
+
+    act(() => {
+      useAppStore.getState().setActiveTab("settings");
+    });
+
+    await waitFor(() => {
+      expect(wrapper.style.display).toBe("block");
+    });
+  });
+
   it("passes a Git rail action to the sidebar for the active local terminal", () => {
     useAppStore.setState({
       tabs: [{ id: "local-tab", type: "terminal", title: "Local terminal", closable: true }],

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -2724,6 +2724,7 @@ export function MainLayout() {
 
   const terminalTabs = tabs.filter((t) => t.type === "terminal");
   const sftpTabs = tabs.filter((t) => t.type === "sftp" && t.sftp);
+  const settingsTabs = tabs.filter((t) => t.type === "settings");
   const gitTabs = tabs.filter((t) => t.type === "git" && t.git);
   const codeWorkspaceTabs = tabs.filter((t) => t.type === "code-workspace" && t.codeWorkspace);
   const vncTabs = tabs.filter((t) => t.type === "vnc" && t.vnc);
@@ -3343,7 +3344,19 @@ export function MainLayout() {
                   );
                 })}
 
-                {activeTab?.type === "settings" && <SettingsPanel />}
+                {settingsTabs.map((tab) => {
+                  const isActive = activeTabId === tab.id;
+                  return (
+                    <div
+                      key={tab.id}
+                      data-testid="settings-tab-panel"
+                      className="absolute inset-0"
+                      style={{ display: isActive ? "block" : "none" }}
+                    >
+                      <SettingsPanel />
+                    </div>
+                  );
+                })}
 
                 {/* Git tabs stay mounted so repository views, loaded logs, and
                     scroll position survive switching to another app tab. */}

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -136,6 +136,7 @@ describe("chatStore new thread provider selection", () => {
       drawerPosition: "right",
       drawerPinned: true,
       pendingComposerText: "",
+      composerDrafts: {},
     });
     invokeMock.mockImplementation((command: string, args: { providerId?: string | null; linkedSessionId?: string | null; mode?: string | null }) => {
       if (command !== "chat_new_thread") throw new Error(`unexpected command: ${command}`);
@@ -238,6 +239,7 @@ describe("chatStore media generation", () => {
       drawerPosition: "right",
       drawerPinned: true,
       pendingComposerText: "",
+      composerDrafts: {},
     });
     invokeMock.mockImplementation((command: string) => {
       if (command !== "chat_generate_media") throw new Error(`unexpected command: ${command}`);
@@ -328,6 +330,7 @@ describe("chatStore DB MCP context bridge", () => {
       drawerPosition: "right",
       drawerPinned: true,
       pendingComposerText: "",
+      composerDrafts: {},
     });
     useAppStore.setState({
       tabs: [
@@ -425,6 +428,7 @@ describe("chatStore code workspace context bridge", () => {
       drawerPosition: "right",
       drawerPinned: true,
       pendingComposerText: "",
+      composerDrafts: {},
     });
     useAppStore.setState({
       tabs: [
@@ -508,6 +512,7 @@ describe("chatStore drawer lifecycle", () => {
       drawerPosition: "right",
       drawerPinned: true,
       pendingComposerText: "",
+      composerDrafts: {},
     });
   });
 

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -59,6 +59,11 @@ export interface ChatMessage {
   attachments?: ChatAttachment[];
 }
 
+export interface ChatComposerDraft {
+  text: string;
+  selectedAttachments: ChatAttachment[];
+}
+
 interface ChatGenerateMediaResponse {
   user_message: ChatMessage;
   assistant_message: ChatMessage;
@@ -272,6 +277,9 @@ interface ChatStore {
   /// Text the Composer should pick up next render (e.g. `@selection ...`).
   /// Cleared by the Composer once consumed.
   pendingComposerText: string;
+  /// Unsent composer drafts keyed by thread/tab scope. Kept in memory so
+  /// switching app tabs does not discard a half-written prompt.
+  composerDrafts: Record<string, ChatComposerDraft>;
 
   loadThreads: () => Promise<void>;
   newThread: (providerId?: string, linkedSessionId?: string, mode?: ChatThreadMode) => Promise<ChatThread>;
@@ -289,6 +297,8 @@ interface ChatStore {
   /// composer. Used by the Selection toolbar's "Send to AI" action.
   attachToComposer: (text: string) => Promise<void>;
   consumePendingComposerText: () => string;
+  setComposerDraft: (key: string, draft: ChatComposerDraft) => void;
+  clearComposerDraft: (key: string) => void;
   /// Open the drawer, create a fresh thread, and auto-send "请解释这段输出".
   /// Used by the Selection toolbar's "Explain" action.
   explainSelection: (text: string) => Promise<void>;
@@ -405,6 +415,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   drawerPinned: initialDrawerLayoutPrefs.pinned,
   ribbonOffsetRatio: initialDrawerLayoutPrefs.ribbonOffsetRatio,
   pendingComposerText: "",
+  composerDrafts: {},
 
   loadThreads: async () => {
     try {
@@ -448,6 +459,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       messages: Object.fromEntries(Object.entries(s.messages).filter(([k]) => k !== threadId)),
       activeThreadIdByTabId: Object.fromEntries(
         Object.entries(s.activeThreadIdByTabId).filter(([, id]) => id !== threadId),
+      ),
+      composerDrafts: Object.fromEntries(
+        Object.entries(s.composerDrafts).filter(([key]) => key !== `thread:${threadId}`),
       ),
       ...(active ? { drawerScope: null, drawerTabId: null } : {}),
     }));
@@ -968,6 +982,24 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     const text = get().pendingComposerText;
     if (text) set({ pendingComposerText: "" });
     return text;
+  },
+
+  setComposerDraft: (key: string, draft: ChatComposerDraft) => {
+    set((s) => ({
+      composerDrafts: {
+        ...s.composerDrafts,
+        [key]: draft,
+      },
+    }));
+  },
+
+  clearComposerDraft: (key: string) => {
+    set((s) => {
+      if (!(key in s.composerDrafts)) return s;
+      const next = { ...s.composerDrafts };
+      delete next[key];
+      return { composerDrafts: next };
+    });
   },
 
   explainSelection: async (text: string) => {


### PR DESCRIPTION
Keep AI chat composer drafts in the chat store, keyed by the active thread or tab, so unsent text and selected attachments survive drawer remounts caused by app tab switches. Clear the draft after a successful send and when the owning thread is deleted to avoid stale prompts.

Render settings tabs as persistent hidden panels instead of conditionally mounting only the active settings view. This keeps scroll position and page-local state intact when the user switches away from Settings and returns.

Add regression coverage for composer draft restoration across unmount/remount and for settings tab persistence across active-tab changes. Update chat store test setup to reset the new composer draft map explicitly.

Validation: pnpm test -- --run src/components/chat/Composer.test.tsx src/components/chat/ChatDrawer.test.tsx src/stores/chatStore.test.ts src/layouts/MainLayout.test.tsx; pnpm build; git diff --check.