### PR TITLE
fix(ui): align mail theme buttons and enable git Tao

### DIFF
--- a/src/components/chat/ChatDrawer.test.tsx
+++ b/src/components/chat/ChatDrawer.test.tsx
@@ -607,6 +607,37 @@ describe("ChatDrawerRibbon", () => {
     expect(openTabChat).toHaveBeenCalledWith("stable-chat-tab");
   });
 
+  it("shows Tao for git tabs and opens the git tab chat", () => {
+    const openTabChat = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({
+      tabs: [{
+        id: "git-tab",
+        type: "git",
+        title: "Git taomni",
+        closable: true,
+        git: { repoRoot: "/repo/taomni" },
+      }],
+      activeTabId: "git-tab",
+    });
+    useChatStore.setState({
+      drawerOpen: false,
+      drawerPosition: "left",
+      drawerPinned: true,
+      openTabChat,
+    });
+
+    render(
+      <div className="relative h-32 w-32">
+        <ChatDrawerRibbon />
+      </div>,
+    );
+
+    const ribbon = screen.getByTestId("ai-chat-drawer-ribbon");
+    expect(ribbon).toHaveTextContent(/^Tao$/);
+    fireEvent.click(ribbon);
+    expect(openTabChat).toHaveBeenCalledWith("git-tab");
+  });
+
   it.each([
     ["left", 4, 300],
     ["right", 796, 300],

--- a/src/components/mail/MailClientTab.test.tsx
+++ b/src/components/mail/MailClientTab.test.tsx
@@ -277,6 +277,10 @@ describe("MailClientTab", () => {
     expect(root.style.getPropertyValue("--taomni-bg")).toBe("#282a36");
     expect(root.style.getPropertyValue("--taomni-text")).toBe("#f8f8f2");
     expect(root.style.getPropertyValue("--taomni-accent")).toBe("#8be9fd");
+    expect(root.style.getPropertyValue("--taomni-accent-soft")).not.toBe("");
+    expect(root.style.getPropertyValue("--taomni-button-from")).not.toBe("");
+    expect(root.style.getPropertyValue("--taomni-button-hover-to")).not.toBe("");
+    expect(root.style.getPropertyValue("--taomni-button-disabled")).not.toBe("");
   });
 
   it("does not force borders onto HTML email layout tables", async () => {

--- a/src/components/mail/MailClientTab.tsx
+++ b/src/components/mail/MailClientTab.tsx
@@ -280,13 +280,44 @@ function mixColor(foreground: string, background: string, amount: number): strin
   return `#${hex(mixed[0])}${hex(mixed[1])}${hex(mixed[2])}`;
 }
 
+function colorLuminance(value: string): number | null {
+  const rgb = parseHexColor(value);
+  if (!rgb) return null;
+  const [r, g, b] = rgb.map((channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
 function mailAppearanceStyle(profile: TerminalProfile | undefined, fontSize: number, appPrefersDark: boolean): CSSProperties {
   const terminalProfile = profile ?? DEFAULT_MAIL_TERMINAL_PROFILE;
   const theme = resolveMailTheme(terminalProfile.theme, appPrefersDark);
   const background = color(theme.background, "#1d1f21");
   const foreground = color(theme.foreground, "#eaeaea");
   const accent = color(theme.blue ?? theme.cyan ?? theme.cursor, "#83a7d8");
+  const darkBackground = (colorLuminance(background) ?? 0) < 0.5;
+  const accentSoft = darkBackground
+    ? mixColor(foreground, accent, 24)
+    : mixColor(background, accent, 24);
   const divider = mixColor(foreground, background, 18);
+  const buttonFrom = darkBackground
+    ? mixColor(foreground, background, 12)
+    : mixColor(foreground, background, 2);
+  const buttonTo = darkBackground
+    ? mixColor(foreground, background, 8)
+    : mixColor(foreground, background, 7);
+  const buttonHoverFrom = darkBackground
+    ? mixColor(foreground, background, 18)
+    : mixColor(foreground, background, 4);
+  const buttonHoverTo = darkBackground
+    ? mixColor(foreground, background, 13)
+    : mixColor(foreground, background, 11);
+  const buttonDisabled = darkBackground
+    ? mixColor(foreground, background, 5)
+    : mixColor(foreground, background, 6);
   return {
     "--taomni-bg": background,
     "--taomni-panel-bg": mixColor(foreground, background, 5),
@@ -300,6 +331,12 @@ function mailAppearanceStyle(profile: TerminalProfile | undefined, fontSize: num
     "--taomni-hover": mixColor(accent, background, 16),
     "--taomni-selected": mixColor(accent, background, 26),
     "--taomni-accent": accent,
+    "--taomni-accent-soft": accentSoft,
+    "--taomni-button-from": buttonFrom,
+    "--taomni-button-to": buttonTo,
+    "--taomni-button-hover-from": buttonHoverFrom,
+    "--taomni-button-hover-to": buttonHoverTo,
+    "--taomni-button-disabled": buttonDisabled,
     "--taomni-text": foreground,
     "--taomni-text-muted": mixColor(foreground, background, 62),
     fontFamily: terminalProfile.fontFamily || DEFAULT_MAIL_TERMINAL_PROFILE.fontFamily,

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -122,6 +122,7 @@ export function isChatCapableTabType(type: string | null | undefined): boolean {
     type === "database" ||
     type === "redis" ||
     type === "mail" ||
+    type === "git" ||
     type === "code-workspace"
   );
 }


### PR DESCRIPTION
Mail tabs derive their chrome colors from the session terminal profile, but the per-tab style did not provide the button variables consumed by .taomni-btn. As a result toolbar and message action buttons kept inheriting the global app button colors instead of the active mail session theme.

Extend the mail appearance style with accent-soft and the normal, hover, and disabled button color variables generated from the resolved mail theme. This keeps Compose, Drafts, Sync, Reply, Summary, Draft, Tasks, Load images, and related controls visually aligned with the selected mail theme.

Also mark git tabs as chat-capable so the existing Tao ribbon appears and binds to the active Git UI tab. This only enables the current Tao entry behavior for Git tabs and does not add MCP context/tooling.

Tests: pnpm vitest run src/components/chat/ChatDrawer.test.tsx; pnpm vitest run src/stores/chatStore.test.ts; pnpm vitest run src/components/mail/MailClientTab.test.tsx -t "applies code view theme colors"; git diff --check. Note: pnpm build, tsc -b, vite build, and the full MailClientTab test file SIGSEGV in the current Node/Vitest environment without diagnostics.