### PR TITLE
fix(build): support older macOS WKWebView syntax

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,11 +28,11 @@ export default defineConfig({
     // core exports the stub intentionally omits).
     exclude: isTauriBuild ? [] : ["@tauri-apps/plugin-notification", "@tauri-apps/plugin-shell", "@tauri-apps/plugin-dialog"],
   },
-  // Tauri 2 targets modern WebView2 / WebKitGTK / WKWebView, all of which
-  // support ES2022. Keep the production transform target explicit so xterm's
-  // modern syntax is not down-leveled into older parser paths.
+  // Tauri ships with the system WebView. macOS 13.2.x uses a WKWebView roughly
+  // equivalent to Safari 16.3, which can white-screen on untransformed ES2022
+  // syntax such as class static initialization blocks emitted by dependencies.
   build: {
-    target: "es2022",
+    target: ["es2020", "safari16"],
   },
   resolve: {
     alias: isTauriBuild


### PR DESCRIPTION
Taomni 0.3.9+ started pulling Mermaid into the frontend bundle through the Code Workspace markdown preview. With the production target left at es2022, dependencies can emit syntax such as class static initialization blocks that older Ventura WKWebView builds do not parse reliably.

macOS 14, Windows 11 WebView2, and recent Linux WebKitGTK can run that output, but macOS 13.2.1 can fail before React mounts and show a blank window. Target the production bundle at es2020 plus Safari 16 so Tauri packages do not require newer system WebView parser support.

Verified with pnpm build, a dist asset scan showing zero class static block files, and pnpm test with 103 files / 960 tests passing.