### PR TITLE
fix(mac): prevent macOS 13 WKWebView startup white screen

### DIFF
--- a/src/lib/webviewCompat.test.ts
+++ b/src/lib/webviewCompat.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { installWebviewCompat } from "./webviewCompat";
+
+type UrlConstructorWithCanParse = typeof URL & {
+  canParse?: (url: string, base?: string) => boolean;
+};
+
+type RegExpConstructorWithEscape = RegExpConstructor & {
+  escape?: (value: string) => string;
+};
+
+const URLCtor = URL as UrlConstructorWithCanParse;
+const RegExpCtor = RegExp as RegExpConstructorWithEscape;
+const originalCanParse = URLCtor.canParse;
+const originalEscape = RegExpCtor.escape;
+
+afterEach(() => {
+  if (originalCanParse) {
+    URLCtor.canParse = originalCanParse;
+  } else {
+    Reflect.deleteProperty(URLCtor, "canParse");
+  }
+
+  if (originalEscape) {
+    RegExpCtor.escape = originalEscape;
+  } else {
+    Reflect.deleteProperty(RegExpCtor, "escape");
+  }
+});
+
+describe("installWebviewCompat", () => {
+  it("polyfills URL.canParse when the WebView does not provide it", () => {
+    Reflect.deleteProperty(URLCtor, "canParse");
+
+    installWebviewCompat();
+
+    expect(URL.canParse("https://taomni.example")).toBe(true);
+    expect(URL.canParse("/relative-only")).toBe(false);
+    expect(URL.canParse("/relative", "https://taomni.example")).toBe(true);
+    expect(URL.canParse("http://[")).toBe(false);
+  });
+
+  it("keeps an existing URL.canParse implementation", () => {
+    const existing = () => true;
+    URLCtor.canParse = existing;
+
+    installWebviewCompat();
+
+    expect(URLCtor.canParse).toBe(existing);
+  });
+
+  it("polyfills RegExp.escape when the WebView does not provide it", () => {
+    Reflect.deleteProperty(RegExpCtor, "escape");
+
+    installWebviewCompat();
+
+    expect(RegExpCtor.escape?.("a+b[c]")).toBe("a\\+b\\[c\\]");
+  });
+});

--- a/src/lib/webviewCompat.ts
+++ b/src/lib/webviewCompat.ts
@@ -1,0 +1,45 @@
+type UrlConstructorWithCanParse = typeof URL & {
+  canParse?: (url: string, base?: string) => boolean;
+};
+
+type RegExpConstructorWithEscape = RegExpConstructor & {
+  escape?: (value: string) => string;
+};
+
+export function installWebviewCompat(): void {
+  installUrlCanParse();
+  installRegExpEscape();
+}
+
+function installUrlCanParse(): void {
+  if (typeof globalThis.URL !== "function") return;
+
+  const URLCtor = globalThis.URL as UrlConstructorWithCanParse;
+  if (typeof URLCtor.canParse === "function") return;
+
+  URLCtor.canParse = (url: string, base?: string): boolean => {
+    try {
+      if (base === undefined) {
+        new URL(url);
+      } else {
+        new URL(url, base);
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  };
+}
+
+function installRegExpEscape(): void {
+  if (typeof globalThis.RegExp !== "function") return;
+
+  const RegExpCtor = globalThis.RegExp as RegExpConstructorWithEscape;
+  if (typeof RegExpCtor.escape === "function") return;
+
+  RegExpCtor.escape = (value: string): string => (
+    String(value).replace(/[\\^$.*+?()[\]{}|/]/g, "\\$&")
+  );
+}
+
+installWebviewCompat();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,85 @@
+import "./lib/webviewCompat";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App";
 import "./index.css";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+interface RootErrorBoundaryState {
+  error: unknown;
+}
+
+class RootErrorBoundary extends React.Component<{ children: React.ReactNode }, RootErrorBoundaryState> {
+  state: RootErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: unknown): RootErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error("[startup] React render failed", error);
+  }
+
+  render() {
+    if (this.state.error) {
+      return <StartupCrash error={this.state.error} />;
+    }
+    return this.props.children;
+  }
+}
+
+function StartupCrash({ error }: { error: unknown }) {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        boxSizing: "border-box",
+        padding: 24,
+        fontFamily: "Inter, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif",
+        background: "#ffffff",
+        color: "#1f2328",
+      }}
+    >
+      <div style={{ maxWidth: 760 }}>
+        <h1 style={{ margin: "0 0 12px", fontSize: 20, fontWeight: 700 }}>Taomni failed to start</h1>
+        <p style={{ margin: "0 0 16px", color: "#59636e", fontSize: 13, lineHeight: 1.5 }}>
+          The app hit a startup error in this WebView. Please include the details below when reporting it.
+        </p>
+        <pre
+          style={{
+            margin: 0,
+            padding: 12,
+            overflow: "auto",
+            whiteSpace: "pre-wrap",
+            border: "1px solid #d0d7de",
+            borderRadius: 6,
+            background: "#f6f8fa",
+            fontSize: 12,
+            lineHeight: 1.45,
+          }}
+        >
+          {message}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+function renderStartupCrash(error: unknown): void {
+  console.error("[startup] App module failed to load", error);
+  ReactDOM.createRoot(document.getElementById("root")!).render(<StartupCrash error={error} />);
+}
+
+async function bootstrap(): Promise<void> {
+  const { default: App } = await import("./App");
+
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <RootErrorBoundary>
+        <App />
+      </RootErrorBoundary>
+    </React.StrictMode>,
+  );
+}
+
+void bootstrap().catch(renderStartupCrash);


### PR DESCRIPTION
macOS 13.2.x ships an older WKWebView runtime than the one used by current frontend dependencies. The previous build-target fix handled newer syntax, but it did not cover missing runtime APIs such as URL.canParse. Mermaid's dependency graph can touch that API during module loading, which means the app can fail before React renders anything, even if the user never opens Code Workspace.

Install a small startup compatibility layer before the app module is imported. It polyfills URL.canParse and RegExp.escape only when the WebView does not provide them, preserving native implementations on newer systems.

Load App through a dynamic bootstrap after compatibility setup and add a root startup error boundary. Future import-time or render-time startup failures now show a diagnostic screen instead of leaving the root empty and presenting as a pure white window.

Add focused Vitest coverage for the compatibility layer, including preserving existing native implementations and handling relative URL parsing with a base URL.