### PR TITLE
fix(code-workspace): stop command registration update loop

### DIFF
--- a/src/components/ContextMenu.test.tsx
+++ b/src/components/ContextMenu.test.tsx
@@ -1,10 +1,47 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ContextMenu, type MenuItem } from "./ContextMenu";
+import { ContextMenu, useContextMenu, type MenuItem } from "./ContextMenu";
 
 afterEach(cleanup);
 
 describe("ContextMenu", () => {
+  it("keeps the hook controller stable across unrelated rerenders", () => {
+    const controllers: Array<ReturnType<typeof useContextMenu>> = [];
+
+    function Harness({ nonce }: { nonce: number }) {
+      const contextMenu = useContextMenu();
+      controllers.push(contextMenu);
+      return (
+        <div data-nonce={nonce}>
+          <button
+            type="button"
+            onClick={() => contextMenu.showAt(10, 10, [{ label: "Inspect" }])}
+          >
+            Open menu
+          </button>
+          {contextMenu.render}
+        </div>
+      );
+    }
+
+    const rendered = render(<Harness nonce={0} />);
+    const initial = controllers[controllers.length - 1];
+
+    rendered.rerender(<Harness nonce={1} />);
+    expect(controllers[controllers.length - 1]).toBe(initial);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
+    const opened = controllers[controllers.length - 1];
+    expect(opened).not.toBe(initial);
+    expect(opened.show).toBe(initial.show);
+    expect(opened.showAt).toBe(initial.showAt);
+    expect(opened.close).toBe(initial.close);
+    expect(screen.getByTestId("context-menu-item-inspect")).toBeInTheDocument();
+
+    rendered.rerender(<Harness nonce={2} />);
+    expect(controllers[controllers.length - 1]).toBe(opened);
+  });
+
   it("renders a flat menu and closes after a leaf click", () => {
     const onClose = vi.fn();
     const onClick = vi.fn();

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useLayoutEffect, useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { forwardRef, useCallback, useLayoutEffect, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { ChevronRight } from "lucide-react";
 
@@ -271,11 +271,16 @@ export function useContextMenu() {
 
   const close = useCallback(() => setMenu(null), []);
 
-  const render = menu ? (
-    <ContextMenu items={menu.items} x={menu.x} y={menu.y} onClose={close} />
-  ) : null;
-
-  return { show, showAt, refreshItems, close, render, isOpen: menu !== null };
+  return useMemo(() => ({
+    show,
+    showAt,
+    refreshItems,
+    close,
+    render: menu ? (
+      <ContextMenu items={menu.items} x={menu.x} y={menu.y} onClose={close} />
+    ) : null,
+    isOpen: menu !== null,
+  }), [close, menu, refreshItems, show, showAt]);
 }
 
 function slugForTestId(value: string): string {

--- a/src/components/editor/CodeWorkspaceTab.test.tsx
+++ b/src/components/editor/CodeWorkspaceTab.test.tsx
@@ -1,7 +1,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import mermaid from "mermaid";
-import type { ComponentProps } from "react";
+import { useCallback, useRef, useState, type ComponentProps } from "react";
 import { useAppStore } from "../../stores/appStore";
 import { selectCodeWorkspaceUi, useCodeWorkspaceStore } from "../../stores/codeWorkspaceStore";
 import { DEFAULT_CODE_VIEW_PROFILE, saveCodeViewProfile } from "../../lib/codeViewProfile";
@@ -340,6 +340,97 @@ describe("CodeWorkspaceTab", () => {
 
   afterEach(() => {
     cleanup();
+  });
+
+  it("keeps command registration stable across unrelated parent rerenders", async () => {
+    const workspace: CodeWorkspaceTabInfo = {
+      repoRoot: "",
+      workspaceId: "ws-registration",
+      workspaceInstanceId: "instance-registration",
+      name: "Registration Workspace",
+      roots: [],
+      looseFiles: [],
+    };
+    const onCommandsChange = vi.fn();
+    const rendered = renderWorkspace(workspace, { onCommandsChange });
+
+    await waitFor(() => {
+      expect(onCommandsChange).toHaveBeenCalledWith(
+        "tab-code",
+        expect.objectContaining({ items: expect.any(Array), execute: expect.any(Function) }),
+      );
+    });
+
+    onCommandsChange.mockClear();
+    rendered.rerender(
+      <CodeWorkspaceTab
+        tabId="tab-code"
+        workspace={workspace}
+        visible
+        onCommandsChange={onCommandsChange}
+      />,
+    );
+    expect(onCommandsChange).not.toHaveBeenCalled();
+
+    rendered.unmount();
+    expect(onCommandsChange).toHaveBeenCalledTimes(1);
+    expect(onCommandsChange).toHaveBeenCalledWith("tab-code", null);
+  });
+
+  it("settles when the parent stores command registrations in state", async () => {
+    const workspace: CodeWorkspaceTabInfo = {
+      repoRoot: "",
+      workspaceId: "ws-registration-feedback",
+      workspaceInstanceId: "instance-registration-feedback",
+      name: "Registration Feedback Workspace",
+      roots: [],
+      looseFiles: [],
+    };
+    let parentRenderCount = 0;
+
+    function RegistrationHost() {
+      const renderCount = useRef(0);
+      renderCount.current += 1;
+      parentRenderCount = Math.max(parentRenderCount, renderCount.current);
+      if (renderCount.current > 20) {
+        throw new Error("Command registration feedback did not settle");
+      }
+
+      const [, setRegistrations] = useState<Record<string, unknown>>({});
+      const handleCommandsChange = useCallback<
+        NonNullable<ComponentProps<typeof CodeWorkspaceTab>["onCommandsChange"]>
+      >((tabId, registration) => {
+        setRegistrations((current) => {
+          if (registration) {
+            return current[tabId] === registration
+              ? current
+              : { ...current, [tabId]: registration };
+          }
+          if (!(tabId in current)) return current;
+          const next = { ...current };
+          delete next[tabId];
+          return next;
+        });
+      }, []);
+
+      return (
+        <CodeWorkspaceTab
+          tabId="tab-code-feedback"
+          workspace={workspace}
+          visible
+          onCommandsChange={handleCommandsChange}
+        />
+      );
+    }
+
+    render(<RegistrationHost />);
+
+    expect(await screen.findByText("Code · Registration Feedback Workspace")).toBeInTheDocument();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(parentRenderCount).toBeGreaterThan(1);
+    expect(parentRenderCount).toBeLessThan(20);
   });
 
   it("opens a multi-root workspace and shows missing C# language server commands", async () => {

--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -1181,7 +1181,11 @@ export function CodeWorkspaceTab({
     onStatus: setStatusMessage,
   });
 
-  const treeContextMenu = useContextMenu();
+  const {
+    show: openTreeContextMenu,
+    showAt: openTreeContextMenuAt,
+    render: treeContextMenu,
+  } = useContextMenu();
 
   const copyEditorTabPath = useCallback(async (key: string, absolute: boolean) => {
     const file = openFilesRef.current[key];
@@ -1323,7 +1327,7 @@ export function CodeWorkspaceTab({
       if (selection.kind === "file" && selection.ref.kind === "root") {
         const ref = selection.ref;
         const dir = parentPath(ref.path);
-        treeContextMenu.show(event, [
+        openTreeContextMenu(event, [
           { label: "Open", onClick: run("workspace.tree.open", { selection }) },
           { separator: true, label: "" },
           { label: "New File...", onClick: run("workspace.tree.newFile", { directory: { rootId: ref.rootId, path: dir } }) },
@@ -1345,7 +1349,7 @@ export function CodeWorkspaceTab({
         return;
       }
       if (selection.kind === "dir") {
-        treeContextMenu.show(event, [
+        openTreeContextMenu(event, [
           { label: "New File...", onClick: run("workspace.tree.newFile", { directory: { rootId: selection.rootId, path: selection.path } }) },
           { label: "New Directory...", onClick: run("workspace.tree.newDirectory", { directory: { rootId: selection.rootId, path: selection.path } }) },
           { label: "Rename...", onClick: run("workspace.tree.rename", { selection }) },
@@ -1367,7 +1371,7 @@ export function CodeWorkspaceTab({
         return;
       }
       if (selection.kind === "root") {
-        treeContextMenu.show(event, [
+        openTreeContextMenu(event, [
           { label: "New File...", onClick: run("workspace.tree.newFile", { directory: { rootId: selection.rootId, path: "" } }) },
           { label: "New Directory...", onClick: run("workspace.tree.newDirectory", { directory: { rootId: selection.rootId, path: "" } }) },
           { label: "Rename Root...", onClick: run("workspace.tree.rename", { selection }) },
@@ -1392,10 +1396,10 @@ export function CodeWorkspaceTab({
     [
       canPasteTreeClipboard,
       openTerminalAt,
+      openTreeContextMenu,
       pasteTreeClipboard,
       revealInExplorer,
       stageTreeClipboard,
-      treeContextMenu,
     ],
   );
 
@@ -2651,19 +2655,11 @@ export function CodeWorkspaceTab({
       if (a.isPreferred !== b.isPreferred) return a.isPreferred ? -1 : 1;
       return a.title.localeCompare(b.title);
     });
-    // Use a synthetic context menu near the caret / lightbulb.
-    const synthetic = {
-      preventDefault() {},
-      stopPropagation() {},
-      clientX,
-      clientY,
-      button: 2,
-    } as unknown as React.MouseEvent;
-    treeContextMenu.show(synthetic, sorted.map((action) => ({
+    openTreeContextMenuAt(clientX, clientY, sorted.map((action) => ({
       label: action.title,
       onClick: () => void runCodeAction(action),
     })));
-  }, [requestCodeActions, runCodeAction, treeContextMenu]);
+  }, [openTreeContextMenuAt, requestCodeActions, runCodeAction, setStatusMessage]);
 
   const openCodeActionsAtCursor = useCallback(async () => {
     const file = activeFile;
@@ -3406,8 +3402,12 @@ export function CodeWorkspaceTab({
   useEffect(() => {
     if (!onCommandsChange) return;
     onCommandsChange(tabId, commandRegistration);
-    return () => onCommandsChange(tabId, null);
   }, [commandRegistration, onCommandsChange, tabId]);
+
+  useEffect(() => {
+    if (!onCommandsChange) return;
+    return () => onCommandsChange(tabId, null);
+  }, [onCommandsChange, tabId]);
 
   const getLspCompletions = useCallback(
     async (
@@ -4383,7 +4383,7 @@ export function CodeWorkspaceTab({
           void openLspLocation(location);
         }}
       />
-      {treeContextMenu.render}
+      {treeContextMenu}
       {localHistoryTarget && openFiles[localHistoryTarget.key] && (
         <LocalHistoryDialog
           path={localHistoryTarget.path}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,29 +5,48 @@ import "./index.css";
 
 interface RootErrorBoundaryState {
   error: unknown;
+  componentStack: string;
 }
 
 class RootErrorBoundary extends React.Component<{ children: React.ReactNode }, RootErrorBoundaryState> {
-  state: RootErrorBoundaryState = { error: null };
+  state: RootErrorBoundaryState = { error: null, componentStack: "" };
 
   static getDerivedStateFromError(error: unknown): RootErrorBoundaryState {
-    return { error };
+    return { error, componentStack: "" };
   }
 
-  componentDidCatch(error: unknown) {
-    console.error("[startup] React render failed", error);
+  componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    const componentStack = info.componentStack ?? "";
+    console.error("[ui] React render failed", error, componentStack);
+    this.setState({ componentStack });
   }
 
   render() {
     if (this.state.error) {
-      return <StartupCrash error={this.state.error} />;
+      return (
+        <AppCrash
+          error={this.state.error}
+          componentStack={this.state.componentStack}
+          phase="ui"
+        />
+      );
     }
     return this.props.children;
   }
 }
 
-function StartupCrash({ error }: { error: unknown }) {
+function AppCrash({
+  error,
+  componentStack = "",
+  phase,
+}: {
+  error: unknown;
+  componentStack?: string;
+  phase: "startup" | "ui";
+}) {
   const message = error instanceof Error ? error.message : String(error);
+  const report = componentStack ? `${message}\n\n--- React component stack ---\n${componentStack}` : message;
+  const startup = phase === "startup";
 
   return (
     <div
@@ -41,9 +60,13 @@ function StartupCrash({ error }: { error: unknown }) {
       }}
     >
       <div style={{ maxWidth: 760 }}>
-        <h1 style={{ margin: "0 0 12px", fontSize: 20, fontWeight: 700 }}>Taomni failed to start</h1>
+        <h1 style={{ margin: "0 0 12px", fontSize: 20, fontWeight: 700 }}>
+          {startup ? "Taomni failed to start" : "Taomni UI encountered an error"}
+        </h1>
         <p style={{ margin: "0 0 16px", color: "#59636e", fontSize: 13, lineHeight: 1.5 }}>
-          The app hit a startup error in this WebView. Please include the details below when reporting it.
+          {startup
+            ? "The app failed while loading in this WebView. Please include the details below when reporting it."
+            : "The app hit a React UI error in this WebView. Please include the details below when reporting it."}
         </p>
         <pre
           style={{
@@ -58,7 +81,7 @@ function StartupCrash({ error }: { error: unknown }) {
             lineHeight: 1.45,
           }}
         >
-          {message}
+          {report}
         </pre>
       </div>
     </div>
@@ -67,7 +90,7 @@ function StartupCrash({ error }: { error: unknown }) {
 
 function renderStartupCrash(error: unknown): void {
   console.error("[startup] App module failed to load", error);
-  ReactDOM.createRoot(document.getElementById("root")!).render(<StartupCrash error={error} />);
+  ReactDOM.createRoot(document.getElementById("root")!).render(<AppCrash error={error} phase="startup" />);
 }
 
 async function bootstrap(): Promise<void> {


### PR DESCRIPTION
Stabilize the useContextMenu controller between unrelated renders and make Code Workspace callbacks depend only on the stable show and showAt actions. This prevents workspace command registrations from being recreated whenever MainLayout stores the latest registration.

Separate command registration publishing from unmount cleanup so legitimate registration updates no longer publish a transient null. Replace the synthetic context-menu event used by code actions with the existing coordinate-based showAt API.

Add regression coverage for controller identity, registration stability, and the real parent-state feedback loop, with a render guard that fails quickly instead of hanging CI. Improve the root error boundary to distinguish startup failures from React UI crashes and include the component stack in reports.

Base the production fix on main and intentionally exclude the opt-in update-probe instrumentation after reviewing its enabled hot-path overhead.

Tests: pnpm build; focused ContextMenu and CodeWorkspaceTab suite (34/34); full Vitest assertions (164 files, 1314/1314 assertions; existing jsdom teardown error remains outside this change).