### PR TITLE
fix(tabs): preserve Welcome and AI chat state across tab switches

### DIFF
--- a/src/components/chat/ChatDrawer.test.tsx
+++ b/src/components/chat/ChatDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatDrawer, ChatDrawerRibbon } from "./ChatDrawer";
 import { useAppStore } from "../../stores/appStore";
@@ -342,6 +342,59 @@ describe("ChatDrawer layout resizing", () => {
       drawerOpen: false,
       tabDrawerOpenByTabId: { "term-1": false },
     });
+  });
+
+  it("keeps the drawer mounted while closed and does not re-animate scroll on reopen", async () => {
+    const scrollIntoView = Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>;
+    useChatStore.setState({
+      drawerPosition: "right",
+      drawerPinned: true,
+      messages: {
+        "thread-1": [
+          {
+            id: "m1",
+            thread_id: "thread-1",
+            role: "user",
+            content: "hello",
+            created_at: 1,
+            redacted: false,
+          },
+          {
+            id: "m2",
+            thread_id: "thread-1",
+            role: "assistant",
+            content: "world",
+            created_at: 2,
+            redacted: false,
+          },
+        ],
+      },
+    });
+
+    render(<ChatDrawer />);
+    const drawer = screen.getByTestId("ai-chat-drawer");
+    expect(drawer).not.toHaveStyle({ display: "none" });
+
+    // Initial open + thread align uses instant scroll, never smooth.
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalled();
+    });
+    expect(scrollIntoView.mock.calls.every((call) => call[0]?.behavior !== "smooth")).toBe(true);
+    scrollIntoView.mockClear();
+
+    act(() => {
+      useChatStore.setState({ drawerOpen: false });
+    });
+    expect(drawer).toBeInTheDocument();
+    expect(drawer).toHaveStyle({ display: "none" });
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    act(() => {
+      useChatStore.setState({ drawerOpen: true });
+    });
+    expect(drawer).not.toHaveStyle({ display: "none" });
+    // Same thread re-shown: preserve scroll, do not jump/animate again.
+    expect(scrollIntoView).not.toHaveBeenCalled();
   });
 
   it("keeps a floating drawer open when the AI safety gate is clicked", () => {

--- a/src/components/chat/ChatDrawer.tsx
+++ b/src/components/chat/ChatDrawer.tsx
@@ -121,6 +121,11 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const resizingRef = useRef(false);
   const resizeStartRef = useRef({ x: 0, y: 0, width: 0, height: 0 });
+  // Track open/thread/length so tab-return (same thread, just re-shown) keeps
+  // the current scroll offset instead of re-animating top→bottom.
+  const prevDrawerOpenRef = useRef(false);
+  const prevScrollThreadIdRef = useRef<string | null>(null);
+  const prevScrollMessageCountRef = useRef(0);
 
   // Subscribe to the active tab so the drawer re-renders (and the
   // scope/picker logic re-evaluates) whenever the user switches tabs. We
@@ -148,7 +153,7 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
 
   const activeMessages = activeThreadId ? (messages[activeThreadId] ?? []) : [];
   const sending = activeThreadId ? sendingByThreadId[activeThreadId] === true : false;
-  const activeThread = threads.find((t) => t.id === activeThreadId);
+  const activeThread = (threads ?? []).find((t) => t.id === activeThreadId);
   const linkedTab = useAppStore((s) =>
     activeThread?.linked_session_id
       ? s.tabs.find((tab) =>
@@ -172,9 +177,12 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
   const linkedTabType = linkedTab?.type ?? null;
   const isQueryThread = linkedTabType === "database";
   const visibleThreads = useMemo(
-    () => drawerTabId
-      ? threads.filter((thread) => thread.linked_session_id === drawerTabId)
-      : threads.filter((thread) => thread.linked_session_id),
+    () => {
+      const list = threads ?? [];
+      return drawerTabId
+        ? list.filter((thread) => thread.linked_session_id === drawerTabId)
+        : list.filter((thread) => thread.linked_session_id);
+    },
     [drawerTabId, threads],
   );
   const taoAlerts = useMemo(
@@ -326,10 +334,39 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
     }
   }, [activeThreadId]);
 
-  // Scroll to bottom on new messages.
+  // Scroll policy:
+  // - same thread re-shown after hide (tab switch away/back): keep scroll
+  // - thread change / first open: jump to bottom instantly
+  // - new messages while open: smooth-scroll only when the list already had content
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [activeMessages.length]);
+    if (!drawerOpen) {
+      prevDrawerOpenRef.current = false;
+      return;
+    }
+    const end = messagesEndRef.current;
+    if (!end) return;
+
+    const opened = !prevDrawerOpenRef.current;
+    const threadChanged = prevScrollThreadIdRef.current !== activeThreadId;
+    const previousCount = prevScrollMessageCountRef.current;
+    const grew = activeMessages.length > previousCount;
+
+    prevDrawerOpenRef.current = true;
+    prevScrollThreadIdRef.current = activeThreadId;
+    prevScrollMessageCountRef.current = activeMessages.length;
+
+    // Re-opening the same transcript (tab return) — preserve scroll position.
+    if (opened && !threadChanged) return;
+
+    if (threadChanged || opened) {
+      end.scrollIntoView({ behavior: "auto" });
+      return;
+    }
+
+    if (grew) {
+      end.scrollIntoView({ behavior: previousCount === 0 ? "auto" : "smooth" });
+    }
+  }, [drawerOpen, activeThreadId, activeMessages.length]);
 
   const pickProviderForMode = (mode: ChatThreadMode, preferredProviderId?: string | null): string | null => {
     const ids = chatDrawerProviderIds(aiConfig, capabilityForMode(mode));
@@ -578,8 +615,6 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
     window.addEventListener("pointercancel", onUp);
   };
 
-  if (!drawerOpen) return null;
-
   const positionLabel = t(`chat.drawerPosition_${drawerPosition}`);
   const PositionIcon = positionIcon(drawerPosition);
   const containerClass = [
@@ -590,7 +625,10 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
     drawerPosition === "left" ? "order-first" : "",
     floating ? "rounded-md" : "",
   ].filter(Boolean).join(" ");
-  const containerStyle: CSSProperties = sideBySide
+  // Stay mounted while hidden so tab switches do not remount the transcript.
+  const containerStyle: CSSProperties = !drawerOpen
+    ? { display: "none" }
+    : sideBySide
     ? { width: drawerWidth }
     : stackedInline
     ? { height: drawerHeight, width: "100%" }
@@ -609,10 +647,10 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
         transform: "translateX(-50%)",
         [drawerPosition]: 0,
       };
-  if (topBottomFloating) {
+  if (drawerOpen && topBottomFloating) {
     containerStyle.opacity = drawerFloatingOpacity;
   }
-  const themedContainerStyle: CSSProperties = hubTab === "notes"
+  const themedContainerStyle: CSSProperties = drawerOpen && hubTab === "notes"
     ? { ...containerStyle, ...notesThemeStyle(notesTheme) }
     : containerStyle;
   const resizeHandleClass = isHorizontalDock
@@ -661,6 +699,8 @@ export function ChatDrawer({ terminalContext }: ChatDrawerProps) {
       data-testid="ai-chat-drawer"
       data-position={drawerPosition}
       data-pinned={drawerPinned || undefined}
+      data-open={drawerOpen || undefined}
+      aria-hidden={!drawerOpen}
     >
       {/* Resize handle */}
       <div

--- a/src/layouts/MainLayout.test.tsx
+++ b/src/layouts/MainLayout.test.tsx
@@ -575,6 +575,40 @@ describe("MainLayout attached SFTP sidebar", () => {
     });
   });
 
+  it("keeps the welcome tab mounted when switching away", async () => {
+    useAppStore.setState({
+      tabs: [
+        { id: "welcome", type: "welcome", title: "Welcome", closable: false },
+        { id: "ssh-tab", type: "terminal", title: "SSH", closable: true },
+      ],
+      activeTabId: "welcome",
+    });
+
+    render(<MainLayout />);
+
+    const wrapper = screen.getByTestId("welcome-tab-panel") as HTMLElement;
+    const panel = screen.getByTestId("welcome-panel");
+    expect(wrapper.style.display).toBe("block");
+
+    act(() => {
+      useAppStore.getState().setActiveTab("ssh-tab");
+    });
+
+    await waitFor(() => {
+      expect(wrapper.style.display).toBe("none");
+    });
+    expect(panel).toBeInTheDocument();
+
+    act(() => {
+      useAppStore.getState().setActiveTab("welcome");
+    });
+
+    await waitFor(() => {
+      expect(wrapper.style.display).toBe("block");
+    });
+    expect(panel).toBeInTheDocument();
+  });
+
   it("passes a Git rail action to the sidebar for the active local terminal", () => {
     useAppStore.setState({
       tabs: [{ id: "local-tab", type: "terminal", title: "Local terminal", closable: true }],

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -3241,14 +3241,20 @@ export function MainLayout() {
   // so the custom resize handles are Windows/Linux only.
   const isMac = getAppPlatform() === "macos";
   const chatDockViewport = useViewportSize();
-  const chatDockMode =
-    chatDrawerOpen && !aiFullyDisabled
-      ? resolveChatDock(chatDrawerPosition, chatDrawerPinned, chatDockViewport.width, chatDockViewport.height)
-      : "floating";
+  // After the drawer has been opened once, keep ChatDrawer mounted (hidden)
+  // across tab switches so the transcript does not remount and re-animate.
+  const [chatDrawerKeepAlive, setChatDrawerKeepAlive] = useState(false);
+  useEffect(() => {
+    if (chatDrawerOpen) setChatDrawerKeepAlive(true);
+  }, [chatDrawerOpen]);
+  const chatDrawerSurfaceActive = !aiFullyDisabled && (chatDrawerOpen || chatDrawerKeepAlive);
+  const chatDockMode = chatDrawerSurfaceActive
+    ? resolveChatDock(chatDrawerPosition, chatDrawerPinned, chatDockViewport.width, chatDockViewport.height)
+    : "floating";
   const chatDrawerInline = chatDockMode === "side-inline";
   const chatDrawerTopPinned = chatDockMode === "stacked-inline" && chatDrawerPosition === "top";
   const chatDrawerBottomPinned = chatDockMode === "stacked-inline" && chatDrawerPosition === "bottom";
-  const chatDrawerFloating = chatDrawerOpen && !aiFullyDisabled && chatDockMode === "floating";
+  const chatDrawerFloating = chatDrawerSurfaceActive && chatDockMode === "floating";
 
   return (
     <TabActionSlotProvider slot={tabActionSlot}>
@@ -3372,8 +3378,13 @@ export function MainLayout() {
                 />
               )}
               <div className="flex-1 min-h-0 overflow-hidden relative">
-                {/* Welcome panel */}
-                {(activeTab?.type === "welcome" || !activeTab) && (
+                {/* Welcome stays mounted so filters, scroll, and shell
+                    selections survive switching to another tab. */}
+                <div
+                  data-testid="welcome-tab-panel"
+                  className="absolute inset-0"
+                  style={{ display: (activeTab?.type === "welcome" || !activeTab) ? "block" : "none" }}
+                >
                   <WelcomePanel
                     onStartLocalTerminal={(localShell, cwd) => openLocalTab(localShell?.name ?? tr("tabs.localTerminal"), undefined, undefined, localShell, cwd)}
                     onNewSession={handleNewSession}
@@ -3394,7 +3405,7 @@ export function MainLayout() {
                     onOpenNewWorkspace={() => void openNewCodeWorkspaceFromWelcome()}
                     onOpenSettings={openSettingsTab}
                   />
-                )}
+                </div>
 
                 {/* All terminal tabs stay mounted. Single-tab mode hides
                     inactive panes; split mode only changes the pane wrappers. */}


### PR DESCRIPTION
Some panels remounted when the user left a tab and came back, so UI state was lost and chat re-animated from top to bottom.

Welcome:
- Keep WelcomePanel mounted and hide it with display:none when inactive (same keep-alive pattern as settings/git/terminal panes).
- Filters, history sub-tab, shell selection, and scroll position now survive switching away and back.

AI chat:
- After the drawer has been opened once, keep ChatDrawer mounted while closed (display:none) so tab-scoped open/close does not remount the transcript DOM.
- Resolve dock placement even when the drawer is hidden so the same surface stays alive across hide/show.
- Replace unconditional smooth scrollIntoView on message count with a policy that: preserves scroll when re-showing the same thread, jumps instantly on thread change / first open, and only smooth-scrolls when new messages arrive while already open (and the list already had content).

Tests:
- MainLayout: welcome tab stays mounted when switching away.
- ChatDrawer: stays mounted while closed and does not re-animate scroll on reopen of the same thread.