### PR TITLE
fix(git): show full commit messages in log

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1,6 +1,6 @@
 use crate::state::AppState;
 use crate::vault::Vault;
-use base64::{engine::general_purpose::STANDARD as B64, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD as B64};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -96,6 +96,7 @@ pub struct GitLogEntry {
     pub author_email: String,
     pub date: String,
     pub subject: String,
+    pub body: String,
     pub refs: Vec<String>,
 }
 
@@ -1332,7 +1333,7 @@ fn list_log(root: &Path, filter: &GitLogFilter) -> Result<Vec<GitLogEntry>, Stri
     let mut args: Vec<String> = vec![
         "log".into(),
         "--date=iso-strict".into(),
-        "--pretty=format:%H%x1f%h%x1f%P%x1f%an%x1f%ae%x1f%ad%x1f%s%x1f%D".into(),
+        "--pretty=format:%x1e%H%x1f%h%x1f%P%x1f%an%x1f%ae%x1f%ad%x1f%s%x1f%D%x1f%b".into(),
         "-n".into(),
         limit,
     ];
@@ -1367,9 +1368,17 @@ fn list_log(root: &Path, filter: &GitLogFilter) -> Result<Vec<GitLogEntry>, Stri
         args.push(path);
     }
     let raw = run_git_strings(Some(root), args)?;
+    Ok(parse_log_entries(&raw))
+}
+
+fn parse_log_entries(raw: &str) -> Vec<GitLogEntry> {
     let mut entries = Vec::new();
-    for line in raw.lines() {
-        let parts: Vec<_> = line.split('\x1f').collect();
+    for record in raw.split('\x1e') {
+        let record = record.trim_start_matches('\n').trim_end_matches('\n');
+        if record.is_empty() {
+            continue;
+        }
+        let parts: Vec<_> = record.splitn(9, '\x1f').collect();
         if parts.len() < 7 {
             continue;
         }
@@ -1385,9 +1394,14 @@ fn list_log(root: &Path, filter: &GitLogFilter) -> Result<Vec<GitLogEntry>, Stri
             date: parts[5].to_string(),
             subject: parts[6].to_string(),
             refs: parts.get(7).map(|d| parse_refs(d)).unwrap_or_default(),
+            body: parts.get(8).map(|d| trim_log_body(d)).unwrap_or_default(),
         });
     }
-    Ok(entries)
+    entries
+}
+
+fn trim_log_body(body: &str) -> String {
+    body.trim_matches(|c| c == '\n' || c == '\r').to_string()
 }
 
 /// Parse a `%D` decoration string ("HEAD -> main, origin/main, tag: v1") into
@@ -1891,11 +1905,7 @@ fn git_path(root: &Path, name: &str) -> Option<PathBuf> {
         .and_then(|s| non_empty_string(&s))
         .map(|p| {
             let pb = PathBuf::from(&p);
-            if pb.is_absolute() {
-                pb
-            } else {
-                root.join(pb)
-            }
+            if pb.is_absolute() { pb } else { root.join(pb) }
         })
 }
 
@@ -2357,6 +2367,33 @@ mod tests {
             ]
         );
         assert!(parse_refs("").is_empty());
+    }
+
+    #[test]
+    fn parses_log_entries_with_multiline_body() {
+        let raw = concat!(
+            "\x1eabcdef0123456789\x1fabcdef0\x1f1234567 7654321\x1fAda\x1fada@example.test\x1f",
+            "2026-07-04T10:00:00Z\x1ffeat: show commit message\x1fHEAD -> main, tag: v1.0\x1f",
+            "Body line one\n\nBody line two\n",
+            "\x1e1234567890abcdef\x1f1234567\x1f\x1fBen\x1fben@example.test\x1f",
+            "2026-07-04T11:00:00Z\x1ffix: compact row\x1f\x1f",
+        );
+
+        let entries = parse_log_entries(raw);
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].subject, "feat: show commit message");
+        assert_eq!(entries[0].body, "Body line one\n\nBody line two");
+        assert_eq!(
+            entries[0].refs,
+            vec!["main".to_string(), "v1.0".to_string()]
+        );
+        assert_eq!(
+            entries[0].parents,
+            vec!["1234567".to_string(), "7654321".to_string()]
+        );
+        assert_eq!(entries[1].subject, "fix: compact row");
+        assert!(entries[1].body.is_empty());
     }
 
     #[test]

--- a/src/components/git/CommitLog.tsx
+++ b/src/components/git/CommitLog.tsx
@@ -12,7 +12,7 @@ import {
 import { buildGraph, graphColor, type GraphRow } from "../../lib/gitGraph";
 import { DiffViewer } from "./DiffViewer";
 
-const ROW_H = 44;
+const ROW_H = 88;
 const LANE_W = 14;
 const AUTO_PREVIEW_FILE_LIMIT = 300;
 
@@ -205,7 +205,8 @@ export function CommitLog({ repoRoot, headOid, busy, onContextMenu, pathFilter, 
                 role="button"
                 tabIndex={0}
                 style={{ height: ROW_H }}
-                className={`w-full flex items-center gap-2 pr-2 cursor-pointer border-b border-[var(--taomni-divider)] ${
+                title={commitTooltip(entry)}
+                className={`w-full flex items-start gap-2 pr-2 overflow-hidden cursor-pointer border-b border-[var(--taomni-divider)] ${
                   selectedOid === entry.oid ? "bg-[var(--taomni-hover)]" : "hover:bg-[var(--taomni-hover)]"
                 }`}
                 onClick={() => setSelectedOid(entry.oid)}
@@ -216,19 +217,24 @@ export function CommitLog({ repoRoot, headOid, busy, onContextMenu, pathFilter, 
                 }}
               >
                 <GraphCell row={graph[i]} maxWidth={maxWidth} />
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-1 min-w-0">
+                <div className="min-w-0 flex-1 py-2">
+                  <div className="flex items-start gap-1 min-w-0">
                     {entry.refs.map((ref) => (
                       <span
                         key={ref}
-                        className="shrink-0 text-[10px] px-1 rounded bg-[var(--taomni-accent)]/15 text-[var(--taomni-accent)] border border-[var(--taomni-accent)]/30"
+                        className="shrink-0 mt-0.5 text-[10px] px-1 rounded bg-[var(--taomni-accent)]/15 text-[var(--taomni-accent)] border border-[var(--taomni-accent)]/30"
                       >
                         {ref}
                       </span>
                     ))}
-                    <span className="truncate text-[12px]">{entry.subject}</span>
+                    <span className="min-w-0 text-[12px] leading-4 font-medium line-clamp-2">{entry.subject}</span>
                   </div>
-                  <div className="text-[11px] text-[var(--taomni-text-muted)] truncate">
+                  {commitBodyPreview(entry) && (
+                    <div className="mt-0.5 text-[11px] leading-4 text-[var(--taomni-text-muted)] line-clamp-1">
+                      {commitBodyPreview(entry)}
+                    </div>
+                  )}
+                  <div className="mt-1 text-[11px] text-[var(--taomni-text-muted)] truncate">
                     <span className="taomni-mono text-[var(--taomni-accent)]">{entry.shortOid}</span> · {entry.authorName} · {formatDate(entry.date)}
                   </div>
                 </div>
@@ -254,6 +260,21 @@ export function CommitLog({ repoRoot, headOid, busy, onContextMenu, pathFilter, 
             <div className="h-8 shrink-0 flex items-center px-3 border-b border-[var(--taomni-divider)] text-[12px] font-semibold">
               {selected ? `${selected.shortOid} · ${files.length} file(s)` : "Commit"}
             </div>
+            {selected && (
+              <div className="shrink-0 px-3 py-2 border-b border-[var(--taomni-divider)]">
+                <div className="text-[12px] leading-5 font-semibold text-[var(--taomni-text)] whitespace-pre-wrap">
+                  {selected.subject}
+                </div>
+                {selected.body.trim() && (
+                  <div className="mt-1 max-h-28 overflow-auto whitespace-pre-wrap text-[11px] leading-4 text-[var(--taomni-text-muted)]">
+                    {selected.body.trim()}
+                  </div>
+                )}
+                <div className="mt-1 text-[11px] text-[var(--taomni-text-muted)] truncate">
+                  {selected.authorName} &lt;{selected.authorEmail}&gt; · {formatDate(selected.date)}
+                </div>
+              </div>
+            )}
             <div className="flex-1 min-h-0 overflow-auto">
               {files.length === 0 ? (
                 <div className="h-full min-h-16 flex items-center justify-center text-[12px] text-[var(--taomni-text-muted)]">
@@ -304,9 +325,16 @@ function statusColor(status: string): string {
   }
 }
 
+function commitBodyPreview(entry: GitLogEntry): string {
+  return entry.body.trim().replace(/\s+/g, " ");
+}
+
+function commitTooltip(entry: GitLogEntry): string {
+  const message = [entry.subject, entry.body.trim()].filter(Boolean).join("\n\n");
+  return `${message}\n\n${entry.shortOid} · ${entry.authorName} · ${formatDate(entry.date)}`;
+}
+
 function formatDate(value: string): string {
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 }
-
-

--- a/src/components/git/GitPanel.test.tsx
+++ b/src/components/git/GitPanel.test.tsx
@@ -156,6 +156,7 @@ describe("GitPanel", () => {
         authorEmail: "ada@example.com",
         date: "2026-06-30T10:00:00Z",
         subject: "Initial commit",
+        body: "",
         refs: [],
       },
     ]);

--- a/src/components/git/GitPanel.tsx
+++ b/src/components/git/GitPanel.tsx
@@ -1372,6 +1372,7 @@ function commitMenuItems(
   const copy = (text: string) => {
     void navigator.clipboard?.writeText(text).catch(() => {});
   };
+  const message = [entry.subject, entry.body.trim()].filter(Boolean).join("\n\n");
   return [
     { label: "Cherry-pick", onClick: () => handlers.onCherryPick(entry) },
     { label: "Revert", onClick: () => handlers.onRevert(entry) },
@@ -1387,6 +1388,7 @@ function commitMenuItems(
     { label: "", separator: true },
     { label: "Copy revision hash", onClick: () => copy(entry.oid) },
     { label: "Copy subject", onClick: () => copy(entry.subject) },
+    { label: "Copy message", onClick: () => copy(message) },
   ];
 }
 

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -88,6 +88,7 @@ export interface GitLogEntry {
   authorEmail: string;
   date: string;
   subject: string;
+  body: string;
   refs: string[];
 }
 

--- a/src/lib/gitGraph.test.ts
+++ b/src/lib/gitGraph.test.ts
@@ -11,6 +11,7 @@ function entry(oid: string, parents: string[]): GitLogEntry {
     authorEmail: "t@e",
     date: "",
     subject: oid,
+    body: "",
     refs: [],
   };
 }


### PR DESCRIPTION
Expand the Git log entry model to include commit body text from git log, using record and field separators so multiline messages do not break parsing.

Update the log list to show longer subjects, a body preview, and a full selected-commit message panel while preserving graph layout and diff preview behavior.

Add copy-message support to the commit context menu and cover multiline log parsing plus updated TypeScript test fixtures.