### PR TITLE
fix(object-storage): repair OSS upload and download paths

### DIFF
--- a/src-tauri/src/objectstorage/mod.rs
+++ b/src-tauri/src/objectstorage/mod.rs
@@ -51,6 +51,14 @@ fn resolve(state: &State<'_, AppState>, value: &Option<String>) -> Result<Option
     }
 }
 
+fn clean_storage_class(value: &Option<String>) -> Option<String> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 /// Build a live session from a connection config (credential resolution +
 /// client construction). Does not insert it into the registry.
 async fn build_session(
@@ -67,7 +75,7 @@ async fn build_session(
                 default_location: config.default_container.clone(),
                 cancel: CancellationToken::new(),
                 forward_task,
-                default_storage_class: config.storage_class.clone(),
+                default_storage_class: clean_storage_class(&config.storage_class),
             })
         }
         _ => {
@@ -75,9 +83,7 @@ async fn build_session(
             // (vault-resolved), environment, or a shared-config profile.
             let creds = match config.aws_auth.as_deref() {
                 Some("environment") => credentials::from_environment()?,
-                Some("profile") => {
-                    credentials::from_profile(config.aws_profile.as_deref()).await?
-                }
+                Some("profile") => credentials::from_profile(config.aws_profile.as_deref()).await?,
                 _ => {
                     let key = resolve(state, &config.access_key_id)?
                         .ok_or("access key id is required")?;
@@ -111,7 +117,7 @@ async fn build_session(
                 default_location,
                 cancel: CancellationToken::new(),
                 forward_task,
-                default_storage_class: config.storage_class.clone(),
+                default_storage_class: clean_storage_class(&config.storage_class),
             })
         }
     }
@@ -304,8 +310,13 @@ pub async fn storage_list_objects(
     state: State<'_, AppState>,
 ) -> Result<ObjectListPage, String> {
     let sess = get_session(&state, &session_id).await?;
-    sess.list_objects(&bucket, prefix.as_deref().unwrap_or(""), continuation.as_deref(), 1000)
-        .await
+    sess.list_objects(
+        &bucket,
+        prefix.as_deref().unwrap_or(""),
+        continuation.as_deref(),
+        1000,
+    )
+    .await
 }
 
 #[tauri::command]
@@ -367,7 +378,10 @@ pub async fn storage_create_bucket(
     bucket: String,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    get_session(&state, &session_id).await?.create_bucket(&bucket).await
+    get_session(&state, &session_id)
+        .await?
+        .create_bucket(&bucket)
+        .await
 }
 
 #[tauri::command]
@@ -376,7 +390,10 @@ pub async fn storage_delete_bucket(
     bucket: String,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    get_session(&state, &session_id).await?.delete_bucket(&bucket).await
+    get_session(&state, &session_id)
+        .await?
+        .delete_bucket(&bucket)
+        .await
 }
 
 /// Recursively delete a "folder" (everything under `prefix`).
@@ -400,7 +417,10 @@ pub async fn storage_head_object(
     key: String,
     state: State<'_, AppState>,
 ) -> Result<ObjectMetadata, String> {
-    get_session(&state, &session_id).await?.head_object(&bucket, &key).await
+    get_session(&state, &session_id)
+        .await?
+        .head_object(&bucket, &key)
+        .await
 }
 
 #[tauri::command]
@@ -473,7 +493,10 @@ pub async fn storage_download(
         Ok(_) => ft::CompletePayload::ok(Some(final_path)),
         Err(e) => ft::CompletePayload::err(e),
     };
-    let _ = app_handle.emit(&format!("storage-transfer-complete-{}", transfer_id), payload);
+    let _ = app_handle.emit(
+        &format!("storage-transfer-complete-{}", transfer_id),
+        payload,
+    );
     result
 }
 
@@ -509,24 +532,36 @@ pub async fn storage_upload(
         Ok(_) => ft::CompletePayload::ok(Some(key.clone())),
         Err(e) => ft::CompletePayload::err(e),
     };
-    let _ = app_handle.emit(&format!("storage-transfer-complete-{}", transfer_id), payload);
+    let _ = app_handle.emit(
+        &format!("storage-transfer-complete-{}", transfer_id),
+        payload,
+    );
     result
 }
 
 #[tauri::command]
-pub async fn storage_cancel_transfer(transfer_id: String, state: State<'_, AppState>) -> Result<(), String> {
+pub async fn storage_cancel_transfer(
+    transfer_id: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
     ft::cancel(&state, &transfer_id).await;
     Ok(())
 }
 
 #[tauri::command]
-pub async fn storage_pause_transfer(transfer_id: String, state: State<'_, AppState>) -> Result<(), String> {
+pub async fn storage_pause_transfer(
+    transfer_id: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
     ft::pause(&state, &transfer_id).await;
     Ok(())
 }
 
 #[tauri::command]
-pub async fn storage_resume_transfer(transfer_id: String, state: State<'_, AppState>) -> Result<(), String> {
+pub async fn storage_resume_transfer(
+    transfer_id: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
     ft::resume(&state, &transfer_id).await;
     Ok(())
 }

--- a/src-tauri/src/objectstorage/s3.rs
+++ b/src-tauri/src/objectstorage/s3.rs
@@ -10,7 +10,7 @@ use std::time::Instant;
 
 use jiff::Timestamp;
 use reqwest::Client;
-use rusty_s3::actions::{CreateMultipartUpload, ListObjectsV2};
+use rusty_s3::actions::{CreateMultipartUpload, ListObjectsV2, ListObjectsV2Response};
 use rusty_s3::{Bucket, Credentials, Method, S3Action, UrlStyle};
 use serde::Deserialize;
 use tauri::{AppHandle, Runtime};
@@ -39,7 +39,13 @@ impl S3Client {
         region: String,
         style: UrlStyle,
     ) -> Self {
-        Self { http, creds, endpoint, region, style }
+        Self {
+            http,
+            creds,
+            endpoint,
+            region,
+            style,
+        }
     }
 
     fn bucket(&self, name: &str) -> Result<Bucket, String> {
@@ -68,8 +74,8 @@ impl S3Client {
             std::iter::empty::<(&str, &str)>(),
         );
         let body = self.get_text(signed).await?;
-        let parsed: ListAllMyBucketsResult =
-            quick_xml::de::from_str(&body).map_err(|e| format!("parse ListBuckets response: {e}"))?;
+        let parsed: ListAllMyBucketsResult = quick_xml::de::from_str(&body)
+            .map_err(|e| format!("parse ListBuckets response: {e}"))?;
         Ok(parsed
             .buckets
             .bucket
@@ -107,13 +113,19 @@ impl S3Client {
         let resp = ListObjectsV2::parse_response(body.as_bytes())
             .map_err(|e| format!("parse ListObjectsV2 response: {e}"))?;
 
+        let page = Self::list_response_to_page(prefix, resp);
+        Ok(page)
+    }
+
+    fn list_response_to_page(prefix: &str, resp: ListObjectsV2Response) -> ObjectListPage {
         let mut entries = Vec::with_capacity(resp.common_prefixes.len() + resp.contents.len());
         for cp in resp.common_prefixes {
-            let trimmed = cp.prefix.trim_end_matches('/');
+            let key = decode_list_value(&cp.prefix);
+            let trimmed = key.trim_end_matches('/');
             let name = trimmed.rsplit('/').next().unwrap_or(trimmed).to_string();
             entries.push(ObjectEntry {
                 name,
-                key: cp.prefix,
+                key,
                 is_dir: true,
                 size: 0,
                 last_modified: None,
@@ -122,14 +134,15 @@ impl S3Client {
             });
         }
         for c in resp.contents {
+            let key = decode_list_value(&c.key);
             // Skip the zero-byte folder marker that equals the prefix itself.
-            if c.key == prefix {
+            if key == prefix {
                 continue;
             }
-            let name = c.key.strip_prefix(prefix).unwrap_or(&c.key).to_string();
+            let name = key.strip_prefix(prefix).unwrap_or(&key).to_string();
             entries.push(ObjectEntry {
                 name,
-                key: c.key,
+                key,
                 is_dir: false,
                 size: c.size,
                 last_modified: parse_iso8601(&c.last_modified),
@@ -137,10 +150,10 @@ impl S3Client {
                 storage_class: c.storage_class,
             });
         }
-        Ok(ObjectListPage {
+        ObjectListPage {
             entries,
             next_token: resp.next_continuation_token,
-        })
+        }
     }
     pub async fn get_object_bytes(&self, bucket: &str, key: &str) -> Result<Vec<u8>, String> {
         let b = self.bucket(bucket)?;
@@ -172,7 +185,9 @@ impl S3Client {
         }
         Ok(ObjectMetadata {
             key: key.to_string(),
-            size: get("content-length").and_then(|s| s.parse().ok()).unwrap_or(0),
+            size: get("content-length")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0),
             content_type: get("content-type"),
             etag: get("etag").map(|e| e.trim_matches('"').to_string()),
             last_modified: get("last-modified").as_deref().and_then(parse_http_date),
@@ -192,7 +207,13 @@ impl S3Client {
     ) -> Result<(), String> {
         let b = self.bucket(bucket)?;
         let url = b.put_object(Some(&self.creds), key).sign(SIGN_TTL);
-        let resp = self.http.put(url).body(body).send().await.map_err(net_err)?;
+        let resp = self
+            .http
+            .put(url)
+            .body(body)
+            .send()
+            .await
+            .map_err(net_err)?;
         self.check(resp).await?;
         Ok(())
     }
@@ -288,7 +309,7 @@ impl S3Client {
             let body = self.get_text(url).await?;
             let resp = ListObjectsV2::parse_response(body.as_bytes())
                 .map_err(|e| format!("parse ListObjectsV2 response: {e}"))?;
-            keys.extend(resp.contents.into_iter().map(|c| c.key));
+            keys.extend(resp.contents.into_iter().map(|c| decode_list_value(&c.key)));
             match resp.next_continuation_token {
                 Some(t) => token = Some(t),
                 None => break,
@@ -365,7 +386,7 @@ impl S3Client {
         handle: &Arc<TransferHandle>,
         app: &AppHandle<R>,
     ) -> Result<(), String> {
-        use super::transfer::{emit_progress, MULTIPART_THRESHOLD};
+        use super::transfer::{MULTIPART_THRESHOLD, emit_progress};
         let total = tokio::fs::metadata(local)
             .await
             .map_err(|e| format!("stat {}: {e}", local.display()))?
@@ -380,7 +401,8 @@ impl S3Client {
                 .map_err(|e| format!("read {}: {e}", local.display()))?;
             let mut put = b.put_object(Some(&self.creds), key);
             if let Some(sc) = storage_class {
-                put.headers_mut().insert("x-amz-storage-class", sc.to_string());
+                put.headers_mut()
+                    .insert("x-amz-storage-class", sc.to_string());
             }
             let url = put.sign(SIGN_TTL);
             let mut req = self.http.put(url).body(data);
@@ -395,7 +417,9 @@ impl S3Client {
 
         let mut create = b.create_multipart_upload(Some(&self.creds), key);
         if let Some(sc) = storage_class {
-            create.headers_mut().insert("x-amz-storage-class", sc.to_string());
+            create
+                .headers_mut()
+                .insert("x-amz-storage-class", sc.to_string());
         }
         let create_url = create.sign(SIGN_TTL);
         let mut create_req = self.http.post(create_url);
@@ -411,7 +435,17 @@ impl S3Client {
             .to_string();
 
         match self
-            .upload_parts(&b, key, &upload_id, local, total, transfer_id, handle, app, started)
+            .upload_parts(
+                &b,
+                key,
+                &upload_id,
+                local,
+                total,
+                transfer_id,
+                handle,
+                app,
+                started,
+            )
             .await
         {
             Ok(etags) => {
@@ -424,7 +458,13 @@ impl S3Client {
                 );
                 let curl = complete.sign(SIGN_TTL);
                 let cbody = complete.body();
-                let resp = self.http.post(curl).body(cbody).send().await.map_err(net_err)?;
+                let resp = self
+                    .http
+                    .post(curl)
+                    .body(cbody)
+                    .send()
+                    .await
+                    .map_err(net_err)?;
                 let resp = self.check(resp).await?;
                 let txt = resp.text().await.unwrap_or_default();
                 if txt.contains("<Error") {
@@ -459,7 +499,7 @@ impl S3Client {
         app: &AppHandle<R>,
         started: Instant,
     ) -> Result<Vec<String>, String> {
-        use super::transfer::{emit_paused, emit_progress, read_full, PART_SIZE};
+        use super::transfer::{PART_SIZE, emit_paused, emit_progress, read_full};
         let mut file = tokio::fs::File::open(local)
             .await
             .map_err(|e| format!("open {}: {e}", local.display()))?;
@@ -552,6 +592,12 @@ fn encode_key_path(key: &str) -> String {
         .join("/")
 }
 
+fn decode_list_value(value: &str) -> String {
+    urlencoding::decode(value)
+        .map(|decoded| decoded.into_owned())
+        .unwrap_or_else(|_| value.to_string())
+}
+
 fn parse_iso8601(s: &str) -> Option<i64> {
     chrono::DateTime::parse_from_rfc3339(s)
         .ok()
@@ -613,6 +659,47 @@ mod it {
     use super::*;
     use rusty_s3::UrlStyle;
 
+    #[test]
+    fn list_objects_decodes_url_encoded_keys() {
+        let input = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>bucket</Name>
+            <Prefix>report%2F</Prefix>
+            <KeyCount>2</KeyCount>
+            <MaxKeys>1000</MaxKeys>
+            <Delimiter>%2F</Delimiter>
+            <IsTruncated>false</IsTruncated>
+            <Contents>
+                <Key>report%2F%E6%89%8B%E6%9C%BA%2BCRM.txt</Key>
+                <LastModified>2026-07-07T12:00:00.000Z</LastModified>
+                <ETag>"etag"</ETag>
+                <Size>42</Size>
+                <StorageClass>STANDARD</StorageClass>
+            </Contents>
+            <CommonPrefixes>
+                <Prefix>report%2F%E5%AD%90%E7%9B%AE%E5%BD%95%2F</Prefix>
+            </CommonPrefixes>
+            <EncodingType>url</EncodingType>
+        </ListBucketResult>
+        "#;
+
+        let parsed = ListObjectsV2::parse_response(input).expect("parse list response");
+        let page = S3Client::list_response_to_page("report/", parsed);
+
+        let file = page.entries.iter().find(|e| !e.is_dir).expect("file entry");
+        assert_eq!(file.key, "report/手机+CRM.txt");
+        assert_eq!(file.name, "手机+CRM.txt");
+
+        let folder = page
+            .entries
+            .iter()
+            .find(|e| e.is_dir)
+            .expect("folder entry");
+        assert_eq!(folder.key, "report/子目录/");
+        assert_eq!(folder.name, "子目录");
+    }
+
     /// End-to-end round trip against a live S3-compatible endpoint (MinIO in
     /// CI/dev). Skipped unless `TAOMNI_S3_IT_ENDPOINT` is set, so the normal
     /// `cargo test` run stays offline. Exercises bucket/object signing, XML
@@ -638,15 +725,24 @@ mod it {
         client.create_bucket(&bucket).await.expect("create_bucket");
 
         let buckets = client.list_buckets().await.expect("list_buckets");
-        assert!(buckets.iter().any(|b| b.name == bucket), "new bucket listed");
+        assert!(
+            buckets.iter().any(|b| b.name == bucket),
+            "new bucket listed"
+        );
 
         client
             .put_object_bytes(&bucket, "dir/hello.txt", b"hi there".to_vec())
             .await
             .expect("put_object");
-        client.create_folder(&bucket, "emptydir").await.expect("create_folder");
+        client
+            .create_folder(&bucket, "emptydir")
+            .await
+            .expect("create_folder");
 
-        let root = client.list_objects(&bucket, "", None, 1000).await.expect("list root");
+        let root = client
+            .list_objects(&bucket, "", None, 1000)
+            .await
+            .expect("list root");
         assert!(
             root.entries.iter().any(|e| e.is_dir && e.name == "dir"),
             "dir/ surfaces as a folder"
@@ -656,16 +752,29 @@ mod it {
             "root has only folders, no loose files"
         );
 
-        let inside = client.list_objects(&bucket, "dir/", None, 1000).await.expect("list dir/");
-        let file = inside.entries.iter().find(|e| !e.is_dir).expect("file under dir/");
+        let inside = client
+            .list_objects(&bucket, "dir/", None, 1000)
+            .await
+            .expect("list dir/");
+        let file = inside
+            .entries
+            .iter()
+            .find(|e| !e.is_dir)
+            .expect("file under dir/");
         assert_eq!(file.name, "hello.txt");
         assert_eq!(file.size, 8);
 
-        let bytes = client.get_object_bytes(&bucket, "dir/hello.txt").await.expect("get");
+        let bytes = client
+            .get_object_bytes(&bucket, "dir/hello.txt")
+            .await
+            .expect("get");
         assert_eq!(bytes, b"hi there");
 
         // --- P3 management ops ---
-        let meta = client.head_object(&bucket, "dir/hello.txt").await.expect("head");
+        let meta = client
+            .head_object(&bucket, "dir/hello.txt")
+            .await
+            .expect("head");
         assert_eq!(meta.size, 8);
 
         // Server-side copy (same bucket) then verify the copy's bytes.
@@ -673,22 +782,47 @@ mod it {
             .copy_object(&bucket, "dir/hello.txt", &bucket, "dir2/copy.txt")
             .await
             .expect("copy");
-        let copied = client.get_object_bytes(&bucket, "dir2/copy.txt").await.expect("get copy");
+        let copied = client
+            .get_object_bytes(&bucket, "dir2/copy.txt")
+            .await
+            .expect("get copy");
         assert_eq!(copied, b"hi there");
 
         // Presigned GET should be fetchable with no further credentials.
-        let url = client.presign_get(&bucket, "dir/hello.txt", 300).expect("presign");
-        let presigned = reqwest::get(&url).await.expect("fetch presigned").bytes().await.expect("bytes");
+        let url = client
+            .presign_get(&bucket, "dir/hello.txt", 300)
+            .expect("presign");
+        let presigned = reqwest::get(&url)
+            .await
+            .expect("fetch presigned")
+            .bytes()
+            .await
+            .expect("bytes");
         assert_eq!(&presigned[..], b"hi there");
 
         // Recursive delete removes everything under the prefix.
-        client.delete_prefix(&bucket, "dir/").await.expect("delete_prefix");
-        let after = client.list_objects(&bucket, "", None, 1000).await.expect("relist");
-        assert!(!after.entries.iter().any(|e| e.name == "dir"), "dir/ gone after delete_prefix");
+        client
+            .delete_prefix(&bucket, "dir/")
+            .await
+            .expect("delete_prefix");
+        let after = client
+            .list_objects(&bucket, "", None, 1000)
+            .await
+            .expect("relist");
+        assert!(
+            !after.entries.iter().any(|e| e.name == "dir"),
+            "dir/ gone after delete_prefix"
+        );
 
         // cleanup
-        client.delete_object(&bucket, "dir2/copy.txt").await.expect("del copy");
-        client.delete_object(&bucket, "emptydir/").await.expect("del marker");
+        client
+            .delete_object(&bucket, "dir2/copy.txt")
+            .await
+            .expect("del copy");
+        client
+            .delete_object(&bucket, "emptydir/")
+            .await
+            .expect("del marker");
         client.delete_bucket(&bucket).await.expect("del bucket");
     }
 

--- a/src-tauri/src/objectstorage/session.rs
+++ b/src-tauri/src/objectstorage/session.rs
@@ -13,6 +13,10 @@ use super::s3::S3Client;
 use super::types::{BucketEntry, ObjectListPage, ObjectMetadata};
 use crate::filebrowser::transfer::TransferHandle;
 
+fn clean_storage_class(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|v| !v.is_empty())
+}
+
 /// Per-engine client handle.
 pub enum OssHandle {
     S3(S3Client),
@@ -71,7 +75,12 @@ impl ObjectStorageSession {
         }
     }
 
-    pub async fn put_object_bytes(&self, bucket: &str, key: &str, data: Vec<u8>) -> Result<(), String> {
+    pub async fn put_object_bytes(
+        &self,
+        bucket: &str,
+        key: &str,
+        data: Vec<u8>,
+    ) -> Result<(), String> {
         match &self.handle {
             OssHandle::S3(c) => c.put_object_bytes(bucket, key, data).await,
             OssHandle::Azure(c) => c.put_object_bytes(bucket, key, data).await,
@@ -108,8 +117,14 @@ impl ObjectStorageSession {
         dst_key: &str,
     ) -> Result<(), String> {
         match &self.handle {
-            OssHandle::S3(c) => c.copy_object(src_bucket, src_key, dst_bucket, dst_key).await,
-            OssHandle::Azure(c) => c.copy_object(src_bucket, src_key, dst_bucket, dst_key).await,
+            OssHandle::S3(c) => {
+                c.copy_object(src_bucket, src_key, dst_bucket, dst_key)
+                    .await
+            }
+            OssHandle::Azure(c) => {
+                c.copy_object(src_bucket, src_key, dst_bucket, dst_key)
+                    .await
+            }
         }
     }
 
@@ -121,7 +136,8 @@ impl ObjectStorageSession {
         dst_bucket: &str,
         dst_key: &str,
     ) -> Result<(), String> {
-        self.copy_object(src_bucket, src_key, dst_bucket, dst_key).await?;
+        self.copy_object(src_bucket, src_key, dst_bucket, dst_key)
+            .await?;
         self.delete_object(src_bucket, src_key).await
     }
 
@@ -144,10 +160,12 @@ impl ObjectStorageSession {
     ) -> Result<(), String> {
         match &self.handle {
             OssHandle::S3(c) => {
-                c.download_to_file(bucket, key, dest, transfer_id, handle, app).await
+                c.download_to_file(bucket, key, dest, transfer_id, handle, app)
+                    .await
             }
             OssHandle::Azure(c) => {
-                c.download_to_file(bucket, key, dest, transfer_id, handle, app).await
+                c.download_to_file(bucket, key, dest, transfer_id, handle, app)
+                    .await
             }
         }
     }
@@ -163,13 +181,16 @@ impl ObjectStorageSession {
         app: &AppHandle<R>,
     ) -> Result<(), String> {
         // Per-upload override, else the session's configured default.
-        let sc = storage_class.or(self.default_storage_class.as_deref());
+        let sc = clean_storage_class(storage_class)
+            .or_else(|| clean_storage_class(self.default_storage_class.as_deref()));
         match &self.handle {
             OssHandle::S3(c) => {
-                c.upload_from_file(local, bucket, key, sc, transfer_id, handle, app).await
+                c.upload_from_file(local, bucket, key, sc, transfer_id, handle, app)
+                    .await
             }
             OssHandle::Azure(c) => {
-                c.upload_from_file(local, bucket, key, sc, transfer_id, handle, app).await
+                c.upload_from_file(local, bucket, key, sc, transfer_id, handle, app)
+                    .await
             }
         }
     }
@@ -201,5 +222,18 @@ impl ObjectStorageSession {
             OssHandle::S3(c) => c.ping(default).await,
             OssHandle::Azure(c) => c.ping(default).await,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_storage_class_ignores_empty_values() {
+        assert_eq!(clean_storage_class(None), None);
+        assert_eq!(clean_storage_class(Some("")), None);
+        assert_eq!(clean_storage_class(Some("   ")), None);
+        assert_eq!(clean_storage_class(Some(" STANDARD ")), Some("STANDARD"));
     }
 }

--- a/src/components/session/SessionEditor.tsx
+++ b/src/components/session/SessionEditor.tsx
@@ -96,6 +96,7 @@ import { RdpOptionsForm } from "./forms/RdpOptionsForm";
 import {
   ObjectStorageSettings,
   ossFormFromOptions,
+  ossFormToConfig,
   type OssFormState,
 } from "./ObjectStorageSettings";
 import { engineForProvider } from "../../types/objectStorage";
@@ -2842,27 +2843,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
       : {};
     const ossOverrides: Record<string, unknown> =
       proto === "S3"
-        ? (ossConfigValue ?? {
-            provider: oss.provider,
-            endpoint: oss.endpoint,
-            region: oss.region,
-            pathStyle: oss.pathStyle,
-            accessKeyId: oss.accessKeyId,
-            secretAccessKey: oss.secretAccessKey,
-            sessionToken: oss.sessionToken,
-            defaultBucket: oss.defaultBucket,
-            awsAuth: oss.awsAuth,
-            awsProfile: oss.awsProfile,
-            accountName: oss.accountName,
-            accountKey: oss.accountKey,
-            connectionString: oss.connectionString,
-            sasToken: oss.sasToken,
-            endpointSuffix: oss.endpointSuffix,
-            defaultContainer: oss.defaultContainer,
-            azureAuth: oss.azureAuth,
-            azureBearerToken: oss.azureBearerToken,
-            storageClass: oss.storageClass,
-          })
+        ? (ossConfigValue ?? { ...ossFormToConfig(oss) })
         : {};
     const hbaseOverrides: Record<string, unknown> = isHBase
       ? {
@@ -3245,27 +3226,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
       }
       const next: OssFormState = { ...oss, ...(resolved as Partial<OssFormState>) };
       setOss(next);
-      ossConfigValue = {
-        provider: next.provider,
-        endpoint: next.endpoint,
-        region: next.region,
-        pathStyle: next.pathStyle,
-        accessKeyId: next.accessKeyId,
-        secretAccessKey: next.secretAccessKey,
-        sessionToken: next.sessionToken,
-        defaultBucket: next.defaultBucket,
-        awsAuth: next.awsAuth,
-        awsProfile: next.awsProfile,
-        accountName: next.accountName,
-        accountKey: next.accountKey,
-        connectionString: next.connectionString,
-        sasToken: next.sasToken,
-        endpointSuffix: next.endpointSuffix,
-        defaultContainer: next.defaultContainer,
-        azureAuth: next.azureAuth,
-        azureBearerToken: next.azureBearerToken,
-        storageClass: next.storageClass,
-      };
+      ossConfigValue = { ...ossFormToConfig(next) };
     }
 
     const config = buildConfig({


### PR DESCRIPTION
Issue #335 shows two long-standing Alibaba OSS failures rather than a 0.3.20 regression.

Uploads failed with S3 error 400 InvalidStorageClass because object-storage sessions could persist an empty storageClass string, and the backend treated Some("") as a real x-amz-storage-class header. Normalize object-storage session serialization through ossFormToConfig and trim/drop empty storage class values before attaching sessions or starting uploads.

Downloads failed with S3 error 404 NoSuchKey for listed objects whose names contain URL-encoded characters. rusty-s3 requests ListObjectsV2 with encoding-type=url, but its parsed response keeps Key/CommonPrefixes encoded. Decode list keys before exposing them to the UI and before recursive delete walks, so later GET/HEAD/DELETE requests sign the real object key instead of double-encoding percent escapes.

Verified with: pnpm exec vitest run src/types/objectStorage.test.ts; cargo test --manifest-path src-tauri/Cargo.toml objectstorage::s3::it::list_objects_decodes_url_encoded_keys --lib; cargo test --manifest-path src-tauri/Cargo.toml objectstorage::session::tests::clean_storage_class_ignores_empty_values --lib; pnpm exec tsc -b --pretty false; git diff --check.