### PR TITLE
feat(sftp): implement automatic and manual reconnection for SFTP sess…

### DIFF
--- a/src/components/filebrowser/FileBrowser.tsx
+++ b/src/components/filebrowser/FileBrowser.tsx
@@ -102,6 +102,7 @@ export function FileBrowser(props: FileBrowserProps) {
   const attach = useSftpStore((s) => s.attach);
   const detach = useSftpStore((s) => s.detach);
   const navigate = useSftpStore((s) => s.navigate);
+  const reconnect = useSftpStore((s) => s.reconnect);
   const setStatus = useAppStore((s) => s.setStatusMessage);
   const controller = useSftpController(props.sessionId);
   const { confirm: confirmDialog, render: confirmDialogRender } = useConfirmDialog();
@@ -228,6 +229,26 @@ export function FileBrowser(props: FileBrowserProps) {
       }
     };
   }, [props.sessionId, detach]);
+
+  useEffect(() => {
+    const handleTerminalReconnected = (e: Event) => {
+      const customEvent = e as CustomEvent<{ tabId: string }>;
+      const targetTabId = customEvent.detail?.tabId;
+      if (!targetTabId) return;
+
+      const isAttachedSidebar = props.sessionId === `attached-${targetTabId}`;
+      if (isAttachedSidebar) {
+        void reconnect(props.sessionId).catch((err) => {
+          console.error("Auto-reconnection of SFTP failed:", err);
+        });
+      }
+    };
+
+    window.addEventListener("taomni:terminal-reconnected", handleTerminalReconnected);
+    return () => {
+      window.removeEventListener("taomni:terminal-reconnected", handleTerminalReconnected);
+    };
+  }, [props.sessionId, reconnect]);
 
   useEffect(() => {
     pendingTerminalSyncRef.current = false;
@@ -837,16 +858,8 @@ export function FileBrowser(props: FileBrowserProps) {
               type="button"
               className="ml-2 underline"
               onClick={() => {
-                void detach(props.sessionId).then(() =>
-                  attach({
-                    sessionId: props.sessionId,
-                    host: props.host,
-                    port: props.port,
-                    username: props.username,
-                    authMethod: props.authMethod,
-                    authData: props.authData,
-                    networkSettingsJson: props.networkSettingsJson ?? null,
-                  }).catch((err) => setStatus(t("fileBrowser.statusReconnectFailed", { error: String(err) })))
+                void reconnect(props.sessionId).catch((err) =>
+                  setStatus(t("fileBrowser.statusReconnectFailed", { error: String(err) }))
                 );
               }}
             >

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -2686,6 +2686,11 @@ export function TerminalPanel({
           term.write(`\r\n\x1b[32m[Reconnected to ${ssh.username}@${ssh.host}:${ssh.port}]\x1b[0m\r\n`);
           setStatusMessage("SSH reconnected");
           window.setTimeout(focusTerminal, 0);
+          window.dispatchEvent(
+            new CustomEvent("taomni:terminal-reconnected", {
+              detail: { tabId },
+            }),
+          );
         } else {
           term.write(formatSshInfoBanner(ssh));
         }

--- a/src/stores/sftpStore.test.ts
+++ b/src/stores/sftpStore.test.ts
@@ -1,15 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useSftpStore, type PaneState, type SftpSessionState } from "./sftpStore";
-import { sftpListRemote, type FileEntry } from "../lib/sftp";
+import { sftpListRemote, sftpAttach, sftpDetach, type FileEntry } from "../lib/sftp";
 
 vi.mock("../lib/sftp", () => ({
-  sftpListRemote: vi.fn(),
-  sftpListLocal: vi.fn(),
-  sftpLocalHome: vi.fn(),
-  sftpLocalDrives: vi.fn(),
-  sftpAttach: vi.fn(),
-  sftpDetach: vi.fn(),
-  sftpRealpath: vi.fn(),
+  sftpListRemote: vi.fn(async () => []),
+  sftpListLocal: vi.fn(async () => []),
+  sftpLocalHome: vi.fn(async () => "/"),
+  sftpLocalDrives: vi.fn(async () => []),
+  sftpAttach: vi.fn(async () => ({ homeDir: "/" })),
+  sftpDetach: vi.fn(async () => {}),
+  sftpRealpath: vi.fn(async (_sid: string, p: string) => p),
 }));
 
 const charsetSwitchEntry: FileEntry = {
@@ -85,5 +85,55 @@ describe("sftpStore", () => {
       ["sid", charsetSwitchEntry.path],
       ["sid", "/"],
     ]);
+  });
+
+  it("caches connectionOpts on attach and uses them on reconnect", async () => {
+    vi.mocked(sftpAttach).mockResolvedValue({ homeDir: "/home/test" });
+    vi.mocked(sftpListRemote).mockResolvedValue([]);
+
+    const opts = {
+      sessionId: "new-sid",
+      host: "example.com",
+      port: 22,
+      username: "user",
+      authMethod: "Password",
+      authData: "pass",
+    };
+
+    await useSftpStore.getState().attach(opts);
+
+    const s = useSftpStore.getState().sessions["new-sid"];
+    expect(s.connectionOpts).toEqual(opts);
+    expect(s.attached).toBe(true);
+
+    // Reset mocks to verify reconnect behavior
+    vi.mocked(sftpDetach).mockResolvedValue(undefined);
+    vi.mocked(sftpAttach).mockClear();
+
+    await useSftpStore.getState().reconnect("new-sid");
+    expect(vi.mocked(sftpDetach)).toHaveBeenCalledWith("new-sid");
+    expect(vi.mocked(sftpAttach)).toHaveBeenCalledWith(opts);
+  });
+
+  it("escalates connection errors on remote navigation to session level error", async () => {
+    vi.mocked(sftpListRemote).mockRejectedValue(new Error("socket closed"));
+
+    await useSftpStore.getState().navigate("sid", "remote", "/some/path");
+
+    const s = useSftpStore.getState().sessions.sid;
+    expect(s.attached).toBe(false);
+    expect(s.error).toBe("socket closed");
+    expect(s.remote.error).toBe("socket closed");
+  });
+
+  it("does not escalate non-connection errors on remote navigation", async () => {
+    vi.mocked(sftpListRemote).mockRejectedValue(new Error("Permission denied"));
+
+    await useSftpStore.getState().navigate("sid", "remote", "/some/path");
+
+    const s = useSftpStore.getState().sessions.sid;
+    expect(s.attached).toBe(true);
+    expect(s.error).toBeNull();
+    expect(s.remote.error).toBe("Permission denied");
   });
 });

--- a/src/stores/sftpStore.ts
+++ b/src/stores/sftpStore.ts
@@ -39,6 +39,7 @@ export interface SftpSessionState {
   attaching: boolean;
   homeDir: string | null;
   error: string | null;
+  connectionOpts?: AttachOptions;
   remote: PaneState;
   local: PaneState;
 }
@@ -76,6 +77,7 @@ export type FilePanelStoreHook = UseBoundStore<StoreApi<FilePanelStore>>;
 interface SftpStoreState {
   sessions: Record<string, SftpSessionState>;
   attach: (opts: AttachOptions) => Promise<void>;
+  reconnect: (sessionId: string) => Promise<void>;
   /**
    * Attach a session id to the store without opening any SFTP channel —
    * used by the embedded local file-browser tab (File session type) so it
@@ -165,6 +167,21 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+export function isConnectionError(err: unknown): boolean {
+  const msg = errorMessage(err).toLowerCase();
+  return (
+    msg.includes("connection closed") ||
+    msg.includes("socket closed") ||
+    msg.includes("channel closed") ||
+    msg.includes("broken pipe") ||
+    msg.includes("not attached") ||
+    msg.includes("ssh error") ||
+    msg.includes("io error") ||
+    msg.includes("timed out") ||
+    msg.includes("eof")
+  );
+}
+
 function isSftpRefreshDirectorySignal(err: unknown): boolean {
   return errorMessage(err)
     .toLowerCase()
@@ -246,6 +263,7 @@ export const useSftpStore = create<SftpStoreState>((set, get) => ({
           ...(state.sessions[sid] ?? freshSession(sid)),
           attaching: true,
           error: null,
+          connectionOpts: opts,
         },
       },
     }));
@@ -453,13 +471,18 @@ export const useSftpStore = create<SftpStoreState>((set, get) => ({
       set((state) => {
         const cur = state.sessions[sessionId];
         if (!cur) return state;
+        const nextSession = {
+          ...cur,
+          [side]: { ...cur[side], loading: false, error: message },
+        };
+        if (side === "remote" && isConnectionError(err)) {
+          nextSession.attached = false;
+          nextSession.error = message;
+        }
         return {
           sessions: {
             ...state.sessions,
-            [sessionId]: {
-              ...cur,
-              [side]: { ...cur[side], loading: false, error: message },
-            },
+            [sessionId]: nextSession,
           },
         };
       });
@@ -528,13 +551,18 @@ export const useSftpStore = create<SftpStoreState>((set, get) => ({
       set((state) => {
         const cur = state.sessions[sessionId];
         if (!cur) return state;
+        const nextSession = {
+          ...cur,
+          [side]: { ...cur[side], loading: false, error: message },
+        };
+        if (side === "remote" && isConnectionError(displayErr)) {
+          nextSession.attached = false;
+          nextSession.error = message;
+        }
         return {
           sessions: {
             ...state.sessions,
-            [sessionId]: {
-              ...cur,
-              [side]: { ...cur[side], loading: false, error: message },
-            },
+            [sessionId]: nextSession,
           },
         };
       });
@@ -577,13 +605,18 @@ export const useSftpStore = create<SftpStoreState>((set, get) => ({
       set((state) => {
         const cur = state.sessions[sessionId];
         if (!cur) return state;
+        const nextSession = {
+          ...cur,
+          [side]: { ...cur[side], loading: false, error: message },
+        };
+        if (side === "remote" && isConnectionError(err)) {
+          nextSession.attached = false;
+          nextSession.error = message;
+        }
         return {
           sessions: {
             ...state.sessions,
-            [sessionId]: {
-              ...cur,
-              [side]: { ...cur[side], loading: false, error: message },
-            },
+            [sessionId]: nextSession,
           },
         };
       });
@@ -626,13 +659,18 @@ export const useSftpStore = create<SftpStoreState>((set, get) => ({
       set((state) => {
         const cur = state.sessions[sessionId];
         if (!cur) return state;
+        const nextSession = {
+          ...cur,
+          [side]: { ...cur[side], loading: false, error: message },
+        };
+        if (side === "remote" && isConnectionError(err)) {
+          nextSession.attached = false;
+          nextSession.error = message;
+        }
         return {
           sessions: {
             ...state.sessions,
-            [sessionId]: {
-              ...cur,
-              [side]: { ...cur[side], loading: false, error: message },
-            },
+            [sessionId]: nextSession,
           },
         };
       });
@@ -714,5 +752,14 @@ export const useSftpStore = create<SftpStoreState>((set, get) => ({
         },
       };
     });
+  },
+
+  reconnect: async (sessionId) => {
+    const session = get().sessions[sessionId];
+    if (!session || !session.connectionOpts) {
+      throw new Error("No connection credentials cached for this session");
+    }
+    await get().detach(sessionId).catch(() => {});
+    await get().attach(session.connectionOpts);
   },
 }));


### PR DESCRIPTION
…ions

- Caches connection options (`connectionOpts`) in `SftpSessionState` upon initial attach.
- Exposes a new `reconnect` action in the SFTP store to clean up stale sessions and reconnect.
- Classifies connection-related errors in remote actions and escalates them to session-level errors to automatically render the retry banner.
- Broadcasts a custom window event (`taomni:terminal-reconnected`) when terminal reconnects.
- Listens for terminal reconnect events in the SFTP sidebar component and auto-heals the SFTP session.
- Adds comprehensive unit tests covering caching, reconnection, and error classification.

Fixes #360