### PR TITLE
feat(workspace): separate workspace instance identity

### DIFF
--- a/src/components/editor/CodeWorkspaceTab.test.tsx
+++ b/src/components/editor/CodeWorkspaceTab.test.tsx
@@ -234,6 +234,7 @@ describe("CodeWorkspaceTab", () => {
     const workspace: CodeWorkspaceTabInfo = {
       repoRoot: "/repo/app",
       workspaceId: "ws-multi",
+      workspaceInstanceId: "instance-multi",
       name: "Multi Repo",
       roots: [
         { id: "app", name: "app", path: "/repo/app", kind: "git" },
@@ -287,7 +288,7 @@ describe("CodeWorkspaceTab", () => {
     await waitFor(() => {
       expect(lspMocks.lspOpenDocument).toHaveBeenCalledWith(
         {
-          workspaceId: "ws-multi",
+          workspaceId: "instance-multi",
           rootPath: "/repo/app",
           filePath: "src/Program.cs",
           serverCommandId: null,
@@ -533,6 +534,8 @@ describe("CodeWorkspaceTab", () => {
 
     expect(onOpenGitManager).toHaveBeenCalledWith({
       workspaceName: "Git",
+      workspaceInstanceId: "ws-git",
+      workspaceId: "ws-git",
       roots: [
         {
           id: "app",
@@ -631,6 +634,8 @@ describe("CodeWorkspaceTab", () => {
 
     expect(onOpenGitManager).toHaveBeenCalledWith({
       workspaceName: "Child Repos",
+      workspaceInstanceId: "ws-child-git",
+      workspaceId: "ws-child-git",
       roots: [
         {
           id: "workspace:/workspace/app",

--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -94,6 +94,7 @@ import {
   gitSnapshot,
   type GitChange,
 } from "../../lib/git";
+import { notifyGitRepoChanged, subscribeGitRepoRefresh } from "../../lib/gitRefresh";
 import {
   lspChangeDocument,
   lspCloseDocument,
@@ -140,11 +141,16 @@ interface CodeWorkspaceTabProps {
   tabId: string;
   workspace: CodeWorkspaceTabInfo;
   visible?: boolean;
-  onOpenGitManager?: (payload: {
+  onOpenGitManager?: (payload: CodeWorkspaceGitManagerPayload) => void;
+  onSyncGitManager?: (payload: CodeWorkspaceGitManagerPayload) => void;
+}
+
+export interface CodeWorkspaceGitManagerPayload {
     workspaceName: string;
+    workspaceInstanceId?: string;
+    workspaceId?: string;
     roots: WorkspaceGitRoot[];
     activeRepoRoot: string | null;
-  }) => void;
 }
 
 interface DirectoryState {
@@ -751,6 +757,7 @@ export function CodeWorkspaceTab({
   workspace,
   visible = true,
   onOpenGitManager,
+  onSyncGitManager,
 }: CodeWorkspaceTabProps) {
   const setStatusMessage = useAppStore((s) => s.setStatusMessage);
   const setTabCodeWorkspaceContext = useAppStore((s) => s.setTabCodeWorkspaceContext);
@@ -1007,9 +1014,9 @@ export function CodeWorkspaceTab({
     return () => el.removeEventListener("wheel", handleWheel, { capture: true });
   }, [stepCodeViewFontSize, stepTreeFontSize, visible, zoomTargetForNode]);
 
-  const workspaceId = useMemo(
-    () => workspace.workspaceId ?? workspace.repoRoot?.trim() ?? tabId,
-    [tabId, workspace.repoRoot, workspace.workspaceId],
+  const workspaceInstanceId = useMemo(
+    () => workspace.workspaceInstanceId ?? workspace.workspaceId ?? workspace.repoRoot?.trim() ?? tabId,
+    [tabId, workspace.repoRoot, workspace.workspaceId, workspace.workspaceInstanceId],
   );
 
   const findRoot = useCallback((rootId: string) => rootsRef.current.find((root) => root.id === rootId) ?? null, []);
@@ -1072,7 +1079,7 @@ export function CodeWorkspaceTab({
         const root = findRoot(file.ref.rootId);
         if (!root) return null;
         return {
-          workspaceId,
+          workspaceId: workspaceInstanceId,
           rootPath: root.path,
           filePath: file.ref.path,
           serverCommandId,
@@ -1080,14 +1087,14 @@ export function CodeWorkspaceTab({
         };
       }
       return {
-        workspaceId,
+        workspaceId: workspaceInstanceId,
         rootPath: null,
         filePath: file.ref.path,
         serverCommandId,
         customServerCommand,
       };
     },
-    [findRoot, lspCommandPrefs, lspCustomCommands, workspaceId],
+    [findRoot, lspCommandPrefs, lspCustomCommands, workspaceInstanceId],
   );
 
   const nextLspVersion = useCallback((key: string) => {
@@ -1429,6 +1436,18 @@ export function CodeWorkspaceTab({
     return () => window.clearInterval(timer);
   }, [gitRoots, refreshWorkspaceGitSnapshots]);
 
+  useEffect(() => subscribeGitRepoRefresh((repoRoot) => {
+    const root = gitRootsRef.current.find((item) => item.repoRoot === repoRoot);
+    if (root) void refreshWorkspaceGitSnapshots([root]);
+  }), [refreshWorkspaceGitSnapshots]);
+
+  const notifyWorkspacePathGitChanged = useCallback((rootId: string, path: string) => {
+    const root = findRoot(rootId);
+    if (!root) return;
+    const repo = gitRootForWorkspacePath(root, path, gitRootsRef.current);
+    if (repo) notifyGitRepoChanged(repo.repoRoot);
+  }, [findRoot]);
+
   useEffect(() => {
     if (treeViewMode !== "compact") return;
     for (const [key, state] of Object.entries(directories)) {
@@ -1619,11 +1638,12 @@ export function CodeWorkspaceTab({
       const ref: CodeWorkspaceFileRef = { kind: "root", rootId: root.id, path: file.path };
       setSelected({ kind: "file", ref });
       await openFile(ref);
+      notifyWorkspacePathGitChanged(root.id, file.path);
       setStatusMessage(`Created ${root.name} / ${file.path}`);
     } catch (err) {
       setStatusMessage(errorMessage(err));
     }
-  }, [findRoot, loadDir, openFile, selectedRootDirectory, setStatusMessage]);
+  }, [findRoot, loadDir, notifyWorkspacePathGitChanged, openFile, selectedRootDirectory, setStatusMessage]);
 
   const createDir = useCallback(async () => {
     if (!selectedRootDirectory) {
@@ -1646,11 +1666,12 @@ export function CodeWorkspaceTab({
       await loadDir(root.id, parentPath(entry.path));
       setExpandedDirs((current) => new Set(current).add(rootDirKey(root.id, parentPath(entry.path))));
       setSelected({ kind: "dir", rootId: root.id, path: entry.path });
+      notifyWorkspacePathGitChanged(root.id, entry.path);
       setStatusMessage(`Created ${root.name} / ${entry.path}`);
     } catch (err) {
       setStatusMessage(errorMessage(err));
     }
-  }, [findRoot, loadDir, selectedRootDirectory, setStatusMessage]);
+  }, [findRoot, loadDir, notifyWorkspacePathGitChanged, selectedRootDirectory, setStatusMessage]);
 
   const renameSelected = useCallback(async () => {
     if (!selected) return;
@@ -1720,11 +1741,13 @@ export function CodeWorkspaceTab({
         return file ? fileKey(remapFileRef(file.ref, root.id, selectedPath, newPath)) : current;
       });
       setSelected(entry.fileType === "dir" ? { kind: "dir", rootId: root.id, path: newPath } : { kind: "file", ref: { kind: "root", rootId: root.id, path: newPath } });
+      notifyWorkspacePathGitChanged(root.id, selectedPath);
+      notifyWorkspacePathGitChanged(root.id, newPath);
       setStatusMessage(`Renamed to ${root.name} / ${newPath}`);
     } catch (err) {
       setStatusMessage(errorMessage(err));
     }
-  }, [findRoot, loadDir, selected, setStatusMessage]);
+  }, [findRoot, loadDir, notifyWorkspacePathGitChanged, selected, setStatusMessage]);
 
   const deleteSelected = useCallback(async () => {
     if (!selected) return;
@@ -1810,11 +1833,12 @@ export function CodeWorkspaceTab({
         return file && fileRefUnder(file.ref, root.id, selectedPath) ? remainingOpen[0] ?? null : current;
       });
       setSelected(null);
+      notifyWorkspacePathGitChanged(root.id, selectedPath);
       setStatusMessage(`Deleted ${root.name} / ${selectedPath}`);
     } catch (err) {
       setStatusMessage(errorMessage(err));
     }
-  }, [findRoot, loadDir, selected, setStatusMessage]);
+  }, [findRoot, loadDir, notifyWorkspacePathGitChanged, selected, setStatusMessage]);
 
   const updateFileText = useCallback((key: string, text: string) => {
     setOpenFiles((current) => {
@@ -1867,6 +1891,9 @@ export function CodeWorkspaceTab({
           };
         });
         setStatusMessage(`Saved ${file.subtitle}`);
+        if (file.ref.kind === "root") {
+          notifyWorkspacePathGitChanged(file.ref.rootId, file.ref.path);
+        }
         void saveLspDocument(file, textToSave);
       } catch (err) {
         const message = errorMessage(err);
@@ -1881,7 +1908,7 @@ export function CodeWorkspaceTab({
         setStatusMessage(message);
       }
     },
-    [activeKey, findRoot, saveLspDocument, setStatusMessage],
+    [activeKey, findRoot, notifyWorkspacePathGitChanged, saveLspDocument, setStatusMessage],
   );
 
   const reloadFile = useCallback(
@@ -2179,14 +2206,26 @@ export function CodeWorkspaceTab({
   );
   const activeDiagnostics = activeLspState?.diagnostics ?? [];
   const title = workspaceTitle(workspace, roots, looseFiles);
-  const openGitManager = useCallback(() => {
-    if (!onOpenGitManager || gitRoots.length === 0) return;
-    onOpenGitManager({
+  const gitManagerPayload = useMemo<CodeWorkspaceGitManagerPayload | null>(() => {
+    if (gitRoots.length === 0) return null;
+    return {
       workspaceName: title,
+      workspaceInstanceId,
+      workspaceId: workspace.workspaceId,
       roots: gitRoots,
       activeRepoRoot: activeGitRoot?.repoRoot ?? gitRoots[0]?.repoRoot ?? null,
-    });
-  }, [activeFile, activeGitRoot, gitRoots, onOpenGitManager, title]);
+    };
+  }, [activeGitRoot, gitRoots, title, workspace.workspaceId, workspaceInstanceId]);
+
+  const openGitManager = useCallback(() => {
+    if (!onOpenGitManager || !gitManagerPayload) return;
+    onOpenGitManager(gitManagerPayload);
+  }, [gitManagerPayload, onOpenGitManager]);
+
+  useEffect(() => {
+    if (!onSyncGitManager || !gitManagerPayload) return;
+    onSyncGitManager(gitManagerPayload);
+  }, [gitManagerPayload, onSyncGitManager]);
 
   useEffect(() => {
     const firstRoot = roots[0] ?? null;
@@ -2600,7 +2639,7 @@ export function CodeWorkspaceTab({
 
       <PanelGroup
         orientation="horizontal"
-        id={`code-workspace-${workspace.workspaceId ?? workspace.repoRoot ?? tabId}`}
+        id={`code-workspace-${workspaceInstanceId}`}
         className="flex-1 min-h-0"
       >
         <Panel id="project" defaultSize="24%" minSize="15%" maxSize="45%" className="min-w-0">
@@ -2827,7 +2866,7 @@ export function CodeWorkspaceTab({
               </div>
             )}
             <div
-              id={`code-workspace-editor-stack-${workspace.workspaceId ?? workspace.repoRoot ?? tabId}`}
+              id={`code-workspace-editor-stack-${workspaceInstanceId}`}
               className="flex-1 min-h-0"
             >
               <div className="h-full min-h-0 relative">

--- a/src/components/git/GitPanel.test.tsx
+++ b/src/components/git/GitPanel.test.tsx
@@ -1,8 +1,9 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppStore } from "../../stores/appStore";
 import { GitPanel } from "./GitPanel";
 import type { GitLogEntry, GitOperationState, GitSnapshot } from "../../lib/git";
+import { notifyGitRepoChanged, subscribeGitRepoRefresh } from "../../lib/gitRefresh";
 
 const gitMocks = vi.hoisted(() => {
   const settings = {
@@ -113,6 +114,16 @@ describe("GitPanel", () => {
     cleanup();
   });
 
+  it("delivers repo refresh events to subscribers", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeGitRepoRefresh(listener);
+
+    notifyGitRepoChanged("D:\\repo");
+
+    expect(listener).toHaveBeenCalledWith("D:\\repo", expect.any(Number));
+    unsubscribe();
+  });
+
   it("uses Ctrl plus/minus/zero to adjust global UI font size while the Git panel is active", async () => {
     render(<GitPanel repoRoot="D:\\repo" />);
 
@@ -218,6 +229,22 @@ describe("GitPanel", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(gitMocks.gitLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes when the same repository publishes a Git refresh revision", async () => {
+    render(<GitPanel repoRoot="/repo" />);
+
+    await waitFor(() => expect(gitMocks.gitSnapshot).toHaveBeenCalledTimes(1));
+    act(() => {
+      notifyGitRepoChanged("/other");
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(gitMocks.gitSnapshot).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      notifyGitRepoChanged("/repo");
+    });
+    await waitFor(() => expect(gitMocks.gitSnapshot).toHaveBeenCalledTimes(2));
   });
 
   it("does not refresh the repository snapshot when selecting a branch", async () => {

--- a/src/components/git/GitPanel.tsx
+++ b/src/components/git/GitPanel.tsx
@@ -79,6 +79,7 @@ import {
   type GitStashEntry,
   type GitTag,
 } from "../../lib/git";
+import { notifyGitRepoChanged, subscribeGitRepoRefresh } from "../../lib/gitRefresh";
 import { alertAppDialog, confirmAppDialog, promptAppDialog } from "../../lib/appDialogs";
 import { ContextMenu, type MenuItem } from "../ContextMenu";
 import { ChangesTree } from "./ChangesTree";
@@ -179,6 +180,7 @@ export function GitPanel({
   const [menu, setMenu] = useState<{ x: number; y: number; path: string } | null>(null);
   const [headerMenu, setHeaderMenu] = useState<{ x: number; y: number } | null>(null);
   const [commitMenu, setCommitMenu] = useState<{ x: number; y: number; entry: GitLogEntry } | null>(null);
+  const [repoRefreshRevision, setRepoRefreshRevision] = useState(0);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const anchorRef = useRef<string | null>(null);
   const [operation, setOperation] = useState<GitOperationState | null>(null);
@@ -312,7 +314,13 @@ export function GitPanel({
 
   useEffect(() => {
     void refresh();
-  }, [refresh, refreshToken]);
+  }, [refresh, refreshToken, repoRefreshRevision]);
+
+  useEffect(() => subscribeGitRepoRefresh((changedRepoRoot) => {
+    if (changedRepoRoot === repoRoot) {
+      setRepoRefreshRevision((current) => current + 1);
+    }
+  }), [repoRoot]);
 
   useEffect(() => {
     let cancelled = false;
@@ -394,6 +402,7 @@ export function GitPanel({
       try {
         await action();
         await refresh();
+        notifyGitRepoChanged(repoRoot);
         setStatusMessage(`${label} completed`);
       } catch (err) {
         const message = errorMessage(err);
@@ -404,7 +413,7 @@ export function GitPanel({
         setBusy(false);
       }
     },
-    [refresh, setStatusMessage],
+    [refresh, repoRoot, setStatusMessage],
   );
 
   const changesList = useMemo(() => snapshot?.changes ?? [], [snapshot]);

--- a/src/components/git/WorkspaceGitManager.test.tsx
+++ b/src/components/git/WorkspaceGitManager.test.tsx
@@ -232,6 +232,34 @@ describe("WorkspaceGitManager", () => {
     expect(gitMocks.gitCommit).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back the active repository when updated roots remove it", async () => {
+    const { rerender } = render(
+      <WorkspaceGitManager
+        workspaceName="Workspace"
+        activeRepoRoot="/repo/service"
+        roots={[
+          { id: "app", name: "app", path: "/repo", repoRoot: "/repo/app", rootIds: ["root"] },
+          { id: "service", name: "service", path: "/repo", repoRoot: "/repo/service", rootIds: ["root"] },
+        ]}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("git-panel")).toHaveAttribute("data-repo-root", "/repo/service"));
+
+    rerender(
+      <WorkspaceGitManager
+        workspaceName="Workspace"
+        activeRepoRoot="/repo/service"
+        roots={[
+          { id: "app", name: "app", path: "/repo", repoRoot: "/repo/app", rootIds: ["root"] },
+          { id: "api", name: "api", path: "/repo", repoRoot: "/repo/api", rootIds: ["root"] },
+        ]}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("git-panel")).toHaveAttribute("data-repo-root", "/repo/api"));
+  });
+
   it("keeps workspace change selections isolated when repositories contain the same file path", async () => {
     gitMocks.gitSnapshot.mockImplementation(async (repoRoot: string) => (
       repoRoot === "/repo/app"

--- a/src/components/git/WorkspaceGitManager.tsx
+++ b/src/components/git/WorkspaceGitManager.tsx
@@ -46,6 +46,7 @@ import {
   type GitBlobPair,
   type GitSnapshot,
 } from "../../lib/git";
+import { notifyGitRepoChanged, subscribeGitRepoRefresh } from "../../lib/gitRefresh";
 import { alertAppDialog, confirmAppDialog, promptAppDialog } from "../../lib/appDialogs";
 import { useAppStore } from "../../stores/appStore";
 import type { GitWorkspaceRootInfo } from "../../types";
@@ -274,6 +275,13 @@ export function WorkspaceGitManager({
     await Promise.allSettled(targets.map((root) => refreshRepo(root.repoRoot)));
   }, [normalizedRoots, refreshRepo]);
 
+  useEffect(() => subscribeGitRepoRefresh((repoRoot) => {
+    if (normalizedRoots.some((root) => root.repoRoot === repoRoot)) {
+      void refreshRepo(repoRoot);
+      setPanelVersion((current) => current + 1);
+    }
+  }), [normalizedRoots, refreshRepo]);
+
   useEffect(() => {
     if (!visible || normalizedRoots.length === 0 || singleRepoMode) return;
     void refreshRepos(normalizedRoots);
@@ -376,6 +384,7 @@ export function WorkspaceGitManager({
           if (result === "completed") {
             completed += 1;
             await refreshRepo(root.repoRoot);
+            notifyGitRepoChanged(root.repoRoot);
           } else {
             skipped += 1;
           }
@@ -543,6 +552,7 @@ export function WorkspaceGitManager({
           if (result === "completed") {
             completed += 1;
             await refreshRepo(root.repoRoot);
+            notifyGitRepoChanged(root.repoRoot);
           } else {
             skipped += 1;
           }

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -33,7 +33,7 @@ import { WindowResizeHandles } from "../components/window/WindowResizeHandles";
 import { TerminalPanel, type TerminalLocalPathUploadRequest } from "../components/terminal/TerminalPanel";
 import { GitPanel } from "../components/git/GitPanel";
 import { WorkspaceGitManager } from "../components/git/WorkspaceGitManager";
-import { CodeWorkspaceTab } from "../components/editor/CodeWorkspaceTab";
+import { CodeWorkspaceTab, type CodeWorkspaceGitManagerPayload } from "../components/editor/CodeWorkspaceTab";
 import { MultiExecBar } from "../components/terminal/MultiExecBar";
 import { SessionEditor } from "../components/session/SessionEditor";
 import { AuthPrompt } from "../components/session/AuthPrompt";
@@ -72,7 +72,7 @@ import {
 import type { DetachedRdpParams, DetachedVncParams, DetachedTerminalParams, DetachedDbParams } from "../components/detached/DetachedSessionWindow";
 import { Columns2, Grid2X2, Lock, Rows3, Unlock, X } from "lucide-react";
 import type { SftpTabInfo, Tab, DbConnectInfo, HBaseConnectInfo, MailConnectionSecurity, MailTabInfo, CodeWorkspaceRootInfo, CodeWorkspaceTabInfo, GitWorkspaceRootInfo, RecentWorkspace } from "../types";
-import { computeNewTerminalTitle, recentWorkspaceIdFromParts, useAppStore, type TerminalSplitLayout } from "../stores/appStore";
+import { computeNewTerminalTitle, newWorkspaceInstanceId, recentWorkspaceIdFromParts, useAppStore, type TerminalSplitLayout } from "../stores/appStore";
 import { useSessionStore } from "../stores/sessionStore";
 import { WelcomePanel } from "../components/WelcomePanel";
 import { AboutDialog } from "../components/AboutDialog";
@@ -605,6 +605,7 @@ export function MainLayout() {
     removeTab,
     duplicateTab,
     updateTabTitle,
+    updateGitTabInfo,
     setActiveTab,
     moveTabToIndex,
     toggleSidebar,
@@ -1803,27 +1804,34 @@ export function MainLayout() {
     });
   }, [addTab, setActiveTab]);
 
-  const openWorkspaceGitManager = useCallback((payload: {
-    workspaceName: string;
-    roots: GitWorkspaceRootInfo[];
-    activeRepoRoot: string | null;
-  }) => {
+  const openWorkspaceGitManager = useCallback((payload: CodeWorkspaceGitManagerPayload) => {
     const workspaceRoots = normalizeGitWorkspaceRoots(payload.roots);
     if (workspaceRoots.length === 0) return;
     const activeRepoRoot = payload.activeRepoRoot && workspaceRoots.some((root) => root.repoRoot === payload.activeRepoRoot)
       ? payload.activeRepoRoot
       : workspaceRoots[0].repoRoot;
-    const key = gitWorkspaceRootsKey(workspaceRoots);
-    const existing = tabsRef.current.find((tab) => (
-      tab.type === "git"
-      && !!tab.git?.workspaceRoots?.length
-      && gitWorkspaceRootsKey(tab.git.workspaceRoots) === key
-    ));
+    const name = payload.workspaceName.trim() || "Code Workspace";
+    const existing = tabsRef.current.find((tab) => {
+      if (tab.type !== "git" || !tab.git?.workspaceRoots?.length) return false;
+      if (payload.workspaceInstanceId) {
+        return tab.git.sourceWorkspaceInstanceId === payload.workspaceInstanceId;
+      }
+      return gitWorkspaceRootsKey(tab.git.workspaceRoots) === gitWorkspaceRootsKey(workspaceRoots);
+    });
     if (existing) {
+      updateGitTabInfo(existing.id, {
+        ...existing.git!,
+        repoRoot: activeRepoRoot,
+        workspaceName: name,
+        workspaceRoots,
+        activeRepoRoot,
+        sourceWorkspaceInstanceId: payload.workspaceInstanceId ?? existing.git?.sourceWorkspaceInstanceId,
+        sourceWorkspaceId: payload.workspaceId ?? existing.git?.sourceWorkspaceId,
+        sourceWorkspaceName: name,
+      }, `Git · ${name}`);
       setActiveTab(existing.id);
       return;
     }
-    const name = payload.workspaceName.trim() || "Code Workspace";
     addTab({
       id: `git-workspace-${Date.now()}`,
       type: "git",
@@ -1834,9 +1842,41 @@ export function MainLayout() {
         workspaceName: name,
         workspaceRoots,
         activeRepoRoot,
+        sourceWorkspaceInstanceId: payload.workspaceInstanceId,
+        sourceWorkspaceId: payload.workspaceId,
+        sourceWorkspaceName: name,
       },
     });
-  }, [addTab, setActiveTab]);
+  }, [addTab, setActiveTab, updateGitTabInfo]);
+
+  const syncWorkspaceGitManager = useCallback((payload: CodeWorkspaceGitManagerPayload) => {
+    const sourceWorkspaceInstanceId = payload.workspaceInstanceId;
+    if (!sourceWorkspaceInstanceId) return;
+    const workspaceRoots = normalizeGitWorkspaceRoots(payload.roots);
+    if (workspaceRoots.length === 0) return;
+    const existing = tabsRef.current.find((tab) => (
+      tab.type === "git"
+      && tab.git?.sourceWorkspaceInstanceId === sourceWorkspaceInstanceId
+    ));
+    if (!existing?.git) return;
+    const existingActiveRepoRoot = existing.git.activeRepoRoot ?? existing.git.repoRoot;
+    const activeRepoRoot = existingActiveRepoRoot && workspaceRoots.some((root) => root.repoRoot === existingActiveRepoRoot)
+      ? existingActiveRepoRoot
+      : payload.activeRepoRoot && workspaceRoots.some((root) => root.repoRoot === payload.activeRepoRoot)
+        ? payload.activeRepoRoot
+        : workspaceRoots[0].repoRoot;
+    const name = payload.workspaceName.trim() || "Code Workspace";
+    updateGitTabInfo(existing.id, {
+      ...existing.git,
+      repoRoot: activeRepoRoot,
+      workspaceName: name,
+      workspaceRoots,
+      activeRepoRoot,
+      sourceWorkspaceInstanceId,
+      sourceWorkspaceId: payload.workspaceId ?? existing.git.sourceWorkspaceId,
+      sourceWorkspaceName: name,
+    }, `Git · ${name}`);
+  }, [updateGitTabInfo]);
 
   const openCodeWorkspaceInfo = useCallback((workspace: CodeWorkspaceTabInfo) => {
     const roots = workspace.roots ?? [];
@@ -1868,6 +1908,7 @@ export function MainLayout() {
       codeWorkspace: {
         ...workspace,
         workspaceId: workspace.workspaceId ?? identity,
+        workspaceInstanceId: workspace.workspaceInstanceId ?? newWorkspaceInstanceId(),
         name: title,
       },
     });
@@ -1914,6 +1955,7 @@ export function MainLayout() {
       codeWorkspace: {
         repoRoot: "",
         workspaceId: id,
+        workspaceInstanceId: newWorkspaceInstanceId(),
         name: "Editor Workspace",
         roots: [],
         looseFiles: [],
@@ -3649,6 +3691,7 @@ export function MainLayout() {
                         workspace={tab.codeWorkspace}
                         visible={isActive}
                         onOpenGitManager={openWorkspaceGitManager}
+                        onSyncGitManager={syncWorkspaceGitManager}
                       />
                     </div>
                   );

--- a/src/lib/gitRefresh.ts
+++ b/src/lib/gitRefresh.ts
@@ -1,0 +1,45 @@
+type GitRefreshListener = (repoRoot: string, revision: number) => void;
+
+const GIT_REFRESH_EVENT = "taomni:git-repo-refresh";
+const listeners = new Set<GitRefreshListener>();
+const revisions = new Map<string, number>();
+
+function normalizeRepoRoot(repoRoot: string): string {
+  return repoRoot.trim();
+}
+
+export function gitRefreshRevision(repoRoot: string): number {
+  const normalized = normalizeRepoRoot(repoRoot);
+  return normalized ? revisions.get(normalized) ?? 0 : 0;
+}
+
+export function notifyGitRepoChanged(repoRoot: string): number {
+  const normalized = normalizeRepoRoot(repoRoot);
+  if (!normalized) return 0;
+  const revision = (revisions.get(normalized) ?? 0) + 1;
+  revisions.set(normalized, revision);
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent(GIT_REFRESH_EVENT, {
+      detail: { repoRoot: normalized, revision },
+    }));
+  } else {
+    listeners.forEach((listener) => listener(normalized, revision));
+  }
+  return revision;
+}
+
+export function subscribeGitRepoRefresh(listener: GitRefreshListener): () => void {
+  if (typeof window !== "undefined") {
+    const handleRefresh = (event: Event) => {
+      const detail = (event as CustomEvent<{ repoRoot?: unknown; revision?: unknown }>).detail;
+      if (typeof detail?.repoRoot !== "string" || typeof detail.revision !== "number") return;
+      listener(detail.repoRoot, detail.revision);
+    };
+    window.addEventListener(GIT_REFRESH_EVENT, handleRefresh);
+    return () => window.removeEventListener(GIT_REFRESH_EVENT, handleRefresh);
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/stores/appStore.test.ts
+++ b/src/stores/appStore.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { computeNewTerminalTitle, useAppStore } from "./appStore";
+import { computeNewTerminalTitle, recentWorkspaceIdFromParts, useAppStore, type CodeWorkspaceContext } from "./appStore";
 import type { RecentWorkspace, Tab } from "../types";
 
 const tab = (id: string, overrides: Partial<Tab> = {}): Tab => ({
@@ -15,6 +15,7 @@ describe("appStore.moveTab", () => {
     useAppStore.setState({
       tabs: [tab("a"), tab("b"), tab("c"), tab("d")],
       activeTabId: "a",
+      recentWorkspaceIdByWorkspaceInstance: {},
     });
   });
 
@@ -187,6 +188,35 @@ describe("appStore.duplicateTab", () => {
     expect(useAppStore.getState().tabs.find((t) => t.id !== "rdp" && t.title === "Desktop-1")?.terminalProfile).toBeUndefined();
   });
 
+  it("duplicates code workspaces as a new runtime instance of the same definition", () => {
+    const root = { id: "root-a", name: "repo", path: "/repo/app", kind: "git" as const };
+    useAppStore.setState({
+      tabs: [
+        tab("code", {
+          type: "code-workspace",
+          title: "Code · repo",
+          codeWorkspace: {
+            repoRoot: "/repo/app",
+            workspaceId: "workspace-definition",
+            workspaceInstanceId: "workspace-instance-original",
+            name: "repo",
+            roots: [root],
+            looseFiles: [],
+            initialFile: null,
+          },
+        }),
+      ],
+      activeTabId: "code",
+    });
+
+    useAppStore.getState().duplicateTab("code");
+
+    const copy = useAppStore.getState().tabs[1];
+    expect(copy.codeWorkspace?.workspaceId).toBe("workspace-definition");
+    expect(copy.codeWorkspace?.workspaceInstanceId).toMatch(/^workspace-instance-/);
+    expect(copy.codeWorkspace?.workspaceInstanceId).not.toBe("workspace-instance-original");
+  });
+
   it("mints a unique id distinct from the source", () => {
     useAppStore.getState().duplicateTab("a");
     const ids = useAppStore.getState().tabs.map((t) => t.id);
@@ -327,8 +357,55 @@ describe("appStore.recentWorkspaces", () => {
       activeTabId: "welcome",
       codeWorkspaceByTab: {},
       recentWorkspaces: [],
+      recentWorkspaceIdByWorkspaceInstance: {},
       welcomeRecentSessionLimit: 20,
     });
+  });
+
+  const workspaceContext = (
+    roots: Array<{ id: string; name: string; path: string; kind: "git" | "folder" }>,
+  ): CodeWorkspaceContext => ({
+    repoRoot: roots[0]?.path ?? "",
+    activePath: null,
+    openPaths: [],
+    dirtyPaths: [],
+    roots,
+    looseFiles: [],
+    activeFile: null,
+    openFiles: [],
+    dirtyFiles: [],
+    lsp: null,
+  });
+
+  const codeWorkspaceTab = (
+    id: string,
+    roots: Array<{ id: string; name: string; path: string; kind: "git" | "folder" }>,
+    workspaceInstanceId: string,
+  ): Tab => tab(id, {
+    type: "code-workspace",
+    title: `Code · ${roots[0]?.name ?? "Workspace"}`,
+    codeWorkspace: {
+      repoRoot: roots[0]?.path ?? "",
+      workspaceId: recentWorkspaceIdFromParts(roots, []),
+      workspaceInstanceId,
+      name: roots[0]?.name ?? "Workspace",
+      roots,
+      looseFiles: [],
+      initialFile: null,
+    },
+  });
+
+  const recentWorkspace = (
+    roots: Array<{ id: string; name: string; path: string; kind: "git" | "folder" }>,
+    lastOpenedAt: number,
+  ): RecentWorkspace => ({
+    id: recentWorkspaceIdFromParts(roots, []),
+    name: roots[0]?.name ?? "Workspace",
+    roots,
+    looseFiles: [],
+    lastOpenedAt,
+    lastActiveFile: null,
+    isGitRepo: roots.some((root) => root.kind === "git"),
   });
 
   it("records a code workspace tab from the latest workspace context", () => {
@@ -381,6 +458,72 @@ describe("appStore.recentWorkspaces", () => {
       lastActiveFile: { kind: "root", rootId: "root-main", path: "src/App.tsx" },
     });
     expect(JSON.parse(window.localStorage.getItem("taomni.recentWorkspaces.v1") ?? "[]")).toHaveLength(1);
+  });
+
+  it("builds recent workspace ids from the path definition, not runtime root ids", () => {
+    const singleA = [{ id: "root-a", name: "repo", path: "/repo/app", kind: "git" as const }];
+    const singleB = [{ id: "root-b", name: "repo", path: "/repo/app", kind: "git" as const }];
+    const multi = [
+      { id: "root-a", name: "repo", path: "/repo/app", kind: "git" as const },
+      { id: "root-c", name: "data", path: "/data/repo2", kind: "folder" as const },
+    ];
+
+    expect(recentWorkspaceIdFromParts(singleA, [])).toBe(recentWorkspaceIdFromParts(singleB, []));
+    expect(recentWorkspaceIdFromParts(singleA, [])).not.toBe(recentWorkspaceIdFromParts(multi, []));
+  });
+
+  it("replaces earlier recent definitions when the same workspace instance changes roots", () => {
+    const roots3 = [
+      { id: "root-1", name: "kiro.rs", path: "/repo/kiro.rs", kind: "git" as const },
+      { id: "root-2", name: "api", path: "/repo/api", kind: "folder" as const },
+      { id: "root-3", name: "web", path: "/repo/web", kind: "folder" as const },
+    ];
+    const roots4 = [...roots3, { id: "root-4", name: "docs", path: "/repo/docs", kind: "folder" as const }];
+    const roots5 = [...roots4, { id: "root-5", name: "tools", path: "/repo/tools", kind: "folder" as const }];
+    useAppStore.setState({
+      tabs: [
+        { id: "welcome", type: "welcome", title: "Welcome", closable: false },
+        codeWorkspaceTab("code", roots3, "workspace-instance-a"),
+      ],
+      recentWorkspaces: [
+        recentWorkspace(roots4, 4),
+        recentWorkspace(roots3, 3),
+      ],
+      recentWorkspaceIdByWorkspaceInstance: {
+        "workspace-instance-a": recentWorkspaceIdFromParts(roots3, []),
+      },
+    });
+
+    useAppStore.getState().setTabCodeWorkspaceContext("code", workspaceContext(roots5));
+
+    const recent = useAppStore.getState().recentWorkspaces;
+    expect(recent).toHaveLength(1);
+    expect(recent[0].id).toBe(recentWorkspaceIdFromParts(roots5, []));
+    expect(recent[0].roots.map((root) => root.name)).toEqual(["kiro.rs", "api", "web", "docs", "tools"]);
+    expect(JSON.parse(window.localStorage.getItem("taomni.recentWorkspaces.v1") ?? "[]")).toHaveLength(1);
+  });
+
+  it("keeps an old recent definition when another workspace instance still uses it", () => {
+    const roots1 = [
+      { id: "root-1", name: "kiro.rs", path: "/repo/kiro.rs", kind: "git" as const },
+    ];
+    const roots2 = [...roots1, { id: "root-2", name: "api", path: "/repo/api", kind: "folder" as const }];
+    useAppStore.setState({
+      tabs: [
+        { id: "welcome", type: "welcome", title: "Welcome", closable: false },
+        codeWorkspaceTab("code-a", roots1, "workspace-instance-a"),
+        codeWorkspaceTab("code-b", roots1, "workspace-instance-b"),
+      ],
+    });
+
+    useAppStore.getState().setTabCodeWorkspaceContext("code-a", workspaceContext(roots1));
+    useAppStore.getState().setTabCodeWorkspaceContext("code-b", workspaceContext(roots1));
+    useAppStore.getState().setTabCodeWorkspaceContext("code-a", workspaceContext(roots2));
+
+    expect(useAppStore.getState().recentWorkspaces.map((workspace) => workspace.id)).toEqual([
+      recentWorkspaceIdFromParts(roots2, []),
+      recentWorkspaceIdFromParts(roots1, []),
+    ]);
   });
 
   it("persists, limits, removes, and clears recent workspace entries", () => {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -4,6 +4,7 @@ import type {
   CodeWorkspaceLooseFileInfo,
   CodeWorkspaceRootInfo,
   CodeWorkspaceRootKind,
+  GitTabInfo,
   RecentWorkspace,
   Tab,
 } from "../types";
@@ -140,6 +141,7 @@ interface AppState {
   uiFontSize: number;
   welcomeRecentSessionLimit: number;
   recentWorkspaces: RecentWorkspace[];
+  recentWorkspaceIdByWorkspaceInstance: Record<string, string>;
   /**
    * Transient focus filter for the open-tab strip (issue #121). When set, the
    * strip only renders tabs matching the filter; the rest are hidden, not
@@ -205,6 +207,7 @@ interface AppState {
   removeTab: (id: string) => void;
   removeTabs: (ids: string[]) => void;
   updateTabTitle: (id: string, title: string) => void;
+  updateGitTabInfo: (id: string, git: GitTabInfo, title?: string) => void;
   setActiveTab: (id: string) => void;
   moveTab: (fromId: string, targetId: string, position: "before" | "after") => void;
   moveTabToIndex: (id: string, toIndex: number) => void;
@@ -491,6 +494,10 @@ export function recentWorkspaceIdFromParts(
   return `workspace-${hashString(identity)}`;
 }
 
+export function newWorkspaceInstanceId(): string {
+  return `workspace-instance-${crypto.randomUUID()}`;
+}
+
 function recentWorkspaceName(
   explicitName: string | undefined,
   roots: readonly CodeWorkspaceRootInfo[],
@@ -580,6 +587,104 @@ function upsertRecentWorkspaceList(
   ]
     .sort((a, b) => b.lastOpenedAt - a.lastOpenedAt)
     .slice(0, clampWelcomeRecentSessionLimit(limit));
+}
+
+function codeWorkspaceInstanceId(tab: Tab | undefined): string | null {
+  if (tab?.type !== "code-workspace" || !tab.codeWorkspace) return null;
+  return tab.codeWorkspace.workspaceInstanceId ?? tab.id;
+}
+
+function hasOtherWorkspaceInstanceWithRecentId(
+  idsByInstance: Readonly<Record<string, string>>,
+  instanceId: string,
+  recentId: string,
+): boolean {
+  return Object.entries(idsByInstance).some(([otherInstanceId, otherRecentId]) => (
+    otherInstanceId !== instanceId && otherRecentId === recentId
+  ));
+}
+
+function recentRootKey(root: CodeWorkspaceRootInfo): string {
+  return `${root.kind}:${normalizeWorkspacePath(root.path)}`;
+}
+
+function isSupersededRecentWorkspaceDefinition(
+  candidate: RecentWorkspace,
+  latest: RecentWorkspace,
+): boolean {
+  if (candidate.id === latest.id) return false;
+  const candidateSize = candidate.roots.length + candidate.looseFiles.length;
+  const latestSize = latest.roots.length + latest.looseFiles.length;
+  if (candidateSize === 0 || candidateSize >= latestSize) return false;
+  if (candidate.name !== latest.name && candidate.roots[0]?.path !== latest.roots[0]?.path) {
+    return false;
+  }
+  const latestRoots = new Set(latest.roots.map(recentRootKey));
+  const latestLooseFiles = new Set(latest.looseFiles.map((file) => normalizeWorkspacePath(file.path)));
+  return (
+    candidate.roots.every((root) => latestRoots.has(recentRootKey(root))) &&
+    candidate.looseFiles.every((file) => latestLooseFiles.has(normalizeWorkspacePath(file.path)))
+  );
+}
+
+function upsertRecentWorkspaceForTab(
+  current: readonly RecentWorkspace[],
+  idsByInstance: Readonly<Record<string, string>>,
+  tab: Tab | undefined,
+  context: CodeWorkspaceContext | undefined,
+  now: number,
+  limit: number,
+): {
+  recentWorkspaces: RecentWorkspace[];
+  recentWorkspaceIdByWorkspaceInstance: Record<string, string>;
+} {
+  const workspace = recentWorkspaceFromTab(tab, context, now);
+  const normalized = workspace ? normalizeRecentWorkspace(workspace) : null;
+  if (!normalized) {
+    return {
+      recentWorkspaces: current as RecentWorkspace[],
+      recentWorkspaceIdByWorkspaceInstance: idsByInstance as Record<string, string>,
+    };
+  }
+
+  const instanceId = codeWorkspaceInstanceId(tab);
+  let base = current;
+  let nextIdsByInstance = idsByInstance as Record<string, string>;
+  if (instanceId) {
+    const previousId = idsByInstance[instanceId] ?? tab?.codeWorkspace?.workspaceId ?? null;
+    if (
+      previousId &&
+      previousId !== normalized.id &&
+      !hasOtherWorkspaceInstanceWithRecentId(idsByInstance, instanceId, previousId)
+    ) {
+      base = base.filter((item) => item.id !== previousId);
+    }
+    if (previousId && previousId !== normalized.id) {
+      base = base.filter((item) => (
+        hasOtherWorkspaceInstanceWithRecentId(idsByInstance, instanceId, item.id) ||
+        !isSupersededRecentWorkspaceDefinition(item, normalized)
+      ));
+    }
+    if (idsByInstance[instanceId] !== normalized.id) {
+      nextIdsByInstance = { ...idsByInstance, [instanceId]: normalized.id };
+    }
+  }
+
+  return {
+    recentWorkspaces: upsertRecentWorkspaceList(base, normalized, limit),
+    recentWorkspaceIdByWorkspaceInstance: nextIdsByInstance,
+  };
+}
+
+function shouldRecordRecentWorkspaceContext(
+  current: CodeWorkspaceContext | undefined,
+  next: CodeWorkspaceContext,
+): boolean {
+  return (
+    !current ||
+    !jsonEqual(current.roots, next.roots) ||
+    !jsonEqual(current.looseFiles, next.looseFiles)
+  );
 }
 
 function readRecentWorkspaces(limit: number): RecentWorkspace[] {
@@ -723,23 +828,28 @@ export const useAppStore = create<AppState>((set) => ({
   uiFontSize: readUiFontSize(),
   welcomeRecentSessionLimit: initialWelcomeRecentSessionLimit,
   recentWorkspaces: readRecentWorkspaces(initialWelcomeRecentSessionLimit),
+  recentWorkspaceIdByWorkspaceInstance: {},
   tabFilter: null,
 
   addTab: (tab) =>
     set((s) => {
       const nextTabs = [...s.tabs, tab];
-      const recentWorkspaces = upsertRecentWorkspaceList(
+      const recentResult = upsertRecentWorkspaceForTab(
         s.recentWorkspaces,
-        recentWorkspaceFromTab(tab, undefined, Date.now()),
+        s.recentWorkspaceIdByWorkspaceInstance,
+        tab,
+        undefined,
+        Date.now(),
         s.welcomeRecentSessionLimit,
       );
-      if (recentWorkspaces !== s.recentWorkspaces) {
-        writeRecentWorkspaces(recentWorkspaces);
+      if (recentResult.recentWorkspaces !== s.recentWorkspaces) {
+        writeRecentWorkspaces(recentResult.recentWorkspaces);
       }
       return {
         tabs: nextTabs,
         activeTabId: tab.id,
-        recentWorkspaces,
+        recentWorkspaces: recentResult.recentWorkspaces,
+        recentWorkspaceIdByWorkspaceInstance: recentResult.recentWorkspaceIdByWorkspaceInstance,
         // A freshly opened tab must be visible, so drop any active focus filter.
         tabFilter: null,
         terminalSplitActive: tab.type === "terminal" ? s.terminalSplitActive : false,
@@ -765,21 +875,32 @@ export const useAppStore = create<AppState>((set) => ({
           source.type === "terminal" ? overrides?.terminalInitialCwd : undefined,
         terminalProfile:
           source.type === "terminal" ? overrides?.terminalProfile ?? source.terminalProfile : source.terminalProfile,
+        codeWorkspace:
+          source.type === "code-workspace" && source.codeWorkspace
+            ? {
+                ...source.codeWorkspace,
+                workspaceInstanceId: newWorkspaceInstanceId(),
+              }
+            : source.codeWorkspace,
       };
       const next = s.tabs.slice();
       next.splice(idx + 1, 0, copy);
-      const recentWorkspaces = upsertRecentWorkspaceList(
+      const recentResult = upsertRecentWorkspaceForTab(
         s.recentWorkspaces,
-        recentWorkspaceFromTab(copy, undefined, Date.now()),
+        s.recentWorkspaceIdByWorkspaceInstance,
+        copy,
+        undefined,
+        Date.now(),
         s.welcomeRecentSessionLimit,
       );
-      if (recentWorkspaces !== s.recentWorkspaces) {
-        writeRecentWorkspaces(recentWorkspaces);
+      if (recentResult.recentWorkspaces !== s.recentWorkspaces) {
+        writeRecentWorkspaces(recentResult.recentWorkspaces);
       }
       return {
         tabs: next,
         activeTabId: copy.id,
-        recentWorkspaces,
+        recentWorkspaces: recentResult.recentWorkspaces,
+        recentWorkspaceIdByWorkspaceInstance: recentResult.recentWorkspaceIdByWorkspaceInstance,
         // A freshly opened tab must be visible, so drop any active focus filter.
         tabFilter: null,
         terminalSplitActive: copy.type === "terminal" ? s.terminalSplitActive : false,
@@ -797,18 +918,22 @@ export const useAppStore = create<AppState>((set) => ({
         activeId = next[Math.min(idx, next.length - 1)]?.id ?? null;
       }
       const validIds = new Set(next.map((tab) => tab.id));
-      const recentWorkspaces = upsertRecentWorkspaceList(
+      const recentResult = upsertRecentWorkspaceForTab(
         s.recentWorkspaces,
-        recentWorkspaceFromTab(tab, s.codeWorkspaceByTab[id], Date.now()),
+        s.recentWorkspaceIdByWorkspaceInstance,
+        tab,
+        s.codeWorkspaceByTab[id],
+        Date.now(),
         s.welcomeRecentSessionLimit,
       );
-      if (recentWorkspaces !== s.recentWorkspaces) {
-        writeRecentWorkspaces(recentWorkspaces);
+      if (recentResult.recentWorkspaces !== s.recentWorkspaces) {
+        writeRecentWorkspaces(recentResult.recentWorkspaces);
       }
       return {
         tabs: next,
         activeTabId: activeId,
-        recentWorkspaces,
+        recentWorkspaces: recentResult.recentWorkspaces,
+        recentWorkspaceIdByWorkspaceInstance: recentResult.recentWorkspaceIdByWorkspaceInstance,
         terminalSplitActive: s.terminalSplitActive && activeTabIsTerminal(next, activeId),
         terminalSplitInputLockedTabIds: pruneSet(s.terminalSplitInputLockedTabIds, validIds),
         multiExecSelectedTabIds: pruneSet(s.multiExecSelectedTabIds, validIds),
@@ -828,13 +953,19 @@ export const useAppStore = create<AppState>((set) => ({
       }
       const validIds = new Set(next.map((tab) => tab.id));
       let recentWorkspaces = s.recentWorkspaces;
+      let recentWorkspaceIdByWorkspaceInstance = s.recentWorkspaceIdByWorkspaceInstance;
       const now = Date.now();
       for (const tab of closingTabs) {
-        recentWorkspaces = upsertRecentWorkspaceList(
+        const recentResult = upsertRecentWorkspaceForTab(
           recentWorkspaces,
-          recentWorkspaceFromTab(tab, s.codeWorkspaceByTab[tab.id], now),
+          recentWorkspaceIdByWorkspaceInstance,
+          tab,
+          s.codeWorkspaceByTab[tab.id],
+          now,
           s.welcomeRecentSessionLimit,
         );
+        recentWorkspaces = recentResult.recentWorkspaces;
+        recentWorkspaceIdByWorkspaceInstance = recentResult.recentWorkspaceIdByWorkspaceInstance;
       }
       if (recentWorkspaces !== s.recentWorkspaces) {
         writeRecentWorkspaces(recentWorkspaces);
@@ -843,6 +974,7 @@ export const useAppStore = create<AppState>((set) => ({
         tabs: next,
         activeTabId: activeId,
         recentWorkspaces,
+        recentWorkspaceIdByWorkspaceInstance,
         terminalSplitActive: s.terminalSplitActive && activeTabIsTerminal(next, activeId),
         terminalSplitInputLockedTabIds: pruneSet(s.terminalSplitInputLockedTabIds, validIds),
         multiExecSelectedTabIds: pruneSet(s.multiExecSelectedTabIds, validIds),
@@ -856,20 +988,41 @@ export const useAppStore = create<AppState>((set) => ({
       statusMessage: tr("status.renamedTab", { title }),
     })),
 
+  updateGitTabInfo: (id, git, title) =>
+    set((s) => {
+      const tab = s.tabs.find((item) => item.id === id);
+      if (!tab || tab.type !== "git") return s;
+      return {
+        tabs: s.tabs.map((item) => (
+          item.id === id
+            ? {
+                ...item,
+                title: title ?? item.title,
+                git,
+              }
+            : item
+        )),
+      };
+    }),
+
   setActiveTab: (id) =>
     set((s) => {
       const tab = s.tabs.find((item) => item.id === id);
-      const recentWorkspaces = upsertRecentWorkspaceList(
+      const recentResult = upsertRecentWorkspaceForTab(
         s.recentWorkspaces,
-        recentWorkspaceFromTab(tab, s.codeWorkspaceByTab[id], Date.now()),
+        s.recentWorkspaceIdByWorkspaceInstance,
+        tab,
+        s.codeWorkspaceByTab[id],
+        Date.now(),
         s.welcomeRecentSessionLimit,
       );
-      if (recentWorkspaces !== s.recentWorkspaces) {
-        writeRecentWorkspaces(recentWorkspaces);
+      if (recentResult.recentWorkspaces !== s.recentWorkspaces) {
+        writeRecentWorkspaces(recentResult.recentWorkspaces);
       }
       return {
         activeTabId: id,
-        recentWorkspaces,
+        recentWorkspaces: recentResult.recentWorkspaces,
+        recentWorkspaceIdByWorkspaceInstance: recentResult.recentWorkspaceIdByWorkspaceInstance,
         terminalSplitActive: tab?.type === "terminal" ? s.terminalSplitActive : false,
       };
     }),
@@ -1098,15 +1251,26 @@ export const useAppStore = create<AppState>((set) => ({
   recordCodeWorkspaceTab: (tabId) =>
     set((s) => {
       const tab = s.tabs.find((item) => item.id === tabId);
-      const recentWorkspaces = upsertRecentWorkspaceList(
+      const recentResult = upsertRecentWorkspaceForTab(
         s.recentWorkspaces,
-        recentWorkspaceFromTab(tab, s.codeWorkspaceByTab[tabId], Date.now()),
+        s.recentWorkspaceIdByWorkspaceInstance,
+        tab,
+        s.codeWorkspaceByTab[tabId],
+        Date.now(),
         s.welcomeRecentSessionLimit,
       );
-      if (recentWorkspaces !== s.recentWorkspaces) {
-        writeRecentWorkspaces(recentWorkspaces);
+      if (recentResult.recentWorkspaces !== s.recentWorkspaces) {
+        writeRecentWorkspaces(recentResult.recentWorkspaces);
       }
-      return recentWorkspaces === s.recentWorkspaces ? s : { recentWorkspaces };
+      return (
+        recentResult.recentWorkspaces === s.recentWorkspaces &&
+        recentResult.recentWorkspaceIdByWorkspaceInstance === s.recentWorkspaceIdByWorkspaceInstance
+      )
+        ? s
+        : {
+            recentWorkspaces: recentResult.recentWorkspaces,
+            recentWorkspaceIdByWorkspaceInstance: recentResult.recentWorkspaceIdByWorkspaceInstance,
+          };
     }),
 
   removeRecentWorkspace: (id) =>
@@ -1185,7 +1349,27 @@ export const useAppStore = create<AppState>((set) => ({
       ) {
         return s;
       }
+      const tab = s.tabs.find((item) => item.id === tabId);
+      const shouldRecordRecent = shouldRecordRecentWorkspaceContext(current, context);
+      const recentResult = shouldRecordRecent
+        ? upsertRecentWorkspaceForTab(
+            s.recentWorkspaces,
+            s.recentWorkspaceIdByWorkspaceInstance,
+            tab,
+            context,
+            Date.now(),
+            s.welcomeRecentSessionLimit,
+          )
+        : {
+            recentWorkspaces: s.recentWorkspaces,
+            recentWorkspaceIdByWorkspaceInstance: s.recentWorkspaceIdByWorkspaceInstance,
+          };
+      if (recentResult.recentWorkspaces !== s.recentWorkspaces) {
+        writeRecentWorkspaces(recentResult.recentWorkspaces);
+      }
       return {
+        recentWorkspaces: recentResult.recentWorkspaces,
+        recentWorkspaceIdByWorkspaceInstance: recentResult.recentWorkspaceIdByWorkspaceInstance,
         codeWorkspaceByTab: {
           ...s.codeWorkspaceByTab,
           [tabId]: context,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -296,6 +296,9 @@ export interface GitTabInfo {
   workspaceName?: string;
   workspaceRoots?: GitWorkspaceRootInfo[];
   activeRepoRoot?: string | null;
+  sourceWorkspaceInstanceId?: string;
+  sourceWorkspaceId?: string;
+  sourceWorkspaceName?: string;
 }
 
 export interface GitWorkspaceRootInfo {
@@ -339,6 +342,7 @@ export interface CodeWorkspaceTabInfo {
   repoRoot: string;
   initialPath?: string | null;
   workspaceId?: string;
+  workspaceInstanceId?: string;
   name?: string;
   roots?: CodeWorkspaceRootInfo[];
   looseFiles?: CodeWorkspaceLooseFileInfo[];


### PR DESCRIPTION
Introduce a runtime workspaceInstanceId alongside the existing path-derived workspaceId so open code workspace tabs can share a Recent Workspace definition without sharing LSP/runtime state.

Bind workspace-opened Git tabs back to their source workspace instance. Reopening a Git manager from the same instance now updates and reuses that bound tab, while separate instances with the same repo roots can keep independent Git tabs.

Keep Recent Workspaces definition-based while tracking the latest definition written by each open workspace instance in memory. When one workspace instance changes its root set, superseded intermediate recent entries are removed unless another instance still uses that definition.

Add repo-root scoped Git refresh notifications and wire Git panels, workspace Git managers, and code workspace file mutations to refresh affected repositories immediately after Git or workspace filesystem changes.

Add focused coverage for definition-based recent workspace IDs, duplicated code workspace runtime instances, Git manager source payloads, active repo fallback after root updates, repo refresh notifications, and recent cleanup after workspace root changes.