### PR TITLE
fix(terminal): preserve macOS Cmd+V clipboardData across async boundary

### DIFF
--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -3048,13 +3048,13 @@ export function TerminalPanel({
       if (Date.now() < suppressNativePasteUntilRef.current) {
         return;
       }
+      const text = event.clipboardData?.getData("text/plain") ?? "";
       if (!isLocal && onUploadLocalPathsRef.current) {
         void clipboardReadFiles()
           .then((paths) => {
             if (paths.length > 0) {
               return handleLocalFilePaths(paths);
             }
-            const text = event.clipboardData?.getData("text/plain") ?? "";
             void pasteTextIntoTerminal(text);
             return undefined;
           })
@@ -3063,7 +3063,6 @@ export function TerminalPanel({
           });
         return;
       }
-      const text = event.clipboardData?.getData("text/plain") ?? "";
       void pasteTextIntoTerminal(text);
     };
     el.addEventListener("paste", onPaste, { capture: true });


### PR DESCRIPTION
Fixes a regression where the Cmd+V paste shortcut fails in remote (SSH) sessions on macOS.

Root Cause:
In the macOS terminal onPaste handler, if the session is remote and the file upload helper is active, clipboardReadFiles() is called to detect copied file paths. Because this is an asynchronous IPC call, the JavaScript event loop yields. During this yield, WebKit/WKWebView immediately disposes of the ClipboardEvent's clipboardData for security/lifecycle reasons. When the promise resolves, any subsequent attempt to call event.clipboardData.getData() returns an empty string, preventing plain text from being pasted.

Fix:
Synchronously extract the text from event.clipboardData at the very beginning of the onPaste handler before any asynchronous yields occur.