### PR TITLE
feat(vault): add blocking startup unlock gate

### DIFF
--- a/src/components/vault/StartupVaultUnlockGate.test.tsx
+++ b/src/components/vault/StartupVaultUnlockGate.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -52,6 +53,8 @@ describe("StartupVaultUnlockGate", () => {
     render(<StartupVaultUnlockGate>app</StartupVaultUnlockGate>);
 
     expect(await screen.findByTestId("vault-unlock-dialog")).toBeInTheDocument();
+    expect(screen.getByText("app")).toBeInTheDocument();
+    expect(screen.queryByTestId("vault-unlock-cancel")).not.toBeInTheDocument();
     expect(screen.getByTestId("vault-unlock-reason")).toHaveTextContent(
       /saved passwords available/i,
     );
@@ -63,6 +66,7 @@ describe("StartupVaultUnlockGate", () => {
     await waitFor(() =>
       expect(screen.queryByTestId("vault-unlock-dialog")).not.toBeInTheDocument(),
     );
+    expect(screen.getByText("app")).toBeInTheDocument();
   });
 
   it("does not prompt on startup when on-demand mode is selected", async () => {
@@ -73,6 +77,7 @@ describe("StartupVaultUnlockGate", () => {
 
     expect(vaultMock.refresh).not.toHaveBeenCalled();
     expect(screen.queryByTestId("vault-unlock-dialog")).not.toBeInTheDocument();
+    expect(screen.getByText("app")).toBeInTheDocument();
   });
 
   it("does not force first-time setup when the vault is empty", async () => {
@@ -84,5 +89,53 @@ describe("StartupVaultUnlockGate", () => {
     await waitFor(() => expect(vaultMock.refresh).toHaveBeenCalled());
     expect(screen.queryByTestId("vault-unlock-dialog")).not.toBeInTheDocument();
     expect(screen.queryByTestId("vault-setup-dialog")).not.toBeInTheDocument();
+    expect(screen.getByText("app")).toBeInTheDocument();
+  });
+
+  it("blocks the app while startup vault status is being checked", async () => {
+    appMock.vaultUnlockMode = "startup";
+    vaultMock.state = "unlocked";
+    let resolveRefresh: (() => void) | undefined;
+    vaultMock.refresh.mockImplementation(
+      () =>
+        new Promise<undefined>((resolve) => {
+          resolveRefresh = () => resolve(undefined);
+        }),
+    );
+
+    render(<StartupVaultUnlockGate>app</StartupVaultUnlockGate>);
+
+    expect(screen.getByTestId("startup-vault-check")).toBeInTheDocument();
+    expect(screen.getByText("app")).toBeInTheDocument();
+
+    resolveRefresh?.();
+    await waitFor(() => expect(screen.getByText("app")).toBeInTheDocument());
+    expect(screen.queryByTestId("startup-vault-check")).not.toBeInTheDocument();
+  });
+
+  it("does not get stuck on the loading screen under React StrictMode", async () => {
+    appMock.vaultUnlockMode = "startup";
+    vaultMock.state = "empty";
+    const resolveRefreshes: Array<() => void> = [];
+    vaultMock.refresh.mockImplementation(
+      () =>
+        new Promise<undefined>((resolve) => {
+          resolveRefreshes.push(() => resolve(undefined));
+        }),
+    );
+
+    render(
+      <StrictMode>
+        <StartupVaultUnlockGate>app</StartupVaultUnlockGate>
+      </StrictMode>,
+    );
+
+    expect(screen.getByTestId("startup-vault-check")).toBeInTheDocument();
+    expect(screen.getByText("app")).toBeInTheDocument();
+    await waitFor(() => expect(resolveRefreshes.length).toBeGreaterThanOrEqual(2));
+    resolveRefreshes.forEach((resolve) => resolve());
+
+    await waitFor(() => expect(screen.getByText("app")).toBeInTheDocument());
+    expect(screen.queryByTestId("startup-vault-check")).not.toBeInTheDocument();
   });
 });

--- a/src/components/vault/StartupVaultUnlockGate.tsx
+++ b/src/components/vault/StartupVaultUnlockGate.tsx
@@ -1,54 +1,75 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useT } from "../../lib/i18n";
 import { useAppStore } from "../../stores/appStore";
 import { useVaultStore } from "../../stores/vaultStore";
 import { VaultUnlockDialog } from "./VaultUnlockDialog";
 
+type StartupVaultGateState = "checking" | "locked" | "ready";
+
 export function StartupVaultUnlockGate({ children }: { children: ReactNode }) {
   const t = useT();
   const unlockMode = useAppStore((s) => s.vaultUnlockMode);
-  const state = useVaultStore((s) => s.state);
   const refresh = useVaultStore((s) => s.refresh);
   const unlock = useVaultStore((s) => s.unlock);
-  const checkedRef = useRef(false);
-  const [promptOpen, setPromptOpen] = useState(false);
+  const [gateState, setGateState] = useState<StartupVaultGateState>(
+    unlockMode === "startup" ? "checking" : "ready",
+  );
 
   useEffect(() => {
-    if (checkedRef.current) return;
-    checkedRef.current = true;
-    if (unlockMode !== "startup") return;
+    if (unlockMode !== "startup") {
+      setGateState("ready");
+      return;
+    }
 
+    setGateState("checking");
     let disposed = false;
     void refresh()
       .then(() => {
-        if (!disposed && useVaultStore.getState().state === "locked") {
-          setPromptOpen(true);
-        }
+        if (disposed) return;
+        setGateState(useVaultStore.getState().state === "locked" ? "locked" : "ready");
       })
-      .catch(() => undefined);
+      .catch(() => {
+        if (!disposed) setGateState("ready");
+      });
 
     return () => {
       disposed = true;
     };
   }, [refresh, unlockMode]);
 
-  useEffect(() => {
-    if (state === "unlocked") setPromptOpen(false);
-  }, [state]);
-
   return (
     <>
       {children}
-      {promptOpen && state === "locked" && (
+      {gateState === "checking" && <StartupVaultCheckOverlay />}
+      {gateState === "locked" && (
         <VaultUnlockDialog
           reason={t("vault.startupUnlockReason")}
-          onCancel={() => setPromptOpen(false)}
+          cancellable={false}
+          zIndex={10001}
           onSubmit={async (pw) => {
             await unlock(pw);
-            setPromptOpen(false);
+            setGateState("ready");
           }}
         />
       )}
     </>
+  );
+}
+
+function StartupVaultCheckOverlay() {
+  const t = useT();
+
+  return (
+    <div
+      data-testid="startup-vault-check"
+      className="fixed inset-0 flex items-center justify-center"
+      style={{
+        background: "rgba(0,0,0,0.4)",
+        color: "white",
+        zIndex: 10001,
+      }}
+    >
+      <div className="text-[12px]">{t("common.loading")}</div>
+    </div>
   );
 }

--- a/src/components/vault/VaultUnlockDialog.test.tsx
+++ b/src/components/vault/VaultUnlockDialog.test.tsx
@@ -50,6 +50,23 @@ describe("VaultUnlockDialog", () => {
     expect(onCancel).toHaveBeenCalled();
   });
 
+  it("can be made non-cancellable", async () => {
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <VaultUnlockDialog
+        cancellable={false}
+        onCancel={onCancel}
+        onSubmit={async () => undefined}
+      />,
+    );
+
+    expect(screen.queryByTestId("vault-unlock-cancel")).not.toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(screen.getByTestId("vault-unlock-dialog")).toBeInTheDocument();
+  });
+
   it("does not cancel when the backdrop is clicked", async () => {
     const onCancel = vi.fn();
     const user = userEvent.setup();

--- a/src/components/vault/VaultUnlockDialog.tsx
+++ b/src/components/vault/VaultUnlockDialog.tsx
@@ -8,10 +8,14 @@ import {
 import { useT } from "../../lib/i18n";
 
 export interface VaultUnlockDialogProps {
-  onCancel: () => void;
+  onCancel?: () => void;
   onSubmit: (masterPassword: string) => Promise<void>;
   /** Optional context line shown below the title (e.g. why we're prompting). */
   reason?: string;
+  /** When false, the dialog cannot be dismissed without unlocking. */
+  cancellable?: boolean;
+  /** Override stacking for app-level locks that must sit above all app chrome. */
+  zIndex?: number;
 }
 
 const FOCUSABLE_SELECTOR = [
@@ -23,7 +27,13 @@ const FOCUSABLE_SELECTOR = [
   "[tabindex]:not([tabindex='-1'])",
 ].join(", ");
 
-export function VaultUnlockDialog({ onCancel, onSubmit, reason }: VaultUnlockDialogProps) {
+export function VaultUnlockDialog({
+  onCancel,
+  onSubmit,
+  reason,
+  cancellable = true,
+  zIndex = 50,
+}: VaultUnlockDialogProps) {
   const [pw, setPw] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -62,7 +72,8 @@ export function VaultUnlockDialog({ onCancel, onSubmit, reason }: VaultUnlockDia
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Escape") {
       event.stopPropagation();
-      onCancel();
+      event.preventDefault();
+      if (cancellable) onCancel?.();
     } else if (event.key === "Enter") {
       const target = event.target as HTMLElement;
       if (target.tagName !== "BUTTON") {
@@ -101,8 +112,8 @@ export function VaultUnlockDialog({ onCancel, onSubmit, reason }: VaultUnlockDia
   return (
     <div
       data-testid="vault-unlock-backdrop"
-      className="fixed inset-0 z-50 flex items-center justify-center"
-      style={{ background: "rgba(0,0,0,0.4)" }}
+      className="fixed inset-0 flex items-center justify-center"
+      style={{ background: "rgba(0,0,0,0.4)", zIndex }}
       onMouseDown={handleBackdropMouseDown}
       onKeyDown={handleKeyDown}
     >
@@ -152,15 +163,17 @@ export function VaultUnlockDialog({ onCancel, onSubmit, reason }: VaultUnlockDia
         )}
 
         <div className="flex gap-2 justify-end mt-4">
-          <button
-            type="button"
-            data-testid="vault-unlock-cancel"
-            className="px-3 py-1 text-[12px] rounded hover:bg-[var(--taomni-hover)]"
-            onClick={onCancel}
-            disabled={busy}
-          >
-            {t("vault.cancel")}
-          </button>
+          {cancellable && (
+            <button
+              type="button"
+              data-testid="vault-unlock-cancel"
+              className="px-3 py-1 text-[12px] rounded hover:bg-[var(--taomni-hover)]"
+              onClick={onCancel}
+              disabled={busy}
+            >
+              {t("vault.cancel")}
+            </button>
+          )}
           <button
             type="button"
             data-testid="vault-unlock-confirm"

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -2132,7 +2132,7 @@ const dict = {
     unlockModeDescription: "Choose when Taomni asks for the master password after the app starts.",
     unlockModeStartup: "At startup",
     unlockModeOnDemand: "On demand",
-    unlockModeStartupHint: "Default. If the vault is locked, Taomni prompts for the master password on startup.",
+    unlockModeStartupHint: "Default. If the vault is locked, Taomni blocks startup until the master password is entered.",
     unlockModeOnDemandHint: "Taomni waits until a saved credential is needed, then prompts to unlock.",
     setMasterPassword: "Set master password",
     unlock: "Unlock",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -2128,7 +2128,7 @@ export const zhCN: DeepPartial<typeof en> = {
     unlockModeDescription: "选择 Taomni 启动后何时要求输入主密码。",
     unlockModeStartup: "启动时",
     unlockModeOnDemand: "按需解锁",
-    unlockModeStartupHint: "默认选项。若凭据库已锁定，Taomni 启动时会要求输入主密码。",
+    unlockModeStartupHint: "默认选项。若凭据库已锁定，Taomni 会阻塞启动，直到输入主密码。",
     unlockModeOnDemandHint: "Taomni 会等到需要使用已保存凭据时，再提示解锁。",
     setMasterPassword: "设置主密码",
     unlock: "解锁",


### PR DESCRIPTION
When the credential vault is configured to unlock at startup, render the main app behind an app-level lock overlay and require the master password before the lock is dismissed. The startup gate now keeps the app shell mounted, shows a high-z-index checking/locked overlay, and uses a non-cancellable vault unlock dialog so Escape or a missing cancel button cannot bypass the lock.

Extend VaultUnlockDialog with cancellable and z-index options so existing on-demand flows keep their dismissible behavior while the startup lock can sit above all app chrome. Update the settings copy in English and Chinese to describe the stronger startup-blocking behavior.

Add focused tests for locked startup behavior, the checking overlay, non-cancellable dialogs, on-demand mode, empty vault handling, and React StrictMode so the gate does not get stuck during development.

Tests: pnpm vitest run src/components/vault/StartupVaultUnlockGate.test.tsx src/components/vault/VaultUnlockDialog.test.tsx

Tests: pnpm build