### PR TITLE
fix(notes): repair popup behavior and compact controls

### DIFF
--- a/src-tauri/src/windowing/mod.rs
+++ b/src-tauri/src/windowing/mod.rs
@@ -60,6 +60,8 @@ pub async fn open_detached_window(
     kind: String,
     session_id: String,
     title: Option<String>,
+    x: Option<f64>,
+    y: Option<f64>,
     width: Option<f64>,
     height: Option<f64>,
 ) -> Result<(), String> {
@@ -104,6 +106,13 @@ pub async fn open_detached_window(
         .min_inner_size(min_w, min_h)
         .resizable(true)
         .enable_clipboard_access();
+
+    let builder = match (x, y) {
+        (Some(x), Some(y)) if x.is_finite() && y.is_finite() => {
+            builder.position(x.max(0.0), y.max(0.0))
+        }
+        _ => builder,
+    };
 
     let builder = if kind == "notes" {
         let builder = builder

--- a/src/components/notes/FloatingNotesPanel.test.tsx
+++ b/src/components/notes/FloatingNotesPanel.test.tsx
@@ -59,6 +59,8 @@ describe("FloatingNotesPanel", () => {
     expect(await screen.findByTestId("floating-notes-panel")).toBeInTheDocument();
     // Exactly one notes panel exists (no duplicate hub instance).
     expect(screen.getAllByTestId("floating-notes-panel")).toHaveLength(1);
+    expect(screen.getByTestId("floating-notes-dock")).toBeInTheDocument();
+    expect(screen.queryByTestId("notes-floating-toggle")).not.toBeInTheDocument();
   });
 
   it("adds a floating panel without removing the hub notes panel", async () => {
@@ -81,6 +83,22 @@ describe("FloatingNotesPanel", () => {
     fireEvent.click(screen.getByTestId("floating-notes-dock"));
     expect(useNotesStore.getState().panelMode).toBe("hub");
     await waitFor(() => expect(screen.queryByTestId("floating-notes-panel")).not.toBeInTheDocument());
+  });
+
+  it("persists the current floating position when docking", async () => {
+    useNotesStore.setState({
+      panelMode: "floating",
+      panelPosition: { x: 40, y: 50, width: 280, height: 340 },
+    });
+    render(<FloatingNotesPanel />);
+    const drag = await screen.findByTestId("floating-notes-drag");
+
+    fireEvent.pointerDown(drag, { button: 0, clientX: 40, clientY: 50, pointerId: 1 });
+    fireEvent.pointerMove(drag, { clientX: 90, clientY: 110, pointerId: 1 });
+    fireEvent.click(screen.getByTestId("floating-notes-dock"));
+
+    expect(useNotesStore.getState().panelPosition).toMatchObject({ x: 90, y: 110, width: 280, height: 340 });
+    expect(useNotesStore.getState().panelMode).toBe("hub");
   });
 
   it("raises z-index when always-on-top is enabled", async () => {
@@ -111,6 +129,8 @@ describe("FloatingNotesPanel", () => {
         kind: "notes",
         sessionId: "panel",
         title: "Notes",
+        x: DEFAULT_NOTES_PANEL_POSITION.x,
+        y: DEFAULT_NOTES_PANEL_POSITION.y,
         width: DEFAULT_NOTES_PANEL_POSITION.width,
         height: DEFAULT_NOTES_PANEL_POSITION.height,
       }),

--- a/src/components/notes/FloatingNotesPanel.tsx
+++ b/src/components/notes/FloatingNotesPanel.tsx
@@ -52,9 +52,11 @@ export function FloatingNotesPanel() {
   useEffect(() => {
     return subscribeNotesDockSignal(() => {
       openedNativeRef.current = false;
+      dragRef.current = null;
+      setPanelPosition(posRef.current);
       setPanelMode("hub");
     });
-  }, [setPanelMode]);
+  }, [setPanelMode, setPanelPosition]);
 
   // Keep local geometry in sync with persisted prefs when not actively dragging.
   useEffect(() => {
@@ -72,13 +74,15 @@ export function FloatingNotesPanel() {
       kind: "notes",
       sessionId: "panel",
       title: t("notes.title"),
+      x: panelPosition.x,
+      y: panelPosition.y,
       width: panelPosition.width,
       height: panelPosition.height,
     }).catch((err) => {
       openedNativeRef.current = false;
       console.warn("notes: failed to open detached window", err);
     });
-  }, [panelMode, panelPosition.height, panelPosition.width, t]);
+  }, [panelMode, panelPosition.height, panelPosition.width, panelPosition.x, panelPosition.y, t]);
 
   if (panelMode !== "floating") return null;
   if (isTauriRuntime()) return null;
@@ -117,6 +121,12 @@ export function FloatingNotesPanel() {
     }
   };
 
+  const dockToHub = () => {
+    dragRef.current = null;
+    setPanelPosition(posRef.current);
+    setPanelMode("hub");
+  };
+
   const style: CSSProperties = {
     left: pos.x,
     top: pos.y,
@@ -147,7 +157,7 @@ export function FloatingNotesPanel() {
         <button
           type="button"
           className="taomni-btn h-5 w-5 p-0 inline-flex items-center justify-center rounded hover:bg-black/10"
-          onClick={() => setPanelMode("hub")}
+          onClick={dockToHub}
           title={t("notes.dock")}
           aria-label={t("notes.dock")}
           data-testid="floating-notes-dock"
@@ -159,7 +169,7 @@ export function FloatingNotesPanel() {
 
       {/* Notes content */}
       <div className="flex-1 min-h-0 flex flex-col">
-        <NotesPanel />
+        <NotesPanel showPanelModeToggle={false} />
       </div>
 
       {/* Resize handle (bottom-right) */}

--- a/src/components/notes/NoteDateTimeField.tsx
+++ b/src/components/notes/NoteDateTimeField.tsx
@@ -350,6 +350,7 @@ export function NoteDateTimeField({ label, value, onChange, testId }: NoteDateTi
               type="button"
               className="taomni-btn h-6 w-6 p-0"
               onClick={() => setMonth((current) => addMonths(current, -1))}
+              title={t("notes.dateTimePreviousMonth")}
               aria-label={t("notes.dateTimePreviousMonth")}
             >
               <ChevronLeft className="w-3.5 h-3.5" />
@@ -359,6 +360,7 @@ export function NoteDateTimeField({ label, value, onChange, testId }: NoteDateTi
               type="button"
               className="taomni-btn h-6 w-6 p-0"
               onClick={() => setMonth((current) => addMonths(current, 1))}
+              title={t("notes.dateTimeNextMonth")}
               aria-label={t("notes.dateTimeNextMonth")}
             >
               <ChevronRight className="w-3.5 h-3.5" />

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -266,13 +266,14 @@ export function NoteEditor({ note, onClose }: NoteEditorProps) {
         </button>
         <button
           type="button"
-          className="taomni-btn h-6 px-2 inline-flex items-center gap-1 text-[11px]"
+          className="taomni-btn h-6 w-6 p-0 inline-flex items-center justify-center"
           onClick={() => void toggleComplete(note.id, !done)}
+          title={done ? t("notes.reopen") : t("notes.complete")}
+          aria-label={done ? t("notes.reopen") : t("notes.complete")}
           aria-pressed={done}
           data-testid="note-editor-complete"
         >
           {done ? <CheckCircle2 className="w-3.5 h-3.5 text-green-400" /> : <Circle className="w-3.5 h-3.5" />}
-          <span>{done ? t("notes.completed") : t("notes.complete")}</span>
         </button>
         <div className="flex-1" />
         <button
@@ -431,6 +432,7 @@ export function NoteEditor({ note, onClose }: NoteEditorProps) {
               className={`w-4 h-4 rounded-full border border-[var(--taomni-divider)] ${note.color === c ? "ring-2 ring-offset-1 ring-[var(--taomni-accent)]" : ""}`}
               style={{ background: c }}
               onClick={() => commit({ color: c })}
+              title={`${t("notes.color")} ${c}`}
               aria-label={`${t("notes.color")} ${c}`}
               data-testid={`note-editor-color-${c}`}
             />
@@ -455,6 +457,7 @@ export function NoteEditor({ note, onClose }: NoteEditorProps) {
                     )
                   }
                   aria-pressed={stepDone}
+                  title={stepDone ? t("notes.reopen") : t("notes.complete")}
                   aria-label={stepDone ? t("notes.reopen") : t("notes.complete")}
                 >
                   {stepDone ? <CheckCircle2 className="w-3.5 h-3.5 text-green-400" /> : <Circle className="w-3.5 h-3.5" />}
@@ -472,6 +475,7 @@ export function NoteEditor({ note, onClose }: NoteEditorProps) {
                   type="button"
                   className="taomni-btn h-6 w-6 p-0 inline-flex items-center justify-center hover:text-red-400"
                   onClick={() => persistSteps(steps.filter((_, j) => j !== i))}
+                  title={t("notes.delete")}
                   aria-label={t("notes.delete")}
                 >
                   <X className="w-3 h-3" />
@@ -503,6 +507,7 @@ export function NoteEditor({ note, onClose }: NoteEditorProps) {
                   setNewStep("");
                 }
               }}
+              title={t("notes.addStep")}
               aria-label={t("notes.addStep")}
             >
               <Plus className="w-3.5 h-3.5" />
@@ -525,6 +530,7 @@ export function NoteEditor({ note, onClose }: NoteEditorProps) {
                   type="button"
                   className="hover:text-red-400"
                   onClick={() => removeTag(id)}
+                  title={`${t("notes.delete")} ${tagName(id)}`}
                   aria-label={`${t("notes.delete")} ${tagName(id)}`}
                 >
                   <X className="w-2.5 h-2.5" />

--- a/src/components/notes/NoteFilters.tsx
+++ b/src/components/notes/NoteFilters.tsx
@@ -44,6 +44,7 @@ export function NoteStatusFilter({ filters, onToggleFilter, className = "" }: No
     selected.length === 1
       ? t(`notes.filters.${selected[0]}`)
       : t("notes.statusCount", { count: selected.length });
+  const buttonLabel = `${t("notes.status")}: ${summary}`;
 
   useEffect(() => {
     if (!open) return;
@@ -70,17 +71,16 @@ export function NoteStatusFilter({ filters, onToggleFilter, className = "" }: No
     >
       <button
         type="button"
-        className="taomni-btn h-6 max-w-[150px] px-2 inline-flex items-center gap-1 text-[11px]"
+        className="taomni-btn h-6 w-8 p-0 inline-flex items-center justify-center gap-0.5"
         onClick={() => setOpen((value) => !value)}
         aria-haspopup="menu"
         aria-expanded={open}
+        aria-label={buttonLabel}
+        title={buttonLabel}
         data-testid="notes-filter-menu"
       >
         <ListFilter className="w-3.5 h-3.5" />
-        <span className="max-w-[112px] truncate">
-          {t("notes.status")}: {summary}
-        </span>
-        <ChevronDown className="w-3 h-3" />
+        <ChevronDown className="w-2.5 h-2.5" />
       </button>
       {open && (
         <div
@@ -100,6 +100,7 @@ export function NoteStatusFilter({ filters, onToggleFilter, className = "" }: No
                 className={`flex h-7 w-full items-center gap-2 rounded px-2 text-left text-[11px] ${
                   active ? "bg-[var(--taomni-selected)] text-[var(--taomni-accent)]" : "hover:bg-[var(--taomni-hover)]"
                 }`}
+                title={t(`notes.filters.${f}`)}
                 onClick={() => onToggleFilter(f)}
               >
                 <span className="w-3.5 shrink-0">{active && <Check className="w-3.5 h-3.5" />}</span>

--- a/src/components/notes/NoteThemeSettings.tsx
+++ b/src/components/notes/NoteThemeSettings.tsx
@@ -40,6 +40,7 @@ export function NoteThemeSettings() {
           options={themeOptions}
           ariaLabel={t("notes.theme")}
           testId="note-theme-select"
+          title={t("notes.theme")}
           onChange={(next) => setTheme(next as NotesTheme)}
         />
       </div>
@@ -56,6 +57,7 @@ export function NoteThemeSettings() {
           onChange={(event) => setFont(event.target.value as NotesFont)}
           data-testid="note-font-select"
           aria-label={t("notes.font")}
+          title={t("notes.font")}
         >
           {NOTES_FONTS.map((value: NotesFont) => (
             <option key={value} value={value}>

--- a/src/components/notes/NotesDetachedWindow.tsx
+++ b/src/components/notes/NotesDetachedWindow.tsx
@@ -17,6 +17,7 @@ import { WindowResizeHandles } from "../window/WindowResizeHandles";
 export function NotesDetachedWindow() {
   const t = useT();
   const setPanelMode = useNotesStore((s) => s.setPanelMode);
+  const setPanelPosition = useNotesStore((s) => s.setPanelPosition);
   const theme = useNotesStore((s) => s.theme);
   const font = useNotesStore((s) => s.font);
   const fontSize = useNotesStore((s) => s.fontSize);
@@ -42,6 +43,28 @@ export function NotesDetachedWindow() {
     });
   }, []);
 
+  const persistWindowGeometry = useCallback(async () => {
+    if (!isTauriRuntime()) return;
+    try {
+      const currentWindow = getCurrentWindow();
+      const [position, size, scaleFactor] = await Promise.all([
+        currentWindow.outerPosition(),
+        currentWindow.innerSize(),
+        currentWindow.scaleFactor(),
+      ]);
+      const logicalPosition = position.toLogical(scaleFactor);
+      const logicalSize = size.toLogical(scaleFactor);
+      setPanelPosition({
+        x: Math.max(0, Math.round(logicalPosition.x)),
+        y: Math.max(0, Math.round(logicalPosition.y)),
+        width: Math.max(220, Math.round(logicalSize.width)),
+        height: Math.max(220, Math.round(logicalSize.height)),
+      });
+    } catch {
+      /* best effort: geometry is persisted for the next notes popup */
+    }
+  }, [setPanelPosition]);
+
   useEffect(() => {
     return subscribeNotesDockSignal(closeDetachedNotesWindow);
   }, [closeDetachedNotesWindow]);
@@ -53,9 +76,12 @@ export function NotesDetachedWindow() {
     void getCurrentWindow()
       .onCloseRequested((event) => {
         event.preventDefault();
-        setPanelMode("hub");
-        emitNotesDockSignal();
-        closeDetachedNotesWindow();
+        void (async () => {
+          await persistWindowGeometry();
+          setPanelMode("hub");
+          emitNotesDockSignal();
+          closeDetachedNotesWindow();
+        })();
       })
       .then((next) => {
         if (disposed) next();
@@ -68,12 +94,15 @@ export function NotesDetachedWindow() {
       disposed = true;
       unlisten?.();
     };
-  }, [closeDetachedNotesWindow, setPanelMode]);
+  }, [closeDetachedNotesWindow, persistWindowGeometry, setPanelMode]);
 
   const dockToHub = () => {
-    setPanelMode("hub");
-    emitNotesDockSignal();
-    closeDetachedNotesWindow();
+    void (async () => {
+      await persistWindowGeometry();
+      setPanelMode("hub");
+      emitNotesDockSignal();
+      closeDetachedNotesWindow();
+    })();
   };
 
   const startDrag = (event: ReactMouseEvent) => {
@@ -118,7 +147,7 @@ export function NotesDetachedWindow() {
         </button>
       </div>
       <div className="flex-1 min-h-0 flex flex-col">
-        <NotesPanel />
+        <NotesPanel showPanelModeToggle={false} />
       </div>
       <WindowResizeHandles className="absolute inset-0 z-20" edgeSize={5} cornerSize={10} />
       <div className="notes-sticky-fold" aria-hidden="true" />

--- a/src/components/notes/NotesPanel.test.tsx
+++ b/src/components/notes/NotesPanel.test.tsx
@@ -157,11 +157,13 @@ describe("NotesPanel", () => {
 
     fireEvent.click(screen.getByTestId("notes-floating-toggle"));
     expect(useNotesStore.getState().panelMode).toBe("floating");
-    expect(screen.getByTestId("notes-floating-toggle")).toHaveTextContent("In hub");
+    expect(screen.getByTestId("notes-floating-toggle")).toHaveAttribute("aria-label", "In hub");
+    expect(screen.getByTestId("notes-floating-toggle")).toHaveAttribute("title", "In hub");
 
     fireEvent.click(screen.getByTestId("notes-floating-toggle"));
     expect(useNotesStore.getState().panelMode).toBe("hub");
-    expect(screen.getByTestId("notes-floating-toggle")).toHaveTextContent("Floating");
+    expect(screen.getByTestId("notes-floating-toggle")).toHaveAttribute("aria-label", "Floating");
+    expect(screen.getByTestId("notes-floating-toggle")).toHaveAttribute("title", "Floating");
   });
 
   it("keeps floating controls out of the settings panel", async () => {
@@ -183,6 +185,26 @@ describe("NotesPanel", () => {
     await waitFor(() => expect(screen.getByTestId("note-editor")).toBeInTheDocument());
     expect(store).toHaveLength(1);
     expect(store[0].completed_at).toBeNull();
+  });
+
+  it("returns to the recent-incomplete view before creating a note from a non-matching view", async () => {
+    useNotesStore.setState({
+      prefsLoaded: true,
+      filter: "completed",
+      statusFilters: ["completed"],
+      search: "missing",
+      tagFilterId: "tag-1",
+    });
+    render(<NotesPanel />);
+    await screen.findByTestId("notes-new");
+
+    fireEvent.click(screen.getByTestId("notes-new"));
+
+    await waitFor(() => expect(screen.getByTestId("note-editor")).toBeInTheDocument());
+    expect(useNotesStore.getState().filter).toBe("recent_incomplete");
+    expect(useNotesStore.getState().statusFilters).toEqual(["recent_incomplete"]);
+    expect(useNotesStore.getState().search).toBe("");
+    expect(useNotesStore.getState().tagFilterId).toBeNull();
   });
 
   it("keeps completed notes out of the default recent-incomplete view", async () => {

--- a/src/components/notes/NotesPanel.tsx
+++ b/src/components/notes/NotesPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Monitor, PanelRightClose, Plus, Search, Settings } from "lucide-react";
 import { useNotesStore } from "../../stores/notesStore";
 import { useT } from "../../lib/i18n";
@@ -9,12 +9,16 @@ import { NoteThemeSettings } from "./NoteThemeSettings";
 import { notesFontSizeStyle, notesFontStyle, notesThemeDensity, notesThemeStyle } from "../../lib/notes/notesTheme";
 import { emitNotesDockSignal } from "../../lib/notes/notesWindowSync";
 
+interface NotesPanelProps {
+  showPanelModeToggle?: boolean;
+}
+
 /**
  * NotesPanel — the 便签 tab content inside the Tao Hub. A master/detail surface
  * sized for the narrow drawer: toolbar + filter chips over the list, with the
  * editor replacing the list when a note is selected (§4.2).
  */
-export function NotesPanel() {
+export function NotesPanel({ showPanelModeToggle = true }: NotesPanelProps = {}) {
   const t = useT();
   const notes = useNotesStore((s) => s.notes);
   const loading = useNotesStore((s) => s.loading);
@@ -38,6 +42,8 @@ export function NotesPanel() {
   const panelMode = useNotesStore((s) => s.panelMode);
   const setPanelMode = useNotesStore((s) => s.setPanelMode);
   const [showSettings, setShowSettings] = useState(false);
+  const [creatingNote, setCreatingNote] = useState(false);
+  const creatingNoteRef = useRef(false);
 
   useEffect(() => {
     // Bootstrap prefs → list in order (prefs may restore a non-default filter),
@@ -63,6 +69,19 @@ export function NotesPanel() {
     setPanelMode("floating");
   };
 
+  const handleCreateNote = async () => {
+    if (creatingNoteRef.current) return;
+    creatingNoteRef.current = true;
+    setCreatingNote(true);
+    try {
+      const note = await createNote({ title: "" });
+      if (note) setActiveNote(note.id);
+    } finally {
+      creatingNoteRef.current = false;
+      setCreatingNote(false);
+    }
+  };
+
   return (
     <div
       className="flex-1 min-h-0 flex flex-col"
@@ -82,14 +101,14 @@ export function NotesPanel() {
           >
             <button
               type="button"
-              className="taomni-btn h-6 px-2 inline-flex items-center gap-1 text-[11px]"
-              onClick={() => void createNote({ title: "" })}
+              className="taomni-btn h-6 w-6 shrink-0 p-0 inline-flex items-center justify-center"
+              onClick={() => void handleCreateNote()}
+              disabled={creatingNote}
               title={t("notes.newNote")}
               aria-label={t("notes.newNoteAria")}
               data-testid="notes-new"
             >
               <Plus className="w-3.5 h-3.5" />
-              <span>{t("notes.newNote")}</span>
             </button>
             <NoteStatusFilter filters={statusFilters} onToggleFilter={toggleStatusFilter} />
             <div className="relative flex-1 min-w-0">
@@ -104,18 +123,19 @@ export function NotesPanel() {
                 data-testid="notes-search"
               />
             </div>
-            <button
-              type="button"
-              className={`taomni-btn h-6 px-2 inline-flex items-center gap-1 text-[11px] ${floatingActive ? "bg-[var(--taomni-selected)] text-[var(--taomni-accent)]" : ""}`}
-              onClick={toggleFloatingPanel}
-              title={floatingActive ? t("notes.panelModeHub") : t("notes.panelModeFloating")}
-              aria-label={floatingActive ? t("notes.panelModeHub") : t("notes.panelModeFloating")}
-              aria-pressed={floatingActive}
-              data-testid="notes-floating-toggle"
-            >
-              {floatingActive ? <PanelRightClose className="w-3.5 h-3.5" /> : <Monitor className="w-3.5 h-3.5" />}
-              <span>{floatingActive ? t("notes.panelModeHub") : t("notes.panelModeFloating")}</span>
-            </button>
+            {showPanelModeToggle && (
+              <button
+                type="button"
+                className={`taomni-btn h-6 w-6 shrink-0 p-0 inline-flex items-center justify-center ${floatingActive ? "bg-[var(--taomni-selected)] text-[var(--taomni-accent)]" : ""}`}
+                onClick={toggleFloatingPanel}
+                title={floatingActive ? t("notes.panelModeHub") : t("notes.panelModeFloating")}
+                aria-label={floatingActive ? t("notes.panelModeHub") : t("notes.panelModeFloating")}
+                aria-pressed={floatingActive}
+                data-testid="notes-floating-toggle"
+              >
+                {floatingActive ? <PanelRightClose className="w-3.5 h-3.5" /> : <Monitor className="w-3.5 h-3.5" />}
+              </button>
+            )}
             <button
               type="button"
               className={`taomni-btn h-6 w-6 p-0 inline-flex items-center justify-center ${showSettings ? "bg-[var(--taomni-selected)]" : ""}`}

--- a/src/index.css
+++ b/src/index.css
@@ -537,10 +537,18 @@ body.notes-detached-document,
   width: 34px;
   height: 34px;
   pointer-events: none;
+  overflow: hidden;
+  border-bottom-right-radius: 14px;
+  background: var(--taomni-sidebar-bg);
+}
+.notes-sticky-fold::after {
+  content: "";
+  position: absolute;
+  inset: 0;
   clip-path: polygon(100% 0, 0 100%, 100% 100%);
   background:
-    linear-gradient(135deg, transparent 0 46%, rgba(0, 0, 0, 0.14) 47% 49%, rgba(255, 255, 255, 0.55) 50% 100%),
-    linear-gradient(135deg, color-mix(in srgb, var(--taomni-panel-bg) 76%, white), var(--taomni-card-bg));
+    linear-gradient(135deg, transparent 0 46%, rgba(0, 0, 0, 0.14) 47% 49%, color-mix(in srgb, var(--taomni-panel-bg) 82%, var(--taomni-sidebar-bg)) 50% 100%),
+    linear-gradient(135deg, var(--taomni-panel-bg), var(--taomni-sidebar-bg));
   box-shadow: -3px -3px 7px rgba(0, 0, 0, 0.14);
 }
 

--- a/src/lib/detachWindowing.ts
+++ b/src/lib/detachWindowing.ts
@@ -5,6 +5,8 @@ export interface OpenDetachedWindowOptions {
   kind: DetachedKind;
   sessionId: string;
   title?: string;
+  x?: number;
+  y?: number;
   width?: number;
   height?: number;
 }
@@ -21,6 +23,8 @@ export async function openDetachedWindow(
     kind: opts.kind,
     sessionId: opts.sessionId,
     title: opts.title,
+    x: opts.x,
+    y: opts.y,
     width: opts.width,
     height: opts.height,
   });

--- a/src/stores/notesStore.test.ts
+++ b/src/stores/notesStore.test.ts
@@ -179,6 +179,25 @@ describe("notesStore", () => {
     expect(useNotesStore.getState().activeNoteId).toBe(note?.id);
   });
 
+  it("resets non-matching filters when creating a new note", async () => {
+    useNotesStore.setState({
+      filter: "completed",
+      statusFilters: ["completed"],
+      search: "missing",
+      tagFilterId: "tag-1",
+    });
+
+    const note = await useNotesStore.getState().createNote({ title: "visible draft" });
+
+    expect(note?.completed_at).toBeNull();
+    expect(useNotesStore.getState().filter).toBe("recent_incomplete");
+    expect(useNotesStore.getState().statusFilters).toEqual(["recent_incomplete"]);
+    expect(useNotesStore.getState().search).toBe("");
+    expect(useNotesStore.getState().tagFilterId).toBeNull();
+    expect(useNotesStore.getState().activeNoteId).toBe(note?.id);
+    expect(useNotesStore.getState().notes.some((n) => n.id === note?.id)).toBe(true);
+  });
+
   it("updates a note's title", async () => {
     const note = await useNotesStore.getState().createNote({ title: "old" });
     await useNotesStore.getState().updateNote(note!.id, { title: "new", body: "" });

--- a/src/stores/notesStore.ts
+++ b/src/stores/notesStore.ts
@@ -69,6 +69,7 @@ const PREF_STATUS_FILTERS = "notes.statusFilters";
 const DEFAULT_NOTES_FONT_SIZE = 12;
 const MIN_NOTES_FONT_SIZE = 10;
 const MAX_NOTES_FONT_SIZE = 20;
+let loadNotesRequestSeq = 0;
 
 const LEGACY_DEFAULT_NOTES_PANEL_SIZE = {
   width: 460,
@@ -241,6 +242,7 @@ export const useNotesStore = create<NotesStore>((set, get) => ({
 
   loadNotes: async () => {
     const { filter, statusFilters, search, tagFilterId } = get();
+    const requestSeq = ++loadNotesRequestSeq;
     set({ loading: true });
     try {
       const notes = await listNotes({
@@ -250,8 +252,10 @@ export const useNotesStore = create<NotesStore>((set, get) => ({
         tag_id: tagFilterId ?? undefined,
         now: nowSecs(),
       });
+      if (requestSeq !== loadNotesRequestSeq) return;
       set({ notes: Array.isArray(notes) ? notes : [], notesLoaded: true, loading: false });
     } catch (e) {
+      if (requestSeq !== loadNotesRequestSeq) return;
       console.error("notes_list failed:", e);
       set({ notesLoaded: true, loading: false });
     }
@@ -269,9 +273,17 @@ export const useNotesStore = create<NotesStore>((set, get) => ({
   createNote: async (input) => {
     try {
       const note = await createNoteIpc(input ?? {});
-      set((s) => ({ notes: [note, ...s.notes], activeNoteId: note.id }));
-      // A brand-new note may not match the current filter (e.g. "completed");
-      // reload so the visible list stays consistent with the active view.
+      const statusFilters: NoteFilter[] = ["recent_incomplete"];
+      set((s) => ({
+        notes: [note, ...s.notes.filter((n) => n.id !== note.id)],
+        activeNoteId: note.id,
+        filter: "recent_incomplete",
+        statusFilters,
+        search: "",
+        tagFilterId: null,
+      }));
+      void persistPref(PREF_LAST_FILTER, "recent_incomplete");
+      void persistPref(PREF_STATUS_FILTERS, statusFilters);
       void get().loadNotes();
       return note;
     } catch (e) {


### PR DESCRIPTION
Fix several sticky-notes popup regressions and polish the notes toolbar UX.

- Guard note creation against duplicate in-flight clicks so a single action does not create many Untitled notes.

- Reset note filters/search around new-note creation and keep the newly created note selected after refresh.

- Hide the internal hub/floating mode toggle inside detached popup surfaces because the window chrome already exposes that action.

- Persist floating and detached window geometry when docking or closing so reopening restores the last position.

- Extend detached-window IPC to accept saved coordinates and apply them when opening the notes window.

- Rework the folded sticky-note corner styling to avoid transparent or white background showing through rounded corners.

- Convert notes controls toward compact icon buttons with tooltips, including filter and editor actions.

Tests: pnpm exec vitest run src/components/notes/NotesPanel.test.tsx src/stores/notesStore.test.ts src/components/notes/FloatingNotesPanel.test.tsx --pool=forks --maxWorkers=2

Tests: pnpm exec vite build

Tests: cd src-tauri && cargo check