### PR TITLE
fix(notes): resolve floating window corners and preserve dock position

### DIFF
--- a/src/components/notes/FloatingNotesPanel.tsx
+++ b/src/components/notes/FloatingNotesPanel.tsx
@@ -53,7 +53,11 @@ export function FloatingNotesPanel() {
     return subscribeNotesDockSignal(() => {
       openedNativeRef.current = false;
       dragRef.current = null;
-      setPanelPosition(posRef.current);
+      if (isTauriRuntime()) {
+        void useNotesStore.getState().loadPrefs();
+      } else {
+        setPanelPosition(posRef.current);
+      }
       setPanelMode("hub");
     });
   }, [setPanelMode, setPanelPosition]);

--- a/src/index.css
+++ b/src/index.css
@@ -322,7 +322,7 @@ html.notes-detached-document,
 html.notes-detached-document body,
 body.notes-detached-document,
 #root.notes-detached-root {
-  background: transparent;
+  background: transparent !important;
 }
 
 #root {


### PR DESCRIPTION
- Fix white corners on native detached windows in Linux/Windows. The inline script in `index.html` that mitigates flash-of-unstyled-content was setting `root.style.background`, overriding the CSS class. Added `!important` to the `background: transparent` rule in `index.css` so the native transparent window correctly exposes the rounded panel borders.
- Preserve notes floating window position across sessions. The main window's panel component was mistakenly overwriting the DB-persisted position with its own stale local state when intercepting the detached window's close signal. It now correctly reloads preferences to pick up the native window's last dragged bounds.