### PR TITLE
feat(mail): expand OAuth flow support

### DIFF
--- a/src-tauri/src/mail/mod.rs
+++ b/src-tauri/src/mail/mod.rs
@@ -166,7 +166,7 @@ struct OAuthDeviceCodeResponse {
     device_code: String,
     #[serde(default)]
     user_code: String,
-    #[serde(default)]
+    #[serde(default, alias = "verification_url")]
     verification_uri: String,
     #[serde(default)]
     expires_in: Option<i64>,
@@ -220,6 +220,8 @@ pub struct MailOAuthDeviceCompleteRequest {
     pub provider: MailProvider,
     pub email_address: String,
     pub client_id: String,
+    #[serde(default)]
+    pub client_secret: Option<String>,
     pub device_code: String,
     #[serde(default)]
     pub interval: Option<i64>,
@@ -1000,7 +1002,8 @@ pub async fn mail_oauth_authorize(
         return Err("OAuth2 mail auth requires Gmail or Outlook provider".into());
     }
 
-    let listener = std::net::TcpListener::bind(("127.0.0.1", 0))
+    let bind_host = oauth_loopback_bind_host(request.provider)?;
+    let listener = std::net::TcpListener::bind((bind_host, 0))
         .map_err(|e| format!("OAuth callback listener failed: {e}"))?;
     listener
         .set_nonblocking(true)
@@ -1009,7 +1012,7 @@ pub async fn mail_oauth_authorize(
         .local_addr()
         .map_err(|e| format!("OAuth callback address failed: {e}"))?
         .port();
-    let redirect_uri = format!("http://127.0.0.1:{port}/mail/oauth/callback");
+    let redirect_uri = oauth_loopback_redirect_uri(request.provider, port)?;
     let state_token = random_urlsafe_token(32);
     let verifier = random_urlsafe_token(48);
     let challenge = pkce_challenge(&verifier);
@@ -1069,8 +1072,8 @@ pub async fn mail_oauth_device_start(
     if client_id.is_empty() {
         return Err("OAuth2 client ID is required".into());
     }
-    if request.provider != MailProvider::Outlook {
-        return Err("Device code authorization is currently supported for Outlook only".into());
+    if request.provider == MailProvider::Custom {
+        return Err("Device code authorization requires Gmail or Outlook provider".into());
     }
     let network_settings = prepare_mail_network(&state, request.network_settings.clone())?;
     let provider = request.provider;
@@ -1107,13 +1110,15 @@ pub async fn mail_oauth_device_complete(
     if client_id.is_empty() {
         return Err("OAuth2 client ID is required".into());
     }
-    if request.provider != MailProvider::Outlook {
-        return Err("Device code authorization is currently supported for Outlook only".into());
+    if request.provider == MailProvider::Custom {
+        return Err("Device code authorization requires Gmail or Outlook provider".into());
     }
     let device_code = request.device_code.trim().to_string();
     if device_code.is_empty() {
         return Err("OAuth2 device code is required".into());
     }
+    let client_secret =
+        resolve_secret(&state, request.client_secret.as_deref())?.and_then(non_empty);
     let network_settings = prepare_mail_network(&state, request.network_settings.clone())?;
     let provider = request.provider;
     let interval = request.interval.unwrap_or(5).max(1);
@@ -1122,6 +1127,7 @@ pub async fn mail_oauth_device_complete(
         complete_oauth_device_code_blocking(
             provider,
             &client_id,
+            client_secret.as_deref(),
             &device_code,
             interval,
             expires_in,
@@ -2271,12 +2277,20 @@ fn start_oauth_device_code_blocking(
 fn complete_oauth_device_code_blocking(
     provider: MailProvider,
     client_id: &str,
+    client_secret: Option<&str>,
     device_code: &str,
     interval: i64,
     expires_in: i64,
     network: Option<&NetworkSettings>,
 ) -> Result<OAuthTokenResponse, String> {
     let token_url = oauth_token_url(provider)?;
+    let client_secret = client_secret.and_then(non_empty_str);
+    if provider == MailProvider::Gmail && client_secret.is_none() {
+        return Err(
+            "Gmail device code authorization requires the OAuth client secret from a Google TV and Limited Input OAuth client"
+                .into(),
+        );
+    }
     let client = build_oauth_http_client_blocking(network)?;
     let deadline = Instant::now() + Duration::from_secs(expires_in.clamp(1, 3600) as u64);
     let mut poll_interval = Duration::from_secs(interval.clamp(1, 30) as u64);
@@ -2286,7 +2300,7 @@ fn complete_oauth_device_code_blocking(
             return Err("OAuth device code expired before authorization completed".into());
         }
 
-        let params = vec![
+        let mut params = vec![
             ("client_id", client_id.to_string()),
             (
                 "grant_type",
@@ -2294,6 +2308,9 @@ fn complete_oauth_device_code_blocking(
             ),
             ("device_code", device_code.to_string()),
         ];
+        if let Some(secret) = client_secret {
+            params.push(("client_secret", secret.to_string()));
+        }
         let response = client
             .post(token_url)
             .header(
@@ -2455,6 +2472,22 @@ fn oauth_form_body(params: &[(&str, String)]) -> String {
     serializer.finish()
 }
 
+fn oauth_loopback_bind_host(provider: MailProvider) -> Result<&'static str, String> {
+    match provider {
+        MailProvider::Gmail => Ok("127.0.0.1"),
+        MailProvider::Outlook => Ok("localhost"),
+        MailProvider::Custom => Err("OAuth2 mail auth requires Gmail or Outlook provider".into()),
+    }
+}
+
+fn oauth_loopback_redirect_uri(provider: MailProvider, port: u16) -> Result<String, String> {
+    match provider {
+        MailProvider::Gmail => Ok(format!("http://127.0.0.1:{port}")),
+        MailProvider::Outlook => Ok(format!("http://localhost:{port}")),
+        MailProvider::Custom => Err("OAuth2 mail auth requires Gmail or Outlook provider".into()),
+    }
+}
+
 fn build_oauth_authorize_url(
     provider: MailProvider,
     client_id: &str,
@@ -2574,10 +2607,13 @@ fn oauth_token_url(provider: MailProvider) -> Result<&'static str, String> {
 
 fn oauth_device_code_url(provider: MailProvider) -> Result<&'static str, String> {
     match provider {
+        MailProvider::Gmail => Ok("https://oauth2.googleapis.com/device/code"),
         MailProvider::Outlook => {
             Ok("https://login.microsoftonline.com/common/oauth2/v2.0/devicecode")
         }
-        _ => Err("Device code authorization is currently supported for Outlook only".into()),
+        MailProvider::Custom => {
+            Err("Device code authorization requires Gmail or Outlook provider".into())
+        }
     }
 }
 
@@ -4997,6 +5033,34 @@ mod tests {
         );
         assert!(message.starts_with(OAUTH_REAUTHORIZE_REQUIRED));
         assert!(message.contains("invalid_grant"));
+    }
+
+    #[test]
+    fn oauth_loopback_redirect_uri_is_provider_specific() {
+        assert_eq!(
+            oauth_loopback_redirect_uri(MailProvider::Gmail, 49152).as_deref(),
+            Ok("http://127.0.0.1:49152")
+        );
+        assert_eq!(
+            oauth_loopback_redirect_uri(MailProvider::Outlook, 49152).as_deref(),
+            Ok("http://localhost:49152")
+        );
+    }
+
+    #[test]
+    fn oauth_device_code_response_accepts_google_verification_url() {
+        let device = serde_json::from_str::<OAuthDeviceCodeResponse>(
+            r#"{
+                "device_code": "device",
+                "user_code": "ABCD-EFGH",
+                "verification_url": "https://www.google.com/device",
+                "expires_in": 900,
+                "interval": 5
+            }"#,
+        )
+        .expect("parse Google device code response");
+
+        assert_eq!(device.verification_uri, "https://www.google.com/device");
     }
 
     fn sample_resolved_account() -> ResolvedMailAccount {

--- a/src/components/session/SessionEditor.test.tsx
+++ b/src/components/session/SessionEditor.test.tsx
@@ -1335,6 +1335,7 @@ describe("SessionEditor SSH settings tabs", { timeout: 15_000 }, () => {
     renderEditor(undefined, { initialProto: "Mail" });
 
     await user.selectOptions(screen.getByLabelText("Mail provider"), "gmail");
+    expect(screen.getByLabelText("OAuth flow")).toHaveValue("browser");
     await user.type(screen.getByLabelText("Mail email or username"), "me@gmail.com");
     await user.type(screen.getByLabelText("OAuth client ID"), "google-client-id");
 
@@ -1360,6 +1361,71 @@ describe("SessionEditor SSH settings tabs", { timeout: 15_000 }, () => {
       },
     });
     expect(screen.getByText("OAuth2 connected.")).toBeInTheDocument();
+  });
+
+  it("authorizes Gmail OAuth with device code and client secret", async () => {
+    const user = userEvent.setup();
+    renderEditor(undefined, { initialProto: "Mail" });
+
+    await user.selectOptions(screen.getByLabelText("Mail provider"), "gmail");
+    await user.selectOptions(screen.getByLabelText("OAuth flow"), "device");
+    await user.type(screen.getByLabelText("Mail email or username"), "me@gmail.com");
+    await user.type(screen.getByLabelText("OAuth client ID"), "google-device-client-id");
+    await user.type(screen.getByLabelText("OAuth client secret"), "google-device-secret");
+
+    await user.click(screen.getByTestId("mail-oauth-connect"));
+
+    await waitFor(() => expect(mailMocks.mailOAuthDeviceStart).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mailMocks.mailOAuthDeviceComplete).toHaveBeenCalledTimes(1));
+    expect(mailMocks.mailOAuthAuthorize).not.toHaveBeenCalled();
+
+    const startRequest = (mailMocks.mailOAuthDeviceStart.mock.calls[0] as unknown[])[0];
+    expect(startRequest).toMatchObject({
+      provider: "gmail",
+      emailAddress: "me@gmail.com",
+      clientId: "google-device-client-id",
+    });
+    const completeRequest = (mailMocks.mailOAuthDeviceComplete.mock.calls[0] as unknown[])[0];
+    expect(completeRequest).toMatchObject({
+      provider: "gmail",
+      emailAddress: "me@gmail.com",
+      clientId: "google-device-client-id",
+      clientSecret: "google-device-secret",
+      deviceCode: "device-code",
+      interval: 1,
+      expiresIn: 900,
+    });
+    expect(screen.getByText("OAuth2 connected.")).toBeInTheDocument();
+  });
+
+  it("persists Gmail device OAuth flow and client secret vault reference", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderEditor(undefined, { initialProto: "Mail" });
+
+    await user.selectOptions(screen.getByLabelText("Mail provider"), "gmail");
+    await user.selectOptions(screen.getByLabelText("OAuth flow"), "device");
+    await user.type(screen.getByLabelText("Mail email or username"), "me@gmail.com");
+    await user.type(screen.getByLabelText("OAuth client ID"), "google-device-client-id");
+    await user.type(screen.getByLabelText("OAuth client secret"), "google-device-secret");
+    await user.click(screen.getByTestId("mail-oauth-connect"));
+    await waitFor(() => expect(screen.getByText("OAuth2 connected.")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "OK" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(ipcMocks.vaultPut).toHaveBeenCalledWith(
+      "mail-oauth-client-secret",
+      "me@gmail.com OAuth client secret",
+      "google-device-secret",
+    );
+    const savedConfig = ipcMocks.saveSession.mock.calls[0][0];
+    const savedOptions = JSON.parse(savedConfig.options_json);
+    expect(savedOptions.mailProvider).toBe("gmail");
+    expect(savedOptions.mailAuthMode).toBe("oauth2");
+    expect(savedOptions.mailOauthFlow).toBe("device");
+    expect(savedOptions.mailOauthClientId).toBe("google-device-client-id");
+    expect(savedOptions.mailOauthClientSecretRef).toBe("vault:pwd");
+    expect(savedOptions.mailOauthTokenRef).toBe("vault:oauth-token");
   });
 
   it("authorizes Outlook OAuth with device code using the Mail Network tab settings", async () => {
@@ -1409,6 +1475,32 @@ describe("SessionEditor SSH settings tabs", { timeout: 15_000 }, () => {
         proxyHost: "socks.mail.corp",
         proxyPort: 1080,
       },
+    });
+    expect(screen.getByText("OAuth2 connected.")).toBeInTheDocument();
+  });
+
+  it("authorizes Outlook OAuth with browser callback when selected", async () => {
+    const user = userEvent.setup();
+    renderEditor(undefined, { initialProto: "Mail" });
+
+    await user.selectOptions(screen.getByLabelText("Mail provider"), "outlook");
+    await user.selectOptions(screen.getByLabelText("OAuth flow"), "browser");
+    await user.type(screen.getByLabelText("Mail email or username"), "me@outlook.com");
+    await user.type(screen.getByLabelText("OAuth client ID"), "azure-client-id");
+    await user.type(screen.getByLabelText("OAuth client secret"), "azure-client-secret");
+
+    await user.click(screen.getByTestId("mail-oauth-connect"));
+
+    await waitFor(() => expect(mailMocks.mailOAuthAuthorize).toHaveBeenCalledTimes(1));
+    expect(mailMocks.mailOAuthDeviceStart).not.toHaveBeenCalled();
+    expect(mailMocks.mailOAuthDeviceComplete).not.toHaveBeenCalled();
+
+    const oauthRequest = (mailMocks.mailOAuthAuthorize.mock.calls[0] as unknown[])[0];
+    expect(oauthRequest).toMatchObject({
+      provider: "outlook",
+      emailAddress: "me@outlook.com",
+      clientId: "azure-client-id",
+      clientSecret: "azure-client-secret",
     });
     expect(screen.getByText("OAuth2 connected.")).toBeInTheDocument();
   });

--- a/src/components/session/SessionEditor.tsx
+++ b/src/components/session/SessionEditor.tsx
@@ -300,8 +300,28 @@ function normalizeMailOAuthFlow(value: unknown): MailOAuthFlow | null {
   return null;
 }
 
+function defaultMailOAuthFlow(provider: MailProvider): MailOAuthFlow {
+  return provider === "outlook" ? "device" : "browser";
+}
+
+function supportsMailOAuthProvider(provider: MailProvider): provider is "gmail" | "outlook" {
+  return provider === "gmail" || provider === "outlook";
+}
+
+function effectiveMailOAuthFlow(provider: MailProvider, flow: MailOAuthFlow): MailOAuthFlow {
+  return supportsMailOAuthProvider(provider) && flow === "device" ? "device" : "browser";
+}
+
+function mailOAuthClientSecretVisible(provider: MailProvider, flow: MailOAuthFlow): boolean {
+  return !(provider === "outlook" && effectiveMailOAuthFlow(provider, flow) === "device");
+}
+
+function mailOAuthClientSecretRequired(provider: MailProvider, flow: MailOAuthFlow): boolean {
+  return provider === "gmail" && effectiveMailOAuthFlow(provider, flow) === "device";
+}
+
 function initialMailOAuthFlow(options: Record<string, unknown>, provider: MailProvider): MailOAuthFlow {
-  return normalizeMailOAuthFlow(options.mailOauthFlow) ?? (provider === "outlook" ? "device" : "browser");
+  return normalizeMailOAuthFlow(options.mailOauthFlow) ?? defaultMailOAuthFlow(provider);
 }
 
 function initialMailProvider(options: Record<string, unknown>, imapHost: string | undefined): MailProvider {
@@ -1385,11 +1405,18 @@ function MailSettings({
   vaultState: "empty" | "locked" | "unlocked";
 }) {
   const isOAuth = authMode === "oauth2";
-  const oauthSupported = provider === "gmail" || provider === "outlook";
-  const usesDeviceCode = provider === "outlook" && oauthFlow === "device";
+  const oauthSupported = supportsMailOAuthProvider(provider);
+  const effectiveOauthFlow = effectiveMailOAuthFlow(provider, oauthFlow);
+  const usesDeviceCode = oauthSupported && effectiveOauthFlow === "device";
+  const showClientSecret = mailOAuthClientSecretVisible(provider, effectiveOauthFlow);
   const oauthConnectLabel = usesDeviceCode
     ? (oauthConnecting ? "Waiting for approval..." : oauthTokenRef ? "Reconnect device code" : "Start device code")
     : (oauthConnecting ? "Connecting..." : oauthTokenRef ? "Reconnect OAuth2" : "Connect OAuth2");
+  const oauthClientSecretPlaceholder = (() => {
+    if (oauthClientSecretRef) return "Saved in vault";
+    if (mailOAuthClientSecretRequired(provider, effectiveOauthFlow)) return "Google device client secret";
+    return "Optional for public clients";
+  })();
   const oauthExpiresLabel = (() => {
     const seconds = Number.parseInt(oauthExpiresAt, 10);
     if (!Number.isFinite(seconds) || seconds <= 0) return "";
@@ -1451,14 +1478,14 @@ function MailSettings({
 
       {isOAuth && (
         <>
-          {provider === "outlook" && (
+          {oauthSupported && (
             <Field label="OAuth flow">
               <Select
                 value={oauthFlow}
                 className="w-44"
                 ariaLabel="OAuth flow"
                 options={MAIL_OAUTH_FLOW_OPTIONS}
-                onChange={(value) => setOauthFlow(normalizeMailOAuthFlow(value) ?? "device")}
+                onChange={(value) => setOauthFlow(normalizeMailOAuthFlow(value) ?? defaultMailOAuthFlow(provider))}
               />
             </Field>
           )}
@@ -1471,14 +1498,14 @@ function MailSettings({
               onChange={(e) => setOauthClientId(e.target.value)}
             />
           </Field>
-          {!usesDeviceCode && (
+          {showClientSecret && (
             <Field label="OAuth client secret">
               <input
                 className="taomni-input w-64"
                 type="password"
                 value={oauthClientSecret}
                 aria-label="OAuth client secret"
-                placeholder={oauthClientSecretRef ? "Saved in vault" : "Optional for public clients"}
+                placeholder={oauthClientSecretPlaceholder}
                 onChange={(e) => {
                   setOauthClientSecret(e.target.value);
                   if (oauthClientSecretRef) clearOauthClientSecretRef();
@@ -2697,7 +2724,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
   const handleMailProviderChange = (provider: MailProvider) => {
     setMailProvider(provider);
     setMailAuthMode(provider === "custom" ? "password" : "oauth2");
-    setMailOauthFlow(provider === "outlook" ? "device" : "browser");
+    setMailOauthFlow(defaultMailOAuthFlow(provider));
     setMailOauthDeviceInfo(null);
     setMailOauthStatus(null);
     const preset = MAIL_PROVIDER_PRESETS[provider];
@@ -2802,7 +2829,8 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
       ? { proxyKind, testUrl: proxyTestUrl }
       : {};
     const mailOauthExpiresAtNumber = Number.parseInt(mailOauthExpiresAtValue, 10);
-    const effectiveMailOauthFlow = mailProvider === "outlook" && mailOauthFlow === "device" ? "device" : "browser";
+    const effectiveMailOauthFlow = effectiveMailOAuthFlow(mailProvider, mailOauthFlow);
+    const persistMailOauthClientSecret = mailOAuthClientSecretVisible(mailProvider, effectiveMailOauthFlow);
     const mailOverrides: Record<string, unknown> = isMail
       ? {
           mailProvider,
@@ -2810,7 +2838,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
           mailOauthFlow: mailAuthMode === "oauth2" ? effectiveMailOauthFlow : "browser",
           mailOauthClientId: mailAuthMode === "oauth2" ? mailOauthClientId : "",
           mailOauthClientSecretRef:
-            mailAuthMode === "oauth2" && effectiveMailOauthFlow !== "device"
+            mailAuthMode === "oauth2" && persistMailOauthClientSecret
               ? mailOauthClientSecretRefValue
               : "",
           mailOauthTokenRef: mailAuthMode === "oauth2" ? mailOauthTokenRefValue : "",
@@ -2987,6 +3015,14 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
       if (mailAuthMode === "oauth2") {
         if (mailProvider === "custom") return "OAuth2 mail auth requires Gmail or Outlook provider.";
         if (!mailOauthClientId.trim()) return "OAuth2 client ID is required.";
+        if (mailOAuthClientSecretRequired(mailProvider, mailOauthFlow)) {
+          if (!mailOauthClientSecretRef.trim() && !mailOauthClientSecret.trim()) {
+            return "Gmail device code requires an OAuth2 client secret.";
+          }
+          if (!mailOauthClientSecretRef.trim() && mailOauthClientSecret.trim() && !mailOauthClientSecretSaveInVault) {
+            return "Gmail device code client secret must be saved in the vault.";
+          }
+        }
         if (!mailOauthTokenRef.trim()) return "OAuth2 token is required. Use Connect OAuth2 first.";
       } else {
         if (!saveInVault) return "Mail credentials must be saved in the vault.";
@@ -3171,7 +3207,8 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
     }
 
     let nextMailOauthClientSecretRef = mailOauthClientSecretRef;
-    if (isMail && mailAuthMode === "oauth2" && mailProvider === "outlook" && mailOauthFlow === "device") {
+    const effectiveMailOauthFlowForSave = effectiveMailOAuthFlow(mailProvider, mailOauthFlow);
+    if (isMail && mailAuthMode === "oauth2" && !mailOAuthClientSecretVisible(mailProvider, effectiveMailOauthFlowForSave)) {
       nextMailOauthClientSecretRef = "";
       setMailOauthClientSecretRef("");
       setMailOauthClientSecret("");
@@ -3528,16 +3565,24 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
 
   const handleMailOAuthConnect = async () => {
     setMailOauthStatus(null);
-    if (mailProvider !== "gmail" && mailProvider !== "outlook") {
+    if (!supportsMailOAuthProvider(mailProvider)) {
       setMailOauthStatus({ ok: false, msg: "Select Gmail or Outlook first." });
       return;
     }
+    const oauthProvider = mailProvider;
+    const oauthProviderLabel = oauthProvider === "gmail" ? "Gmail" : "Outlook";
+    const selectedMailOauthFlow = effectiveMailOAuthFlow(oauthProvider, mailOauthFlow);
     if (!username.trim()) {
       setMailOauthStatus({ ok: false, msg: "Enter the mail email address first." });
       return;
     }
     if (!mailOauthClientId.trim()) {
       setMailOauthStatus({ ok: false, msg: "Enter the OAuth2 client ID first." });
+      return;
+    }
+    const oauthClientSecretValue = mailOauthClientSecret || mailOauthClientSecretRef || null;
+    if (mailOAuthClientSecretRequired(oauthProvider, selectedMailOauthFlow) && !oauthClientSecretValue) {
+      setMailOauthStatus({ ok: false, msg: "Enter the OAuth2 client secret first." });
       return;
     }
     const ready = await ensureVaultReady(t("vault.gateReasonSession"));
@@ -3554,11 +3599,11 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
         networkSettings.proxyKind !== "none"
           ? toNetworkSettingsPayload(networkSettings)
           : null;
-      const result = mailProvider === "outlook" && mailOauthFlow === "device"
+      const result = selectedMailOauthFlow === "device"
         ? await (async () => {
             const device = await mailOAuthDeviceStart({
               sessionId,
-              provider: "outlook",
+              provider: oauthProvider,
               emailAddress: username.trim(),
               clientId: mailOauthClientId.trim(),
               networkSettings: networkPayload,
@@ -3571,25 +3616,26 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
             });
             setMailOauthStatus({
               ok: true,
-              msg: `Enter code ${device.userCode} to approve Outlook access.`,
+              msg: `Enter code ${device.userCode} to approve ${oauthProviderLabel} access.`,
             });
             return mailOAuthDeviceComplete({
               sessionId,
-              provider: "outlook",
+              provider: oauthProvider,
               emailAddress: username.trim(),
               clientId: mailOauthClientId.trim(),
+              clientSecret: oauthProvider === "gmail" ? oauthClientSecretValue : null,
               deviceCode: device.deviceCode,
               interval: device.interval,
               expiresIn: device.expiresIn,
               networkSettings: networkPayload,
             });
-          })()
+        })()
         : await mailOAuthAuthorize({
             sessionId,
-            provider: mailProvider,
+            provider: oauthProvider,
             emailAddress: username.trim(),
             clientId: mailOauthClientId.trim(),
-            clientSecret: mailOauthClientSecret || mailOauthClientSecretRef || null,
+            clientSecret: oauthClientSecretValue,
             networkSettings: networkPayload,
           });
       setMailAuthMode("oauth2");

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -134,7 +134,7 @@ export interface MailOAuthAuthorizeResult {
 
 export interface MailOAuthDeviceStartRequest {
   sessionId: string;
-  provider: "outlook";
+  provider: "gmail" | "outlook";
   emailAddress: string;
   clientId: string;
   networkSettings?: NetworkSettingsPayload | null;
@@ -151,9 +151,10 @@ export interface MailOAuthDeviceStartResult {
 
 export interface MailOAuthDeviceCompleteRequest {
   sessionId: string;
-  provider: "outlook";
+  provider: "gmail" | "outlook";
   emailAddress: string;
   clientId: string;
+  clientSecret?: string | null;
   deviceCode: string;
   interval?: number | null;
   expiresIn?: number | null;

--- a/src/stubs/tauri-core.ts
+++ b/src/stubs/tauri-core.ts
@@ -2146,10 +2146,12 @@ export async function invoke<T>(cmd: string, args?: any, options?: InvokeOptions
       } as T;
     }
     case "mail_oauth_device_start": {
+      const invokeArgs = args as InvokeArgs | undefined;
+      const provider = (invokeArgs?.request as { provider?: string } | undefined)?.provider;
       return {
         deviceCode: "stub-device-code",
         userCode: "ABCD-EFGH",
-        verificationUri: "https://microsoft.com/devicelogin",
+        verificationUri: provider === "gmail" ? "https://www.google.com/device" : "https://microsoft.com/devicelogin",
         message: "Open the verification URL and enter code ABCD-EFGH.",
         expiresIn: 900,
         interval: 1,


### PR DESCRIPTION
Normalize browser callback redirects per provider: Gmail keeps loopback IP redirects while Outlook now uses localhost with a random OS-assigned port for Microsoft desktop app registration compatibility.

Add Gmail device-code authorization alongside Outlook, including Google device-code endpoint handling, verification_url parsing, and client-secret propagation for the Google limited-input flow.

Expose OAuth flow selection for Gmail and Outlook in the mail session editor, preserve Gmail device-flow settings on save, require a vaulted client secret where Gmail device flow needs one, and keep Outlook device flow secretless.

Update mail OAuth TypeScript types, browser stubs, and focused SessionEditor/Rust OAuth tests for Gmail browser, Gmail device, Outlook device, Outlook browser, and provider-specific loopback behavior.