### PR TITLE
feat(git): add workspace multi-repo manager

### DIFF
--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -9,6 +9,8 @@ const DEFAULT_RECURSIVE_MAX_DEPTH: usize = 25;
 const DEFAULT_RECURSIVE_MAX_FILES: usize = 2_000;
 const HARD_RECURSIVE_MAX_DEPTH: usize = 100;
 const HARD_RECURSIVE_MAX_FILES: usize = 10_000;
+const GIT_ROOT_SCAN_MAX_DEPTH: usize = 4;
+const GIT_ROOT_SCAN_MAX_DIRS: usize = 2_000;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -139,23 +141,22 @@ pub fn workspace_detect_git_roots(
         if !meta.is_dir() {
             continue;
         }
-        let Some(repo_root) = find_git_repo_root(&path) else {
-            continue;
-        };
-        let repo_root = path_to_string(&repo_root);
-        if let Some(existing) = repos.iter_mut().find(|item| item.repo_root == repo_root) {
-            if !existing.root_ids.contains(&root.id) {
-                existing.root_ids.push(root.id);
-            }
-            continue;
+        let mut found = Vec::new();
+        if let Some(repo_root) = find_git_repo_root(&path) {
+            found.push(repo_root);
         }
-        repos.push(WorkspaceGitRoot {
-            id: root.id.clone(),
-            name: root.name,
-            path: path_to_string(&path),
-            repo_root,
-            root_ids: vec![root.id],
-        });
+        let mut remaining_dirs = GIT_ROOT_SCAN_MAX_DIRS;
+        collect_nested_git_roots(
+            &path,
+            0,
+            GIT_ROOT_SCAN_MAX_DEPTH,
+            &mut remaining_dirs,
+            &mut found,
+        )?;
+
+        for repo_root in found {
+            upsert_workspace_git_root(&mut repos, &root, &path, &repo_root);
+        }
     }
     repos.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
     Ok(repos)
@@ -591,6 +592,97 @@ fn find_git_repo_root(path: &Path) -> Option<PathBuf> {
     None
 }
 
+fn upsert_workspace_git_root(
+    repos: &mut Vec<WorkspaceGitRoot>,
+    workspace_root: &WorkspaceGitRootCandidate,
+    workspace_path: &Path,
+    repo_root: &Path,
+) {
+    let repo_root = path_to_string(repo_root);
+    if let Some(existing) = repos.iter_mut().find(|item| item.repo_root == repo_root) {
+        if !existing.root_ids.contains(&workspace_root.id) {
+            existing.root_ids.push(workspace_root.id.clone());
+        }
+        return;
+    }
+    repos.push(WorkspaceGitRoot {
+        id: format!("{}:{}", workspace_root.id, repo_root),
+        name: repo_display_name(repo_root.as_str(), &workspace_root.name),
+        path: path_to_string(workspace_path),
+        repo_root,
+        root_ids: vec![workspace_root.id.clone()],
+    });
+}
+
+fn collect_nested_git_roots(
+    dir: &Path,
+    depth: usize,
+    max_depth: usize,
+    remaining_dirs: &mut usize,
+    repos: &mut Vec<PathBuf>,
+) -> Result<(), String> {
+    if depth > max_depth || *remaining_dirs == 0 {
+        return Ok(());
+    }
+    *remaining_dirs = (*remaining_dirs).saturating_sub(1);
+    if dir.join(".git").exists() && !repos.iter().any(|repo| repo == dir) {
+        repos.push(dir.to_path_buf());
+    }
+    if depth == max_depth {
+        return Ok(());
+    }
+    let Ok(read) = fs::read_dir(dir) else {
+        return Ok(());
+    };
+    for entry in read {
+        if *remaining_dirs == 0 {
+            return Ok(());
+        }
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let path = entry.path();
+        let Ok(meta) = fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if !meta.is_dir() || meta.file_type().is_symlink() {
+            continue;
+        }
+        if should_skip_git_root_scan_dir(&path) {
+            continue;
+        }
+        collect_nested_git_roots(&path, depth + 1, max_depth, remaining_dirs, repos)?;
+    }
+    Ok(())
+}
+
+fn should_skip_git_root_scan_dir(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    matches!(
+        name,
+        ".git"
+            | ".hg"
+            | ".svn"
+            | "node_modules"
+            | "target"
+            | "dist"
+            | "build"
+            | ".next"
+            | ".turbo"
+            | ".cache"
+    )
+}
+
+fn repo_display_name(repo_root: &str, fallback: &str) -> String {
+    Path::new(repo_root)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| fallback.to_string())
+}
+
 fn path_to_string(path: &Path) -> String {
     path.to_string_lossy().to_string()
 }
@@ -914,6 +1006,31 @@ mod tests {
             .find(|item| item.repo_root == repo_root)
             .expect("target repo should be detected");
         assert_eq!(detected.root_ids, vec!["repo", "app"]);
+    }
+
+    #[test]
+    fn detects_child_git_roots_under_plain_workspace_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().join("workspace");
+        let app = workspace.join("app");
+        let service = workspace.join("service");
+        fs::create_dir_all(app.join(".git")).unwrap();
+        fs::create_dir_all(service.join(".git")).unwrap();
+        fs::create_dir_all(workspace.join("node_modules/ignored/.git")).unwrap();
+
+        let repos = workspace_detect_git_roots(vec![WorkspaceGitRootCandidate {
+            id: "workspace".into(),
+            name: "workspace".into(),
+            path: workspace.to_string_lossy().to_string(),
+        }])
+        .unwrap();
+
+        let app_root = app.to_string_lossy().to_string();
+        let service_root = service.to_string_lossy().to_string();
+        let repo_roots: Vec<_> = repos.iter().map(|item| item.repo_root.as_str()).collect();
+        assert!(repo_roots.contains(&app_root.as_str()));
+        assert!(repo_roots.contains(&service_root.as_str()));
+        assert_eq!(repos.len(), 2);
     }
 
     #[test]

--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -50,6 +50,7 @@ import {
   Braces,
   ChevronDown,
   ChevronRight,
+  ExternalLink,
   File,
   FilePlus,
   Folder,
@@ -141,6 +142,11 @@ interface CodeWorkspaceTabProps {
   tabId: string;
   workspace: CodeWorkspaceTabInfo;
   visible?: boolean;
+  onOpenGitManager?: (payload: {
+    workspaceName: string;
+    roots: WorkspaceGitRoot[];
+    activeRepoRoot: string | null;
+  }) => void;
 }
 
 interface DirectoryState {
@@ -747,6 +753,7 @@ export function CodeWorkspaceTab({
   tabId,
   workspace,
   visible = true,
+  onOpenGitManager,
 }: CodeWorkspaceTabProps) {
   const setStatusMessage = useAppStore((s) => s.setStatusMessage);
   const setTabCodeWorkspaceContext = useAppStore((s) => s.setTabCodeWorkspaceContext);
@@ -2009,6 +2016,7 @@ export function CodeWorkspaceTab({
     }
     return map;
   }, [gitRoots]);
+  const activeGitRoot = activeRootId ? gitRootByRootId.get(activeRootId) ?? null : null;
   const gitChangeByRootPath = useMemo(() => {
     const map = new Map<string, GitChange>();
     for (const root of roots) {
@@ -2196,6 +2204,14 @@ export function CodeWorkspaceTab({
   );
   const activeDiagnostics = activeLspState?.diagnostics ?? [];
   const title = workspaceTitle(workspace, roots, looseFiles);
+  const openGitManager = useCallback(() => {
+    if (!onOpenGitManager || gitRoots.length === 0) return;
+    onOpenGitManager({
+      workspaceName: title,
+      roots: gitRoots,
+      activeRepoRoot: activeGitRoot?.repoRoot ?? gitRoots[0]?.repoRoot ?? null,
+    });
+  }, [activeGitRoot, gitRoots, onOpenGitManager, title]);
 
   useEffect(() => {
     const firstRoot = roots[0] ?? null;
@@ -2606,6 +2622,13 @@ export function CodeWorkspaceTab({
           disabled={!gitRootsLoading && !gitRootsError && gitRoots.length === 0}
           onClick={() => setBottomPanelOpen(!bottomPanelOpen)}
         />
+        <IconButton
+          label="Open Git manager"
+          testId="code-workspace-git-manager-open"
+          icon={<ExternalLink className="w-3.5 h-3.5" />}
+          disabled={!onOpenGitManager || gitRoots.length === 0}
+          onClick={openGitManager}
+        />
       </header>
 
       <PanelGroup
@@ -2963,6 +2986,7 @@ export function CodeWorkspaceTab({
                         gitRoots={gitRoots}
                         activeRootId={activeRootId}
                         visible={visible && bottomPanelOpen}
+                        onOpenManager={openGitManager}
                       />
                     )}
                   </Panel>

--- a/src/components/editor/WorkspaceGitContainer.test.tsx
+++ b/src/components/editor/WorkspaceGitContainer.test.tsx
@@ -45,4 +45,20 @@ describe("WorkspaceGitContainer", () => {
 
     expect(screen.getByTestId("git-panel")).toHaveAttribute("data-repo-root", "/repo/app");
   });
+
+  it("opens the workspace Git manager from the embedded panel header", async () => {
+    const onOpenManager = vi.fn();
+    render(
+      <WorkspaceGitContainer
+        visible
+        activeRootId="app"
+        gitRoots={[gitRoot({ id: "app", name: "app", repoRoot: "/repo/app", rootIds: ["app"] })]}
+        onOpenManager={onOpenManager}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Open Git manager" }));
+
+    expect(onOpenManager).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/editor/WorkspaceGitContainer.tsx
+++ b/src/components/editor/WorkspaceGitContainer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { GitBranch } from "lucide-react";
+import { ExternalLink, GitBranch } from "lucide-react";
 import type { WorkspaceGitRoot } from "../../lib/editor/workspace";
 import { GitPanel } from "../git/GitPanel";
 
@@ -7,12 +7,14 @@ interface WorkspaceGitContainerProps {
   gitRoots: WorkspaceGitRoot[];
   activeRootId: string | null;
   visible: boolean;
+  onOpenManager?: () => void;
 }
 
 export function WorkspaceGitContainer({
   gitRoots,
   activeRootId,
   visible,
+  onOpenManager,
 }: WorkspaceGitContainerProps) {
   const [selectedRepoRoot, setSelectedRepoRoot] = useState("");
   const lastActiveRootIdRef = useRef<string | null>(null);
@@ -67,6 +69,19 @@ export function WorkspaceGitContainer({
           <span className="min-w-0 truncate text-[11px] text-[var(--taomni-code-muted)]" title={selectedRepo.repoRoot}>
             {selectedRepo.repoRoot}
           </span>
+        )}
+        <div className="flex-1" />
+        {onOpenManager && (
+          <button
+            type="button"
+            className="h-7 w-7 shrink-0 inline-flex items-center justify-center rounded hover:bg-[var(--taomni-code-active-line-bg)] disabled:opacity-40 disabled:cursor-default"
+            title="Open Git manager"
+            aria-label="Open Git manager"
+            disabled={gitRoots.length === 0}
+            onClick={onOpenManager}
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+          </button>
         )}
       </div>
       <div className="flex-1 min-h-0">

--- a/src/components/git/WorkspaceGitManager.test.tsx
+++ b/src/components/git/WorkspaceGitManager.test.tsx
@@ -1,0 +1,125 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "../../stores/appStore";
+import type { GitSnapshot } from "../../lib/git";
+import { WorkspaceGitManager } from "./WorkspaceGitManager";
+
+const gitMocks = vi.hoisted(() => ({
+  gitCommit: vi.fn(),
+  gitChangeLabel: vi.fn((change: { conflict?: boolean; status: string }) => (
+    change.conflict ? "Conflicted" : change.status[0]?.toUpperCase() + change.status.slice(1)
+  )),
+  gitFetch: vi.fn(),
+  gitPull: vi.fn(),
+  gitPush: vi.fn(),
+  gitRepoName: vi.fn((repoRoot: string) => repoRoot.split("/").pop() ?? repoRoot),
+  gitSnapshot: vi.fn(),
+  selectedRemote: vi.fn(() => null),
+}));
+
+const dialogMocks = vi.hoisted(() => ({
+  alertAppDialog: vi.fn(),
+}));
+
+vi.mock("../../lib/git", () => gitMocks);
+
+vi.mock("../../lib/appDialogs", () => dialogMocks);
+
+vi.mock("./GitPanel", () => ({
+  GitPanel: ({ repoRoot }: { repoRoot: string }) => (
+    <div data-testid="git-panel" data-repo-root={repoRoot} />
+  ),
+}));
+
+function snapshot(repoRoot: string, changes: GitSnapshot["changes"] = []): GitSnapshot {
+  return {
+    repoRoot,
+    currentBranch: "main",
+    headOid: "abc123",
+    detached: false,
+    upstream: null,
+    ahead: 0,
+    behind: 0,
+    changes,
+    remotes: [],
+    branches: [],
+    stashes: [],
+    tags: [],
+    settings: {
+      userName: null,
+      userEmail: null,
+      httpProxy: null,
+      httpsProxy: null,
+      pullRebase: null,
+      pushDefault: null,
+      coreAutocrlf: null,
+      coreFilemode: null,
+      commitGpgsign: null,
+    },
+  };
+}
+
+describe("WorkspaceGitManager", () => {
+  beforeEach(() => {
+    useAppStore.setState({ statusMessage: "Ready" });
+    gitMocks.gitCommit.mockReset();
+    gitMocks.gitCommit.mockResolvedValue(undefined);
+    gitMocks.gitSnapshot.mockReset();
+    gitMocks.gitSnapshot.mockImplementation(async (repoRoot: string) => (
+      repoRoot === "/repo/app"
+        ? snapshot("/repo/app", [{
+          path: "src/App.tsx",
+          oldPath: null,
+          status: "modified",
+          staged: false,
+          unstaged: true,
+          conflict: false,
+        }, {
+          path: "src/ignored.ts",
+          oldPath: null,
+          status: "modified",
+          staged: false,
+          unstaged: true,
+          conflict: false,
+        }])
+        : snapshot(repoRoot)
+    ));
+    dialogMocks.alertAppDialog.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("commits changed files across checked repositories and keeps the selected repo in the Git panel", async () => {
+    render(
+      <WorkspaceGitManager
+        workspaceName="Workspace"
+        activeRepoRoot="/repo/service"
+        roots={[
+          { id: "app", name: "app", path: "/repo", repoRoot: "/repo/app", rootIds: ["root"] },
+          { id: "service", name: "service", path: "/repo", repoRoot: "/repo/service", rootIds: ["root"] },
+        ]}
+      />,
+    );
+
+    await waitFor(() => expect(gitMocks.gitSnapshot).toHaveBeenCalledWith("/repo/app"));
+    expect(screen.getByTestId("git-panel")).toHaveAttribute("data-repo-root", "/repo/service");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select src/ignored.ts" }));
+    fireEvent.change(screen.getByPlaceholderText("Commit message"), {
+      target: { value: "batch commit" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Commit" }));
+
+    await waitFor(() => {
+      expect(gitMocks.gitCommit).toHaveBeenCalledWith(
+        "/repo/app",
+        "batch commit",
+        false,
+        ["src/App.tsx"],
+      );
+    });
+    expect(gitMocks.gitCommit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/git/WorkspaceGitManager.tsx
+++ b/src/components/git/WorkspaceGitManager.tsx
@@ -1,0 +1,643 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  AlertTriangle,
+  Download,
+  FileText,
+  GitBranch,
+  GitCommitHorizontal,
+  GitMerge,
+  Loader2,
+  RefreshCw,
+  Upload,
+} from "lucide-react";
+import {
+  gitCommit,
+  gitFetch,
+  gitChangeLabel,
+  gitPull,
+  gitPush,
+  gitRepoName,
+  gitSnapshot,
+  selectedRemote,
+  type GitChange,
+  type GitSnapshot,
+} from "../../lib/git";
+import { alertAppDialog } from "../../lib/appDialogs";
+import { useAppStore } from "../../stores/appStore";
+import type { GitWorkspaceRootInfo } from "../../types";
+import { GitPanel } from "./GitPanel";
+
+interface WorkspaceGitManagerProps {
+  workspaceName?: string | null;
+  roots: GitWorkspaceRootInfo[];
+  activeRepoRoot?: string | null;
+  visible?: boolean;
+  onOpenWorkspace?: (repoRoot: string) => void;
+}
+
+interface RepoSnapshotState {
+  snapshot: GitSnapshot | null;
+  loading: boolean;
+  error: string | null;
+}
+
+type BatchResult = "completed" | "skipped";
+
+export function WorkspaceGitManager({
+  workspaceName,
+  roots,
+  activeRepoRoot,
+  visible = true,
+  onOpenWorkspace,
+}: WorkspaceGitManagerProps) {
+  const setStatusMessage = useAppStore((s) => s.setStatusMessage);
+  const normalizedRoots = useMemo(() => dedupeRoots(roots), [roots]);
+  const [selectedRepoRoot, setSelectedRepoRoot] = useState(activeRepoRoot ?? normalizedRoots[0]?.repoRoot ?? "");
+  const [checkedRepoRoots, setCheckedRepoRoots] = useState<Set<string>>(() => (
+    new Set(normalizedRoots.map((root) => root.repoRoot))
+  ));
+  const [snapshots, setSnapshots] = useState<Record<string, RepoSnapshotState>>({});
+  const [busyLabel, setBusyLabel] = useState<string | null>(null);
+  const [panelVersion, setPanelVersion] = useState(0);
+  const [commitMessage, setCommitMessage] = useState("");
+  const [excludedCommitPaths, setExcludedCommitPaths] = useState<Record<string, Set<string>>>({});
+
+  const selectedRoot = useMemo(
+    () => normalizedRoots.find((root) => root.repoRoot === selectedRepoRoot) ?? normalizedRoots[0] ?? null,
+    [normalizedRoots, selectedRepoRoot],
+  );
+  const checkedRoots = useMemo(
+    () => normalizedRoots.filter((root) => checkedRepoRoots.has(root.repoRoot)),
+    [checkedRepoRoots, normalizedRoots],
+  );
+  const commitSelection = useMemo(() => {
+    const byRepo: Record<string, string[]> = {};
+    let totalFiles = 0;
+    let selectedFiles = 0;
+    let selectedRepos = 0;
+    for (const root of normalizedRoots) {
+      const changes = snapshots[root.repoRoot]?.snapshot?.changes ?? [];
+      const excluded = excludedCommitPaths[root.repoRoot] ?? new Set<string>();
+      const selected = changes.filter((change) => !excluded.has(change.path)).map((change) => change.path);
+      byRepo[root.repoRoot] = selected;
+      totalFiles += changes.length;
+      selectedFiles += selected.length;
+      if (selected.length > 0) selectedRepos += 1;
+    }
+    return { byRepo, totalFiles, selectedFiles, selectedRepos };
+  }, [excludedCommitPaths, normalizedRoots, snapshots]);
+  const allChecked = normalizedRoots.length > 0
+    && checkedRoots.length === normalizedRoots.length
+    && (commitSelection.totalFiles === 0 || commitSelection.selectedFiles === commitSelection.totalFiles);
+  const title = workspaceName?.trim() || "Code Workspace";
+
+  useEffect(() => {
+    setSelectedRepoRoot((current) => {
+      if (normalizedRoots.some((root) => root.repoRoot === current)) return current;
+      if (activeRepoRoot && normalizedRoots.some((root) => root.repoRoot === activeRepoRoot)) {
+        return activeRepoRoot;
+      }
+      return normalizedRoots[0]?.repoRoot ?? "";
+    });
+    setCheckedRepoRoots((current) => {
+      const valid = new Set(normalizedRoots.map((root) => root.repoRoot));
+      const retained = new Set([...current].filter((repoRoot) => valid.has(repoRoot)));
+      return retained.size > 0 ? retained : valid;
+    });
+  }, [activeRepoRoot, normalizedRoots]);
+
+  const refreshRepo = useCallback(async (repoRoot: string) => {
+    setSnapshots((current) => ({
+      ...current,
+      [repoRoot]: {
+        snapshot: current[repoRoot]?.snapshot ?? null,
+        loading: true,
+        error: null,
+      },
+    }));
+    try {
+      const snapshot = await gitSnapshot(repoRoot);
+      setSnapshots((current) => ({
+        ...current,
+        [repoRoot]: {
+          snapshot,
+          loading: false,
+          error: null,
+        },
+      }));
+      return snapshot;
+    } catch (err) {
+      const message = errorMessage(err);
+      setSnapshots((current) => ({
+        ...current,
+        [repoRoot]: {
+          snapshot: current[repoRoot]?.snapshot ?? null,
+          loading: false,
+          error: message,
+        },
+      }));
+      throw err;
+    }
+  }, []);
+
+  const refreshRepos = useCallback(async (targets = normalizedRoots) => {
+    await Promise.allSettled(targets.map((root) => refreshRepo(root.repoRoot)));
+  }, [normalizedRoots, refreshRepo]);
+
+  useEffect(() => {
+    if (!visible || normalizedRoots.length === 0) return;
+    void refreshRepos(normalizedRoots);
+  }, [normalizedRoots, refreshRepos, visible]);
+
+  const toggleChecked = useCallback((repoRoot: string, checked: boolean) => {
+    setCheckedRepoRoots((current) => {
+      const next = new Set(current);
+      if (checked) next.add(repoRoot);
+      else next.delete(repoRoot);
+      return next;
+    });
+    setExcludedCommitPaths((current) => {
+      const changes = snapshots[repoRoot]?.snapshot?.changes ?? [];
+      if (changes.length === 0) return current;
+      const next = { ...current };
+      if (checked) {
+        delete next[repoRoot];
+      } else {
+        next[repoRoot] = new Set(changes.map((change) => change.path));
+      }
+      return next;
+    });
+  }, [snapshots]);
+
+  const toggleFileChecked = useCallback((repoRoot: string, path: string, checked: boolean) => {
+    setExcludedCommitPaths((current) => {
+      const next = { ...current };
+      const excluded = new Set(next[repoRoot] ?? []);
+      if (checked) excluded.delete(path);
+      else excluded.add(path);
+      if (excluded.size > 0) next[repoRoot] = excluded;
+      else delete next[repoRoot];
+      return next;
+    });
+    if (checked) {
+      setCheckedRepoRoots((current) => {
+        if (current.has(repoRoot)) return current;
+        const next = new Set(current);
+        next.add(repoRoot);
+        return next;
+      });
+    }
+  }, []);
+
+  const setAllChecked = useCallback((checked: boolean) => {
+    setCheckedRepoRoots(checked ? new Set(normalizedRoots.map((root) => root.repoRoot)) : new Set());
+    setExcludedCommitPaths(() => {
+      if (checked) return {};
+      return Object.fromEntries(normalizedRoots.map((root) => [
+        root.repoRoot,
+        new Set((snapshots[root.repoRoot]?.snapshot?.changes ?? []).map((change) => change.path)),
+      ]));
+    });
+  }, [normalizedRoots, snapshots]);
+
+  const runBatch = useCallback(async (
+    label: string,
+    action: (root: GitWorkspaceRootInfo, snapshot: GitSnapshot) => Promise<BatchResult>,
+  ) => {
+    if (checkedRoots.length === 0) return;
+    setBusyLabel(label);
+    const failures: string[] = [];
+    let completed = 0;
+    let skipped = 0;
+    try {
+      for (const root of checkedRoots) {
+        try {
+          const snapshot = await refreshRepo(root.repoRoot);
+          const result = await action(root, snapshot);
+          if (result === "completed") {
+            completed += 1;
+            await refreshRepo(root.repoRoot);
+          } else {
+            skipped += 1;
+          }
+        } catch (err) {
+          failures.push(`${root.name}: ${errorMessage(err)}`);
+        }
+      }
+      const summary = `${label}: ${completed} completed${skipped ? `, ${skipped} skipped` : ""}`;
+      setStatusMessage(failures.length ? `${summary}, ${failures.length} failed` : summary);
+      if (failures.length) {
+        await alertAppDialog({
+          title: label,
+          message: failures.join("\n"),
+        });
+      }
+    } finally {
+      setPanelVersion((current) => current + 1);
+      setBusyLabel(null);
+    }
+  }, [checkedRoots, refreshRepo, setStatusMessage]);
+
+  const batchCommit = useCallback(async (push: boolean) => {
+    const message = commitMessage.trim();
+    if (!message || commitSelection.selectedFiles === 0) return;
+    await runBatch(push ? "Commit and Push" : "Commit", async (_root, snapshot) => {
+      const excluded = excludedCommitPaths[snapshot.repoRoot] ?? new Set<string>();
+      const paths = snapshot.changes.filter((change) => !excluded.has(change.path)).map((change) => change.path);
+      if (paths.length === 0) return "skipped";
+      await gitCommit(snapshot.repoRoot, message, false, paths);
+      if (push) {
+        const remote = selectedRemote(snapshot);
+        if (remote && snapshot.currentBranch) {
+          await gitPush(snapshot.repoRoot, remote.name, snapshot.currentBranch, !snapshot.upstream);
+        }
+      }
+      return "completed";
+    });
+    setCommitMessage("");
+  }, [commitMessage, commitSelection.selectedFiles, excludedCommitPaths, runBatch]);
+
+  const batchFetch = useCallback(() => runBatch("Fetch", async (_root, snapshot) => {
+    const remote = selectedRemote(snapshot);
+    if (!remote) return "skipped";
+    await gitFetch(snapshot.repoRoot, remote.name);
+    return "completed";
+  }), [runBatch]);
+
+  const batchPull = useCallback(() => runBatch("Pull", async (_root, snapshot) => {
+    const remote = selectedRemote(snapshot);
+    if (!remote) return "skipped";
+    await gitPull(snapshot.repoRoot, remote.name, pullBranchForRemote(snapshot, remote.name));
+    return "completed";
+  }), [runBatch]);
+
+  const batchPush = useCallback(() => runBatch("Push", async (_root, snapshot) => {
+    const remote = selectedRemote(snapshot);
+    if (!remote || !snapshot.currentBranch) return "skipped";
+    await gitPush(snapshot.repoRoot, remote.name, snapshot.currentBranch, !snapshot.upstream);
+    return "completed";
+  }), [runBatch]);
+
+  const busy = busyLabel !== null;
+  const canCommit = !busy && commitSelection.selectedFiles > 0 && commitMessage.trim().length > 0;
+  const refreshChecked = useCallback(async () => {
+    if (checkedRoots.length === 0) return;
+    setBusyLabel("Refresh");
+    try {
+      await refreshRepos(checkedRoots);
+      setStatusMessage(`Refresh: ${checkedRoots.length} completed`);
+    } finally {
+      setPanelVersion((current) => current + 1);
+      setBusyLabel(null);
+    }
+  }, [checkedRoots, refreshRepos, setStatusMessage]);
+
+  return (
+    <div
+      data-testid="workspace-git-manager"
+      className="h-full w-full min-h-0 flex flex-col bg-[var(--taomni-bg)] text-[var(--taomni-text)]"
+    >
+      <header className="h-10 shrink-0 flex items-center gap-2 border-b border-[var(--taomni-divider)] bg-[var(--taomni-quick-bg)] px-3">
+        <GitBranch className="w-4 h-4 text-[var(--taomni-accent)]" />
+        <div className="min-w-0">
+          <div className="font-semibold leading-4 truncate">Git · {title}</div>
+          <div className="text-[11px] text-[var(--taomni-text-muted)] truncate">
+            {normalizedRoots.length} repositories · {commitSelection.totalFiles} changed files
+          </div>
+        </div>
+        <div className="flex-1" />
+        <ToolbarButton
+          label="Refresh"
+          icon={<RefreshCw className={`w-3.5 h-3.5 ${busyLabel === "Refresh" ? "animate-spin" : ""}`} />}
+          disabled={busy || checkedRoots.length === 0}
+          onClick={() => void refreshChecked()}
+        />
+        <ToolbarButton
+          label="Fetch"
+          icon={<Download className="w-3.5 h-3.5" />}
+          disabled={busy || checkedRoots.length === 0}
+          onClick={() => void batchFetch()}
+        />
+        <ToolbarButton
+          label="Pull"
+          icon={<GitMerge className="w-3.5 h-3.5" />}
+          disabled={busy || checkedRoots.length === 0}
+          onClick={() => void batchPull()}
+        />
+        <ToolbarButton
+          label="Push"
+          icon={<Upload className="w-3.5 h-3.5" />}
+          disabled={busy || checkedRoots.length === 0}
+          onClick={() => void batchPush()}
+        />
+      </header>
+
+      <div className="flex-1 min-h-0 flex">
+        <aside className="w-[340px] min-w-[260px] max-w-[45%] shrink-0 border-r border-[var(--taomni-divider)] bg-[var(--taomni-quick-bg)] flex flex-col">
+          <div className="h-9 shrink-0 flex items-center gap-2 border-b border-[var(--taomni-divider)] px-3">
+            <label className="inline-flex items-center gap-2 text-[12px]">
+              <input
+                type="checkbox"
+                className="accent-[var(--taomni-accent)]"
+                checked={allChecked}
+                disabled={normalizedRoots.length === 0}
+                onChange={(event) => setAllChecked(event.target.checked)}
+              />
+              <span>Changes</span>
+              <span className="text-[11px] text-[var(--taomni-text-muted)]">
+                {commitSelection.selectedFiles}/{commitSelection.totalFiles}
+              </span>
+            </label>
+            <div className="flex-1" />
+            {busyLabel && <Loader2 className="w-3.5 h-3.5 animate-spin text-[var(--taomni-accent)]" />}
+          </div>
+          <div className="flex-1 min-h-0 overflow-auto">
+            {normalizedRoots.length === 0 ? (
+              <EmptyState title="No Git repositories detected" />
+            ) : normalizedRoots.map((root) => {
+              const state = snapshots[root.repoRoot];
+              const snapshot = state?.snapshot ?? null;
+              const selected = selectedRoot?.repoRoot === root.repoRoot;
+              const checked = checkedRepoRoots.has(root.repoRoot);
+              return (
+                <RepoRow
+                  key={root.repoRoot}
+                  root={root}
+                  snapshot={snapshot}
+                  loading={!!state?.loading}
+                  error={state?.error ?? null}
+                  selected={selected}
+                  checked={checked}
+                  excludedPaths={excludedCommitPaths[root.repoRoot] ?? new Set()}
+                  onChecked={(next) => toggleChecked(root.repoRoot, next)}
+                  onFileChecked={(path, next) => toggleFileChecked(root.repoRoot, path, next)}
+                  onSelect={() => setSelectedRepoRoot(root.repoRoot)}
+                />
+              );
+            })}
+          </div>
+          <div className="shrink-0 border-t border-[var(--taomni-divider)] p-2">
+            <textarea
+              value={commitMessage}
+              onChange={(event) => setCommitMessage(event.target.value)}
+              placeholder="Commit message"
+              className="taomni-input h-24 w-full resize-none p-2 text-[12px]"
+            />
+            <div className="mt-2 flex items-center gap-2">
+              <span className="min-w-0 flex-1 truncate text-[11px] text-[var(--taomni-text-muted)]">
+                {commitSelection.selectedFiles} files in {commitSelection.selectedRepos} repos
+              </span>
+              <button
+                type="button"
+                className="taomni-btn h-7 px-2 inline-flex items-center gap-1"
+                disabled={!canCommit}
+                onClick={() => void batchCommit(false)}
+              >
+                <GitCommitHorizontal className="w-3.5 h-3.5" />
+                <span>Commit</span>
+              </button>
+              <button
+                type="button"
+                className="taomni-btn h-7 px-2 inline-flex items-center gap-1"
+                disabled={!canCommit}
+                onClick={() => void batchCommit(true)}
+              >
+                <Upload className="w-3.5 h-3.5" />
+                <span>Commit and Push</span>
+              </button>
+            </div>
+          </div>
+        </aside>
+
+        <main className="flex-1 min-w-0 min-h-0">
+          {selectedRoot ? (
+            <GitPanel
+              key={`${selectedRoot.repoRoot}:${panelVersion}`}
+              repoRoot={selectedRoot.repoRoot}
+              visible={visible}
+              onOpenWorkspace={onOpenWorkspace}
+            />
+          ) : (
+            <EmptyState title="No Git repositories detected" />
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function RepoRow({
+  root,
+  snapshot,
+  loading,
+  error,
+  selected,
+  checked,
+  excludedPaths,
+  onChecked,
+  onFileChecked,
+  onSelect,
+}: {
+  root: GitWorkspaceRootInfo;
+  snapshot: GitSnapshot | null;
+  loading: boolean;
+  error: string | null;
+  selected: boolean;
+  checked: boolean;
+  excludedPaths: Set<string>;
+  onChecked: (checked: boolean) => void;
+  onFileChecked: (path: string, checked: boolean) => void;
+  onSelect: () => void;
+}) {
+  const branch = snapshot?.detached ? `detached ${snapshot.headOid ?? ""}` : snapshot?.currentBranch ?? "";
+  const changes = snapshot?.changes ?? [];
+  const selectedChanges = changes.filter((change) => !excludedPaths.has(change.path)).length;
+  const repoChecked = changes.length > 0 ? selectedChanges === changes.length : checked;
+  return (
+    <div
+      className={`group border-b border-[var(--taomni-divider)] ${selected ? "bg-[var(--taomni-hover)]" : "hover:bg-[var(--taomni-hover)]"}`}
+    >
+      <div className="flex items-start gap-2 px-3 py-2">
+        <input
+          type="checkbox"
+          className="mt-1 accent-[var(--taomni-accent)]"
+          checked={repoChecked}
+          onChange={(event) => onChecked(event.target.checked)}
+          onClick={(event) => event.stopPropagation()}
+          aria-label={`Select ${root.name}`}
+        />
+        <button
+          type="button"
+          className="min-w-0 flex-1 text-left"
+          onClick={onSelect}
+        >
+          <div className="flex items-center gap-2">
+            <span className="min-w-0 truncate text-[13px] font-medium">{root.name || gitRepoName(root.repoRoot)}</span>
+            {loading && <Loader2 className="w-3 h-3 shrink-0 animate-spin text-[var(--taomni-accent)]" />}
+            {error && <AlertTriangle className="w-3.5 h-3.5 shrink-0 text-red-500" />}
+          </div>
+          <div className="mt-1 flex items-center gap-2 text-[11px] text-[var(--taomni-text-muted)]">
+            <GitCommitHorizontal className="w-3 h-3 shrink-0" />
+            <span className="min-w-0 truncate">{branch || "No branch"}</span>
+          </div>
+          <div className="mt-1 truncate text-[11px] text-[var(--taomni-text-muted)]" title={root.repoRoot}>
+            {root.repoRoot}
+          </div>
+          {error && (
+            <div className="mt-1 truncate text-[11px] text-red-500" title={error}>
+              {error}
+            </div>
+          )}
+        </button>
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <span className={`rounded px-1.5 py-0.5 text-[11px] ${changes.length > 0 ? "bg-[var(--taomni-accent)] text-white" : "bg-[var(--taomni-hover)] text-[var(--taomni-text-muted)]"}`}>
+            {selectedChanges}/{changes.length}
+          </span>
+          {snapshot && (snapshot.ahead > 0 || snapshot.behind > 0) && (
+            <span className="text-[10px] text-[var(--taomni-text-muted)]">
+              ↑{snapshot.ahead} ↓{snapshot.behind}
+            </span>
+          )}
+        </div>
+      </div>
+      {changes.length > 0 ? (
+        <div className="pb-1">
+          {changes.map((change) => (
+            <ChangeRow
+              key={`${change.path}:${change.staged}:${change.unstaged}`}
+              change={change}
+              checked={!excludedPaths.has(change.path)}
+              onChecked={(next) => onFileChecked(change.path, next)}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      ) : snapshot && !loading && !error ? (
+        <div className="px-9 pb-2 text-[11px] text-[var(--taomni-text-muted)]">
+          No changes
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ChangeRow({
+  change,
+  checked,
+  onChecked,
+  onSelect,
+}: {
+  change: GitChange;
+  checked: boolean;
+  onChecked: (checked: boolean) => void;
+  onSelect: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 py-1 pl-9 pr-3 text-[12px] hover:bg-[var(--taomni-hover)]">
+      <input
+        type="checkbox"
+        className="shrink-0 accent-[var(--taomni-accent)]"
+        checked={checked}
+        onChange={(event) => onChecked(event.target.checked)}
+        aria-label={`Select ${change.path}`}
+      />
+      <StatusBadge change={change} />
+      <button
+        type="button"
+        className="min-w-0 flex-1 text-left"
+        title={change.path}
+        onClick={onSelect}
+      >
+        <span className="inline-flex min-w-0 max-w-full items-center gap-1.5">
+          <FileText className="w-3.5 h-3.5 shrink-0 text-[var(--taomni-text-muted)]" />
+          <span className="truncate">{change.path}</span>
+        </span>
+      </button>
+    </div>
+  );
+}
+
+function StatusBadge({ change }: { change: GitChange }) {
+  const label = change.conflict ? "!" : change.status.slice(0, 1).toUpperCase();
+  const color = change.conflict
+    ? "border-red-500/40 bg-red-500/10 text-red-500"
+    : change.staged
+      ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-500"
+      : "border-[var(--taomni-divider)] bg-[var(--taomni-hover)] text-[var(--taomni-text-muted)]";
+  return (
+    <span
+      className={`inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded border px-1 text-[10px] font-semibold ${color}`}
+      title={gitChangeLabel(change)}
+    >
+      {label || "?"}
+    </span>
+  );
+}
+
+function ToolbarButton({
+  label,
+  icon,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  icon: ReactNode;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="taomni-btn h-7 px-2 inline-flex items-center gap-1"
+      title={label}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+function EmptyState({ title }: { title: string }) {
+  return (
+    <div className="h-full min-h-24 flex items-center justify-center text-[12px] text-[var(--taomni-text-muted)]">
+      {title}
+    </div>
+  );
+}
+
+function dedupeRoots(roots: GitWorkspaceRootInfo[]): GitWorkspaceRootInfo[] {
+  const seen = new Set<string>();
+  const next: GitWorkspaceRootInfo[] = [];
+  for (const root of roots) {
+    const repoRoot = root.repoRoot.trim();
+    if (!repoRoot || seen.has(repoRoot)) continue;
+    seen.add(repoRoot);
+    next.push({
+      ...root,
+      repoRoot,
+      name: root.name || gitRepoName(repoRoot),
+    });
+  }
+  return next.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+}
+
+function pullBranchForRemote(snapshot: GitSnapshot, remoteName: string): string | null {
+  if (!snapshot.currentBranch || !remoteName) return null;
+  const prefix = `${remoteName}/`;
+  if (snapshot.upstream?.startsWith(prefix)) {
+    return snapshot.upstream.slice(prefix.length) || snapshot.currentBranch;
+  }
+  return snapshot.currentBranch;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -32,6 +32,7 @@ import { StatusBar } from "../components/statusbar/StatusBar";
 import { WindowResizeHandles } from "../components/window/WindowResizeHandles";
 import { TerminalPanel, type TerminalLocalPathUploadRequest } from "../components/terminal/TerminalPanel";
 import { GitPanel } from "../components/git/GitPanel";
+import { WorkspaceGitManager } from "../components/git/WorkspaceGitManager";
 import { CodeWorkspaceTab } from "../components/editor/CodeWorkspaceTab";
 import { MultiExecBar } from "../components/terminal/MultiExecBar";
 import { SessionEditor } from "../components/session/SessionEditor";
@@ -70,7 +71,7 @@ import {
 } from "../lib/detachedSession";
 import type { DetachedRdpParams, DetachedVncParams, DetachedTerminalParams, DetachedDbParams } from "../components/detached/DetachedSessionWindow";
 import { Columns2, Grid2X2, Lock, Rows3, Unlock, X } from "lucide-react";
-import type { SftpTabInfo, Tab, DbConnectInfo, HBaseConnectInfo, MailConnectionSecurity, MailTabInfo, CodeWorkspaceRootInfo, CodeWorkspaceTabInfo, RecentWorkspace } from "../types";
+import type { SftpTabInfo, Tab, DbConnectInfo, HBaseConnectInfo, MailConnectionSecurity, MailTabInfo, CodeWorkspaceRootInfo, CodeWorkspaceTabInfo, GitWorkspaceRootInfo, RecentWorkspace } from "../types";
 import { computeNewTerminalTitle, recentWorkspaceIdFromParts, useAppStore, type TerminalSplitLayout } from "../stores/appStore";
 import { useSessionStore } from "../stores/sessionStore";
 import { WelcomePanel } from "../components/WelcomePanel";
@@ -569,6 +570,27 @@ function sessionToHBaseConnectInfo(session: SessionConfig, password?: string): H
     krb5ConfPath: str("hbaseKrb5ConfPath") || null,
     hbaseSitePath: str("hbaseSitePath") || null,
   };
+}
+
+function normalizeGitWorkspaceRoots(roots: readonly GitWorkspaceRootInfo[]): GitWorkspaceRootInfo[] {
+  const seen = new Set<string>();
+  const next: GitWorkspaceRootInfo[] = [];
+  for (const root of roots) {
+    const repoRoot = root.repoRoot.trim();
+    if (!repoRoot || seen.has(repoRoot)) continue;
+    seen.add(repoRoot);
+    next.push({
+      ...root,
+      repoRoot,
+      name: root.name || gitRepoName(repoRoot),
+      rootIds: root.rootIds ?? [],
+    });
+  }
+  return next.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+}
+
+function gitWorkspaceRootsKey(roots: readonly GitWorkspaceRootInfo[]): string {
+  return roots.map((root) => root.repoRoot).sort((a, b) => a.localeCompare(b)).join("\n");
 }
 
 export function MainLayout() {
@@ -1765,7 +1787,9 @@ export function MainLayout() {
   const openGitTab = useCallback((repoRoot: string) => {
     const normalized = repoRoot.trim();
     if (!normalized) return;
-    const existing = tabsRef.current.find((tab) => tab.type === "git" && tab.git?.repoRoot === normalized);
+    const existing = tabsRef.current.find(
+      (tab) => tab.type === "git" && tab.git?.repoRoot === normalized && !tab.git?.workspaceRoots?.length,
+    );
     if (existing) {
       setActiveTab(existing.id);
       return;
@@ -1776,6 +1800,41 @@ export function MainLayout() {
       title: `Git · ${gitRepoName(normalized)}`,
       closable: true,
       git: { repoRoot: normalized },
+    });
+  }, [addTab, setActiveTab]);
+
+  const openWorkspaceGitManager = useCallback((payload: {
+    workspaceName: string;
+    roots: GitWorkspaceRootInfo[];
+    activeRepoRoot: string | null;
+  }) => {
+    const workspaceRoots = normalizeGitWorkspaceRoots(payload.roots);
+    if (workspaceRoots.length === 0) return;
+    const activeRepoRoot = payload.activeRepoRoot && workspaceRoots.some((root) => root.repoRoot === payload.activeRepoRoot)
+      ? payload.activeRepoRoot
+      : workspaceRoots[0].repoRoot;
+    const key = gitWorkspaceRootsKey(workspaceRoots);
+    const existing = tabsRef.current.find((tab) => (
+      tab.type === "git"
+      && !!tab.git?.workspaceRoots?.length
+      && gitWorkspaceRootsKey(tab.git.workspaceRoots) === key
+    ));
+    if (existing) {
+      setActiveTab(existing.id);
+      return;
+    }
+    const name = payload.workspaceName.trim() || "Code Workspace";
+    addTab({
+      id: `git-workspace-${Date.now()}`,
+      type: "git",
+      title: `Git · ${name}`,
+      closable: true,
+      git: {
+        repoRoot: activeRepoRoot,
+        workspaceName: name,
+        workspaceRoots,
+        activeRepoRoot,
+      },
     });
   }, [addTab, setActiveTab]);
 
@@ -3550,17 +3609,28 @@ export function MainLayout() {
                 {gitTabs.map((tab) => {
                   if (!tab.git) return null;
                   const isActive = activeTabId === tab.id;
+                  const workspaceRoots = tab.git.workspaceRoots ?? [];
                   return (
                     <div
                       key={tab.id}
                       className="absolute inset-0"
                       style={{ display: isActive ? "block" : "none" }}
                     >
-                      <GitPanel
-                        repoRoot={tab.git.repoRoot}
-                        visible={isActive}
-                        onOpenWorkspace={openCodeWorkspaceTab}
-                      />
+                      {workspaceRoots.length > 0 ? (
+                        <WorkspaceGitManager
+                          workspaceName={tab.git.workspaceName}
+                          roots={workspaceRoots}
+                          activeRepoRoot={tab.git.activeRepoRoot ?? tab.git.repoRoot}
+                          visible={isActive}
+                          onOpenWorkspace={openCodeWorkspaceTab}
+                        />
+                      ) : (
+                        <GitPanel
+                          repoRoot={tab.git.repoRoot}
+                          visible={isActive}
+                          onOpenWorkspace={openCodeWorkspaceTab}
+                        />
+                      )}
                     </div>
                   );
                 })}
@@ -3578,6 +3648,7 @@ export function MainLayout() {
                         tabId={tab.id}
                         workspace={tab.codeWorkspace}
                         visible={isActive}
+                        onOpenGitManager={openWorkspaceGitManager}
                       />
                     </div>
                   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -293,6 +293,17 @@ export interface MailTabInfo {
 
 export interface GitTabInfo {
   repoRoot: string;
+  workspaceName?: string;
+  workspaceRoots?: GitWorkspaceRootInfo[];
+  activeRepoRoot?: string | null;
+}
+
+export interface GitWorkspaceRootInfo {
+  id: string;
+  name: string;
+  path: string;
+  repoRoot: string;
+  rootIds: string[];
 }
 
 export type CodeWorkspaceRootKind = "git" | "folder";


### PR DESCRIPTION
Detect nested Git repositories when a Code Workspace is opened from a parent directory, while skipping heavyweight/generated folders such as .git, node_modules, target, dist, and build.

Add a dedicated workspace Git manager tab that mirrors the IDEA-style workflow: repositories are grouped in a left-side changes tree, individual files can be selected for commit, and a shared commit message supports Commit and Commit and Push across selected repositories.

Keep the existing GitPanel as the detailed per-repository view on the right side so existing changes, log, branch, stash, tag, and settings workflows remain intact. Add entry points from both the Code Workspace toolbar and the embedded bottom Git panel.

Cover the behavior with focused frontend tests for the manager and embedded entry point, plus a Rust test for detecting child repositories under a plain workspace root.

Verified with: pnpm vitest run src/components/git/WorkspaceGitManager.test.tsx src/components/editor/WorkspaceGitContainer.test.tsx src/components/editor/CodeWorkspaceTab.test.tsx; cargo test detects_child_git_roots_under_plain_workspace_root; pnpm build.