### PR TITLE
fix(build): support older macOS WKWebView syntax

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,8 @@ export default defineConfig({
   // Tauri ships with the system WebView. macOS 13.2.x uses a WKWebView roughly
   // equivalent to Safari 16.3, which can white-screen on untransformed ES2022
   // syntax such as class static initialization blocks emitted by dependencies.
+  // Keep this no lower than ES2020: older down-leveling previously broke xterm's
+  // DECRQM/requestMode path used by `vi` on some SSH servers.
   build: {
     target: ["es2020", "safari16"],
   },


### PR DESCRIPTION
Taomni 0.3.9+ started pulling Mermaid into the frontend bundle through the Code Workspace markdown preview. With the production target left at es2022, dependencies can emit syntax such as class static initialization blocks that older Ventura WKWebView builds do not parse reliably.

macOS 14, Windows 11 WebView2, and recent Linux WebKitGTK can run that output, but macOS 13.2.1 can fail before React mounts and show a blank window. Target the production bundle at es2020 plus Safari 16 so Tauri packages do not require newer system WebView parser support.

Keep the target no lower than es2020 because an earlier down-leveling path broke xterm's DECRQM/requestMode handling used by vi on some SSH servers. The rebuilt bundle was checked to ensure requestMode is still emitted with valid local declarations.

Verified with pnpm build, a dist asset scan showing zero class static block files, requestMode output inspection, and pnpm test with 103 files / 960 tests passing.