### PR TITLE
fix(build): align dev xterm prebundle target

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,14 @@ export default defineConfig({
     // optimizer from pre-bundling the real packages (whose imports reference
     // core exports the stub intentionally omits).
     exclude: isTauriBuild ? [] : ["@tauri-apps/plugin-notification", "@tauri-apps/plugin-shell", "@tauri-apps/plugin-dialog"],
+    // Match the production floor for dependency pre-bundles. xterm's
+    // DECRQM/requestMode path is exercised by `vi`, so dev output needs the
+    // same parser-safe target as packaged builds.
+    rolldownOptions: {
+      transform: {
+        target: "es2020",
+      },
+    },
   },
   // Tauri ships with the system WebView. macOS 13.2.x uses a WKWebView roughly
   // equivalent to Safari 16.3, which can white-screen on untransformed ES2022


### PR DESCRIPTION
Set Vite 8's dependency optimizer Rolldown transform target to es2020 so cargo tauri dev emits the same parser-safe xterm dependency output as packaged builds.

The release build already uses an ES2020 floor, but the dev optimizer cache was still able to preserve newer syntax in @xterm/xterm. On affected Linux WebKitGTK/JSCore environments this broke xterm's DECRQM/requestMode path, which is exercised when vi starts in local and SSH terminals.

Keeping the dev prebundle target aligned with build.target prevents machine-specific dev cache/runtime differences while preserving the existing macOS WebView compatibility floor.