### PR TITLE
perf(code-workspace): batch typing updates and idle-schedule LSP/Git …

### DIFF
--- a/src/components/editor/CodeWorkspaceTab.test.tsx
+++ b/src/components/editor/CodeWorkspaceTab.test.tsx
@@ -1706,6 +1706,154 @@ describe("CodeWorkspaceTab", () => {
     await waitFor(() => expect(lspMocks.lspSelectionRanges).toHaveBeenCalled());
   });
 
+  it("syncs edits before idle intelligence work and ignores an older semantic-token response", async () => {
+    const workspace: CodeWorkspaceTabInfo = {
+      repoRoot: "/repo/app",
+      workspaceId: "ws-lsp-scheduler",
+      workspaceInstanceId: "instance-lsp-scheduler",
+      name: "LSP scheduler",
+      roots: [{ id: "app", name: "app", path: "/repo/app", kind: "git" }],
+      looseFiles: [],
+      initialFile: { kind: "root", rootId: "app", path: "src/main.ts" },
+    };
+    const capabilities = {
+      completion: false,
+      signatureHelp: false,
+      hover: false,
+      definition: false,
+      typeDefinition: false,
+      implementation: false,
+      references: false,
+      documentSymbol: true,
+      workspaceSymbol: false,
+      rename: false,
+      formatting: false,
+      rangeFormatting: false,
+      codeAction: false,
+      documentHighlight: true,
+      callHierarchy: false,
+      typeHierarchy: false,
+      inlayHint: false,
+      selectionRange: false,
+      semanticTokens: true,
+      completionTriggerCharacters: [],
+      signatureTriggerCharacters: [],
+    };
+    const status = documentStatus({
+      path: "/repo/app/src/main.ts",
+      uri: "file:///repo/app/src/main.ts",
+      available: true,
+      active: true,
+      capabilities,
+    });
+    workspaceMocks.workspaceReadFile.mockResolvedValue(file("src/main.ts", "const alpha = 1;"));
+    lspMocks.lspOpenDocument.mockResolvedValue(status);
+    lspMocks.lspChangeDocument.mockResolvedValue(status);
+    lspMocks.lspGetDiagnostics.mockResolvedValue({ status, diagnostics: [] });
+    lspMocks.lspDocumentHighlights.mockResolvedValue({ status, highlights: [] });
+    lspMocks.lspDocumentSymbols.mockResolvedValue({ status, symbols: [] });
+
+    const rendered = renderWorkspace(workspace);
+    const fileKey = "root:app:src/main.ts";
+    await screen.findByTitle("app / src/main.ts");
+    await waitFor(() => expect(
+      selectCodeWorkspaceUi(useCodeWorkspaceStore.getState(), "instance-lsp-scheduler")
+        .lspFiles[fileKey]?.syncedText,
+    ).toBe("const alpha = 1;"));
+
+    lspMocks.lspChangeDocument.mockClear();
+    lspMocks.lspDocumentHighlights.mockClear();
+    lspMocks.lspDocumentSymbols.mockClear();
+    lspMocks.lspSemanticTokens.mockClear();
+    let resolveOldSemantic: ((value: { status: LspDocumentStatus; tokens: unknown[] }) => void) | null = null;
+    lspMocks.lspSemanticTokens.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveOldSemantic = resolve;
+    }));
+
+    act(() => {
+      useCodeWorkspaceStore.getState().updateOpenFiles("instance-lsp-scheduler", (current) => ({
+        ...current,
+        [fileKey]: {
+          ...current[fileKey]!,
+          text: "const beta = 2;",
+          dirty: true,
+        },
+      }));
+    });
+
+    await waitFor(() => expect(lspMocks.lspChangeDocument).toHaveBeenCalledOnce());
+    await waitFor(() => expect(lspMocks.lspDocumentHighlights).toHaveBeenCalledOnce());
+    await waitFor(() => expect(lspMocks.lspDocumentSymbols).toHaveBeenCalledOnce());
+    await waitFor(() => expect(lspMocks.lspSemanticTokens).toHaveBeenCalledOnce());
+    const changeOrder = lspMocks.lspChangeDocument.mock.invocationCallOrder[0]!;
+    expect(changeOrder).toBeLessThan(lspMocks.lspDocumentHighlights.mock.invocationCallOrder[0]!);
+    expect(changeOrder).toBeLessThan(lspMocks.lspDocumentSymbols.mock.invocationCallOrder[0]!);
+    expect(changeOrder).toBeLessThan(lspMocks.lspSemanticTokens.mock.invocationCallOrder[0]!);
+
+    act(() => {
+      useCodeWorkspaceStore.getState().updateOpenFiles("instance-lsp-scheduler", (current) => ({
+        ...current,
+        [fileKey]: {
+          ...current[fileKey]!,
+          text: "const gamma = 3;",
+          dirty: true,
+        },
+      }));
+    });
+    await waitFor(() => expect(lspMocks.lspChangeDocument).toHaveBeenCalledTimes(2));
+
+    expect(resolveOldSemantic).not.toBeNull();
+    await act(async () => {
+      resolveOldSemantic!({
+        status,
+        tokens: [{
+          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+          tokenType: "function",
+          modifiers: [],
+        }],
+      });
+      await Promise.resolve();
+    });
+    expect(rendered.container.querySelector(".cm-lsp-sem-function")).toBeNull();
+  });
+
+  it("coalesces editor text publications until the input burst is idle", async () => {
+    const workspace: CodeWorkspaceTabInfo = {
+      repoRoot: "/repo/app",
+      workspaceId: "ws-editor-text-batch",
+      workspaceInstanceId: "instance-editor-text-batch",
+      name: "Editor text batch",
+      roots: [{ id: "app", name: "app", path: "/repo/app", kind: "git" }],
+      looseFiles: [],
+      initialFile: { kind: "root", rootId: "app", path: "src/main.ts" },
+    };
+    workspaceMocks.workspaceReadFile.mockResolvedValue(file("src/main.ts", "one\ntwo"));
+
+    const rendered = renderWorkspace(workspace);
+    await screen.findByTitle("app / src/main.ts");
+    const content = rendered.container.querySelector<HTMLElement>(".cm-content");
+    expect(content).not.toBeNull();
+    const fileKey = "root:app:src/main.ts";
+    const getBufferText = () => selectCodeWorkspaceUi(
+      useCodeWorkspaceStore.getState(),
+      "instance-editor-text-batch",
+    ).openFiles[fileKey]?.text;
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.keyDown(content!, { key: "d", code: "KeyD", ctrlKey: true });
+      expect(getBufferText()).toBe("one\ntwo");
+
+      act(() => vi.advanceTimersByTime(124));
+      expect(getBufferText()).toBe("one\ntwo");
+
+      act(() => vi.advanceTimersByTime(1));
+      expect(getBufferText()).toBe("one\none\ntwo");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("offers tree context menu actions: copy path and scoped search", async () => {
     clipboardMocks.writeText.mockClear();
     const workspace: CodeWorkspaceTabInfo = {

--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -105,7 +106,6 @@ import {
   type RightPaneTabId,
 } from "../../stores/codeWorkspaceStore";
 import {
-  detectWorkspaceEol,
   useCodeWorkspaceStatusStore,
 } from "../../stores/codeWorkspaceStatusStore";
 import { historySnapshot } from "../../lib/localHistory";
@@ -156,11 +156,11 @@ import {
 import { TodosBookmarksPanel } from "./workspace/panels/TodosBookmarksPanel";
 import {
   readWorkspaceBookmarks,
-  scanTodosInOpenFiles,
   toggleWorkspaceBookmark,
   writeWorkspaceBookmarks,
   type WorkspaceBookmark,
 } from "./workspace/todoBookmarks";
+import { useDeferredOpenFileTodos } from "./workspace/useDeferredOpenFileTodos";
 import { type QuickDocContent } from "./workspace/QuickDocPopup";
 import { type LocationPeekState } from "./workspace/LocationPeek";
 import {
@@ -175,7 +175,7 @@ import { ProjectTree } from "./workspace/ProjectTree";
 import { MarkdownPreview } from "./workspace/MarkdownPreview";
 import { IconButton, LspStatusPill } from "./workspace/workspaceChrome";
 import { OutlinePane } from "./workspace/OutlinePane";
-import { buildGitLineChanges, type GitLineChange } from "./workspace/gitEditorChrome";
+import { useDeferredGitLineChanges } from "./workspace/useDeferredGitLineChanges";
 import {
   dispatchWorkspaceCommandKeydown,
   runWorkspaceCommand,
@@ -246,6 +246,19 @@ function initialInlayHintRange(text: string): LspRange {
     end: { line: endLine, character: lines[endLine]?.length ?? 0 },
   };
 }
+
+// Keep document synchronization ahead of the comparatively expensive derived
+// LSP features.  In particular, rust-analyzer semantic tokens can be large
+// enough that applying them while somebody is still typing is noticeable.
+const LSP_CHANGE_SYNC_DELAY_MS = 150;
+const LSP_HIGHLIGHT_IDLE_DELAY_MS = 500;
+const LSP_INLAY_HINT_IDLE_DELAY_MS = 650;
+const LSP_SEMANTIC_TOKENS_IDLE_DELAY_MS = 900;
+const LSP_DOCUMENT_SYMBOLS_IDLE_DELAY_MS = 650;
+// CodeMirror owns the live text while the user is typing. Publishing every
+// keypress into the workspace-wide Zustand object redraws the file tree,
+// panels, and command chrome, so commit an editing burst as one update.
+const EDITOR_TEXT_COMMIT_IDLE_DELAY_MS = 125;
 
 import {
   type LspFileState,
@@ -348,8 +361,7 @@ export function CodeWorkspaceTab({
   useEffect(() => {
     ensureWorkspaceUi(workspaceInstanceId);
     setBookmarks(readWorkspaceBookmarks(workspaceInstanceId));
-    return () => disposeWorkspaceUi(workspaceInstanceId);
-  }, [disposeWorkspaceUi, ensureWorkspaceUi, workspaceInstanceId]);
+  }, [ensureWorkspaceUi, workspaceInstanceId]);
 
   // Restore chrome/layout once per instance, then seed expand keys only when empty.
   const layoutHydratedRef = useRef<string | null>(null);
@@ -447,6 +459,8 @@ export function CodeWorkspaceTab({
   const openFilesRef = useRef(openFiles);
   const openOrderRef = useRef(openOrder);
   const lspFilesRef = useRef(lspFiles);
+  const pendingEditorTextByFileRef = useRef(new Map<string, OpenFileState>());
+  const pendingEditorTextTimerRef = useRef<number | null>(null);
 
   const setLanguagePanelOpen = useCallback((open: boolean | ((prev: boolean) => boolean)) => {
     const next = typeof open === "function" ? open(selectCodeWorkspaceUi(useCodeWorkspaceStore.getState(), workspaceInstanceId).languagePanelOpen) : open;
@@ -583,14 +597,47 @@ export function CodeWorkspaceTab({
     updateStoreExpandedDirKeys(workspaceInstanceId, [...next]);
   }, [updateStoreExpandedDirKeys, workspaceInstanceId]);
 
-  const setOpenFiles = useCallback((
-    updater: Record<string, OpenFileState> | ((prev: Record<string, OpenFileState>) => Record<string, OpenFileState>),
-  ) => {
-    const prev = selectCodeWorkspaceUi(useCodeWorkspaceStore.getState(), workspaceInstanceId).openFiles;
-    const next = typeof updater === "function" ? updater(prev) : updater;
+  const flushPendingEditorText = useCallback(() => {
+    if (pendingEditorTextTimerRef.current !== null) {
+      window.clearTimeout(pendingEditorTextTimerRef.current);
+      pendingEditorTextTimerRef.current = null;
+    }
+    const pending = pendingEditorTextByFileRef.current;
+    if (pending.size === 0) return;
+    const current = selectCodeWorkspaceUi(useCodeWorkspaceStore.getState(), workspaceInstanceId).openFiles;
+    let next = current;
+    for (const [key, file] of pending) {
+      // A close/reload may have removed the buffer while its input callback
+      // was queued. Do not resurrect it.
+      if (!(key in current) || current[key] === file) continue;
+      if (next === current) next = { ...current };
+      next[key] = file;
+    }
+    pending.clear();
+    if (next === current) return;
     openFilesRef.current = next;
     updateStoreOpenFiles(workspaceInstanceId, next);
   }, [updateStoreOpenFiles, workspaceInstanceId]);
+  const setOpenFiles = useCallback((
+    updater: Record<string, OpenFileState> | ((prev: Record<string, OpenFileState>) => Record<string, OpenFileState>),
+  ) => {
+    // External operations (save, reload, rename, close, WorkspaceEdit) need
+    // a coherent current buffer, so they flush any in-progress typing first.
+    flushPendingEditorText();
+    const prev = selectCodeWorkspaceUi(useCodeWorkspaceStore.getState(), workspaceInstanceId).openFiles;
+    const next = typeof updater === "function" ? updater(prev) : updater;
+    if (next === prev) return;
+    openFilesRef.current = next;
+    updateStoreOpenFiles(workspaceInstanceId, next);
+  }, [flushPendingEditorText, updateStoreOpenFiles, workspaceInstanceId]);
+
+  useEffect(() => () => {
+    // Capture this workspace's flush callback in the effect closure. A tab can
+    // be rebound to a different workspace without unmounting, and a ref read
+    // during cleanup would then point at the new instance.
+    flushPendingEditorText();
+    disposeWorkspaceUi(workspaceInstanceId);
+  }, [disposeWorkspaceUi, flushPendingEditorText, workspaceInstanceId]);
 
   const setLspFiles = useCallback((
     updater: Record<string, LspFileState> | ((prev: Record<string, LspFileState>) => Record<string, LspFileState>),
@@ -651,7 +698,6 @@ export function CodeWorkspaceTab({
     secondary: [],
   });
   const [gitHeadTextByFile, setGitHeadTextByFile] = useState<Record<string, { sourceKey: string; text: string | null }>>({});
-  const [gitLineChangesByFile, setGitLineChangesByFile] = useState<Record<string, GitLineChange[]>>({});
   const [gitBlameByGroup, setGitBlameByGroup] = useState<Record<EditorGroupId, GitBlameLine | null>>({
     primary: null,
     secondary: null,
@@ -687,6 +733,9 @@ export function CodeWorkspaceTab({
   const treeFontSizeRef = useRef(treeFontSize);
   const gitHeadRequestsRef = useRef(new Set<string>());
   const gitBlameCacheRef = useRef(new Map<string, GitBlameLine | null>());
+  // Incremented for each active-buffer revision.  Async LSP responses capture
+  // this value so an older response can never repaint a newer buffer.
+  const lspDocumentEpochRef = useRef<Record<string, number>>({});
   const revealNonceRef = useRef(0);
   const editorSelectionRef = useRef<EditorSelectionRange>({
     start: { line: 0, character: 0 },
@@ -931,6 +980,9 @@ export function CodeWorkspaceTab({
 
   const openFile = useCallback(
     async (ref: CodeWorkspaceFileRef, options: { preview?: boolean; groupId?: EditorGroupId } = {}) => {
+      // Switching tabs before the input idle timer fires must never show an
+      // older buffer snapshot in the newly activated editor.
+      flushPendingEditorText();
       const key = fileKey(ref);
       const currentUi = selectCodeWorkspaceUi(useCodeWorkspaceStore.getState(), workspaceInstanceId);
       const groupId = options.groupId ?? currentUi.activeEditorGroupId;
@@ -1011,7 +1063,14 @@ export function CodeWorkspaceTab({
         setStatusMessage(message);
       }
     },
-    [activateEditorGroup, findRoot, setStatusMessage, updateEditorGroup, workspaceInstanceId],
+    [
+      activateEditorGroup,
+      findRoot,
+      flushPendingEditorText,
+      setStatusMessage,
+      updateEditorGroup,
+      workspaceInstanceId,
+    ],
   );
 
   const {
@@ -1412,11 +1471,32 @@ export function CodeWorkspaceTab({
       dirty: text !== file.savedText,
       error: null,
     };
-    // Sync ref immediately so WorkspaceEdit apply → save sees the new text
-    // without waiting for React to flush setState.
-    openFilesRef.current = { ...openFilesRef.current, [key]: next };
+    // Non-editor callers need the updated model immediately (formatting,
+    // WorkspaceEdit, reload), so they intentionally bypass the input batch.
     setOpenFiles((current) => ({ ...current, [key]: next }));
-  }, []);
+  }, [setOpenFiles]);
+
+  const queueEditorTextUpdate = useCallback((key: string, text: string) => {
+    const file = openFilesRef.current[key];
+    if (!file || file.text === text) return;
+    const next: OpenFileState = {
+      ...file,
+      text,
+      dirty: text !== file.savedText,
+      error: null,
+    };
+    // Keep every command/save/LSP call correct immediately, but delay the
+    // store publication that causes the surrounding workspace to re-render.
+    openFilesRef.current = { ...openFilesRef.current, [key]: next };
+    pendingEditorTextByFileRef.current.set(key, next);
+    if (pendingEditorTextTimerRef.current !== null) {
+      window.clearTimeout(pendingEditorTextTimerRef.current);
+    }
+    pendingEditorTextTimerRef.current = window.setTimeout(
+      flushPendingEditorText,
+      EDITOR_TEXT_COMMIT_IDLE_DELAY_MS,
+    );
+  }, [flushPendingEditorText]);
 
   const absolutePathForOpenFile = useCallback((file: OpenFileState): string | null => {
     if (file.ref.kind === "loose") return normalizeFsPath(file.ref.path);
@@ -1871,8 +1951,47 @@ export function CodeWorkspaceTab({
   }, [activateEditorGroup, editorGroups, setStoreSplitOrientation, splitOrientation, updateEditorGroup, workspaceInstanceId]);
 
   const activeFile = activeKey ? openFiles[activeKey] ?? null : null;
+  // Metadata panels and AI workspace context do not need a new snapshot for
+  // every character.  Let React publish that non-interactive work after the
+  // input update has painted.
+  const deferredOpenFiles = useDeferredValue(openFiles);
   const activeLspState = activeKey ? lspFiles[activeKey] ?? null : null;
   const activeCapabilities = activeLspState?.status?.capabilities ?? null;
+  const activeLspDocumentIsSynced = Boolean(
+    activeFile
+    && !activeFile.loading
+    && activeLspState?.status
+    && !activeLspState.syncing
+    && activeLspState.syncedText === activeFile.text,
+  );
+
+  // The backend is responsible for serializing didOpen/didChange calls, but
+  // the view also needs a revision token so a slow feature response cannot
+  // paint a document revision that has already been replaced locally.
+  useEffect(() => {
+    if (!activeFile) return;
+    lspDocumentEpochRef.current[activeFile.key] =
+      (lspDocumentEpochRef.current[activeFile.key] ?? 0) + 1;
+  }, [activeFile?.key, activeFile?.text]);
+
+  const isCurrentLspDocumentRequest = useCallback((file: OpenFileState, epoch: number) => {
+    const latestFile = openFilesRef.current[file.key];
+    const lspState = lspFilesRef.current[file.key];
+    return latestFile?.text === file.text
+      && lspDocumentEpochRef.current[file.key] === epoch
+      && lspState?.syncedText === file.text
+      && !lspState.syncing;
+  }, []);
+
+  const currentSyncedLspDocument = useCallback((file: OpenFileState) => {
+    const latestFile = openFilesRef.current[file.key];
+    const lspState = lspFilesRef.current[file.key];
+    if (!latestFile || lspState?.syncing || lspState?.syncedText !== latestFile.text) return null;
+    return {
+      file: latestFile,
+      epoch: lspDocumentEpochRef.current[file.key] ?? 0,
+    };
+  }, []);
   const openHierarchy = useCallback(async (mode: "call" | "type") => {
     const file = activeFile;
     if (!file || file.loading) return;
@@ -1960,41 +2079,70 @@ export function CodeWorkspaceTab({
     setStatusMessage(`Format on save ${enabled ? "enabled" : "disabled"} for this workspace`);
   }, [setIntelligencePreferences, setStatusMessage]);
 
+  // Send the latest document update before scheduling any derived LSP work.
+  // A short debounce coalesces normal typing without leaving the server one
+  // full feature-refresh cycle behind the editor.
+  useEffect(() => {
+    if (!visible || !activeFile || activeFile.loading) return;
+    const lspState = lspFilesRef.current[activeFile.key];
+    if (lspState?.syncedText === activeFile.text && lspState.status) return;
+    const mode: "open" | "change" = lspState?.status ? "change" : "open";
+    const timer = window.setTimeout(() => {
+      const latest = openFilesRef.current[activeFile.key];
+      if (latest) void syncLspDocument(latest, mode);
+    }, mode === "open" ? 0 : LSP_CHANGE_SYNC_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [activeFile, syncLspDocument, visible]);
+
   useEffect(() => {
     const groupId = activeEditorGroupId;
     const file = activeFile;
     if (!file || file.loading) {
-      setHighlightsByGroup((current) => ({ ...current, [groupId]: [] }));
+      setHighlightsByGroup((current) => (
+        current[groupId].length === 0 ? current : { ...current, [groupId]: [] }
+      ));
       return;
     }
     let cancelled = false;
     const position = cursorPositions[groupId] ?? { line: 0, character: 0 };
-    const timer = window.setTimeout(() => {
-      const descriptor = lspDescriptorForFile(file);
-      if (!activeCapabilities?.documentHighlight || !descriptor) {
-        if (!cancelled) {
+    const descriptor = lspDescriptorForFile(file);
+    if (!activeCapabilities?.documentHighlight || !descriptor) {
+      const timer = window.setTimeout(() => {
+        if (!cancelled && openFilesRef.current[file.key]?.text === file.text) {
           setHighlightsByGroup((current) => ({
             ...current,
             [groupId]: fallbackWordHighlights(file.text, position),
           }));
         }
-        return;
-      }
+      }, LSP_HIGHLIGHT_IDLE_DELAY_MS);
+      return () => {
+        cancelled = true;
+        window.clearTimeout(timer);
+      };
+    }
+    if (!activeLspDocumentIsSynced) {
+      setHighlightsByGroup((current) => (
+        current[groupId].length === 0 ? current : { ...current, [groupId]: [] }
+      ));
+      return () => { cancelled = true; };
+    }
+    const epoch = lspDocumentEpochRef.current[file.key] ?? 0;
+    const timer = window.setTimeout(() => {
+      if (!isCurrentLspDocumentRequest(file, epoch)) return;
       void lspDocumentHighlights(descriptor, position)
         .then((result) => {
-          if (cancelled) return;
+          if (cancelled || !isCurrentLspDocumentRequest(file, epoch)) return;
           updateLspStatusForFile(file, result.status);
           setHighlightsByGroup((current) => ({ ...current, [groupId]: result.highlights }));
         })
         .catch(() => {
-          if (!cancelled) {
-            setHighlightsByGroup((current) => ({
-              ...current,
-              [groupId]: fallbackWordHighlights(file.text, position),
-            }));
-          }
+          if (cancelled || !isCurrentLspDocumentRequest(file, epoch)) return;
+          setHighlightsByGroup((current) => ({
+            ...current,
+            [groupId]: fallbackWordHighlights(file.text, position),
+          }));
         });
-    }, 300);
+    }, LSP_HIGHLIGHT_IDLE_DELAY_MS);
     return () => {
       cancelled = true;
       window.clearTimeout(timer);
@@ -2003,7 +2151,9 @@ export function CodeWorkspaceTab({
     activeCapabilities?.documentHighlight,
     activeEditorGroupId,
     activeFile,
+    activeLspDocumentIsSynced,
     cursorPositions,
+    isCurrentLspDocumentRequest,
     lspDescriptorForFile,
     updateLspStatusForFile,
   ]);
@@ -2012,24 +2162,37 @@ export function CodeWorkspaceTab({
     const groupId = activeEditorGroupId;
     const file = activeFile;
     if (!file || file.loading || !activeInlayHintsEnabled || !activeCapabilities?.inlayHint) {
-      setInlayHintsByGroup((current) => ({ ...current, [groupId]: [] }));
+      setInlayHintsByGroup((current) => (
+        current[groupId].length === 0 ? current : { ...current, [groupId]: [] }
+      ));
+      return;
+    }
+    if (!activeLspDocumentIsSynced) {
+      setInlayHintsByGroup((current) => (
+        current[groupId].length === 0 ? current : { ...current, [groupId]: [] }
+      ));
       return;
     }
     const range = viewportRanges[groupId] ?? initialInlayHintRange(file.text);
     const descriptor = lspDescriptorForFile(file);
     if (!descriptor) return;
     let cancelled = false;
+    const epoch = lspDocumentEpochRef.current[file.key] ?? 0;
     const timer = window.setTimeout(() => {
+      if (!isCurrentLspDocumentRequest(file, epoch)) return;
       void lspInlayHints(descriptor, range)
         .then((result) => {
-          if (cancelled) return;
+          if (cancelled || !isCurrentLspDocumentRequest(file, epoch)) return;
           updateLspStatusForFile(file, result.status);
           setInlayHintsByGroup((current) => ({ ...current, [groupId]: result.hints }));
         })
         .catch(() => {
-          if (!cancelled) setInlayHintsByGroup((current) => ({ ...current, [groupId]: [] }));
+          if (cancelled || !isCurrentLspDocumentRequest(file, epoch)) return;
+          setInlayHintsByGroup((current) => (
+            current[groupId].length === 0 ? current : { ...current, [groupId]: [] }
+          ));
         });
-    }, 200);
+    }, LSP_INLAY_HINT_IDLE_DELAY_MS);
     return () => {
       cancelled = true;
       window.clearTimeout(timer);
@@ -2039,6 +2202,8 @@ export function CodeWorkspaceTab({
     activeEditorGroupId,
     activeFile,
     activeInlayHintsEnabled,
+    activeLspDocumentIsSynced,
+    isCurrentLspDocumentRequest,
     lspDescriptorForFile,
     updateLspStatusForFile,
     viewportRanges,
@@ -2048,23 +2213,36 @@ export function CodeWorkspaceTab({
     const groupId = activeEditorGroupId;
     const file = activeFile;
     if (!file || file.loading || !activeCapabilities?.semanticTokens) {
-      setSemanticTokensByGroup((current) => ({ ...current, [groupId]: [] }));
+      setSemanticTokensByGroup((current) => (
+        current[groupId].length === 0 ? current : { ...current, [groupId]: [] }
+      ));
+      return;
+    }
+    if (!activeLspDocumentIsSynced) {
+      setSemanticTokensByGroup((current) => (
+        current[groupId].length === 0 ? current : { ...current, [groupId]: [] }
+      ));
       return;
     }
     const descriptor = lspDescriptorForFile(file);
     if (!descriptor) return;
     let cancelled = false;
+    const epoch = lspDocumentEpochRef.current[file.key] ?? 0;
     const timer = window.setTimeout(() => {
+      if (!isCurrentLspDocumentRequest(file, epoch)) return;
       void lspSemanticTokens(descriptor)
         .then((result) => {
-          if (cancelled) return;
+          if (cancelled || !isCurrentLspDocumentRequest(file, epoch)) return;
           updateLspStatusForFile(file, result.status);
           setSemanticTokensByGroup((current) => ({ ...current, [groupId]: result.tokens }));
         })
         .catch(() => {
-          if (!cancelled) setSemanticTokensByGroup((current) => ({ ...current, [groupId]: [] }));
+          if (cancelled || !isCurrentLspDocumentRequest(file, epoch)) return;
+          setSemanticTokensByGroup((current) => (
+            current[groupId].length === 0 ? current : { ...current, [groupId]: [] }
+          ));
         });
-    }, 250);
+    }, LSP_SEMANTIC_TOKENS_IDLE_DELAY_MS);
     return () => {
       cancelled = true;
       window.clearTimeout(timer);
@@ -2073,7 +2251,8 @@ export function CodeWorkspaceTab({
     activeCapabilities?.semanticTokens,
     activeEditorGroupId,
     activeFile,
-    activeFile?.text,
+    activeLspDocumentIsSynced,
+    isCurrentLspDocumentRequest,
     lspDescriptorForFile,
     updateLspStatusForFile,
   ]);
@@ -2098,25 +2277,33 @@ export function CodeWorkspaceTab({
     return activeFile ? breadcrumbSegmentsForFile(activeFile, roots) : [];
   }, [activeFile, roots]);
 
-  const openFileTodos = useMemo(() => scanTodosInOpenFiles(
-    Object.values(openFiles).map((file) => ({
-      key: file.key,
-      pathLabel: file.subtitle || file.path,
-      text: file.text,
-    })),
-  ), [openFiles]);
+  const openFileTodos = useDeferredOpenFileTodos(openFiles);
 
   useEffect(() => {
     let cancelled = false;
     if (!activeFile || activeFile.loading || !activeCapabilities?.documentSymbol) {
-      setBreadcrumbSymbolsByGroup((current) => ({ ...current, [activeEditorGroupId]: [] }));
+      setBreadcrumbSymbolsByGroup((current) => (
+        current[activeEditorGroupId].length === 0
+          ? current
+          : { ...current, [activeEditorGroupId]: [] }
+      ));
+      return () => { cancelled = true; };
+    }
+    if (!activeLspDocumentIsSynced) {
+      setBreadcrumbSymbolsByGroup((current) => (
+        current[activeEditorGroupId].length === 0
+          ? current
+          : { ...current, [activeEditorGroupId]: [] }
+      ));
       return () => { cancelled = true; };
     }
     const descriptor = lspDescriptorForFile(activeFile);
     if (!descriptor) return () => { cancelled = true; };
+    const epoch = lspDocumentEpochRef.current[activeFile.key] ?? 0;
     const timer = window.setTimeout(() => {
+      if (!isCurrentLspDocumentRequest(activeFile, epoch)) return;
       void lspDocumentSymbols(descriptor).then((result) => {
-        if (!cancelled) {
+        if (!cancelled && isCurrentLspDocumentRequest(activeFile, epoch)) {
           updateLspStatusForFile(activeFile, result.status);
           setBreadcrumbSymbolsByGroup((current) => ({
             ...current,
@@ -2124,16 +2311,28 @@ export function CodeWorkspaceTab({
           }));
         }
       }).catch(() => {
-        if (!cancelled) {
-          setBreadcrumbSymbolsByGroup((current) => ({ ...current, [activeEditorGroupId]: [] }));
+        if (!cancelled && isCurrentLspDocumentRequest(activeFile, epoch)) {
+          setBreadcrumbSymbolsByGroup((current) => (
+            current[activeEditorGroupId].length === 0
+              ? current
+              : { ...current, [activeEditorGroupId]: [] }
+          ));
         }
       });
-    }, 200);
+    }, LSP_DOCUMENT_SYMBOLS_IDLE_DELAY_MS);
     return () => {
       cancelled = true;
       window.clearTimeout(timer);
     };
-  }, [activeCapabilities?.documentSymbol, activeEditorGroupId, activeFile, lspDescriptorForFile, updateLspStatusForFile]);
+  }, [
+    activeCapabilities?.documentSymbol,
+    activeEditorGroupId,
+    activeFile,
+    activeLspDocumentIsSynced,
+    isCurrentLspDocumentRequest,
+    lspDescriptorForFile,
+    updateLspStatusForFile,
+  ]);
   const activeRootId = activeFile?.ref.kind === "root" ? activeFile.ref.rootId : null;
   const activeRoot = activeRootId ? roots.find((root) => root.id === activeRootId) ?? null : null;
   const activeGitRoot = activeRoot && activeFile?.ref.kind === "root"
@@ -2169,7 +2368,7 @@ export function CodeWorkspaceTab({
       line: cursor.line + 1,
       column: cursor.character + 1,
       encoding: "UTF-8",
-      eol: activeFile?.eol ?? detectWorkspaceEol(activeFile?.text ?? ""),
+      eol: activeFile?.eol ?? "LF",
       languageId: status?.languageId ?? activeLanguageId,
       lspActive: !!status?.active,
       lspLabel: status?.displayName ?? (status?.active ? "LSP" : null),
@@ -2179,23 +2378,29 @@ export function CodeWorkspaceTab({
       gitBehind: gitSnapshot?.behind ?? 0,
       fontSize: codeViewProfile.fontSize,
     });
-    setWorkspaceStatusActions(tabId, {
-      openLanguagePanel: () => setLanguagePanelOpen(true),
-      openGitManager: gitManagerPayload && onOpenGitManager ? openGitManager : undefined,
-    });
-    return () => clearWorkspaceStatus(tabId);
   }, [
     activeEditorGroupId,
     activeFile?.eol,
-    activeFile?.text,
     activeGitRoot,
     activeLanguageId,
     activeLspState,
     clearWorkspaceStatus,
     codeViewProfile.fontSize,
     cursorPositions,
-    gitManagerPayload,
     gitSnapshots,
+    setWorkspaceStatusSegments,
+    tabId,
+    visible,
+  ]);
+
+  useEffect(() => {
+    if (!visible) return;
+    setWorkspaceStatusActions(tabId, {
+      openLanguagePanel: () => setLanguagePanelOpen(true),
+      openGitManager: gitManagerPayload && onOpenGitManager ? openGitManager : undefined,
+    });
+  }, [
+    gitManagerPayload,
     onOpenGitManager,
     openGitManager,
     setLanguagePanelOpen,
@@ -2204,6 +2409,10 @@ export function CodeWorkspaceTab({
     tabId,
     visible,
   ]);
+
+  useEffect(() => {
+    return () => clearWorkspaceStatus(tabId);
+  }, [clearWorkspaceStatus, tabId]);
 
   const gitChangeByRootPath = useMemo(() => {
     const map = new Map<string, GitChange>();
@@ -2239,6 +2448,46 @@ export function CodeWorkspaceTab({
     };
   }, [gitRoots, gitSnapshots, roots]);
 
+  const activeGitFileStateSignature = useMemo(() => {
+    const stateForKey = (key: string | null) => {
+      if (!key) return "empty";
+      const file = openFiles[key];
+      if (!file) return "missing";
+      return file.loading ? "loading" : "ready";
+    };
+    return [
+      editorGroups.primary.activeKey,
+      stateForKey(editorGroups.primary.activeKey),
+      editorGroups.secondary.activeKey,
+      stateForKey(editorGroups.secondary.activeKey),
+    ].join(":");
+  }, [editorGroups.primary.activeKey, editorGroups.secondary.activeKey, openFiles]);
+
+  const gitDiffSources = useMemo(() => {
+    const seen = new Set<string>();
+    return [editorGroups.primary.activeKey, editorGroups.secondary.activeKey].flatMap((key) => {
+      if (!key || seen.has(key)) return [];
+      seen.add(key);
+      const file = openFiles[key];
+      const target = gitTargetForFile(file ?? null);
+      const head = gitHeadTextByFile[key];
+      if (!file || !target || !head || head.sourceKey !== target.sourceKey) return [];
+      return [{
+        key,
+        sourceKey: target.sourceKey,
+        headText: head.text,
+        bufferText: file.text,
+      }];
+    });
+  }, [
+    editorGroups.primary.activeKey,
+    editorGroups.secondary.activeKey,
+    gitHeadTextByFile,
+    gitTargetForFile,
+    openFiles,
+  ]);
+  const gitLineChangesByFile = useDeferredGitLineChanges(gitDiffSources);
+
   useEffect(() => {
     let cancelled = false;
     const activeKeys = new Set([
@@ -2246,7 +2495,7 @@ export function CodeWorkspaceTab({
       editorGroups.secondary.activeKey,
     ].filter((key): key is string => !!key));
     for (const key of activeKeys) {
-      const file = openFiles[key];
+      const file = openFilesRef.current[key];
       const target = gitTargetForFile(file ?? null);
       if (!file || !target || gitHeadTextByFile[key]?.sourceKey === target.sourceKey) continue;
       if (!target.headOid) {
@@ -2280,28 +2529,47 @@ export function CodeWorkspaceTab({
         .finally(() => gitHeadRequestsRef.current.delete(target.sourceKey));
     }
     return () => { cancelled = true; };
-  }, [editorGroups.primary.activeKey, editorGroups.secondary.activeKey, gitHeadTextByFile, gitTargetForFile, openFiles]);
+  }, [activeGitFileStateSignature, gitHeadTextByFile, gitTargetForFile]);
 
-  useEffect(() => {
-    const timer = window.setTimeout(() => {
-      const next: Record<string, GitLineChange[]> = {};
-      for (const [key, head] of Object.entries(gitHeadTextByFile)) {
-        const file = openFiles[key];
-        const target = gitTargetForFile(file ?? null);
-        if (!file || !target || head.sourceKey !== target.sourceKey || head.text === null) continue;
-        next[key] = buildGitLineChanges(head.text, file.text);
+  const gitBlameRequestSignature = useMemo(() => {
+    const signatureForGroup = (groupId: EditorGroupId) => {
+      const key = editorGroups[groupId].activeKey;
+      // Input batching keeps the store snapshot stable during a typing burst,
+      // but the ref is updated immediately.  Use it here so inline blame is
+      // disabled from the first dirty keystroke rather than one batch later.
+      const file = key ? openFilesRef.current[key] ?? null : null;
+      const target = gitTargetForFile(file);
+      if (!intelligencePreferences.inlineBlameEnabled || !file || file.dirty || !target?.headOid) {
+        return `${groupId}:${key ?? "empty"}:disabled`;
       }
-      setGitLineChangesByFile(next);
-    }, 500);
-    return () => window.clearTimeout(timer);
-  }, [gitHeadTextByFile, gitTargetForFile, openFiles]);
+      const line = (cursorPositions[groupId]?.line ?? 0) + 1;
+      return `${groupId}:${key}:${target.sourceKey}:${file.hash}:${line}`;
+    };
+    return `${signatureForGroup("primary")}|${signatureForGroup("secondary")}`;
+  }, [
+    cursorPositions,
+    editorGroups.primary.activeKey,
+    editorGroups.secondary.activeKey,
+    gitTargetForFile,
+    intelligencePreferences.inlineBlameEnabled,
+    openFiles,
+  ]);
 
   useEffect(() => {
     let cancelled = false;
     const timers: number[] = [];
+    const cacheBlame = (cacheKey: string, blame: GitBlameLine | null) => {
+      const cache = gitBlameCacheRef.current;
+      cache.delete(cacheKey);
+      cache.set(cacheKey, blame);
+      if (cache.size > 256) {
+        const oldest = cache.keys().next().value;
+        if (oldest) cache.delete(oldest);
+      }
+    };
     const loadForGroup = (groupId: EditorGroupId) => {
       const key = editorGroups[groupId].activeKey;
-      const file = key ? openFiles[key] ?? null : null;
+      const file = key ? openFilesRef.current[key] ?? null : null;
       const target = gitTargetForFile(file);
       if (!intelligencePreferences.inlineBlameEnabled || !file || file.dirty || !target?.headOid) {
         setGitBlameByGroup((current) => current[groupId] === null ? current : { ...current, [groupId]: null });
@@ -2311,6 +2579,7 @@ export function CodeWorkspaceTab({
       const cacheKey = `${target.sourceKey}:${file.hash}:${line}`;
       if (gitBlameCacheRef.current.has(cacheKey)) {
         const cached = gitBlameCacheRef.current.get(cacheKey) ?? null;
+        cacheBlame(cacheKey, cached);
         setGitBlameByGroup((current) => current[groupId] === cached ? current : { ...current, [groupId]: cached });
         return;
       }
@@ -2318,14 +2587,14 @@ export function CodeWorkspaceTab({
         void gitBlameLines(target.repoRoot, target.path, line, line)
           .then((lines) => {
             const blame = lines[0] ?? null;
-            gitBlameCacheRef.current.set(cacheKey, blame);
+            cacheBlame(cacheKey, blame);
             if (!cancelled) setGitBlameByGroup((current) => ({ ...current, [groupId]: blame }));
           })
           .catch(() => {
-            gitBlameCacheRef.current.set(cacheKey, null);
+            cacheBlame(cacheKey, null);
             if (!cancelled) setGitBlameByGroup((current) => ({ ...current, [groupId]: null }));
           });
-      }, 250));
+      }, 500));
     };
     loadForGroup("primary");
     loadForGroup("secondary");
@@ -2333,19 +2602,11 @@ export function CodeWorkspaceTab({
       cancelled = true;
       timers.forEach((timer) => window.clearTimeout(timer));
     };
-  }, [cursorPositions, editorGroups, gitTargetForFile, intelligencePreferences.inlineBlameEnabled, openFiles]);
-
-  useEffect(() => {
-    if (!visible || !activeFile || activeFile.loading) return;
-    const lspState = lspFilesRef.current[activeFile.key];
-    if (lspState?.syncedText === activeFile.text && lspState.status) return;
-    const mode: "open" | "change" = lspState?.status ? "change" : "open";
-    const timer = window.setTimeout(() => {
-      const latest = openFilesRef.current[activeFile.key];
-      if (latest) void syncLspDocument(latest, mode);
-    }, mode === "open" ? 0 : 350);
-    return () => window.clearTimeout(timer);
-  }, [activeFile, syncLspDocument, visible]);
+  }, [
+    gitBlameRequestSignature,
+    gitTargetForFile,
+    intelligencePreferences.inlineBlameEnabled,
+  ]);
 
   const openMarkdownHref = useCallback(
     (href: string) => {
@@ -3415,17 +3676,29 @@ export function CodeWorkspaceTab({
       position: LspPosition,
       triggerCharacter: string | null,
     ): Promise<LspCompletionResult | null> => {
-      const descriptor = lspDescriptorForFile(file);
+      // CodeMirror can ask for completion while an edit is still crossing the
+      // IPC boundary.  Returning null here lets its local sources handle the
+      // keystroke and prevents a stale server completion from doing work (or
+      // reopening a completion list) for a superseded document version.
+      const snapshot = currentSyncedLspDocument(file);
+      if (!snapshot) return null;
+      const descriptor = lspDescriptorForFile(snapshot.file);
       if (!descriptor) return null;
       try {
         const result = await lspCompletion(descriptor, position, triggerCharacter);
-        updateLspStatusForFile(file, result.status);
+        if (!isCurrentLspDocumentRequest(snapshot.file, snapshot.epoch)) return null;
+        updateLspStatusForFile(snapshot.file, result.status);
         return result;
       } catch {
         return null;
       }
     },
-    [lspDescriptorForFile, updateLspStatusForFile],
+    [
+      currentSyncedLspDocument,
+      isCurrentLspDocumentRequest,
+      lspDescriptorForFile,
+      updateLspStatusForFile,
+    ],
   );
 
   const resolveLspCompletion = useCallback(
@@ -3650,23 +3923,24 @@ export function CodeWorkspaceTab({
     [lspDescriptorForFile, setStatusMessage, updateLspStatusForFile],
   );
 
+  const deferredActiveFile = activeKey ? deferredOpenFiles[activeKey] ?? activeFile : null;
   const dirtyCount = useMemo(
-    () => Object.values(openFiles).filter((file) => file.dirty).length,
-    [openFiles],
+    () => Object.values(deferredOpenFiles).filter((file) => file.dirty).length,
+    [deferredOpenFiles],
   );
   const dirtyFiles = useMemo(
-    () => openOrder.map((key) => openFiles[key]).filter((file): file is OpenFileState => !!file?.dirty),
-    [openFiles, openOrder],
+    () => openOrder.map((key) => deferredOpenFiles[key]).filter((file): file is OpenFileState => !!file?.dirty),
+    [deferredOpenFiles, openOrder],
   );
   const problemFiles = useMemo<ProblemFileGroup[]>(
     () => openOrder.flatMap((key) => {
-      const file = openFiles[key];
+      const file = deferredOpenFiles[key];
       const diagnostics = lspFiles[key]?.diagnostics ?? [];
       return file && diagnostics.length > 0
         ? [{ key, title: file.title, subtitle: file.subtitle, diagnostics }]
         : [];
     }),
-    [lspFiles, openFiles, openOrder],
+    [deferredOpenFiles, lspFiles, openOrder],
   );
   const problemCounts = useMemo(
     () => problemFiles.reduce(
@@ -3697,7 +3971,7 @@ export function CodeWorkspaceTab({
 
   useEffect(() => {
     const firstRoot = roots[0] ?? null;
-    const openStates = openOrder.map((key) => openFiles[key]).filter((file): file is OpenFileState => !!file);
+    const openStates = openOrder.map((key) => deferredOpenFiles[key]).filter((file): file is OpenFileState => !!file);
     const toContextFile = (file: OpenFileState) => {
       const ref = file.ref;
       if (ref.kind === "root") {
@@ -3754,17 +4028,29 @@ export function CodeWorkspaceTab({
       : null;
     setTabCodeWorkspaceContext(tabId, {
       repoRoot: firstRoot?.path ?? workspace.repoRoot ?? "",
-      activePath: activeFile?.ref.kind === "root" && activeFile.ref.rootId === firstRoot?.id ? activeFile.ref.path : null,
+      activePath: deferredActiveFile?.ref.kind === "root" && deferredActiveFile.ref.rootId === firstRoot?.id ? deferredActiveFile.ref.path : null,
       openPaths: firstRoot ? openStates.filter((file) => file.ref.kind === "root" && file.ref.rootId === firstRoot.id).map((file) => file.ref.path) : [],
       dirtyPaths: firstRoot ? dirtyFiles.filter((file) => file.ref.kind === "root" && file.ref.rootId === firstRoot.id).map((file) => file.ref.path) : [],
       roots,
       looseFiles,
-      activeFile: activeFile ? toContextFile(activeFile) : null,
+      activeFile: deferredActiveFile ? toContextFile(deferredActiveFile) : null,
       openFiles: openStates.map(toContextFile),
       dirtyFiles: dirtyFiles.map(toContextFile),
       lsp: lspContext,
     });
-  }, [activeFile, activeLspState, dirtyFiles, looseFiles, lspFiles, openFiles, openOrder, roots, setTabCodeWorkspaceContext, tabId, workspace.repoRoot]);
+  }, [
+    activeLspState,
+    deferredActiveFile,
+    deferredOpenFiles,
+    dirtyFiles,
+    looseFiles,
+    lspFiles,
+    openOrder,
+    roots,
+    setTabCodeWorkspaceContext,
+    tabId,
+    workspace.repoRoot,
+  ]);
 
   useEffect(() => {
     return () => setTabCodeWorkspaceContext(tabId, null);
@@ -3829,6 +4115,7 @@ export function CodeWorkspaceTab({
         editorPaneRef={groupId === activeEditorGroupId ? editorPaneRef : inactiveEditorPaneRef}
         editorPaneStyle={editorPaneStyle}
         onActivate={(key) => {
+          flushPendingEditorText();
           updateEditorGroup(groupId, (current) => ({ ...current, activeKey: key }));
           activateEditorGroup(groupId);
         }}
@@ -3870,7 +4157,7 @@ export function CodeWorkspaceTab({
           if (!groupFile) return;
           setMarkdownModes((current) => ({ ...current, [groupFile.key]: mode }));
         }}
-        onChangeText={updateFileText}
+        onChangeText={queueEditorTextUpdate}
         onSave={(key) => void saveFile(key)}
         onHover={getLspHover}
         onDefinition={goToDefinition}

--- a/src/components/editor/workspace/CodeMirrorHost.test.tsx
+++ b/src/components/editor/workspace/CodeMirrorHost.test.tsx
@@ -157,12 +157,18 @@ describe("CodeMirrorHost search", () => {
         paddingLeft: true,
         paddingRight: false,
       }],
+      semanticTokens: [{
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+        tokenType: "keyword",
+        modifiers: [],
+      }],
       onViewportChange,
       onExpandSelection,
     });
 
     expect(container.querySelector(".cm-lsp-usage-read")).not.toBeNull();
     expect(container.querySelector(".cm-lsp-inlay-hint")).toHaveTextContent(": string");
+    expect(container.querySelector(".cm-lsp-sem-keyword")).not.toBeNull();
     expect(onViewportChange).toHaveBeenCalled();
     fireEvent.keyDown(content, { key: "w", code: "KeyW", ctrlKey: true });
     await waitFor(() => expect(onExpandSelection).toHaveBeenCalledWith(expect.objectContaining({ empty: true })));

--- a/src/components/editor/workspace/CodeMirrorHost.tsx
+++ b/src/components/editor/workspace/CodeMirrorHost.tsx
@@ -43,7 +43,11 @@ import { languageForPath } from "../../git/diffLanguage";
 import { createWorkspaceSearchPanel, WORKSPACE_SEARCH_STYLE } from "./editorSearchPanel";
 import { createLspCompletionSource } from "./lspCompletion";
 import { createDiagnosticChrome } from "./lspDiagnosticChrome";
-import { createLspIntelligenceChrome } from "./lspIntelligenceChrome";
+import {
+  createLspOverlayChrome,
+  createLspSemanticTokenChrome,
+  LSP_INTELLIGENCE_THEME,
+} from "./lspIntelligenceChrome";
 import { createGitEditorChrome, type GitLineChange } from "./gitEditorChrome";
 import type { GitBlameLine } from "../../../lib/git";
 import { lspPositionFromOffset, offsetFromLspPosition } from "./lspPositions";
@@ -139,6 +143,16 @@ const LSP_EDITOR_STYLE = EditorView.theme({
   },
 });
 
+const EMPTY_HIGHLIGHTS: LspDocumentHighlight[] = [];
+const EMPTY_INLAY_HINTS: LspInlayHint[] = [];
+const EMPTY_SEMANTIC_TOKENS: LspSemanticToken[] = [];
+const EMPTY_GIT_CHANGES: GitLineChange[] = [];
+
+/** New empty-array props are common while LSP requests are debounced. */
+function sameArrayOrBothEmpty<T>(previous: readonly T[], next: readonly T[]): boolean {
+  return previous === next || (previous.length === 0 && next.length === 0);
+}
+
 function signatureTooltipDom(result: LspSignatureHelpResult): HTMLElement {
   const dom = document.createElement("div");
   dom.className = "cm-lsp-hover taomni-chat-md";
@@ -233,10 +247,10 @@ export function CodeMirrorHost({
   doc,
   visible,
   diagnostics,
-  highlights = [],
-  inlayHints = [],
-  semanticTokens = [],
-  gitChanges = [],
+  highlights = EMPTY_HIGHLIGHTS,
+  inlayHints = EMPTY_INLAY_HINTS,
+  semanticTokens = EMPTY_SEMANTIC_TOKENS,
+  gitChanges = EMPTY_GIT_CHANGES,
   gitBlame = null,
   reveal,
   onChange,
@@ -259,12 +273,21 @@ export function CodeMirrorHost({
   const viewRef = useRef<EditorView | null>(null);
   const languageCompartment = useRef(new Compartment());
   const diagnosticsCompartment = useRef(new Compartment());
-  const intelligenceCompartment = useRef(new Compartment());
+  const overlayCompartment = useRef(new Compartment());
+  const semanticTokensCompartment = useRef(new Compartment());
   const gitCompartment = useRef(new Compartment());
   const signatureCompartment = useRef(new Compartment());
   const signatureShownRef = useRef(false);
   /** True while applying a prop-driven doc replace so it is not treated as a user edit. */
   const applyingExternalDocRef = useRef(false);
+  /** Mirrors the last full text sent through onChange or applied from props. */
+  const lastDocumentTextRef = useRef(doc);
+  const lastSelectionRef = useRef<{ from: number; to: number } | null>(null);
+  const selectionEmitTimerRef = useRef<number | null>(null);
+  const renderedDiagnosticsRef = useRef(diagnostics);
+  const renderedOverlayRef = useRef({ highlights, inlayHints });
+  const renderedSemanticTokensRef = useRef(semanticTokens);
+  const renderedGitRef = useRef({ changes: gitChanges, blame: gitBlame });
   const onChangeRef = useRef(onChange);
   const onSaveRef = useRef(onSave);
   const onHoverRef = useRef(onHover);
@@ -302,6 +325,9 @@ export function CodeMirrorHost({
     const main = view.state.selection.main;
     const from = Math.min(main.from, main.to);
     const to = Math.max(main.from, main.to);
+    const previous = lastSelectionRef.current;
+    if (previous?.from === from && previous.to === to) return;
+    lastSelectionRef.current = { from, to };
     let rect: EditorSelectionRange["rect"] = null;
     if (!main.empty) {
       const startCoords = view.coordsAtPos(from);
@@ -333,6 +359,23 @@ export function CodeMirrorHost({
 
   useEffect(() => {
     if (!hostRef.current) return;
+    const initialDoc = EditorState.create({ doc }).doc;
+    const clearPendingSelectionEmit = () => {
+      if (selectionEmitTimerRef.current === null) return;
+      window.clearTimeout(selectionEmitTimerRef.current);
+      selectionEmitTimerRef.current = null;
+    };
+    const scheduleSelectionEmit = (view: EditorView, delay = 0) => {
+      clearPendingSelectionEmit();
+      if (delay === 0) {
+        emitSelection(view);
+        return;
+      }
+      selectionEmitTimerRef.current = window.setTimeout(() => {
+        selectionEmitTimerRef.current = null;
+        if (viewRef.current === view) emitSelection(view);
+      }, delay);
+    };
     const saveHandler = () => {
       onSaveRef.current();
       return true;
@@ -409,7 +452,7 @@ export function CodeMirrorHost({
       return true;
     };
     const state = EditorState.create({
-      doc,
+      doc: initialDoc,
       extensions: [
         lineNumbers(),
         foldGutter(),
@@ -427,6 +470,10 @@ export function CodeMirrorHost({
         closeBrackets(),
         indentOnInput(),
         autocompletion({
+          // The default 100ms queries a language server while the user is
+          // still typing. Keep automatic completion, but wait for a short
+          // idle window so the document sync can get ahead of it.
+          activateOnTypingDelay: 350,
           override: [
             createLspCompletionSource({
               fetch: (position, trigger) =>
@@ -444,11 +491,16 @@ export function CodeMirrorHost({
           diagnostics,
           (line) => onLightbulbRef.current?.(line),
         )),
-        intelligenceCompartment.current.of(createLspIntelligenceChrome(
-          EditorState.create({ doc }).doc,
+        overlayCompartment.current.of(createLspOverlayChrome(
+          initialDoc,
           highlights,
           inlayHints,
         )),
+        semanticTokensCompartment.current.of(createLspSemanticTokenChrome(
+          initialDoc,
+          semanticTokens,
+        )),
+        LSP_INTELLIGENCE_THEME,
         gitCompartment.current.of(createGitEditorChrome(
           gitChanges,
           gitBlame,
@@ -476,7 +528,12 @@ export function CodeMirrorHost({
         EditorView.updateListener.of((update) => {
           if (update.docChanged) {
             if (!applyingExternalDocRef.current) {
-              onChangeRef.current(update.state.doc.toString());
+              // onChange currently carries a full string, so one conversion is
+              // unavoidable. Remember it to avoid a second full conversion in
+              // the controlled-doc effect after React reflects the change.
+              const nextDoc = update.state.doc.toString();
+              lastDocumentTextRef.current = nextDoc;
+              onChangeRef.current(nextDoc);
             }
             let inserted = "";
             update.changes.iterChanges((_fromA, _toA, _fromB, _toB, text) => {
@@ -500,9 +557,12 @@ export function CodeMirrorHost({
             hideSignature();
           }
           if (update.selectionSet || update.docChanged) {
-            emitSelection(update.view);
+            // Cursor state fans out into workspace UI and LSP effects. During
+            // a text burst, publish the final cursor after a short idle rather
+            // than causing a React render for every keypress.
+            scheduleSelectionEmit(update.view, update.docChanged ? 125 : 0);
           }
-          if (update.viewportChanged || update.docChanged) emitViewport(update.view);
+          if (update.viewportChanged) emitViewport(update.view);
         }),
       ],
     });
@@ -511,6 +571,7 @@ export function CodeMirrorHost({
     emitSelection(view);
     emitViewport(view);
     return () => {
+      clearPendingSelectionEmit();
       view.destroy();
       viewRef.current = null;
     };
@@ -539,6 +600,8 @@ export function CodeMirrorHost({
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
+    if (sameArrayOrBothEmpty(renderedDiagnosticsRef.current, diagnostics)) return;
+    renderedDiagnosticsRef.current = diagnostics;
     view.dispatch({
       effects: diagnosticsCompartment.current.reconfigure(createDiagnosticChrome(
         diagnostics,
@@ -550,16 +613,39 @@ export function CodeMirrorHost({
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
+    const previous = renderedOverlayRef.current;
+    if (
+      sameArrayOrBothEmpty(previous.highlights, highlights)
+      && sameArrayOrBothEmpty(previous.inlayHints, inlayHints)
+    ) {
+      return;
+    }
+    renderedOverlayRef.current = { highlights, inlayHints };
     view.dispatch({
-      effects: intelligenceCompartment.current.reconfigure(
-        createLspIntelligenceChrome(view.state.doc, highlights, inlayHints, semanticTokens),
+      effects: overlayCompartment.current.reconfigure(
+        createLspOverlayChrome(view.state.doc, highlights, inlayHints),
       ),
     });
-  }, [highlights, inlayHints, semanticTokens]);
+  }, [highlights, inlayHints]);
 
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
+    if (sameArrayOrBothEmpty(renderedSemanticTokensRef.current, semanticTokens)) return;
+    renderedSemanticTokensRef.current = semanticTokens;
+    view.dispatch({
+      effects: semanticTokensCompartment.current.reconfigure(
+        createLspSemanticTokenChrome(view.state.doc, semanticTokens),
+      ),
+    });
+  }, [semanticTokens]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    const previous = renderedGitRef.current;
+    if (sameArrayOrBothEmpty(previous.changes, gitChanges) && previous.blame === gitBlame) return;
+    renderedGitRef.current = { changes: gitChanges, blame: gitBlame };
     view.dispatch({
       effects: gitCompartment.current.reconfigure(createGitEditorChrome(
         gitChanges,
@@ -572,11 +658,11 @@ export function CodeMirrorHost({
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
-    const current = view.state.doc.toString();
-    if (current === doc) return;
+    if (lastDocumentTextRef.current === doc) return;
     applyingExternalDocRef.current = true;
     try {
-      view.dispatch({ changes: { from: 0, to: current.length, insert: doc } });
+      lastDocumentTextRef.current = doc;
+      view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: doc } });
     } finally {
       applyingExternalDocRef.current = false;
     }

--- a/src/components/editor/workspace/lspCompletion.ts
+++ b/src/components/editor/workspace/lspCompletion.ts
@@ -187,6 +187,9 @@ export function createLspCompletionSource(hooks: LspCompletionHooks): Completion
     const isTrigger = !word && !!charBefore && hooks.triggerCharacters().includes(charBefore);
     if (!context.explicit && !word && !isTrigger) return null;
 
+    // LSP responses are tied to a document version. Do not spend renderer time
+    // mapping a response that became stale while the user kept typing.
+    context.addEventListener("abort", () => {}, { onDocChange: true });
     let result: LspCompletionResult | null = null;
     try {
       result = await hooks.fetch(
@@ -196,6 +199,7 @@ export function createLspCompletionSource(hooks: LspCompletionHooks): Completion
     } catch {
       result = null;
     }
+    if (context.aborted) return null;
     // No language service: fall back to buffer-word completion.
     if (!result || (!result.status.active && result.items.length === 0)) {
       return completeAnyWord(context);

--- a/src/components/editor/workspace/lspIntelligenceChrome.ts
+++ b/src/components/editor/workspace/lspIntelligenceChrome.ts
@@ -77,6 +77,91 @@ export function buildLspIntelligenceDecorations(
   return Decoration.set(ranges, true);
 }
 
+/**
+ * Semantic tokens are typically the largest LSP payload. Keep their
+ * decorations separate from cursor-dependent highlights and viewport hints so
+ * a highlight refresh does not rebuild the whole document's token chrome.
+ */
+export function buildLspSemanticTokenDecorations(
+  doc: Text,
+  semanticTokens: LspSemanticToken[] = [],
+): DecorationSet {
+  const ranges = semanticTokens.flatMap((token) => {
+    const { from, to } = rangeOffsets(doc, token.range);
+    if (to <= from) return [];
+    return [Decoration.mark({ class: semanticTokenClass(token) }).range(from, to)];
+  });
+  return Decoration.set(ranges, true);
+}
+
+/** Cursor- and viewport-scoped intelligence chrome. */
+export function buildLspOverlayDecorations(
+  doc: Text,
+  highlights: LspDocumentHighlight[],
+  hints: LspInlayHint[],
+): DecorationSet {
+  const ranges = [];
+  for (const highlight of highlights) {
+    const { from, to } = rangeOffsets(doc, highlight.range);
+    if (to <= from) continue;
+    const suffix = highlight.kind === 3 ? "write" : highlight.kind === 2 ? "read" : "text";
+    ranges.push(Decoration.mark({ class: `cm-lsp-usage cm-lsp-usage-${suffix}` }).range(from, to));
+  }
+  for (const hint of hints) {
+    const position = offsetFromLspPosition(doc, hint.position);
+    ranges.push(Decoration.widget({
+      widget: new InlayHintWidget(hint),
+      side: 1,
+    }).range(position));
+  }
+  return Decoration.set(ranges, true);
+}
+
+export function createLspSemanticTokenChrome(
+  doc: Text,
+  semanticTokens: LspSemanticToken[] = [],
+): Extension[] {
+  return [EditorView.decorations.of(buildLspSemanticTokenDecorations(doc, semanticTokens))];
+}
+
+export function createLspOverlayChrome(
+  doc: Text,
+  highlights: LspDocumentHighlight[],
+  hints: LspInlayHint[],
+): Extension[] {
+  return [EditorView.decorations.of(buildLspOverlayDecorations(doc, highlights, hints))];
+}
+
+export const LSP_INTELLIGENCE_THEME = EditorView.theme({
+  ".cm-lsp-usage-text": { backgroundColor: "color-mix(in srgb, var(--taomni-accent) 10%, transparent)" },
+  ".cm-lsp-usage-read": { backgroundColor: "color-mix(in srgb, #38bdf8 18%, transparent)" },
+  ".cm-lsp-usage-write": { backgroundColor: "color-mix(in srgb, #f59e0b 22%, transparent)" },
+  ".cm-lsp-inlay-hint": {
+    margin: "0 2px",
+    borderRadius: "3px",
+    padding: "0 3px",
+    color: "var(--taomni-code-muted)",
+    backgroundColor: "var(--taomni-code-active-line-bg)",
+    fontSize: "0.85em",
+    fontStyle: "italic",
+    userSelect: "none",
+  },
+  ".cm-lsp-inlay-parameter": { opacity: "0.82" },
+  ".cm-lsp-inlay-type": { opacity: "0.68" },
+  ".cm-lsp-sem-function, .cm-lsp-sem-method, .cm-lsp-sem-macro": { color: "#7dd3fc" },
+  ".cm-lsp-sem-class, .cm-lsp-sem-struct, .cm-lsp-sem-interface, .cm-lsp-sem-type, .cm-lsp-sem-enum": { color: "#f9a8d4" },
+  ".cm-lsp-sem-variable, .cm-lsp-sem-parameter, .cm-lsp-sem-property": { color: "#fde68a" },
+  ".cm-lsp-sem-namespace": { color: "#c4b5fd" },
+  ".cm-lsp-sem-keyword, .cm-lsp-sem-modifier": { color: "#fda4af" },
+  ".cm-lsp-sem-string": { color: "#86efac" },
+  ".cm-lsp-sem-number": { color: "#fdba74" },
+  ".cm-lsp-sem-comment": { color: "var(--taomni-code-muted)", fontStyle: "italic" },
+  ".cm-lsp-sem-operator, .cm-lsp-sem-regexp": { color: "#a5b4fc" },
+  ".cm-lsp-sem-mod-deprecated": { textDecoration: "line-through", opacity: "0.75" },
+  ".cm-lsp-sem-mod-readonly": { fontStyle: "italic" },
+  ".cm-lsp-sem-mod-defaultLibrary": { opacity: "0.9" },
+});
+
 export function createLspIntelligenceChrome(
   doc: Text,
   highlights: LspDocumentHighlight[],
@@ -84,36 +169,9 @@ export function createLspIntelligenceChrome(
   semanticTokens: LspSemanticToken[] = [],
 ): Extension[] {
   return [
-    EditorView.decorations.of(buildLspIntelligenceDecorations(doc, highlights, hints, semanticTokens)),
-    EditorView.theme({
-      ".cm-lsp-usage-text": { backgroundColor: "color-mix(in srgb, var(--taomni-accent) 10%, transparent)" },
-      ".cm-lsp-usage-read": { backgroundColor: "color-mix(in srgb, #38bdf8 18%, transparent)" },
-      ".cm-lsp-usage-write": { backgroundColor: "color-mix(in srgb, #f59e0b 22%, transparent)" },
-      ".cm-lsp-inlay-hint": {
-        margin: "0 2px",
-        borderRadius: "3px",
-        padding: "0 3px",
-        color: "var(--taomni-code-muted)",
-        backgroundColor: "var(--taomni-code-active-line-bg)",
-        fontSize: "0.85em",
-        fontStyle: "italic",
-        userSelect: "none",
-      },
-      ".cm-lsp-inlay-parameter": { opacity: "0.82" },
-      ".cm-lsp-inlay-type": { opacity: "0.68" },
-      ".cm-lsp-sem-function, .cm-lsp-sem-method, .cm-lsp-sem-macro": { color: "#7dd3fc" },
-      ".cm-lsp-sem-class, .cm-lsp-sem-struct, .cm-lsp-sem-interface, .cm-lsp-sem-type, .cm-lsp-sem-enum": { color: "#f9a8d4" },
-      ".cm-lsp-sem-variable, .cm-lsp-sem-parameter, .cm-lsp-sem-property": { color: "#fde68a" },
-      ".cm-lsp-sem-namespace": { color: "#c4b5fd" },
-      ".cm-lsp-sem-keyword, .cm-lsp-sem-modifier": { color: "#fda4af" },
-      ".cm-lsp-sem-string": { color: "#86efac" },
-      ".cm-lsp-sem-number": { color: "#fdba74" },
-      ".cm-lsp-sem-comment": { color: "var(--taomni-code-muted)", fontStyle: "italic" },
-      ".cm-lsp-sem-operator, .cm-lsp-sem-regexp": { color: "#a5b4fc" },
-      ".cm-lsp-sem-mod-deprecated": { textDecoration: "line-through", opacity: "0.75" },
-      ".cm-lsp-sem-mod-readonly": { fontStyle: "italic" },
-      ".cm-lsp-sem-mod-defaultLibrary": { opacity: "0.9" },
-    }),
+    ...createLspSemanticTokenChrome(doc, semanticTokens),
+    ...createLspOverlayChrome(doc, highlights, hints),
+    LSP_INTELLIGENCE_THEME,
   ];
 }
 

--- a/src/components/editor/workspace/todoBookmarks.test.ts
+++ b/src/components/editor/workspace/todoBookmarks.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  createOpenFileTodoScanner,
   readWorkspaceBookmarks,
   scanTodosInText,
+  sameWorkspaceTodoItems,
   toggleWorkspaceBookmark,
 } from "./todoBookmarks";
 
@@ -46,5 +48,26 @@ describe("todoBookmarks", () => {
       label: "entry",
     }, first);
     expect(second).toHaveLength(0);
+  });
+
+  it("caches unchanged open buffers while still updating the edited buffer", () => {
+    const scanner = createOpenFileTodoScanner();
+    const first = scanner.scan([
+      { key: "a", pathLabel: "a.ts", text: "// TODO: first" },
+      { key: "b", pathLabel: "b.ts", text: "// FIXME: second" },
+    ]);
+    const second = scanner.scan([
+      { key: "a", pathLabel: "a.ts", text: "// TODO: changed" },
+      { key: "b", pathLabel: "b.ts", text: "// FIXME: second" },
+    ]);
+
+    expect(second).toHaveLength(2);
+    expect(second.find((item) => item.fileKey === "a")?.text).toBe("changed");
+    expect(second.find((item) => item.fileKey === "b")).toBe(first.find((item) => item.fileKey === "b"));
+    expect(sameWorkspaceTodoItems(first, second)).toBe(false);
+    expect(sameWorkspaceTodoItems(second, scanner.scan([
+      { key: "a", pathLabel: "a.ts", text: "// TODO: changed" },
+      { key: "b", pathLabel: "b.ts", text: "// FIXME: second" },
+    ]))).toBe(true);
   });
 });

--- a/src/components/editor/workspace/todoBookmarks.ts
+++ b/src/components/editor/workspace/todoBookmarks.ts
@@ -20,6 +20,12 @@ export interface WorkspaceBookmark {
   createdAt: number;
 }
 
+export interface WorkspaceTodoFile {
+  key: string;
+  pathLabel: string;
+  text: string;
+}
+
 const BOOKMARKS_PREFIX = "taomni.codeWorkspace.bookmarks.v1.";
 const TODO_PATTERN = /\b(TODO|FIXME|XXX|HACK)\b(?:[:\s-]+(.*))?$/i;
 
@@ -50,13 +56,74 @@ export function scanTodosInText(
 }
 
 export function scanTodosInOpenFiles(
-  files: Array<{ key: string; pathLabel: string; text: string }>,
+  files: WorkspaceTodoFile[],
 ): WorkspaceTodoItem[] {
   return files
     .flatMap((file) => scanTodosInText(file.key, file.pathLabel, file.text))
     .sort((left, right) => left.pathLabel.localeCompare(right.pathLabel)
       || left.line - right.line
       || left.character - right.character);
+}
+
+/**
+ * Incremental cache for open-file TODOs.  Open editor state preserves the
+ * object/text of untouched files, so one edit only needs to rescan its own
+ * buffer rather than all open tabs.
+ */
+export interface OpenFileTodoScanner {
+  scan: (files: WorkspaceTodoFile[]) => WorkspaceTodoItem[];
+}
+
+export function createOpenFileTodoScanner(): OpenFileTodoScanner {
+  let cachedByFile = new Map<string, {
+    pathLabel: string;
+    text: string;
+    items: WorkspaceTodoItem[];
+  }>();
+
+  return {
+    scan(files) {
+      const nextCache = new Map<string, {
+        pathLabel: string;
+        text: string;
+        items: WorkspaceTodoItem[];
+      }>();
+      const items: WorkspaceTodoItem[] = [];
+      for (const file of files) {
+        const cached = cachedByFile.get(file.key);
+        const fileItems = cached && cached.pathLabel === file.pathLabel && cached.text === file.text
+          ? cached.items
+          : scanTodosInText(file.key, file.pathLabel, file.text);
+        nextCache.set(file.key, {
+          pathLabel: file.pathLabel,
+          text: file.text,
+          items: fileItems,
+        });
+        items.push(...fileItems);
+      }
+      cachedByFile = nextCache;
+      return items.sort((left, right) => left.pathLabel.localeCompare(right.pathLabel)
+        || left.line - right.line
+        || left.character - right.character);
+    },
+  };
+}
+
+export function sameWorkspaceTodoItems(
+  left: WorkspaceTodoItem[],
+  right: WorkspaceTodoItem[],
+): boolean {
+  if (left === right) return true;
+  if (left.length !== right.length) return false;
+  return left.every((item, index) => {
+    const other = right[index];
+    return item.key === other?.key
+      && item.pathLabel === other.pathLabel
+      && item.kind === other.kind
+      && item.line === other.line
+      && item.character === other.character
+      && item.text === other.text;
+  });
 }
 
 function bookmarksKey(workspaceInstanceId: string): string {

--- a/src/components/editor/workspace/useDeferredGitLineChanges.test.tsx
+++ b/src/components/editor/workspace/useDeferredGitLineChanges.test.tsx
@@ -1,0 +1,64 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GitLineChange } from "./gitEditorChrome";
+import { useDeferredGitLineChanges } from "./useDeferredGitLineChanges";
+
+const changed: GitLineChange[] = [{
+  kind: "modified",
+  startLine: 0,
+  endLine: 0,
+  oldStartLine: 0,
+  oldEndLine: 0,
+  oldText: "before",
+  newText: "after",
+}];
+
+describe("useDeferredGitLineChanges", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("coalesces text changes and only computes the latest visible buffer after idle", () => {
+    vi.useFakeTimers();
+    const buildChanges = vi.fn(() => changed);
+    const initial = [{
+      key: "main.rs",
+      sourceKey: "head-1",
+      headText: "before",
+      bufferText: "first",
+    }];
+    const { result, rerender } = renderHook(
+      ({ sources }) => useDeferredGitLineChanges(sources, { delayMs: 100, buildChanges }),
+      { initialProps: { sources: initial } },
+    );
+
+    rerender({ sources: [{ ...initial[0], bufferText: "second" }] });
+    rerender({ sources: [{ ...initial[0], bufferText: "final" }] });
+    act(() => vi.advanceTimersByTime(99));
+    expect(buildChanges).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(1));
+    act(() => vi.runOnlyPendingTimers());
+    expect(buildChanges).toHaveBeenCalledTimes(1);
+    expect(buildChanges).toHaveBeenCalledWith("before", "final");
+    expect(result.current["main.rs"]).toEqual(changed);
+  });
+
+  it("reuses a cached diff when the active buffer has not changed", () => {
+    vi.useFakeTimers();
+    const buildChanges = vi.fn(() => changed);
+    const source = {
+      key: "main.rs",
+      sourceKey: "head-1",
+      headText: "before",
+      bufferText: "after",
+    };
+    const { rerender } = renderHook(
+      ({ sources }) => useDeferredGitLineChanges(sources, { delayMs: 10, buildChanges }),
+      { initialProps: { sources: [source] } },
+    );
+
+    act(() => vi.runAllTimers());
+    rerender({ sources: [{ ...source }] });
+    act(() => vi.runAllTimers());
+    expect(buildChanges).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/editor/workspace/useDeferredGitLineChanges.ts
+++ b/src/components/editor/workspace/useDeferredGitLineChanges.ts
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from "react";
+import { buildGitLineChanges, type GitLineChange } from "./gitEditorChrome";
+
+export interface GitLineChangeSource {
+  key: string;
+  sourceKey: string;
+  headText: string | null;
+  bufferText: string;
+}
+
+type BuildGitLineChanges = (headText: string, bufferText: string) => GitLineChange[];
+
+interface UseDeferredGitLineChangesOptions {
+  delayMs?: number;
+  buildChanges?: BuildGitLineChanges;
+}
+
+type IdleWindow = Window & {
+  requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+function scheduleWhenIdle(callback: () => void): () => void {
+  const idleWindow = window as IdleWindow;
+  if (typeof idleWindow.requestIdleCallback === "function") {
+    const handle = idleWindow.requestIdleCallback(callback, { timeout: 1_000 });
+    return () => idleWindow.cancelIdleCallback?.(handle);
+  }
+  const handle = window.setTimeout(callback, 0);
+  return () => window.clearTimeout(handle);
+}
+
+function sameGitLineChanges(left: GitLineChange[], right: GitLineChange[]): boolean {
+  if (left === right) return true;
+  if (left.length !== right.length) return false;
+  return left.every((change, index) => {
+    const other = right[index];
+    return change.kind === other?.kind
+      && change.startLine === other.startLine
+      && change.endLine === other.endLine
+      && change.oldStartLine === other.oldStartLine
+      && change.oldEndLine === other.oldEndLine
+      && change.oldText === other.oldText
+      && change.newText === other.newText;
+  });
+}
+
+export function sameGitLineChangesByFile(
+  left: Record<string, GitLineChange[]>,
+  right: Record<string, GitLineChange[]>,
+): boolean {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  return leftKeys.length === rightKeys.length
+    && leftKeys.every((key) => !!right[key] && sameGitLineChanges(left[key], right[key]));
+}
+
+/**
+ * Builds Git gutter changes outside the keypress render path.  A full
+ * CodeMirror merge can be comparatively expensive on a large Rust source
+ * file, so only visible editors are considered and the calculation waits for
+ * both an editing pause and browser idle time.
+ */
+export function useDeferredGitLineChanges(
+  sources: GitLineChangeSource[],
+  {
+    delayMs = 900,
+    buildChanges = buildGitLineChanges,
+  }: UseDeferredGitLineChangesOptions = {},
+): Record<string, GitLineChange[]> {
+  const [changesByFile, setChangesByFile] = useState<Record<string, GitLineChange[]>>({});
+  const cacheRef = useRef(new Map<string, {
+    sourceKey: string;
+    bufferText: string;
+    changes: GitLineChange[];
+  }>());
+
+  useEffect(() => {
+    let cancelled = false;
+    let cancelIdle: (() => void) | null = null;
+    const timer = window.setTimeout(() => {
+      cancelIdle = scheduleWhenIdle(() => {
+        if (cancelled) return;
+        const next: Record<string, GitLineChange[]> = {};
+        const nextCache = new Map<string, {
+          sourceKey: string;
+          bufferText: string;
+          changes: GitLineChange[];
+        }>();
+        for (const source of sources) {
+          if (source.headText === null) continue;
+          const cached = cacheRef.current.get(source.key);
+          const changes = cached
+            && cached.sourceKey === source.sourceKey
+            && cached.bufferText === source.bufferText
+            ? cached.changes
+            : buildChanges(source.headText, source.bufferText);
+          next[source.key] = changes;
+          nextCache.set(source.key, {
+            sourceKey: source.sourceKey,
+            bufferText: source.bufferText,
+            changes,
+          });
+        }
+        cacheRef.current = nextCache;
+        setChangesByFile((current) => (sameGitLineChangesByFile(current, next) ? current : next));
+      });
+    }, delayMs);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+      cancelIdle?.();
+    };
+  }, [buildChanges, delayMs, sources]);
+
+  return changesByFile;
+}

--- a/src/components/editor/workspace/useDeferredOpenFileTodos.test.tsx
+++ b/src/components/editor/workspace/useDeferredOpenFileTodos.test.tsx
@@ -1,0 +1,36 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useDeferredOpenFileTodos } from "./useDeferredOpenFileTodos";
+
+describe("useDeferredOpenFileTodos", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("defers repeated buffer scans until editing has been idle", () => {
+    vi.useFakeTimers();
+    const initial = {
+      first: {
+        key: "first",
+        path: "first.rs",
+        text: "// TODO: initial",
+      },
+    };
+    const { result, rerender } = renderHook(
+      ({ files }) => useDeferredOpenFileTodos(files, 100),
+      { initialProps: { files: initial } },
+    );
+
+    expect(result.current[0]?.text).toBe("initial");
+    rerender({ files: {
+      first: { ...initial.first, text: "// TODO: first change" },
+    } });
+    rerender({ files: {
+      first: { ...initial.first, text: "// TODO: final change" },
+    } });
+
+    act(() => vi.advanceTimersByTime(99));
+    expect(result.current[0]?.text).toBe("initial");
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current[0]?.text).toBe("final change");
+  });
+});

--- a/src/components/editor/workspace/useDeferredOpenFileTodos.ts
+++ b/src/components/editor/workspace/useDeferredOpenFileTodos.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import {
+  createOpenFileTodoScanner,
+  sameWorkspaceTodoItems,
+  type WorkspaceTodoItem,
+} from "./todoBookmarks";
+
+interface TodoOpenFile {
+  key: string;
+  path: string;
+  subtitle?: string;
+  text: string;
+}
+
+/**
+ * TODO markers are useful navigation chrome, but scanning every open buffer on
+ * the synchronous editor update path makes an ordinary keystroke proportional
+ * to the size of every open file.  Keep the last result while the user is
+ * typing, then rescan only after the buffer has been idle briefly.
+ */
+export function useDeferredOpenFileTodos(
+  openFiles: Readonly<Record<string, TodoOpenFile>>,
+  delayMs = 500,
+): WorkspaceTodoItem[] {
+  const [scanner] = useState(createOpenFileTodoScanner);
+  const [todos, setTodos] = useState<WorkspaceTodoItem[]>(() => scanner.scan(Object.values(openFiles).map((file) => ({
+    key: file.key,
+    pathLabel: file.subtitle || file.path,
+    text: file.text,
+  }))));
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      const next = scanner.scan(Object.values(openFiles).map((file) => ({
+        key: file.key,
+        pathLabel: file.subtitle || file.path,
+        text: file.text,
+      })));
+      setTodos((current) => (sameWorkspaceTodoItems(current, next) ? current : next));
+    }, delayMs);
+    return () => window.clearTimeout(timer);
+  }, [delayMs, openFiles, scanner]);
+
+  return todos;
+}

--- a/src/components/editor/workspace/useWorkspaceLspSession.ts
+++ b/src/components/editor/workspace/useWorkspaceLspSession.ts
@@ -51,6 +51,30 @@ interface DocumentSyncQueue {
   pending: PendingDocumentSync | null;
 }
 
+/**
+ * LSP feature responses all carry a document status.  Most responses for an
+ * already-open document repeat that exact status, and publishing a new store
+ * map for each one makes the whole workspace chrome render again.  Keep the
+ * comparison local and cheap (the capability summary is small) so feature
+ * requests that do not change observable state are true no-ops.
+ */
+function sameDocumentStatus(left: LspDocumentStatus, right: LspDocumentStatus): boolean {
+  return left === right || (
+    left.path === right.path
+    && left.uri === right.uri
+    && left.presetId === right.presetId
+    && left.languageId === right.languageId
+    && left.displayName === right.displayName
+    && left.available === right.available
+    && left.active === right.active
+    && left.selectedCommandId === right.selectedCommandId
+    && left.selectedCommand === right.selectedCommand
+    && left.installHint === right.installHint
+    && left.error === right.error
+    && JSON.stringify(left.capabilities ?? null) === JSON.stringify(right.capabilities ?? null)
+  );
+}
+
 export interface WorkspaceLspSessionController {
   serverStatuses: LspServerStatus[];
   commandPrefs: Record<string, string>;
@@ -181,15 +205,22 @@ export function useWorkspaceLspSession({
 
   const updateStatus = useCallback((file: OpenFileState, status: LspDocumentStatus) => {
     if (!mountedRef.current) return;
-    updateLspFiles((current) => ({
-      ...current,
-      [file.key]: {
-        ...(current[file.key] ?? emptyLspFileState()),
-        status,
-        syncing: false,
-        error: null,
-      },
-    }));
+    updateLspFiles((current) => {
+      const existing = current[file.key] ?? emptyLspFileState();
+      if (existing.status && sameDocumentStatus(existing.status, status)
+        && !existing.syncing && existing.error === null) {
+        return current;
+      }
+      return {
+        ...current,
+        [file.key]: {
+          ...existing,
+          status,
+          syncing: false,
+          error: null,
+        },
+      };
+    });
   }, [updateLspFiles]);
 
   const refreshDiagnostics = useCallback(async (file: OpenFileState) => {

--- a/src/stores/codeWorkspaceStore.ts
+++ b/src/stores/codeWorkspaceStore.ts
@@ -307,12 +307,14 @@ export const useCodeWorkspaceStore = create<CodeWorkspaceStoreState>((set, get) 
     get().ensureInstance(instanceId);
     set((state) => {
       const current = state.byInstanceId[instanceId] ?? createDefaultCodeWorkspaceUi();
+      const openFiles = resolveUpdater(current.openFiles, updater);
+      if (openFiles === current.openFiles) return state;
       return {
         byInstanceId: {
           ...state.byInstanceId,
           [instanceId]: {
             ...current,
-            openFiles: resolveUpdater(current.openFiles, updater),
+            openFiles,
           },
         },
       };
@@ -323,12 +325,14 @@ export const useCodeWorkspaceStore = create<CodeWorkspaceStoreState>((set, get) 
     get().ensureInstance(instanceId);
     set((state) => {
       const current = state.byInstanceId[instanceId] ?? createDefaultCodeWorkspaceUi();
+      const lspFiles = resolveUpdater(current.lspFiles, updater);
+      if (lspFiles === current.lspFiles) return state;
       return {
         byInstanceId: {
           ...state.byInstanceId,
           [instanceId]: {
             ...current,
-            lspFiles: resolveUpdater(current.lspFiles, updater),
+            lspFiles,
           },
         },
       };


### PR DESCRIPTION
…chrome

Cut the cost of ordinary keystrokes in the Code Workspace so a large Rust/TypeScript buffer no longer fans out into full-workspace React renders, stale language-server work, and expensive gutter recomputation while the user is still typing.

### Problem

After the React #185 command-registration loop was fixed, idle CPU stayed low, but the editing path remained expensive:

- Every CodeMirror onChange published a full buffer string into the workspace-wide Zustand openFiles map, re-rendering the project tree, panels, status bar, and AI context on each keypress.
- Highlight / inlay / semantic-token / symbol effects raced ahead of document sync and could apply responses for superseded revisions.
- Semantic tokens shared one CodeMirror decoration compartment with cursor-scoped highlights and inlay hints, so a highlight refresh rebuilt the whole document token chrome.
- Git line-diff walked every cached HEAD buffer and rebuilt changes on a short timer; TODO scanning rescanned every open file on each openFiles identity change.
- Empty array defaults and identical status payloads still produced new object identities that reconfigured compartments or rewrote store maps.

### Typing / React data path

- Introduce queueEditorTextUpdate with a 125ms idle commit (EDITOR_TEXT_COMMIT_IDLE_DELAY_MS). CodeMirror remains the live buffer via openFilesRef; Zustand only receives a coalesced burst so save, WorkspaceEdit, rename, close, and tab switches stay coherent.
- flushPendingEditorText before setOpenFiles, openFile, editor-group activate, and workspace dispose so queued keystrokes never resurrect a closed buffer or show a stale snapshot after tab switch.
- useDeferredValue(openFiles) for dirty counts, problem lists, AI workspace context, and similar non-interactive chrome so metadata work paints after the input update.
- CodeMirrorHost remembers lastDocumentTextRef to avoid a second full toString() when React reflects the same edit; selection emits are debounced 125ms during doc changes and skipped when the range is unchanged; viewport is emitted only on viewportChanged (not every docChanged).
- autocompletion activateOnTypingDelay raised to 350ms so automatic completion waits for document sync instead of querying mid-burst.
- Completion sources abort on document change and ignore aborted responses; fetchCompletion returns null when the buffer is not yet synced so local sources handle the keystroke.

### LSP scheduling and staleness

- Prefer document sync (open: 0ms, change: 150ms) ahead of derived intelligence. Idle delays: highlights 500ms, inlay/symbols 650ms, semantic tokens 900ms.
- Track lspDocumentEpochRef per file; gate feature requests and response application with isCurrentLspDocumentRequest / currentSyncedLspDocument so older semantic tokens cannot repaint a newer buffer.
- Skip derived LSP requests while the active document is not synced; clear empty group state only when the previous value was non-empty (avoid setState no-ops that still re-render).
- sameDocumentStatus in useWorkspaceLspSession: feature responses that only repeat the same document status no longer rewrite lspFiles.
- codeWorkspaceStore updateOpenFiles / updateLspFiles return the same state object when the updater yields the previous map reference.

### LSP chrome compartment split

- Split semantic-token decorations from overlay (highlights + inlay) into separate CodeMirror compartments plus a shared LSP_INTELLIGENCE_THEME so highlight/inlay refreshes do not rebuild large semantic token sets.
- Module-level EMPTY_* array constants and sameArrayOrBothEmpty / rendered*Ref guards skip compartment reconfigure when props are empty-stable or semantically unchanged for diagnostics, overlay, semantic tokens, and git chrome.

### Deferred Git and TODO work

- useDeferredGitLineChanges: only visible primary/secondary active buffers, 900ms pause + requestIdleCallback, per-file cache keyed by sourceKey + bufferText, and structural equality before setState.
- Git HEAD fetch depends on a compact activeGitFileStateSignature instead of the full openFiles object; inline blame uses a request signature, LRU cache (256), and 500ms debounce, reading openFilesRef so dirty-from-first-keystroke is respected under input batching.
- useDeferredOpenFileTodos + createOpenFileTodoScanner: per-file TODO cache and 500ms idle rescan so one edit does not re-scan every open tab; sameWorkspaceTodoItems avoids redundant panel updates.

### Status bar and lifecycle

- Split status segments, status actions, and clear-on-unmount into separate effects; drop full-text dependency for EOL (use stored file.eol with LF default) so typing does not republish status.
- Dispose workspace UI only after flushing pending editor text, with the flush callback captured in the effect closure so tab rebinding cannot flush the wrong instance.

### Tests

- CodeWorkspaceTab: edit sync runs before idle intelligence; stale semantic-token responses are ignored; editor text publications coalesce until the 125ms idle window.
- useDeferredGitLineChanges / useDeferredOpenFileTodos unit tests for idle scheduling and per-file caching.
- todoBookmarks scanner cache and CodeMirrorHost empty-array stability coverage extended.

This advances several items from claudedocs/code-workspace-performance-todo.md (P0 stable empty arrays / reconfigure guards / status-bar split; P1 on-demand git line-diff; P2 partial buffer-commit batching) without changing save, restore, Git, or LSP user-visible behavior when idle.