### PR TITLE
fix(object-storage): normalize COS and OSS bucket endpoints

### DIFF
--- a/src-tauri/src/objectstorage/config.rs
+++ b/src-tauri/src/objectstorage/config.rs
@@ -63,6 +63,7 @@ pub struct S3Endpoint {
     pub url: Url,
     pub style: UrlStyle,
     pub region: String,
+    pub default_bucket: Option<String>,
 }
 
 impl ObjectStorageConfig {
@@ -83,7 +84,7 @@ impl ObjectStorageConfig {
                 return Err(format!(
                     "endpoint is required for provider '{}'",
                     self.provider
-                ))
+                ));
             }
         };
         let endpoint = if endpoint.contains("://") {
@@ -91,7 +92,8 @@ impl ObjectStorageConfig {
         } else {
             format!("https://{endpoint}")
         };
-        let url = Url::parse(&endpoint).map_err(|e| format!("invalid endpoint url: {e}"))?;
+        let mut url = Url::parse(&endpoint).map_err(|e| format!("invalid endpoint url: {e}"))?;
+        let inferred_bucket = normalize_bucket_endpoint(self.provider.as_str(), &mut url);
 
         // Path-style by explicit override, else by provider default. MinIO,
         // Ceph and "custom" default to path-style; everything else uses
@@ -103,17 +105,59 @@ impl ObjectStorageConfig {
             .as_ref()
             .map(|n| n.uses_jump_host())
             .unwrap_or(false);
-        let path_style = self.path_style.unwrap_or_else(|| {
-            matches!(self.provider.as_str(), "minio" | "ceph" | "custom")
-        }) || jump;
+        let path_style = self
+            .path_style
+            .unwrap_or_else(|| matches!(self.provider.as_str(), "minio" | "ceph" | "custom"))
+            || jump;
         let style = if path_style {
             UrlStyle::Path
         } else {
             UrlStyle::VirtualHost
         };
 
-        Ok(S3Endpoint { url, style, region })
+        let default_bucket = self
+            .default_bucket
+            .as_deref()
+            .map(str::trim)
+            .filter(|b| !b.is_empty())
+            .map(ToOwned::to_owned)
+            .or(inferred_bucket);
+
+        Ok(S3Endpoint {
+            url,
+            style,
+            region,
+            default_bucket,
+        })
     }
+}
+
+fn normalize_bucket_endpoint(provider: &str, url: &mut Url) -> Option<String> {
+    let host = url.host_str()?.to_ascii_lowercase();
+    let markers: &[&str] = match provider {
+        "tencent-cos" => &[".cos."],
+        "alibaba-oss" => &[".oss-", ".oss."],
+        _ => return None,
+    };
+
+    for marker in markers {
+        if let Some(idx) = host.find(marker) {
+            if idx == 0 {
+                continue;
+            }
+            let bucket = host[..idx].to_string();
+            let service_host = &host[idx + 1..];
+            if url.set_host(Some(service_host)).is_err() {
+                return None;
+            }
+            url.set_path("/");
+            url.set_query(None);
+            url.set_fragment(None);
+            return Some(bucket);
+        }
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -155,11 +199,58 @@ mod tests {
 
     #[test]
     fn bare_host_endpoint_gets_https_scheme() {
-        let e = cfg("alibaba-oss", Some("oss-cn-hangzhou.aliyuncs.com"), Some("oss-cn-hangzhou"))
-            .resolve_s3_endpoint()
-            .unwrap();
+        let e = cfg(
+            "alibaba-oss",
+            Some("oss-cn-hangzhou.aliyuncs.com"),
+            Some("oss-cn-hangzhou"),
+        )
+        .resolve_s3_endpoint()
+        .unwrap();
         assert_eq!(e.url.scheme(), "https");
         assert!(matches!(e.style, UrlStyle::VirtualHost));
+    }
+
+    #[test]
+    fn tencent_cos_bucket_endpoint_infers_default_bucket() {
+        let e = cfg(
+            "tencent-cos",
+            Some("https://photos-1234567890.cos.ap-beijing.myqcloud.com"),
+            Some("ap-beijing"),
+        )
+        .resolve_s3_endpoint()
+        .unwrap();
+
+        assert_eq!(e.url.as_str(), "https://cos.ap-beijing.myqcloud.com/");
+        assert_eq!(e.default_bucket.as_deref(), Some("photos-1234567890"));
+    }
+
+    #[test]
+    fn alibaba_oss_bucket_endpoint_infers_default_bucket() {
+        let e = cfg(
+            "alibaba-oss",
+            Some("archive.oss-cn-hangzhou.aliyuncs.com"),
+            Some("oss-cn-hangzhou"),
+        )
+        .resolve_s3_endpoint()
+        .unwrap();
+
+        assert_eq!(e.url.as_str(), "https://oss-cn-hangzhou.aliyuncs.com/");
+        assert_eq!(e.default_bucket.as_deref(), Some("archive"));
+    }
+
+    #[test]
+    fn explicit_default_bucket_wins_over_bucket_endpoint() {
+        let c = ObjectStorageConfig {
+            provider: "tencent-cos".into(),
+            endpoint: Some("https://endpoint-bucket.cos.ap-beijing.myqcloud.com".into()),
+            region: Some("ap-beijing".into()),
+            default_bucket: Some("configured-bucket".into()),
+            ..Default::default()
+        };
+        let e = c.resolve_s3_endpoint().unwrap();
+
+        assert_eq!(e.url.as_str(), "https://cos.ap-beijing.myqcloud.com/");
+        assert_eq!(e.default_bucket.as_deref(), Some("configured-bucket"));
     }
 
     #[test]

--- a/src-tauri/src/objectstorage/mod.rs
+++ b/src-tauri/src/objectstorage/mod.rs
@@ -103,11 +103,12 @@ async fn build_session(
             let ep = config.resolve_s3_endpoint()?;
             let (http, forward_task) =
                 build_http_client(state, config.network.as_ref(), &ep.url).await?;
+            let default_location = ep.default_bucket.clone();
             let client = S3Client::new(http, creds, ep.url, ep.region, ep.style);
             Ok(ObjectStorageSession {
                 session_id,
                 handle: OssHandle::S3(client),
-                default_location: config.default_bucket.clone(),
+                default_location,
                 cancel: CancellationToken::new(),
                 forward_task,
                 default_storage_class: config.storage_class.clone(),

--- a/src/components/session/ObjectStorageSettings.tsx
+++ b/src/components/session/ObjectStorageSettings.tsx
@@ -3,6 +3,7 @@ import {
   PROVIDER_PRESETS,
   presetFor,
   engineForProvider,
+  normalizeObjectStorageConfig,
   type ObjectStorageConfig,
   type ObjectStorageProvider,
   type AwsAuthSource,
@@ -101,7 +102,7 @@ export function ossFormFromOptions(optionsJson: string | null | undefined): OssF
 /** Build the wire config from form state (secrets as-is — plaintext or refs). */
 export function ossFormToConfig(f: OssFormState): ObjectStorageConfig {
   const isAzure = engineForProvider(f.provider) === "azure";
-  return {
+  return normalizeObjectStorageConfig({
     provider: f.provider,
     endpoint: f.endpoint || null,
     region: f.region || null,
@@ -121,7 +122,7 @@ export function ossFormToConfig(f: OssFormState): ObjectStorageConfig {
     azureAuth: isAzure ? f.azureAuth : null,
     azureBearerToken: isAzure && f.azureAuth === "bearer" ? f.azureBearerToken || null : null,
     storageClass: f.storageClass || null,
-  };
+  });
 }
 
 // PLACEHOLDER_FORM_COMPONENT
@@ -320,4 +321,3 @@ export function ObjectStorageSettings({ value, onChange, saveInVault, setSaveInV
     </div>
   );
 }
-

--- a/src/lib/objectStorage.ts
+++ b/src/lib/objectStorage.ts
@@ -7,6 +7,7 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { withVaultLockedNotice, type SessionConfig } from "./ipc";
 import { parseSessionOptions } from "./terminalProfile";
 import { normalizeNetworkSettings, toNetworkSettingsPayload } from "./networkSettings";
+import { normalizeObjectStorageConfig } from "../types/objectStorage";
 import type {
   BucketEntry,
   ObjectListPage,
@@ -44,7 +45,7 @@ export function sessionToObjectStorageConfig(session: SessionConfig): ObjectStor
   const ns = normalizeNetworkSettings(o.networkSettings);
   const network =
     ns.proxyKind && ns.proxyKind !== "none" ? toNetworkSettingsPayload(ns) : null;
-  return {
+  return normalizeObjectStorageConfig({
     provider,
     endpoint: str("endpoint"),
     region: str("region"),
@@ -65,7 +66,7 @@ export function sessionToObjectStorageConfig(session: SessionConfig): ObjectStor
     azureBearerToken: str("azureBearerToken"),
     network,
     storageClass: str("storageClass"),
-  };
+  });
 }
 
 /** True if any object-storage secret in the session is a locked `vault:` ref. */
@@ -79,7 +80,7 @@ export async function storageAttach(
   config: ObjectStorageConfig,
 ): Promise<void> {
   return withVaultLockedNotice(() =>
-    invoke("storage_attach", { sessionId, config }),
+    invoke("storage_attach", { sessionId, config: normalizeObjectStorageConfig(config) }),
   );
 }
 
@@ -95,7 +96,7 @@ export async function storageTestConnection(
   config: ObjectStorageConfig,
 ): Promise<void> {
   return withVaultLockedNotice(() =>
-    invoke("storage_test_connection", { config }),
+    invoke("storage_test_connection", { config: normalizeObjectStorageConfig(config) }),
   );
 }
 

--- a/src/stores/objectStorageStore.ts
+++ b/src/stores/objectStorageStore.ts
@@ -11,7 +11,12 @@ import {
   storageListBuckets,
   storageListObjects,
 } from "../lib/objectStorage";
-import type { ObjectEntry, ObjectStorageConfig, BucketEntry } from "../types/objectStorage";
+import {
+  normalizeObjectStorageConfig,
+  type ObjectEntry,
+  type ObjectStorageConfig,
+  type BucketEntry,
+} from "../types/objectStorage";
 import { WINDOWS_DRIVES_ROOT, type PaneSide, type PaneState } from "./sftpStore";
 
 // Remote path scheme: "/" is the bucket-list root; "/{bucket}/{prefix...}"
@@ -171,6 +176,7 @@ export const useObjectStorageStore = create<ObjStorageStoreState>((set, get) => 
   },
 
   attach: async (sessionId, config) => {
+    const effectiveConfig = normalizeObjectStorageConfig(config);
     refCounts.set(sessionId, (refCounts.get(sessionId) ?? 0) + 1);
     const pending = inFlight.get(sessionId);
     if (pending) {
@@ -189,14 +195,14 @@ export const useObjectStorageStore = create<ObjStorageStoreState>((set, get) => 
     set((state) => ({
       sessions: {
         ...state.sessions,
-        [sessionId]: { ...(state.sessions[sessionId] ?? freshSession(sessionId)), attaching: true, error: null, config },
+        [sessionId]: { ...(state.sessions[sessionId] ?? freshSession(sessionId)), attaching: true, error: null, config: effectiveConfig },
       },
     }));
 
     const attachPromise = (async () => {
       try {
-        await storageAttach(sessionId, config);
-        const home = config.defaultBucket || config.defaultContainer;
+        await storageAttach(sessionId, effectiveConfig);
+        const home = effectiveConfig.defaultBucket || effectiveConfig.defaultContainer;
         const remotePath = home ? `/${home}` : OBJ_ROOT;
         const localHome = await sftpLocalHome().catch(() => "");
         const remoteEntries = await listSide(sessionId, "remote", remotePath).catch(() => []);
@@ -211,7 +217,7 @@ export const useObjectStorageStore = create<ObjStorageStoreState>((set, get) => 
               attached: true,
               attaching: false,
               homeDir: remotePath,
-              config,
+              config: effectiveConfig,
               remote: { ...emptyPane(), path: remotePath, entries: remoteEntries, history: [remotePath], historyIndex: 0 },
               local: { ...emptyPane(), path: localHome, entries: localEntries, history: localHome ? [localHome] : [], historyIndex: localHome ? 0 : -1 },
             },

--- a/src/types/objectStorage.test.ts
+++ b/src/types/objectStorage.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { normalizeObjectStorageConfig, type ObjectStorageConfig } from "./objectStorage";
+
+function base(provider: ObjectStorageConfig["provider"], endpoint: string): ObjectStorageConfig {
+  return {
+    provider,
+    endpoint,
+    region: "ap-beijing",
+    accessKeyId: "key",
+    secretAccessKey: "secret",
+  };
+}
+
+describe("normalizeObjectStorageConfig", () => {
+  it("infers a Tencent COS bucket endpoint", () => {
+    const cfg = normalizeObjectStorageConfig(
+      base("tencent-cos", "https://photos-1234567890.cos.ap-beijing.myqcloud.com"),
+    );
+
+    expect(cfg.endpoint).toBe("https://cos.ap-beijing.myqcloud.com/");
+    expect(cfg.defaultBucket).toBe("photos-1234567890");
+  });
+
+  it("infers an Alibaba OSS bucket endpoint", () => {
+    const cfg = normalizeObjectStorageConfig(
+      base("alibaba-oss", "archive.oss-cn-hangzhou.aliyuncs.com"),
+    );
+
+    expect(cfg.endpoint).toBe("https://oss-cn-hangzhou.aliyuncs.com/");
+    expect(cfg.defaultBucket).toBe("archive");
+  });
+
+  it("keeps an explicitly configured default bucket", () => {
+    const cfg = normalizeObjectStorageConfig({
+      ...base("tencent-cos", "https://endpoint-bucket.cos.ap-beijing.myqcloud.com"),
+      defaultBucket: "configured-bucket",
+    });
+
+    expect(cfg.endpoint).toBe("https://cos.ap-beijing.myqcloud.com/");
+    expect(cfg.defaultBucket).toBe("configured-bucket");
+  });
+
+  it("leaves service endpoints unchanged", () => {
+    const cfg = normalizeObjectStorageConfig(
+      base("tencent-cos", "https://cos.ap-beijing.myqcloud.com"),
+    );
+
+    expect(cfg.endpoint).toBe("https://cos.ap-beijing.myqcloud.com");
+    expect(cfg.defaultBucket).toBeUndefined();
+  });
+});

--- a/src/types/objectStorage.ts
+++ b/src/types/objectStorage.ts
@@ -137,3 +137,71 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
 export function presetFor(provider: ObjectStorageProvider): ProviderPreset {
   return PROVIDER_PRESETS.find((p) => p.id === provider) ?? PROVIDER_PRESETS[0];
 }
+
+interface BucketEndpointParts {
+  bucket: string;
+  endpoint: string;
+}
+
+function s3BucketEndpointMarkers(provider: ObjectStorageProvider): string[] {
+  switch (provider) {
+    case "tencent-cos":
+      return [".cos."];
+    case "alibaba-oss":
+      return [".oss-", ".oss."];
+    default:
+      return [];
+  }
+}
+
+function parseEndpointUrl(endpoint: string): URL | null {
+  try {
+    return new URL(endpoint.includes("://") ? endpoint : `https://${endpoint}`);
+  } catch {
+    return null;
+  }
+}
+
+function splitBucketEndpoint(provider: ObjectStorageProvider, endpoint: string): BucketEndpointParts | null {
+  const markers = s3BucketEndpointMarkers(provider);
+  if (!markers.length) return null;
+
+  const url = parseEndpointUrl(endpoint);
+  if (!url) return null;
+  const host = url.hostname.toLowerCase();
+
+  for (const marker of markers) {
+    const idx = host.indexOf(marker);
+    if (idx <= 0) continue;
+    const bucket = host.slice(0, idx);
+    const serviceHost = host.slice(idx + 1);
+    url.hostname = serviceHost;
+    url.pathname = "/";
+    url.search = "";
+    url.hash = "";
+    return { bucket, endpoint: url.toString() };
+  }
+
+  return null;
+}
+
+function nonEmpty(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed ? trimmed : null;
+}
+
+export function normalizeObjectStorageConfig(config: ObjectStorageConfig): ObjectStorageConfig {
+  if (engineForProvider(config.provider) !== "s3") return config;
+
+  const endpoint = nonEmpty(config.endpoint);
+  if (!endpoint) return config;
+
+  const parts = splitBucketEndpoint(config.provider, endpoint);
+  if (!parts) return config;
+
+  return {
+    ...config,
+    endpoint: parts.endpoint,
+    defaultBucket: nonEmpty(config.defaultBucket) ?? parts.bucket,
+  };
+}


### PR DESCRIPTION
COS and OSS sessions can be configured with bucket-scoped endpoints such as bucket.cos.<region>.myqcloud.com or bucket.oss-<region>.aliyuncs.com. Taomni previously treated those values as service endpoints, so the connection test could succeed while the browser stayed at the service root and showed an empty bucket list. Uploads also appeared successful but were not visible from the UI because the frontend and backend were not opening the inferred bucket consistently.

Normalize Tencent COS and Alibaba OSS bucket endpoints into service endpoints, infer the default bucket when it is omitted, and preserve an explicitly configured default bucket when present. Apply the same normalization in the editor, saved-session conversion, IPC attach/test paths, frontend store attach flow, and backend endpoint resolution so existing sessions and direct backend calls behave the same way.

Add focused frontend and Rust coverage for COS/OSS endpoint normalization, including explicit default-bucket precedence. Verified with: pnpm exec vitest run src/types/objectStorage.test.ts; cargo test objectstorage::config --lib; pnpm exec vite build. TypeScript still SIGSEGVs in this environment when running tsc directly, without emitting diagnostics.