### PR TITLE
fix(sftp): restore cwd sync and compact path scrolling

### DIFF
--- a/qa-ui-auto-tests/feature-list.md
+++ b/qa-ui-auto-tests/feature-list.md
@@ -452,6 +452,7 @@ components: [TerminalPanel]
 files:
   - src/components/terminal/TerminalPanel.tsx
   - src/components/ContextMenu.tsx
+  - src/lib/terminalCommand.ts
 controls:
   - id: terminal-pane
     selector: '[data-testid="terminal-pane"]'

--- a/src/components/filebrowser/PathBreadcrumb.tsx
+++ b/src/components/filebrowser/PathBreadcrumb.tsx
@@ -89,7 +89,7 @@ export function PathBreadcrumb({
   return (
     <div
       data-testid={testId}
-      className="flex-1 h-6 flex items-center gap-0.5 px-1.5 overflow-x-auto text-[12px] cursor-text"
+      className="taomni-path-breadcrumb flex-1 h-6 flex items-center gap-0.5 px-1.5 overflow-x-auto text-[12px] leading-none cursor-text"
       style={{ background: "var(--taomni-input-bg)", border: "1px solid var(--taomni-input-border)", borderRadius: 2 }}
       onClick={() => setEditing(true)}
       onContextMenu={(e) => {

--- a/src/components/filebrowser/SftpPolish.test.tsx
+++ b/src/components/filebrowser/SftpPolish.test.tsx
@@ -389,6 +389,24 @@ describe("sftpController.download empty-local-dir fallback", () => {
 });
 
 describe("PathBreadcrumb Windows drives root", () => {
+  it("uses the compact horizontal scroller for a long path", () => {
+    const { getByTestId, getByText } = render(
+      <PathBreadcrumb
+        testId="long-path"
+        path="/home/me/projects/taomni/deeply/nested/directory"
+        onNavigate={vi.fn()}
+      />,
+    );
+
+    const breadcrumb = getByTestId("long-path");
+    expect(breadcrumb).toHaveClass(
+      "taomni-path-breadcrumb",
+      "overflow-x-auto",
+      "leading-none",
+    );
+    expect(getByText("directory")).toBeVisible();
+  });
+
   it("renders the virtual drives root as a single 'Drives' segment", () => {
     const onNavigate = vi.fn();
     const { getByText, queryByTestId } = render(

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -105,6 +105,7 @@ import {
   isVaultLockedError,
 } from "../../lib/ipc";
 import { getAppPlatform, isTauriRuntime } from "../../lib/runtime";
+import { extractTerminalCommand } from "../../lib/terminalCommand";
 import { normalizeLocalStartCwd } from "../../lib/terminalCwd";
 import { buildSshCwdIntegration } from "../../lib/terminalShellIntegration";
 import { registerTerminal, consumeTerminalDetachPending } from "../../lib/terminal/terminalRegistry";
@@ -3998,20 +3999,7 @@ function captureBufferCommand(term: Terminal): string {
     }
   }
 
-  const trimmed = text.replace(/\s+$/, "");
-
-  // Heuristic prompt removal: take the tail after the last common shell
-  // prompt terminator. Covers bash/zsh ("$ "/"# "), fish/tcsh ("% "),
-  // PowerShell ("> "). If no terminator is found, return the whole line.
-  const markers = ["$ ", "# ", "> ", "% "];
-  let best = -1;
-  for (const marker of markers) {
-    const idx = trimmed.lastIndexOf(marker);
-    if (idx > best) best = idx + marker.length;
-  }
-
-  const command = best >= 0 ? trimmed.slice(best) : trimmed;
-  return command.trim();
+  return extractTerminalCommand(text);
 }
 
 // Heuristic: does the terminal currently show an idle shell prompt waiting for

--- a/src/index.css
+++ b/src/index.css
@@ -386,6 +386,23 @@ body.notes-detached-document,
 .taomni-scroll-y::-webkit-scrollbar-thumb { background: var(--taomni-scrollbar-thumb); border: 2px solid var(--taomni-scrollbar-track); border-radius: 2px; }
 .taomni-scroll-y::-webkit-scrollbar-thumb:hover { background: var(--taomni-scrollbar-thumb-hover); }
 
+/* Keep the compact SFTP breadcrumb readable when classic scrollbars consume
+   layout space (notably Windows WebView2). WebKit/Blink expose an exact-size
+   hook; other engines fall back to their platform-defined thin scrollbar. */
+.taomni-path-breadcrumb::-webkit-scrollbar { height: 4px; }
+.taomni-path-breadcrumb::-webkit-scrollbar-track { background: transparent; }
+.taomni-path-breadcrumb::-webkit-scrollbar-thumb {
+  background: var(--taomni-scrollbar-thumb);
+  border-radius: 9999px;
+}
+.taomni-path-breadcrumb::-webkit-scrollbar-thumb:hover { background: var(--taomni-scrollbar-thumb-hover); }
+@supports not selector(::-webkit-scrollbar) {
+  .taomni-path-breadcrumb {
+    scrollbar-color: var(--taomni-scrollbar-thumb) transparent;
+    scrollbar-width: thin;
+  }
+}
+
 /* Form inputs */
 .taomni-input {
   height: 22px;

--- a/src/lib/terminalCommand.test.ts
+++ b/src/lib/terminalCommand.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { extractTerminalCommand } from "./terminalCommand";
+
+describe("extractTerminalCommand", () => {
+  it.each([
+    "[user@host ~]$ ",
+    "root@host:/srv# ",
+    "fish@host /tmp% ",
+    "PS C:\\Users\\me> ",
+  ])("recognizes an idle standard prompt: %s", (text) => {
+    expect(extractTerminalCommand(text)).toBe("");
+  });
+
+  it.each([
+    ["[user@host ~]$ ls -la", "ls -la"],
+    ["root@host:/srv# systemctl status sshd", "systemctl status sshd"],
+    ["PS C:\\Users\\me> Get-Location", "Get-Location"],
+  ])("extracts a typed command from %s", (text, expected) => {
+    expect(extractTerminalCommand(text)).toBe(expected);
+  });
+
+  it.each([
+    "[user@host ~]$ echo $ ",
+    "[user@host ~]$ printf foo > ",
+    "[user@host ~]$ echo 100% ",
+    "[user@host ~]$ echo foo # ",
+  ])("does not mistake prompt-like command text for an idle prompt: %s", (text) => {
+    expect(extractTerminalCommand(text)).not.toBe("");
+  });
+
+  it("fails safe when the prompt has no separating space", () => {
+    expect(extractTerminalCommand("[user@host ~]$")).toBe("[user@host ~]$");
+  });
+
+  it("trims a wrapped command assembled from multiple buffer rows", () => {
+    expect(extractTerminalCommand("[user@host ~]$ printf '%s' \\\nvalue   ")).toBe("printf '%s' \\\nvalue");
+  });
+});

--- a/src/lib/terminalCommand.ts
+++ b/src/lib/terminalCommand.ts
@@ -1,0 +1,22 @@
+const PROMPT_MARKERS = ["$ ", "# ", "> ", "% "];
+
+/**
+ * Extract the command displayed after a common shell prompt terminator.
+ *
+ * Search the untrimmed text so an idle prompt keeps the space that is part of
+ * its terminator. Prefer the first marker: prompt-like text typed later in the
+ * command must never make an active input line look idle to callers that may
+ * inject terminal input.
+ */
+export function extractTerminalCommand(text: string): string {
+  let promptEnd = -1;
+
+  for (const marker of PROMPT_MARKERS) {
+    const index = text.indexOf(marker);
+    if (index >= 0 && (promptEnd < 0 || index < promptEnd)) {
+      promptEnd = index + marker.length;
+    }
+  }
+
+  return (promptEnd >= 0 ? text.slice(promptEnd) : text).trim();
+}


### PR DESCRIPTION
Preserve prompt terminator whitespace while extracting commands from the xterm buffer so idle bash, zsh, fish, and PowerShell prompts no longer block CWD probes. Prefer the first prompt marker to fail safely when typed commands end with prompt-like characters, and cover idle, active, wrapped, and ambiguous prompt cases with focused unit tests.

Give SFTP path breadcrumbs an explicit 4px WebKit/Blink scrollbar with a standards-based thin fallback and a compact line height, keeping long LOCAL and REMOTE paths readable in Windows WebView2. Add component regression coverage and register the new terminal helper in the UI feature catalog.

Fixes #350

Fixes #351