### PR TITLE
fix(release): align Tauri action artifacts and git mock typing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Build and upload release bundles
+        id: tauri_release
         if: steps.version.outputs.tag != ''
         uses: tauri-apps/tauri-action@action-v0.6.2
         env:
@@ -116,11 +117,26 @@ jobs:
           releaseBody: Desktop bundles for Taomni v${{ steps.version.outputs.version }}.
           generateReleaseNotes: true
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
-          uploadWorkflowArtifacts: true
-          workflowArtifactNamePattern: "[name]-[version]-[platform]-[arch]-[bundle]"
           args: ${{ matrix.args }}
 
+      - name: Collect release workflow artifacts
+        if: steps.version.outputs.tag != ''
+        shell: bash
+        env:
+          TAURI_ACTION_ARTIFACT_PATHS: ${{ steps.tauri_release.outputs.artifactPaths }}
+          TAURI_ACTION_ARTIFACT_OUT_DIR: tauri-artifacts/${{ matrix.platform }}
+        run: node scripts/collect-tauri-action-artifacts.mjs
+
+      - name: Upload release workflow artifacts
+        if: steps.version.outputs.tag != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: taomni-${{ steps.version.outputs.version }}-${{ matrix.platform }}
+          path: tauri-artifacts/${{ matrix.platform }}
+          if-no-files-found: error
+
       - name: Build workflow bundles
+        id: tauri_workflow
         if: steps.version.outputs.tag == ''
         uses: tauri-apps/tauri-action@action-v0.6.2
         env:
@@ -128,9 +144,23 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          uploadWorkflowArtifacts: true
-          workflowArtifactNamePattern: "[name]-[version]-[platform]-[arch]-[bundle]"
           args: ${{ matrix.args }}
+
+      - name: Collect workflow artifacts
+        if: steps.version.outputs.tag == ''
+        shell: bash
+        env:
+          TAURI_ACTION_ARTIFACT_PATHS: ${{ steps.tauri_workflow.outputs.artifactPaths }}
+          TAURI_ACTION_ARTIFACT_OUT_DIR: tauri-artifacts/${{ matrix.platform }}
+        run: node scripts/collect-tauri-action-artifacts.mjs
+
+      - name: Upload workflow artifacts
+        if: steps.version.outputs.tag == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: taomni-${{ steps.version.outputs.version }}-${{ matrix.platform }}
+          path: tauri-artifacts/${{ matrix.platform }}
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # macOS – single arm64 runner, cross-compiles both architectures
@@ -219,6 +249,7 @@ jobs:
 
       # ---------- aarch64-apple-darwin (native) ----------
       - name: Build and upload release bundle (aarch64)
+        id: tauri_macos_aarch64_release
         if: steps.version.outputs.tag != ''
         uses: tauri-apps/tauri-action@action-v0.6.2
         env:
@@ -235,11 +266,26 @@ jobs:
           releaseBody: Desktop bundles for Taomni v${{ steps.version.outputs.version }}.
           generateReleaseNotes: true
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
-          uploadWorkflowArtifacts: true
-          workflowArtifactNamePattern: "[name]-[version]-[platform]-[arch]-[bundle]"
           args: --target aarch64-apple-darwin
 
+      - name: Collect release workflow artifacts (aarch64)
+        if: steps.version.outputs.tag != ''
+        shell: bash
+        env:
+          TAURI_ACTION_ARTIFACT_PATHS: ${{ steps.tauri_macos_aarch64_release.outputs.artifactPaths }}
+          TAURI_ACTION_ARTIFACT_OUT_DIR: tauri-artifacts/macos-aarch64
+        run: node scripts/collect-tauri-action-artifacts.mjs
+
+      - name: Upload release workflow artifacts (aarch64)
+        if: steps.version.outputs.tag != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: taomni-${{ steps.version.outputs.version }}-macos-aarch64
+          path: tauri-artifacts/macos-aarch64
+          if-no-files-found: error
+
       - name: Build workflow bundle (aarch64)
+        id: tauri_macos_aarch64_workflow
         if: steps.version.outputs.tag == ''
         uses: tauri-apps/tauri-action@action-v0.6.2
         env:
@@ -250,12 +296,27 @@ jobs:
           LIBGSSAPI_PREFIX: /opt/homebrew/opt/krb5
           PKG_CONFIG_PATH: /opt/homebrew/opt/krb5/lib/pkgconfig
         with:
-          uploadWorkflowArtifacts: true
-          workflowArtifactNamePattern: "[name]-[version]-[platform]-[arch]-[bundle]"
           args: --target aarch64-apple-darwin
+
+      - name: Collect workflow artifacts (aarch64)
+        if: steps.version.outputs.tag == ''
+        shell: bash
+        env:
+          TAURI_ACTION_ARTIFACT_PATHS: ${{ steps.tauri_macos_aarch64_workflow.outputs.artifactPaths }}
+          TAURI_ACTION_ARTIFACT_OUT_DIR: tauri-artifacts/macos-aarch64
+        run: node scripts/collect-tauri-action-artifacts.mjs
+
+      - name: Upload workflow artifacts (aarch64)
+        if: steps.version.outputs.tag == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: taomni-${{ steps.version.outputs.version }}-macos-aarch64
+          path: tauri-artifacts/macos-aarch64
+          if-no-files-found: error
 
       # ---------- x86_64-apple-darwin (cross-compile) ----------
       - name: Build and upload release bundle (x86_64)
+        id: tauri_macos_x86_64_release
         if: steps.version.outputs.tag != ''
         uses: tauri-apps/tauri-action@action-v0.6.2
         env:
@@ -273,11 +334,26 @@ jobs:
           releaseBody: Desktop bundles for Taomni v${{ steps.version.outputs.version }}.
           generateReleaseNotes: true
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
-          uploadWorkflowArtifacts: true
-          workflowArtifactNamePattern: "[name]-[version]-[platform]-[arch]-[bundle]"
           args: --target x86_64-apple-darwin
 
+      - name: Collect release workflow artifacts (x86_64)
+        if: steps.version.outputs.tag != ''
+        shell: bash
+        env:
+          TAURI_ACTION_ARTIFACT_PATHS: ${{ steps.tauri_macos_x86_64_release.outputs.artifactPaths }}
+          TAURI_ACTION_ARTIFACT_OUT_DIR: tauri-artifacts/macos-x86_64
+        run: node scripts/collect-tauri-action-artifacts.mjs
+
+      - name: Upload release workflow artifacts (x86_64)
+        if: steps.version.outputs.tag != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: taomni-${{ steps.version.outputs.version }}-macos-x86_64
+          path: tauri-artifacts/macos-x86_64
+          if-no-files-found: error
+
       - name: Build workflow bundle (x86_64)
+        id: tauri_macos_x86_64_workflow
         if: steps.version.outputs.tag == ''
         uses: tauri-apps/tauri-action@action-v0.6.2
         env:
@@ -289,9 +365,23 @@ jobs:
           PKG_CONFIG_PATH: /usr/local/opt/krb5/lib/pkgconfig
           PKG_CONFIG_ALLOW_CROSS: "1"
         with:
-          uploadWorkflowArtifacts: true
-          workflowArtifactNamePattern: "[name]-[version]-[platform]-[arch]-[bundle]"
           args: --target x86_64-apple-darwin
+
+      - name: Collect workflow artifacts (x86_64)
+        if: steps.version.outputs.tag == ''
+        shell: bash
+        env:
+          TAURI_ACTION_ARTIFACT_PATHS: ${{ steps.tauri_macos_x86_64_workflow.outputs.artifactPaths }}
+          TAURI_ACTION_ARTIFACT_OUT_DIR: tauri-artifacts/macos-x86_64
+        run: node scripts/collect-tauri-action-artifacts.mjs
+
+      - name: Upload workflow artifacts (x86_64)
+        if: steps.version.outputs.tag == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: taomni-${{ steps.version.outputs.version }}-macos-x86_64
+          path: tauri-artifacts/macos-x86_64
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Compose a single, complete latest.json for tauri-plugin-updater.

--- a/scripts/collect-tauri-action-artifacts.mjs
+++ b/scripts/collect-tauri-action-artifacts.mjs
@@ -1,0 +1,28 @@
+import { copyFileSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+
+const artifactPaths = JSON.parse(process.env.TAURI_ACTION_ARTIFACT_PATHS || "[]");
+const outDir = process.env.TAURI_ACTION_ARTIFACT_OUT_DIR;
+
+if (!outDir) {
+  throw new Error("TAURI_ACTION_ARTIFACT_OUT_DIR is required");
+}
+if (!Array.isArray(artifactPaths)) {
+  throw new Error("TAURI_ACTION_ARTIFACT_PATHS must be a JSON array");
+}
+
+mkdirSync(outDir, { recursive: true });
+
+let copied = 0;
+for (const source of artifactPaths) {
+  if (typeof source !== "string" || !source || !existsSync(source)) continue;
+  if (statSync(source).isDirectory()) continue;
+  copyFileSync(source, join(outDir, basename(source)));
+  copied += 1;
+}
+
+if (copied === 0) {
+  throw new Error("No Tauri action artifacts were copied");
+}
+
+console.log(`Copied ${copied} Tauri artifact(s) to ${outDir}`);

--- a/src/components/git/WorkspaceGitManager.test.tsx
+++ b/src/components/git/WorkspaceGitManager.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppStore } from "../../stores/appStore";
-import type { GitSnapshot } from "../../lib/git";
+import type { GitRemote, GitSnapshot } from "../../lib/git";
 import { WorkspaceGitManager } from "./WorkspaceGitManager";
 
 const gitMocks = vi.hoisted(() => ({
@@ -20,7 +20,7 @@ const gitMocks = vi.hoisted(() => ({
   gitSnapshot: vi.fn(),
   gitStage: vi.fn(),
   gitUnstage: vi.fn(),
-  selectedRemote: vi.fn(() => null),
+  selectedRemote: vi.fn<(snapshot: GitSnapshot | null) => GitRemote | null>(() => null),
 }));
 
 const dialogMocks = vi.hoisted(() => ({


### PR DESCRIPTION
Release builds were passing uploadWorkflowArtifacts and workflowArtifactNamePattern to tauri-apps/tauri-action@action-v0.6.2, but that action version no longer declares those inputs. GitHub Actions treated them as unexpected inputs, and the later updater manifest job still depended on workflow artifacts being available.

Remove the unsupported Tauri action inputs and explicitly upload workflow artifacts with actions/upload-artifact. A small Node helper copies the JSON artifactPaths output from tauri-action into stable per-platform directories before upload, preserving the finalize-updater-manifest download-artifact flow.

The release build also failed during pnpm build because WorkspaceGitManager.test.tsx inferred selectedRemote as a zero-argument mock returning null. Give the mock the same (GitSnapshot | null) => GitRemote | null signature as the real helper so tests can override it with snapshot-aware implementations under strict TypeScript.

Validation run: focused WorkspaceGitManager Vitest case passed; artifact collection helper smoke test passed; vite build passed. Local tsc still exits with SIGSEGV in this environment before reporting diagnostics, and actionlint was interrupted before completion.