### PR TITLE
fix(session): preserve localized SSH tunnel network settings

### DIFF
--- a/src/components/session/SessionEditor.test.tsx
+++ b/src/components/session/SessionEditor.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionEditor } from "./SessionEditor";
+import { setLocale } from "../../lib/i18n";
 
 const ipcMocks = vi.hoisted(() => ({
   testSshConnection: vi.fn(),
@@ -53,6 +54,7 @@ function checkboxInLabel(text: string): HTMLInputElement {
 
 describe("SessionEditor SSH settings tabs", { timeout: 15_000 }, () => {
   beforeEach(() => {
+    setLocale("en");
     Object.values(ipcMocks).forEach((mock) => {
       if (typeof mock === "function" && "mockReset" in mock) {
         (mock as any).mockReset();
@@ -85,6 +87,7 @@ describe("SessionEditor SSH settings tabs", { timeout: 15_000 }, () => {
   });
 
   afterEach(() => {
+    setLocale("en");
     cleanup();
   });
 
@@ -298,6 +301,31 @@ describe("SessionEditor SSH settings tabs", { timeout: 15_000 }, () => {
     expect(screen.getByDisplayValue("127.0.0.1:5432")).toBeInTheDocument();
     expect(screen.getByDisplayValue("db.lan:5432")).toBeInTheDocument();
   }, 10_000);
+
+  it("persists localized Local SSH tunnel selection as a stable proxy kind", async () => {
+    setLocale("zh-CN");
+    const user = userEvent.setup();
+    const { onClose } = renderEditor();
+
+    await user.type(screen.getByLabelText("远程主机"), "app.internal");
+    await user.click(screen.getByRole("button", { name: "网络设置" }));
+
+    const proxySelect = screen.getByDisplayValue("无 — 直连");
+    await user.selectOptions(proxySelect, screen.getByRole("option", { name: "本地 SSH 隧道" }));
+    await user.type(screen.getByLabelText("跳板机主机"), "bastion.internal");
+    await user.type(screen.getByLabelText("跳板机用户"), "ops");
+
+    await user.click(screen.getByTestId("session-save"));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    const saved = ipcMocks.saveSession.mock.calls[0][0];
+    const opts = JSON.parse(saved.options_json);
+    expect(opts.networkSettings).toMatchObject({
+      proxyKind: "ssh-tunnel",
+      jumpHost: "bastion.internal",
+      jumpUser: "ops",
+    });
+  });
 
   it("forwards proxy/jump network settings when testing a DB connection", async () => {
     const user = userEvent.setup();

--- a/src/components/session/SessionEditor.tsx
+++ b/src/components/session/SessionEditor.tsx
@@ -51,12 +51,10 @@ import type { DbConnectInfo, HBaseConnectInfo } from "../../types";
 import { getAppPlatform } from "../../lib/runtime";
 import {
   getSessionNetworkSettings,
-  ipKindToLabel,
-  ipLabelToKind,
-  proxyKindToLabel,
-  proxyLabelToKind,
   toNetworkSettingsPayload,
+  type IpVersion,
   type NetworkSettings as NetworkSettingsValue,
+  type ProxyKind,
 } from "../../lib/networkSettings";
 import { parseUserHostPort } from "../../lib/quickConnect";
 import {
@@ -298,6 +296,16 @@ function Radio({
   );
 }
 
+type SelectOption = string | { value: string; label: string };
+
+function selectOptionValue(option: SelectOption): string {
+  return typeof option === "string" ? option : option.value;
+}
+
+function selectOptionLabel(option: SelectOption): string {
+  return typeof option === "string" ? option : option.label;
+}
+
 function Select({
   value,
   options,
@@ -305,7 +313,7 @@ function Select({
   className = "",
 }: {
   value: string;
-  options: string[];
+  options: SelectOption[];
   onChange?: (v: string) => void;
   className?: string;
 }) {
@@ -317,7 +325,9 @@ function Select({
         onChange={(e) => onChange?.(e.target.value)}
       >
         {options.map((o) => (
-          <option key={o}>{o}</option>
+          <option key={selectOptionValue(o)} value={selectOptionValue(o)}>
+            {selectOptionLabel(o)}
+          </option>
         ))}
       </select>
       <ChevronDown className="w-3 h-3 absolute right-1 top-1/2 -translate-y-1/2 pointer-events-none text-[var(--taomni-text-muted)]" />
@@ -582,7 +592,6 @@ function ProxyJumpFields({
   onSaveAsProxySession?: () => void;
 }) {
   const patch = (delta: Partial<NetworkSettingsValue>) => onChange({ ...value, ...delta });
-  const proxy = proxyKindToLabel(value.proxyKind);
   const isJump = value.proxyKind === "ssh-tunnel";
   const isHttpOrSocks = value.proxyKind === "http" || value.proxyKind === "socks5";
   const proxyManual = value.proxySessionId?.trim() === "";
@@ -591,15 +600,15 @@ function ProxyJumpFields({
     <>
       <Field label={t("sessionEditor2.fieldProxy")}>
         <Select
-          value={proxy}
+          value={value.proxyKind}
           options={[
-            t("sessionEditor2.proxyNone"),
-            t("sessionEditor2.proxyHttp"),
-            t("sessionEditor2.proxySocks5"),
-            t("sessionEditor2.proxyLocalSshTunnel"),
-            t("sessionEditor2.proxySystem"),
+            { value: "none", label: t("sessionEditor2.proxyNone") },
+            { value: "http", label: t("sessionEditor2.proxyHttp") },
+            { value: "socks5", label: t("sessionEditor2.proxySocks5") },
+            { value: "ssh-tunnel", label: t("sessionEditor2.proxyLocalSshTunnel") },
+            { value: "system", label: t("sessionEditor2.proxySystem") },
           ]}
-          onChange={(label) => patch({ proxyKind: proxyLabelToKind(label) })}
+          onChange={(kind) => patch({ proxyKind: kind as ProxyKind })}
         />
       </Field>
 
@@ -845,12 +854,11 @@ function NetworkSettings({
   const keepAliveInterval = value.keepAliveIntervalSecs;
   const tcpNodelay = value.tcpNodelay;
   const disableNagle = value.disableNagle;
-  const ipVersion = ipKindToLabel(value.ipVersion);
   const forwards = value.localForwards;
 
   const setKeepAlive = (v: boolean) => patch({ keepAlive: v });
   const setKeepAliveInterval = (v: string) => patch({ keepAliveIntervalSecs: v });
-  const setIpVersion = (label: string) => patch({ ipVersion: ipLabelToKind(label) });
+  const setIpVersion = (kind: string) => patch({ ipVersion: kind as IpVersion });
   const setForwards = (
     updater: (items: NetworkSettingsValue["localForwards"]) => NetworkSettingsValue["localForwards"],
   ) => patch({ localForwards: updater(value.localForwards) });
@@ -906,8 +914,12 @@ function NetworkSettings({
 
       <Field label={t("sessionEditor2.fieldIpVersion")}>
         <Select
-          value={ipVersion}
-          options={[t("sessionEditor2.ipAuto"), t("sessionEditor2.ipForceIpv4"), t("sessionEditor2.ipForceIpv6")]}
+          value={value.ipVersion}
+          options={[
+            { value: "auto", label: t("sessionEditor2.ipAuto") },
+            { value: "ipv4", label: t("sessionEditor2.ipForceIpv4") },
+            { value: "ipv6", label: t("sessionEditor2.ipForceIpv6") },
+          ]}
           onChange={setIpVersion}
         />
       </Field>


### PR DESCRIPTION
The session editor previously used localized select labels as the persisted value for Network settings. In non-English locales, selecting Local SSH tunnel could fall through to the default proxy kind, leaving the saved networkSettings without proxyKind=ssh-tunnel and causing SFTP attach paths to miss the jump-host configuration.

Update the shared Select helper to support stable option values with localized labels, then wire Proxy and IP version fields to store backend-facing enum values directly. This keeps SSH, attached SFTP, and standalone SFTP using the same networkSettings payload regardless of UI language.

Add a zh-CN regression test that selects 本地 SSH 隧道 and verifies the saved options_json keeps proxyKind=ssh-tunnel with jump-host fields.

Validation: pnpm test src/lib/networkSettings.test.ts src/components/session/SessionEditor.test.tsx --run; pnpm exec tsc -b --pretty false.