### PR TITLE
fix(objectstorage): stabilize COS folder operations

### DIFF
--- a/src-tauri/src/objectstorage/s3.rs
+++ b/src-tauri/src/objectstorage/s3.rs
@@ -139,6 +139,12 @@ impl S3Client {
             if key == prefix {
                 continue;
             }
+            if let Some(entry) = folder_marker_entry(prefix, &key, c.size) {
+                if !entries.iter().any(|e| e.is_dir && e.key == entry.key) {
+                    entries.push(entry);
+                }
+                continue;
+            }
             let name = key.strip_prefix(prefix).unwrap_or(&key).to_string();
             entries.push(ObjectEntry {
                 name,
@@ -205,15 +211,28 @@ impl S3Client {
         key: &str,
         body: Vec<u8>,
     ) -> Result<(), String> {
-        let b = self.bucket(bucket)?;
-        let url = b.put_object(Some(&self.creds), key).sign(SIGN_TTL);
-        let resp = self
-            .http
-            .put(url)
-            .body(body)
-            .send()
+        self.put_object_bytes_with_headers(bucket, key, body, &[])
             .await
-            .map_err(net_err)?;
+    }
+
+    async fn put_object_bytes_with_headers(
+        &self,
+        bucket: &str,
+        key: &str,
+        body: Vec<u8>,
+        headers: &[(&str, &str)],
+    ) -> Result<(), String> {
+        let b = self.bucket(bucket)?;
+        let mut action = b.put_object(Some(&self.creds), key);
+        for (name, value) in headers {
+            action.headers_mut().insert(*name, (*value).to_string());
+        }
+        let url = action.sign(SIGN_TTL);
+        let mut req = self.http.put(url).body(body);
+        for (name, value) in headers {
+            req = req.header(*name, *value);
+        }
+        let resp = req.send().await.map_err(net_err)?;
         self.check(resp).await?;
         Ok(())
     }
@@ -276,7 +295,13 @@ impl S3Client {
     /// DeleteObjects API.
     pub async fn delete_prefix(&self, bucket: &str, prefix: &str) -> Result<(), String> {
         use futures::stream::{self, StreamExt};
-        let keys = self.list_all_keys(bucket, prefix).await?;
+        let marker = folder_marker_key(prefix);
+        let mut keys = self.list_all_keys(bucket, &marker).await?;
+        if !marker.is_empty() && !keys.iter().any(|k| k == &marker) {
+            keys.push(marker);
+        }
+        keys.sort();
+        keys.dedup();
         let results: Vec<Result<(), String>> = stream::iter(keys.into_iter().map(|k| {
             let bucket = bucket.to_string();
             async move { self.delete_object(&bucket, &k).await }
@@ -320,12 +345,14 @@ impl S3Client {
 
     /// Create a folder by writing a zero-byte object whose key ends in '/'.
     pub async fn create_folder(&self, bucket: &str, prefix: &str) -> Result<(), String> {
-        let key = if prefix.ends_with('/') {
-            prefix.to_string()
-        } else {
-            format!("{prefix}/")
-        };
-        self.put_object_bytes(bucket, &key, Vec::new()).await
+        let key = folder_marker_key(prefix);
+        self.put_object_bytes_with_headers(
+            bucket,
+            &key,
+            Vec::new(),
+            &[("content-type", "application/x-directory")],
+        )
+        .await
     }
 
     pub async fn create_bucket(&self, bucket: &str) -> Result<(), String> {
@@ -592,6 +619,36 @@ fn encode_key_path(key: &str) -> String {
         .join("/")
 }
 
+fn folder_marker_key(prefix: &str) -> String {
+    if prefix.is_empty() || prefix.ends_with('/') {
+        prefix.to_string()
+    } else {
+        format!("{prefix}/")
+    }
+}
+
+fn folder_marker_entry(prefix: &str, key: &str, size: u64) -> Option<ObjectEntry> {
+    if size != 0 || !key.ends_with('/') {
+        return None;
+    }
+    let name = key
+        .strip_prefix(prefix)
+        .unwrap_or(key)
+        .trim_end_matches('/');
+    if name.is_empty() || name.contains('/') {
+        return None;
+    }
+    Some(ObjectEntry {
+        name: name.to_string(),
+        key: key.to_string(),
+        is_dir: true,
+        size: 0,
+        last_modified: None,
+        etag: None,
+        storage_class: None,
+    })
+}
+
 fn decode_list_value(value: &str) -> String {
     urlencoding::decode(value)
         .map(|decoded| decoded.into_owned())
@@ -698,6 +755,88 @@ mod it {
             .expect("folder entry");
         assert_eq!(folder.key, "report/子目录/");
         assert_eq!(folder.name, "子目录");
+    }
+
+    #[test]
+    fn list_objects_treats_zero_byte_folder_markers_as_dirs() {
+        let input = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>bucket</Name>
+            <Prefix></Prefix>
+            <KeyCount>2</KeyCount>
+            <MaxKeys>1000</MaxKeys>
+            <Delimiter>/</Delimiter>
+            <IsTruncated>false</IsTruncated>
+            <CommonPrefixes>
+                <Prefix>existing/</Prefix>
+            </CommonPrefixes>
+            <Contents>
+                <Key>empty/</Key>
+                <LastModified>2026-07-07T12:00:00.000Z</LastModified>
+                <ETag>"d41d8cd98f00b204e9800998ecf8427e"</ETag>
+                <Size>0</Size>
+                <StorageClass>STANDARD</StorageClass>
+            </Contents>
+            <Contents>
+                <Key>existing/</Key>
+                <LastModified>2026-07-07T12:00:00.000Z</LastModified>
+                <ETag>"d41d8cd98f00b204e9800998ecf8427e"</ETag>
+                <Size>0</Size>
+                <StorageClass>STANDARD</StorageClass>
+            </Contents>
+        </ListBucketResult>
+        "#;
+
+        let parsed = ListObjectsV2::parse_response(input).expect("parse list response");
+        let page = S3Client::list_response_to_page("", parsed);
+
+        let empty = page
+            .entries
+            .iter()
+            .find(|e| e.key == "empty/")
+            .expect("folder marker entry");
+        assert!(empty.is_dir);
+        assert_eq!(empty.name, "empty");
+        assert_eq!(
+            page.entries.iter().filter(|e| e.key == "existing/").count(),
+            1,
+            "common-prefix folder should not be duplicated by its marker object"
+        );
+    }
+
+    #[test]
+    fn list_objects_skips_current_folder_marker() {
+        let input = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>bucket</Name>
+            <Prefix>empty/</Prefix>
+            <KeyCount>1</KeyCount>
+            <MaxKeys>1000</MaxKeys>
+            <Delimiter>/</Delimiter>
+            <IsTruncated>false</IsTruncated>
+            <Contents>
+                <Key>empty/</Key>
+                <LastModified>2026-07-07T12:00:00.000Z</LastModified>
+                <ETag>"d41d8cd98f00b204e9800998ecf8427e"</ETag>
+                <Size>0</Size>
+                <StorageClass>STANDARD</StorageClass>
+            </Contents>
+        </ListBucketResult>
+        "#;
+
+        let parsed = ListObjectsV2::parse_response(input).expect("parse list response");
+        let page = S3Client::list_response_to_page("empty/", parsed);
+
+        assert!(page.entries.is_empty());
+    }
+
+    #[test]
+    fn folder_marker_key_normalizes_trailing_slash() {
+        assert_eq!(folder_marker_key(""), "");
+        assert_eq!(folder_marker_key("empty"), "empty/");
+        assert_eq!(folder_marker_key("empty/"), "empty/");
     }
 
     /// End-to-end round trip against a live S3-compatible endpoint (MinIO in

--- a/src/lib/objectStorageController.ts
+++ b/src/lib/objectStorageController.ts
@@ -39,8 +39,42 @@ function parentPrefix(key: string): string {
   return i < 0 ? "" : trimmed.slice(0, i + 1);
 }
 
+function folderMarkerKey(key: string): string {
+  return key.endsWith("/") ? key : `${key}/`;
+}
+
+function firstFolderSegment(name: string): string {
+  return name.trim().replace(/^[/\\]+/, "").split(/[\\/]/).filter(Boolean)[0] ?? "";
+}
+
+function remoteDirEntry(bucket: string, key: string, name: string): FileEntry {
+  return {
+    name,
+    path: `/${bucket}/${key}`,
+    size: 0,
+    mtime: Math.floor(Date.now() / 1000),
+    mode: 0,
+    fileType: "dir",
+    isHidden: false,
+  };
+}
+
+function remoteBucketEntry(name: string): FileEntry {
+  return {
+    name,
+    path: `/${name}`,
+    size: 0,
+    mtime: Math.floor(Date.now() / 1000),
+    mode: 0,
+    fileType: "dir",
+    isHidden: false,
+  };
+}
+
 export function useObjectStorageController(sessionId: string) {
   const refreshPane = useObjectStorageStore((s) => s.refreshPane);
+  const upsertRemoteEntry = useObjectStorageStore((s) => s.upsertRemoteEntry);
+  const removeRemoteEntries = useObjectStorageStore((s) => s.removeRemoteEntries);
   const setStatus = useAppStore((s) => s.setStatusMessage);
   const addTransfer = useTransferStore((s) => s.add);
   const patchTransfer = useTransferStore((s) => s.patch);
@@ -211,18 +245,32 @@ export function useObjectStorageController(sessionId: string) {
   const mkdir = useCallback(
     async (remoteParent: string, name: string) => {
       const { bucket, key: prefix } = splitRemote(remoteParent);
+      const cleanName = name.trim();
+      const folderName = cleanName.replace(/^[/\\]+|[/\\]+$/g, "");
+      const visibleName = firstFolderSegment(folderName);
+      if (!cleanName || (!bucket && !visibleName)) return;
       try {
         if (!bucket) {
-          await storageCreateBucket(sessionId, name);
+          await storageCreateBucket(sessionId, cleanName);
+          await refreshPane(sessionId, "remote");
+          upsertRemoteEntry(sessionId, remoteBucketEntry(cleanName));
         } else {
-          await storageCreateFolder(sessionId, bucket, `${prefix}${name}`);
+          if (!folderName) return;
+          const markerKey = folderMarkerKey(`${prefix}${folderName}`);
+          await storageCreateFolder(sessionId, bucket, markerKey);
+          await refreshPane(sessionId, "remote");
+          if (visibleName) {
+            upsertRemoteEntry(
+              sessionId,
+              remoteDirEntry(bucket, folderMarkerKey(`${prefix}${visibleName}`), visibleName),
+            );
+          }
         }
-        await refreshPane(sessionId, "remote");
       } catch (err) {
         setStatus(`Create failed: ${err instanceof Error ? err.message : err}`);
       }
     },
-    [refreshPane, sessionId, setStatus],
+    [refreshPane, sessionId, setStatus, upsertRemoteEntry],
   );
 
   const remove = useCallback(
@@ -237,11 +285,12 @@ export function useObjectStorageController(sessionId: string) {
           await storageDeleteObject(sessionId, bucket, key);
         }
         await refreshPane(sessionId, "remote");
+        removeRemoteEntries(sessionId, [entry.path]);
       } catch (err) {
         setStatus(`Delete failed: ${err instanceof Error ? err.message : err}`);
       }
     },
-    [refreshPane, sessionId, setStatus],
+    [refreshPane, removeRemoteEntries, sessionId, setStatus],
   );
 
   const rename = useCallback(

--- a/src/stores/objectStorageStore.test.ts
+++ b/src/stores/objectStorageStore.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useObjectStorageStore, type ObjStorageSessionState } from "./objectStorageStore";
+import type { FileEntry } from "../lib/sftp";
+
+vi.mock("../lib/sftp", () => ({
+  sftpListLocal: vi.fn(),
+  sftpLocalHome: vi.fn(),
+  sftpLocalDrives: vi.fn(),
+}));
+
+vi.mock("../lib/objectStorage", () => ({
+  storageAttach: vi.fn(),
+  storageDetach: vi.fn(),
+  storageListBuckets: vi.fn(),
+  storageListObjects: vi.fn(),
+}));
+
+function entry(name: string, path: string, fileType: FileEntry["fileType"] = "dir"): FileEntry {
+  return {
+    name,
+    path,
+    fileType,
+    size: 0,
+    mtime: 0,
+    mode: 0,
+    isHidden: false,
+  };
+}
+
+function session(entries: FileEntry[] = []): ObjStorageSessionState {
+  return {
+    sessionId: "sid",
+    attached: true,
+    attaching: false,
+    homeDir: "/bucket",
+    error: null,
+    config: null,
+    remote: {
+      path: "/bucket",
+      entries,
+      selection: [],
+      loading: false,
+      error: null,
+      history: ["/bucket"],
+      historyIndex: 0,
+      showHidden: false,
+    },
+    local: {
+      path: "",
+      entries: [],
+      selection: [],
+      loading: false,
+      error: null,
+      history: [],
+      historyIndex: -1,
+      showHidden: false,
+    },
+  };
+}
+
+describe("objectStorageStore remote entry reconciliation", () => {
+  beforeEach(() => {
+    useObjectStorageStore.setState({ sessions: { sid: session([entry("old", "/bucket/old/")]) } });
+  });
+
+  it("upserts a remote entry after a successful create", () => {
+    const created = entry("new", "/bucket/new/");
+
+    useObjectStorageStore.getState().upsertRemoteEntry("sid", created);
+    useObjectStorageStore.getState().upsertRemoteEntry("sid", { ...created, mtime: 123 });
+
+    const remote = useObjectStorageStore.getState().sessions.sid.remote;
+    expect(remote.entries.map((e) => e.path)).toEqual(["/bucket/old/", "/bucket/new/"]);
+    expect(remote.entries.find((e) => e.path === "/bucket/new/")?.mtime).toBe(123);
+    expect(remote.error).toBeNull();
+  });
+
+  it("removes stale remote entries and selection after a successful delete", () => {
+    useObjectStorageStore.setState({ sessions: { sid: session([entry("old", "/bucket/old/")]) } });
+    useObjectStorageStore.getState().setSelection("sid", "remote", ["/bucket/old/"]);
+
+    useObjectStorageStore.getState().removeRemoteEntries("sid", ["/bucket/old/"]);
+
+    const remote = useObjectStorageStore.getState().sessions.sid.remote;
+    expect(remote.entries).toEqual([]);
+    expect(remote.selection).toEqual([]);
+    expect(remote.error).toBeNull();
+  });
+});

--- a/src/stores/objectStorageStore.ts
+++ b/src/stores/objectStorageStore.ts
@@ -121,6 +121,8 @@ interface ObjStorageStoreState {
   navigateHome: (sessionId: string, side: PaneSide) => Promise<void>;
   setSelection: (sessionId: string, side: PaneSide, selection: string[]) => void;
   toggleHidden: (sessionId: string, side: PaneSide) => void;
+  upsertRemoteEntry: (sessionId: string, entry: FileEntry) => void;
+  removeRemoteEntries: (sessionId: string, paths: string[]) => void;
 }
 
 function emptyPane(): PaneState {
@@ -154,6 +156,25 @@ function pushHistory(pane: PaneState, path: string): PaneState {
   const trimmed = pane.history.slice(0, pane.historyIndex + 1);
   trimmed.push(path);
   return { ...pane, history: trimmed, historyIndex: trimmed.length - 1 };
+}
+
+function upsertPaneEntry(pane: PaneState, entry: FileEntry): PaneState {
+  const idx = pane.entries.findIndex((e) => e.path === entry.path);
+  const entries =
+    idx >= 0
+      ? pane.entries.map((e, i) => (i === idx ? entry : e))
+      : [...pane.entries, entry];
+  return { ...pane, entries, error: null };
+}
+
+function removePaneEntries(pane: PaneState, paths: string[]): PaneState {
+  const remove = new Set(paths);
+  return {
+    ...pane,
+    entries: pane.entries.filter((e) => !remove.has(e.path)),
+    selection: pane.selection.filter((path) => !remove.has(path)),
+    error: null,
+  };
 }
 
 function errMsg(err: unknown): string {
@@ -412,6 +433,32 @@ export const useObjectStorageStore = create<ObjStorageStoreState>((set, get) => 
         sessions: {
           ...state.sessions,
           [sessionId]: { ...cur, [side]: { ...cur[side], showHidden: !cur[side].showHidden } },
+        },
+      };
+    });
+  },
+
+  upsertRemoteEntry: (sessionId, entry) => {
+    set((state) => {
+      const cur = state.sessions[sessionId];
+      if (!cur) return state;
+      return {
+        sessions: {
+          ...state.sessions,
+          [sessionId]: { ...cur, remote: upsertPaneEntry(cur.remote, entry) },
+        },
+      };
+    });
+  },
+
+  removeRemoteEntries: (sessionId, paths) => {
+    set((state) => {
+      const cur = state.sessions[sessionId];
+      if (!cur) return state;
+      return {
+        sessions: {
+          ...state.sessions,
+          [sessionId]: { ...cur, remote: removePaneEntries(cur.remote, paths) },
         },
       };
     });


### PR DESCRIPTION
Fix issue #344 by making S3-compatible folder markers robust for Tencent COS.

- create folders as signed zero-byte marker objects with application/x-directory metadata

- treat zero-byte keys ending in / from list Contents as directory entries and avoid duplicating CommonPrefixes

- recursively delete the normalized folder marker even when provider listings omit it

- reconcile the current object-storage pane after successful create/delete so eventual COS listings do not hide the completed operation

- add Rust marker parsing tests and object-storage store reconciliation tests