### PR TITLE
fix(code-workspace): restore LSP settings build

### DIFF
--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -466,10 +466,6 @@ export function CodeWorkspaceTab({
   const pendingEditorTextByFileRef = useRef(new Map<string, OpenFileState>());
   const pendingEditorTextTimerRef = useRef<number | null>(null);
 
-  const setLanguagePanelOpen = useCallback((open: boolean | ((prev: boolean) => boolean)) => {
-    const next = typeof open === "function" ? open(selectCodeWorkspaceUi(useCodeWorkspaceStore.getState(), workspaceInstanceId).languagePanelOpen) : open;
-    patchWorkspaceUi(workspaceInstanceId, { languagePanelOpen: next });
-  }, [patchWorkspaceUi, workspaceInstanceId]);
   const setBottomDockOpen = useCallback((open: boolean | ((prev: boolean) => boolean)) => {
     const prev = selectCodeWorkspaceUi(useCodeWorkspaceStore.getState(), workspaceInstanceId).bottomDockOpen;
     patchWorkspaceUi(workspaceInstanceId, { bottomDockOpen: typeof open === "function" ? open(prev) : open });

--- a/src/components/editor/workspace/FileTreePane.tsx
+++ b/src/components/editor/workspace/FileTreePane.tsx
@@ -33,12 +33,6 @@ import {
 
 export type { FileTreeViewMode };
 
-/** Custom LSP command shape (prefs shared with Settings Language Servers). */
-export interface LspCustomCommandConfig {
-  command: string;
-  args: string;
-}
-
 interface FileTreePaneProps {
   paneRef: RefObject<HTMLElement | null>;
   style: CSSProperties;

--- a/src/components/editor/workspace/codeWorkspaceModel.ts
+++ b/src/components/editor/workspace/codeWorkspaceModel.ts
@@ -7,7 +7,6 @@ import type { WorkspaceEntry, WorkspaceGitRoot } from "../../../lib/editor/works
 import type { LspCustomServerCommand, LspDocumentStatus, LspDiagnostic } from "../../../lib/editor/lsp";
 import type { GitChange } from "../../../lib/git";
 import { DEFAULT_CODE_VIEW_PROFILE } from "../../../lib/codeViewProfile";
-import type { LspCustomCommandConfig } from "./FileTreePane";
 import type { OpenFileEol, OpenFileViewModel } from "./editorGroupTypes";
 import type { FileTreeViewMode } from "./FileTreePane";
 
@@ -16,6 +15,13 @@ export type MermaidApi = typeof import("mermaid").default;
 export type OpenFileState = OpenFileViewModel;
 export type TreeViewMode = FileTreeViewMode;
 export type MarkdownViewMode = "edit" | "preview" | "split";
+
+/** Custom LSP command shape shared by workspace sessions and Settings. */
+export interface LspCustomCommandConfig {
+  command: string;
+  args: string;
+}
+
 export interface DirectoryState {
   entries: WorkspaceEntry[];
   loaded: boolean;

--- a/src/components/editor/workspace/useWorkspaceLspSession.ts
+++ b/src/components/editor/workspace/useWorkspaceLspSession.ts
@@ -12,7 +12,6 @@ import {
   type LspServerStatus,
 } from "../../../lib/editor/lsp";
 import type { CodeWorkspaceRootInfo } from "../../../types";
-import type { LspCustomCommandConfig } from "./FileTreePane";
 import { buildIncrementalContentChange } from "./lspTextEdits";
 import {
   CUSTOM_LSP_COMMAND_ID,
@@ -25,6 +24,7 @@ import {
   subscribeLspServerPrefs,
   writeLspCommandPrefs,
   writeLspCustomCommands,
+  type LspCustomCommandConfig,
   type LspFileState,
   type OpenFileState,
 } from "./codeWorkspaceModel";


### PR DESCRIPTION
The Language Servers settings migration left an unused setLanguagePanelOpen callback in CodeWorkspaceTab and kept LspCustomCommandConfig declared in FileTreePane even though the Settings screen imports it from codeWorkspaceModel. With strict TypeScript checks, those two inconsistencies caused pnpm tauri build to fail before packaging.

Remove the obsolete callback, make codeWorkspaceModel the owner and exporter of the shared custom-command configuration type, and update the LSP session to consume that model type. This also removes the model-to-UI type dependency introduced by the migration.

Validation: pnpm build