### PR TITLE
fix(mail): align reader/composer with Thunderbird for images and atta…

### DIFF
--- a/src-tauri/src/mail/mod.rs
+++ b/src-tauri/src/mail/mod.rs
@@ -33,6 +33,10 @@ use crate::terminal::network::NetworkSettings;
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_MESSAGE_LIMIT: usize = 200;
 const DEFAULT_BODY_MAX_BYTES: usize = 256 * 1024;
+/// Cap for HTML bodies after embedding inline CID images as data URLs for display.
+const MAX_EMBEDDED_BODY_BYTES: usize = 5 * 1024 * 1024;
+/// Skip individual CID parts larger than this when rewriting for display.
+const MAX_INLINE_CID_IMAGE_BYTES: usize = 2 * 1024 * 1024;
 const OAUTH_REFRESH_SKEW_SECS: i64 = 300;
 const OAUTH_REAUTHORIZE_REQUIRED: &str = "OAuth2 authorization expired or was revoked. Reauthorize this mail account in session settings.";
 const IMAP_LOGIN_RETRY_DELAYS_MS: [u64; 2] = [500, 1500];
@@ -3438,9 +3442,17 @@ fn parse_body_message(
             let text = message
                 .body_text(0)
                 .map(|s| truncate_utf8_bytes(s.as_ref(), max_bytes));
-            let html = message
-                .body_html(0)
-                .map(|s| truncate_utf8_bytes(s.as_ref(), max_bytes));
+            let html = message.body_html(0).map(|s| {
+                // Thunderbird-style: rewrite embedded cid: images to data: URLs so
+                // the reader can show them without a network fetch. Remote http(s)
+                // images stay as-is and are gated by the frontend privacy toggle.
+                let rewritten = rewrite_cid_images_in_html(&message, s.as_ref());
+                let limit = rewritten
+                    .len()
+                    .max(max_bytes)
+                    .min(MAX_EMBEDDED_BODY_BYTES);
+                truncate_utf8_bytes(&rewritten, limit)
+            });
             MailMessageCached {
                 header: MailMessageHeader {
                     account_id: account_id.to_string(),
@@ -4899,6 +4911,126 @@ fn clean_message_id(value: &str) -> String {
         .to_string()
 }
 
+/// Rewrite `src="cid:..."` / `src='cid:...'` references to data URLs using matching
+/// MIME parts (Content-ID). Enables embedded images in the HTML reader without
+/// requiring a separate attachment download round-trip.
+fn rewrite_cid_images_in_html(message: &mail_parser::Message<'_>, html: &str) -> String {
+    if !html.to_ascii_lowercase().contains("cid:") {
+        return html.to_string();
+    }
+
+    let mut by_cid: HashMap<String, (String, Vec<u8>)> = HashMap::new();
+    for part in &message.parts {
+        let Some(raw_cid) = part.content_id() else {
+            continue;
+        };
+        let cid = clean_message_id(raw_cid);
+        if cid.is_empty() {
+            continue;
+        }
+        let content_type = part
+            .content_type()
+            .map(|ct| match ct.c_subtype.as_ref() {
+                Some(subtype) => format!("{}/{}", ct.c_type, subtype),
+                None => ct.c_type.to_string(),
+            })
+            .unwrap_or_else(|| "application/octet-stream".into());
+        // Only embed image/* parts — other cid targets (e.g. calendar) stay as cid:.
+        if !content_type.to_ascii_lowercase().starts_with("image/") {
+            continue;
+        }
+        let bytes = match &part.body {
+            PartType::Binary(b) | PartType::InlineBinary(b) => b.as_ref().to_vec(),
+            PartType::Text(s) | PartType::Html(s) => s.as_ref().as_bytes().to_vec(),
+            PartType::Message(nested) => nested.raw_message.to_vec(),
+            PartType::Multipart(_) => continue,
+        };
+        if bytes.is_empty() || bytes.len() > MAX_INLINE_CID_IMAGE_BYTES {
+            continue;
+        }
+        by_cid.insert(cid.to_ascii_lowercase(), (content_type, bytes));
+    }
+    if by_cid.is_empty() {
+        return html.to_string();
+    }
+
+    let mut out = String::with_capacity(html.len());
+    let bytes = html.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        let rest = &html[index..];
+        let lower = rest.to_ascii_lowercase();
+        let Some(rel_src) = lower.find("src=") else {
+            out.push_str(rest);
+            break;
+        };
+        out.push_str(&rest[..rel_src + 4]);
+        index += rel_src + 4;
+        if index >= bytes.len() {
+            break;
+        }
+        let quote = html.as_bytes()[index];
+        let (quote_char, value_start) = if quote == b'"' || quote == b'\'' {
+            (Some(quote as char), index + 1)
+        } else {
+            (None, index)
+        };
+        let value_end = match quote_char {
+            Some(q) => html[value_start..]
+                .find(q)
+                .map(|n| value_start + n)
+                .unwrap_or(html.len()),
+            None => {
+                let end_rel = html[value_start..]
+                    .find(|c: char| c.is_whitespace() || c == '>')
+                    .unwrap_or(html[value_start..].len());
+                value_start + end_rel
+            }
+        };
+        let raw_src = &html[value_start..value_end];
+        let cid_key = raw_src
+            .trim()
+            .strip_prefix("cid:")
+            .or_else(|| raw_src.trim().strip_prefix("CID:"))
+            .map(|v| clean_message_id(v).to_ascii_lowercase());
+        if let Some(cid) = cid_key.as_ref() {
+            if let Some((content_type, data)) = by_cid.get(cid) {
+                let encoded = BASE64_STANDARD.encode(data);
+                if let Some(q) = quote_char {
+                    out.push(q);
+                    out.push_str("data:");
+                    out.push_str(content_type);
+                    out.push_str(";base64,");
+                    out.push_str(&encoded);
+                    out.push(q);
+                } else {
+                    out.push_str("data:");
+                    out.push_str(content_type);
+                    out.push_str(";base64,");
+                    out.push_str(&encoded);
+                }
+                index = if quote_char.is_some() {
+                    value_end + 1
+                } else {
+                    value_end
+                };
+                continue;
+            }
+        }
+        // Unmatched cid or non-cid src: copy through unchanged.
+        if let Some(q) = quote_char {
+            out.push(q);
+            out.push_str(raw_src);
+            out.push(q);
+            index = value_end + 1;
+        } else {
+            out.push_str(raw_src);
+            index = value_end;
+        }
+    }
+    out
+}
+
 fn truncate_utf8_bytes(value: &str, max_bytes: usize) -> String {
     if value.len() <= max_bytes {
         return value.to_string();
@@ -4969,6 +5101,29 @@ mod tests {
 
     fn sample_attachment_message() -> Vec<u8> {
         b"From: Example Sender <sender@example.com>\r\nTo: Receiver <receiver@example.com>\r\nSubject: Attachment sample\r\nMIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=\"b\"\r\n\r\n--b\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nBody text.\r\n--b\r\nContent-Type: text/plain; name=\"report.txt\"\r\nContent-Disposition: attachment; filename=\"report.txt\"\r\n\r\nAttachment content.\r\n--b--\r\n"
+            .to_vec()
+    }
+
+    fn sample_inline_image_message() -> Vec<u8> {
+        // 1x1 PNG (68 bytes raw) base64-encoded for a multipart/related sample.
+        b"From: Example Sender <sender@example.com>\r\n\
+To: Receiver <receiver@example.com>\r\n\
+Subject: Inline image sample\r\n\
+MIME-Version: 1.0\r\n\
+Content-Type: multipart/related; boundary=\"rel\"\r\n\
+\r\n\
+--rel\r\n\
+Content-Type: text/html; charset=utf-8\r\n\
+\r\n\
+<p>Logo: <img src=\"cid:logo@inline.local\" alt=\"logo\"></p>\r\n\
+--rel\r\n\
+Content-Type: image/png; name=\"logo.png\"\r\n\
+Content-Transfer-Encoding: base64\r\n\
+Content-ID: <logo@inline.local>\r\n\
+Content-Disposition: inline; filename=\"logo.png\"\r\n\
+\r\n\
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==\r\n\
+--rel--\r\n"
             .to_vec()
     }
 
@@ -5551,6 +5706,22 @@ mod tests {
         assert_eq!(attachment.name.as_deref(), Some("report.txt"));
         assert_eq!(attachment.content_type.as_deref(), Some("text/plain"));
         assert_eq!(attachment.bytes, b"Attachment content.");
+    }
+
+    #[test]
+    fn parse_body_rewrites_cid_images_to_data_urls() {
+        let raw = sample_inline_image_message();
+        let parsed = parse_body_message("acct", "INBOX", 9, Some(raw.len() as u32), &raw, 4096);
+        let html = parsed.body_html.as_deref().expect("html body");
+        assert!(
+            html.contains("data:image/png;base64,"),
+            "expected embedded data URL, got: {html}"
+        );
+        assert!(
+            !html.to_ascii_lowercase().contains("cid:logo@inline.local"),
+            "cid reference should be rewritten for display"
+        );
+        assert!(html.contains("alt=\"logo\""));
     }
 
     #[test]

--- a/src/components/mail/MailClientTab.test.tsx
+++ b/src/components/mail/MailClientTab.test.tsx
@@ -45,6 +45,11 @@ vi.mock("../../lib/ipc", () => ({
   openLocalPath: vi.fn(),
   selectUploadFile: vi.fn(async () => []),
   temporaryFilePath: vi.fn(async (name: string) => `/tmp/${name}`),
+  readFileBytes: vi.fn(async () => new Uint8Array([1, 2, 3])),
+  writeStreamOpen: vi.fn(async () => "handle-1"),
+  writeStreamAppend: vi.fn(async () => undefined),
+  writeStreamClose: vi.fn(async () => undefined),
+  writeStreamAbort: vi.fn(async () => undefined),
 }));
 
 vi.mock("../../stores/chatStore", () => {

--- a/src/components/mail/MailClientTab.tsx
+++ b/src/components/mail/MailClientTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode, type UIEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent, type ReactNode, type UIEvent } from "react";
 import {
   Group as PanelGroup,
   Panel,
@@ -98,16 +98,36 @@ import {
 } from "../../lib/mailRecipients";
 import {
   buildForwardHtml,
+  buildInlineImageHtml,
   buildReplyHtml,
   hasRichMailFormatting,
+  mailHtmlHasRemoteImages,
   mailHtmlToPlainText,
   plainTextToMailHtml,
+  prepareMailHtmlForSend,
   quotePlainText,
   sanitizeMailComposeHtml,
   sanitizeMailDisplayHtml,
   signatureToMailHtml,
 } from "../../lib/mailHtml";
-import { openLocalPath, selectUploadFile, temporaryFilePath } from "../../lib/ipc";
+import {
+  openLocalPath,
+  readFileBytes,
+  selectUploadFile,
+  temporaryFilePath,
+  writeStreamAbort,
+  writeStreamAppend,
+  writeStreamClose,
+  writeStreamOpen,
+} from "../../lib/ipc";
+import {
+  droppedFilePaths,
+  droppedFiles,
+  isOsFileDrag,
+  NATIVE_FILE_DROP_EVENT,
+  preventDefaultForOsFileDrag,
+  type NativeFileDropDetail,
+} from "../../lib/osFileDrop";
 import { useChatStore } from "../../stores/chatStore";
 import { useTaoAlertStore } from "../../stores/taoAlertStore";
 import { loadResizableLayout, saveResizableLayout } from "../../lib/resizableLayout";
@@ -759,8 +779,77 @@ function appendUniqueAddress(target: string[], seen: Set<string>, address: MailA
   target.push(label);
 }
 
-function sanitizeMailHtml(html: string, allowImages: boolean): string {
-  return sanitizeMailDisplayHtml(html, allowImages);
+function sanitizeMailHtml(html: string, allowRemoteImages: boolean): string {
+  return sanitizeMailDisplayHtml(html, allowRemoteImages);
+}
+
+async function writeBytesToPath(path: string, bytes: Uint8Array): Promise<void> {
+  let handleId: string | null = null;
+  try {
+    handleId = await writeStreamOpen(path);
+    const chunkSize = 256 * 1024;
+    for (let offset = 0; offset < bytes.byteLength; offset += chunkSize) {
+      const end = Math.min(offset + chunkSize, bytes.byteLength);
+      await writeStreamAppend(handleId, bytes.subarray(offset, end));
+    }
+    await writeStreamClose(handleId);
+  } catch (err) {
+    if (handleId) await writeStreamAbort(handleId).catch(() => undefined);
+    throw err;
+  }
+}
+
+function uint8ToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
+
+function extensionForMime(mime: string): string {
+  const lower = mime.toLowerCase();
+  if (lower.includes("jpeg") || lower.includes("jpg")) return "jpg";
+  if (lower.includes("png")) return "png";
+  if (lower.includes("gif")) return "gif";
+  if (lower.includes("webp")) return "webp";
+  if (lower.includes("bmp")) return "bmp";
+  if (lower.includes("svg")) return "svg";
+  return "bin";
+}
+
+function RemoteImagesBanner({
+  visible,
+  allowRemoteImages,
+  onToggle,
+}: {
+  visible: boolean;
+  allowRemoteImages: boolean;
+  onToggle: () => void;
+}) {
+  if (!visible) return null;
+  return (
+    <div
+      className="mx-4 mt-3 mb-0 flex flex-wrap items-center gap-2 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-sidebar-bg)] px-3 py-2 text-[12px]"
+      data-testid="mail-remote-images-banner"
+    >
+      <ImageOff className="w-3.5 h-3.5 shrink-0 text-[var(--taomni-text-muted)]" />
+      <span className="flex-1 text-[var(--taomni-text-muted)]">
+        {allowRemoteImages
+          ? "Remote images are shown for this message."
+          : "To protect your privacy, remote images in this message have been blocked."}
+      </span>
+      <button
+        type="button"
+        className="taomni-btn h-6 px-2 text-[11px]"
+        data-testid="mail-remote-images-toggle"
+        onClick={onToggle}
+      >
+        {allowRemoteImages ? "Block remote content" : "Show remote content"}
+      </button>
+    </div>
+  );
 }
 
 function htmlToText(html: string): string {
@@ -832,6 +921,9 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
   const [sending, setSending] = useState(false);
   const [downloadingAttachmentIndex, setDownloadingAttachmentIndex] = useState<number | null>(null);
   const [allowRemoteImages, setAllowRemoteImages] = useState(false);
+  const [composeDragActive, setComposeDragActive] = useState(false);
+  const [attachProgress, setAttachProgress] = useState<{ done: number; total: number; label: string } | null>(null);
+  const composeRootRef = useRef<HTMLDivElement>(null);
   const visibleRef = useRef(visible);
   const pendingCacheRefreshRef = useRef(false);
   const initialSyncDoneRef = useRef(false);
@@ -956,6 +1048,10 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
     if (!selectedBody?.html) return null;
     return sanitizeMailHtml(selectedBody.html, allowRemoteImages);
   }, [allowRemoteImages, selectedBody?.html]);
+  const selectedHasRemoteImages = useMemo(
+    () => mailHtmlHasRemoteImages(selectedBody?.html),
+    [selectedBody?.html],
+  );
 
   const visibleAttachments = useMemo(
     () => (selectedBody?.attachments.length ? selectedBody.attachments : selectedMessage?.attachments ?? []),
@@ -1982,7 +2078,8 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
   };
 
   const handleSendDraft = async () => {
-    const htmlBody = sanitizeMailComposeHtml(draft.htmlBody);
+    // Convert compose-time data-URL previews (data-taomni-cid) to cid: for MIME.
+    const htmlBody = prepareMailHtmlForSend(draft.htmlBody);
     const textBody = draft.textBody.trim() || mailHtmlToPlainText(htmlBody);
     const sendHtml = draft.richFormatUsed || hasRichMailFormatting(htmlBody);
     const request = {
@@ -2028,13 +2125,14 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
     }
   };
 
-  const handleAddDraftAttachments = async () => {
+  const addDraftAttachmentPaths = useCallback(async (paths: string[]) => {
+    const unique = paths.map((path) => path.trim()).filter(Boolean);
+    if (unique.length === 0) return;
+    setAttachProgress({ done: 0, total: unique.length, label: "Attaching files…" });
     try {
-      const paths = await selectUploadFile();
-      if (!paths.length) return;
       setDraft((current) => {
         const existing = new Set(current.attachments.map((attachment) => attachment.path));
-        const nextAttachments = paths
+        const nextAttachments = unique
           .filter((path) => !existing.has(path))
           .map((path) => {
             const name = basename(path);
@@ -2048,43 +2146,140 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
           });
         return { ...current, attachments: [...current.attachments, ...nextAttachments] };
       });
+      setAttachProgress({ done: unique.length, total: unique.length, label: "Attachments ready" });
+      setStatus(
+        unique.length === 1
+          ? `Attached ${basename(unique[0])}`
+          : `Attached ${unique.length} files`,
+      );
+      window.setTimeout(() => setAttachProgress(null), 1200);
+    } catch (e) {
+      setAttachProgress(null);
+      setError(mailClientErrorMessage(e));
+    }
+  }, []);
+
+  const handleAddDraftAttachments = async () => {
+    try {
+      const paths = await selectUploadFile();
+      if (!paths.length) return;
+      await addDraftAttachmentPaths(paths);
     } catch (e) {
       setError(mailClientErrorMessage(e));
     }
   };
+
+  const insertInlineImageFromPath = useCallback(async (path: string): Promise<string | null> => {
+    const name = basename(path);
+    const contentType = guessContentType(name);
+    if (!contentType.toLowerCase().startsWith("image/")) {
+      setError("Inline image must be a local image file.");
+      return null;
+    }
+    const bytes = await readFileBytes(path);
+    const dataUrl = `data:${contentType};base64,${uint8ToBase64(bytes)}`;
+    const contentId = makeInlineImageContentId(name);
+    const attachment: MailDraftAttachment = {
+      path,
+      name,
+      contentType,
+      inline: true,
+      contentId,
+      size: bytes.byteLength,
+      modifiedAt: null,
+    };
+    setDraft((current) => ({
+      ...current,
+      richFormatUsed: true,
+      attachments: [...current.attachments, attachment],
+    }));
+    return buildInlineImageHtml({ contentId, dataUrl, alt: name });
+  }, []);
+
+  const insertInlineImageFromFile = useCallback(async (file: File): Promise<string | null> => {
+    const mime = file.type || "image/png";
+    if (!mime.toLowerCase().startsWith("image/")) {
+      setError("Inline image must be an image file.");
+      return null;
+    }
+    const ext = extensionForMime(mime);
+    const name = (file.name?.trim() || `pasted-image.${ext}`).replace(/[\\/]/g, "_");
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    const path = await temporaryFilePath(name);
+    await writeBytesToPath(path, bytes);
+    const dataUrl = `data:${mime};base64,${uint8ToBase64(bytes)}`;
+    const contentId = makeInlineImageContentId(name);
+    const attachment: MailDraftAttachment = {
+      path,
+      name,
+      contentType: mime,
+      inline: true,
+      contentId,
+      size: bytes.byteLength,
+      modifiedAt: null,
+    };
+    setDraft((current) => ({
+      ...current,
+      richFormatUsed: true,
+      attachments: [...current.attachments, attachment],
+    }));
+    return buildInlineImageHtml({ contentId, dataUrl, alt: name });
+  }, []);
 
   const handleInsertInlineImage = async (): Promise<string | null> => {
     try {
       const paths = await selectUploadFile();
       const path = paths[0];
       if (!path) return null;
-      const name = basename(path);
-      const contentType = guessContentType(name);
-      if (!contentType.toLowerCase().startsWith("image/")) {
-        setError("Inline image must be a local image file.");
-        return null;
-      }
-      const contentId = makeInlineImageContentId(name);
-      const attachment: MailDraftAttachment = {
-        path,
-        name,
-        contentType,
-        inline: true,
-        contentId,
-        size: null,
-        modifiedAt: null,
-      };
-      setDraft((current) => ({
-        ...current,
-        richFormatUsed: true,
-        attachments: [...current.attachments, attachment],
-      }));
-      return `<img src="cid:${escapeHtml(contentId)}" alt="${escapeHtml(name)}">`;
+      return await insertInlineImageFromPath(path);
     } catch (e) {
       setError(mailClientErrorMessage(e));
       return null;
     }
   };
+
+  const handlePasteImages = useCallback(async (files: File[]): Promise<string[]> => {
+    const snippets: string[] = [];
+    setAttachProgress({ done: 0, total: files.length, label: "Inserting images…" });
+    try {
+      for (let i = 0; i < files.length; i += 1) {
+        const html = await insertInlineImageFromFile(files[i]);
+        if (html) snippets.push(html);
+        setAttachProgress({ done: i + 1, total: files.length, label: "Inserting images…" });
+      }
+      setAttachProgress({ done: files.length, total: files.length, label: "Images inserted" });
+      if (snippets.length > 0) {
+        setStatus(snippets.length === 1 ? "Image pasted" : `${snippets.length} images pasted`);
+      }
+      window.setTimeout(() => setAttachProgress(null), 1200);
+      return snippets;
+    } catch (e) {
+      setAttachProgress(null);
+      setError(mailClientErrorMessage(e));
+      return snippets;
+    }
+  }, [insertInlineImageFromFile]);
+
+  const handleDropComposeFiles = useCallback(async (files: File[]) => {
+    if (files.length === 0) return;
+    setAttachProgress({ done: 0, total: files.length, label: "Attaching files…" });
+    try {
+      const paths: string[] = [];
+      for (let i = 0; i < files.length; i += 1) {
+        const file = files[i];
+        const name = (file.name?.trim() || `attachment-${i + 1}`).replace(/[\\/]/g, "_");
+        const path = await temporaryFilePath(name);
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        await writeBytesToPath(path, bytes);
+        paths.push(path);
+        setAttachProgress({ done: i + 1, total: files.length, label: "Attaching files…" });
+      }
+      await addDraftAttachmentPaths(paths);
+    } catch (e) {
+      setAttachProgress(null);
+      setError(mailClientErrorMessage(e));
+    }
+  }, [addDraftAttachmentPaths]);
 
   const removeDraftAttachment = (index: number) => {
     setDraft((current) => {
@@ -2094,10 +2289,9 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
         return { ...current, attachments };
       }
       const cid = escapeRegExp(removed.contentId);
-      const htmlBody = current.htmlBody.replace(
-        new RegExp(`<img\\b[^>]*\\bsrc=["']cid:${cid}["'][^>]*>`, "gi"),
-        "",
-      );
+      const htmlBody = current.htmlBody
+        .replace(new RegExp(`<img\\b[^>]*\\bdata-taomni-cid=["']${cid}["'][^>]*>`, "gi"), "")
+        .replace(new RegExp(`<img\\b[^>]*\\bsrc=["']cid:${cid}["'][^>]*>`, "gi"), "");
       return {
         ...current,
         attachments,
@@ -2106,6 +2300,25 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
       };
     });
   };
+
+  useEffect(() => {
+    if (!composeOpen) {
+      setComposeDragActive(false);
+      return;
+    }
+    const handleNativeFileDrop = (event: Event) => {
+      if (sending) return;
+      const detail = (event as CustomEvent<NativeFileDropDetail>).detail;
+      if (!detail?.paths?.length) return;
+      const root = composeRootRef.current;
+      const target = document.elementFromPoint(detail.clientX, detail.clientY);
+      if (!root || !target || !root.contains(target)) return;
+      setComposeDragActive(false);
+      void addDraftAttachmentPaths(detail.paths);
+    };
+    window.addEventListener(NATIVE_FILE_DROP_EVENT, handleNativeFileDrop);
+    return () => window.removeEventListener(NATIVE_FILE_DROP_EVENT, handleNativeFileDrop);
+  }, [addDraftAttachmentPaths, composeOpen, sending]);
 
   const discardCurrentDraft = async () => {
     const draftId = draft.id;
@@ -2808,6 +3021,7 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
     const currentBody = message
       ? bodyCache.get(messageKey(message)) ?? (bodyMatchesMessage(body, message) ? body : null)
       : null;
+    const currentHasRemoteImages = mailHtmlHasRemoteImages(currentBody?.html);
     const currentHtml = currentBody?.html ? sanitizeMailHtml(currentBody.html, allowRemoteImages) : null;
     const currentAttachments = currentBody?.attachments.length ? currentBody.attachments : message?.attachments ?? [];
     const loadingThisBody = !!message && bodyLoadingKey === messageKey(message);
@@ -2889,13 +3103,14 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
               <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-[var(--taomni-text-muted)]">
                 <span>{currentBody?.source === "cache" ? "cached body" : currentBody?.source === "remote" ? "remote body" : "header cached"}</span>
                 {message.rawSize ? <span>{formatBytes(message.rawSize)}</span> : null}
-                {currentBody?.html && (
+                {currentHasRemoteImages && (
                   <button
                     type="button"
                     className="taomni-btn h-5 px-2 text-[10px]"
+                    data-testid="mail-remote-images-header-toggle"
                     onClick={() => setAllowRemoteImages((value) => !value)}
                   >
-                    {allowRemoteImages ? "Block images" : "Load images"}
+                    {allowRemoteImages ? "Block remote images" : "Load remote images"}
                   </button>
                 )}
               </div>
@@ -2941,6 +3156,12 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
                 </div>
               ) : null}
             </div>
+
+            <RemoteImagesBanner
+              visible={currentHasRemoteImages}
+              allowRemoteImages={allowRemoteImages}
+              onToggle={() => setAllowRemoteImages((value) => !value)}
+            />
 
             <div className="p-5 text-[13px] leading-6">
               {loadingThisBody && !currentBody ? (
@@ -3455,13 +3676,14 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
                       <span>{selectedBody?.source === "cache" ? "cached body" : selectedBody?.source === "remote" ? "remote body" : "header cached"}</span>
                       {selectedMessage.rawSize ? <span>{formatBytes(selectedMessage.rawSize)}</span> : null}
                       {info.ai.enabled && <span>AI confirm {info.ai.skipBodyConfirm ? "skipped" : "required"}</span>}
-                      {selectedBody?.html && (
+                      {selectedHasRemoteImages && (
                         <button
                           type="button"
                           className="taomni-btn h-5 px-2 text-[10px]"
+                          data-testid="mail-remote-images-header-toggle"
                           onClick={() => setAllowRemoteImages((value) => !value)}
                         >
-                          {allowRemoteImages ? "Block images" : "Load images"}
+                          {allowRemoteImages ? "Block remote images" : "Load remote images"}
                         </button>
                       )}
                     </div>
@@ -3507,6 +3729,12 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
                       </div>
                     ) : null}
                   </div>
+
+                  <RemoteImagesBanner
+                    visible={selectedHasRemoteImages}
+                    allowRemoteImages={allowRemoteImages}
+                    onToggle={() => setAllowRemoteImages((value) => !value)}
+                  />
 
                   <div className="p-4 text-[13px] leading-6">
                     {selectedMessage && bodyLoadingKey === messageKey(selectedMessage) && !selectedBody ? (
@@ -3655,7 +3883,42 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
       )}
 
       {composeOpen && (
-        <div className="absolute inset-0 z-[150] bg-black/30 flex items-center justify-center p-4" data-testid="mail-compose-dialog">
+        <div
+          ref={composeRootRef}
+          className="absolute inset-0 z-[150] bg-black/30 flex items-center justify-center p-4"
+          data-testid="mail-compose-dialog"
+          onDragEnter={(event: ReactDragEvent<HTMLDivElement>) => {
+            if (sending || !isOsFileDrag(event.dataTransfer)) return;
+            preventDefaultForOsFileDrag(event);
+            event.preventDefault();
+            setComposeDragActive(true);
+          }}
+          onDragOver={(event: ReactDragEvent<HTMLDivElement>) => {
+            if (sending || !isOsFileDrag(event.dataTransfer)) return;
+            preventDefaultForOsFileDrag(event);
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "copy";
+            setComposeDragActive(true);
+          }}
+          onDragLeave={(event: ReactDragEvent<HTMLDivElement>) => {
+            if (!composeRootRef.current?.contains(event.relatedTarget as Node | null)) {
+              setComposeDragActive(false);
+            }
+          }}
+          onDrop={(event: ReactDragEvent<HTMLDivElement>) => {
+            if (sending) return;
+            if (!isOsFileDrag(event.dataTransfer)) return;
+            event.preventDefault();
+            setComposeDragActive(false);
+            const paths = droppedFilePaths(event.dataTransfer);
+            if (paths.length > 0) {
+              void addDraftAttachmentPaths(paths);
+              return;
+            }
+            const files = droppedFiles(event.dataTransfer);
+            if (files.length > 0) void handleDropComposeFiles(files);
+          }}
+        >
           <MailDraggableDialog
             title={draft.id ? "Edit draft" : draft.replyContext?.kind ? "Reply" : "New message"}
             icon={<MailIcon className="w-4 h-4 text-[var(--taomni-text-muted)]" />}
@@ -3673,9 +3936,36 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
               <button type="button" className="taomni-btn h-6 px-2" disabled={sending}>Options</button>
               <button type="button" className="taomni-btn h-6 px-2" disabled={sending}>Tools</button>
               <span className="ml-auto text-[11px] text-[var(--taomni-text-muted)]">
-                {savingDraft ? "Saving draft..." : draft.id ? "Draft saved locally" : "Auto draft"}
+                {attachProgress
+                  ? `${attachProgress.label} ${attachProgress.done}/${attachProgress.total}`
+                  : savingDraft
+                    ? "Saving draft..."
+                    : draft.id
+                      ? "Draft saved locally"
+                      : "Auto draft"}
               </span>
             </div>
+            {attachProgress && (
+              <div
+                className="px-3 py-1.5 border-b border-[var(--taomni-divider)] bg-[var(--taomni-sidebar-bg)] text-[11px] text-[var(--taomni-text-muted)] flex items-center gap-2"
+                data-testid="mail-compose-attach-progress"
+              >
+                {attachProgress.done < attachProgress.total
+                  ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  : <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500" />}
+                <span>
+                  {attachProgress.label}
+                  {" "}
+                  ({attachProgress.done}/{attachProgress.total})
+                </span>
+                <div className="ml-auto h-1.5 w-32 rounded bg-[var(--taomni-divider)] overflow-hidden">
+                  <div
+                    className="h-full bg-[var(--taomni-accent)] transition-all"
+                    style={{ width: `${attachProgress.total ? Math.round((attachProgress.done / attachProgress.total) * 100) : 0}%` }}
+                  />
+                </div>
+              </div>
+            )}
             <div className="p-3 grid grid-cols-[56px_1fr] gap-2 text-[12px]">
               <RecipientField
                 id={`mail-to-${tabId}`}
@@ -3725,37 +4015,55 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
             <RichMailEditor
               html={draft.htmlBody}
               disabled={sending}
+              dragActive={composeDragActive}
               onAttach={() => void handleAddDraftAttachments()}
               onInlineImage={() => handleInsertInlineImage()}
+              onPasteImages={handlePasteImages}
+              onDropFiles={(files) => void handleDropComposeFiles(files)}
               onRichFormatUsed={() => setDraft((current) => ({ ...current, richFormatUsed: true }))}
               onChange={(htmlBody, textBody) => setDraft((current) => ({ ...current, htmlBody, textBody }))}
             />
-            {draft.attachments.length > 0 && (
-              <div className="mx-3 mb-3 flex flex-wrap gap-1.5" data-testid="mail-compose-attachments">
-                {draft.attachments.map((attachment, index) => (
-                  <span
-                    key={`${attachment.path}-${index}`}
-                    className="inline-flex items-center gap-1 rounded border border-[var(--taomni-divider)] px-2 py-1 text-[11px] text-[var(--taomni-text-muted)] bg-[var(--taomni-sidebar-bg)]"
-                    data-testid="mail-compose-attachment-chip"
-                    title={attachment.path}
-                  >
-                    {attachment.inline ? <ImageIcon className="w-3 h-3" /> : <Paperclip className="w-3 h-3" />}
-                    <span className="max-w-[280px] truncate">
-                      {attachment.inline ? "Inline " : ""}{attachment.name || basename(attachment.path)}
-                    </span>
-                    <button
-                      type="button"
-                      className="ml-1 text-[var(--taomni-text-muted)] hover:text-[var(--taomni-text)]"
-                      aria-label={`Remove ${attachment.name || "attachment"}`}
-                      onClick={() => removeDraftAttachment(index)}
-                      disabled={sending}
+            <div
+              className={`mx-3 mb-3 min-h-[40px] rounded border border-dashed px-2 py-2 ${
+                composeDragActive
+                  ? "border-[var(--taomni-accent)] bg-[var(--taomni-accent)]/10"
+                  : "border-[var(--taomni-divider)]"
+              }`}
+              data-testid="mail-compose-attachments"
+              data-drag-active={composeDragActive ? "true" : "false"}
+            >
+              {draft.attachments.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5">
+                  {draft.attachments.map((attachment, index) => (
+                    <span
+                      key={`${attachment.path}-${index}`}
+                      className="inline-flex items-center gap-1 rounded border border-[var(--taomni-divider)] px-2 py-1 text-[11px] text-[var(--taomni-text-muted)] bg-[var(--taomni-sidebar-bg)]"
+                      data-testid="mail-compose-attachment-chip"
+                      title={attachment.path}
                     >
-                      <X className="w-3 h-3" />
-                    </button>
-                  </span>
-                ))}
-              </div>
-            )}
+                      {attachment.inline ? <ImageIcon className="w-3 h-3" /> : <Paperclip className="w-3 h-3" />}
+                      <span className="max-w-[280px] truncate">
+                        {attachment.inline ? "Inline " : ""}{attachment.name || basename(attachment.path)}
+                      </span>
+                      <button
+                        type="button"
+                        className="ml-1 text-[var(--taomni-text-muted)] hover:text-[var(--taomni-text)]"
+                        aria-label={`Remove ${attachment.name || "attachment"}`}
+                        onClick={() => removeDraftAttachment(index)}
+                        disabled={sending}
+                      >
+                        <X className="w-3 h-3" />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-[11px] text-[var(--taomni-text-muted)] flex items-center gap-1.5">
+                  <Paperclip className="w-3.5 h-3.5" />
+                  Drop files here to attach, or use Attach / paste images into the editor
+                </div>
+              )}
+            </div>
             <div className="h-10 px-3 flex items-center justify-end gap-2 border-t border-[var(--taomni-divider)] bg-[var(--taomni-sidebar-bg)]">
               <button type="button" className="taomni-btn h-7 px-3 text-[12px] inline-flex items-center gap-1.5 mr-auto" onClick={() => void handleAddDraftAttachments()} disabled={sending}>
                 <Paperclip className="w-3.5 h-3.5" />

--- a/src/components/mail/RichMailEditor.test.tsx
+++ b/src/components/mail/RichMailEditor.test.tsx
@@ -88,7 +88,7 @@ describe("RichMailEditor", () => {
       <RichMailEditor
         html="<p>Hello</p>"
         onChange={vi.fn()}
-        onInlineImage={vi.fn(async () => "<img src=\"cid:logo-1@inline.local\" alt=\"logo\">")}
+        onInlineImage={vi.fn(async () => "<img src=\"data:image/png;base64,aa\" data-taomni-cid=\"logo-1@inline.local\" alt=\"logo\">")}
       />,
     );
 
@@ -99,7 +99,47 @@ describe("RichMailEditor", () => {
       expect(execCommand).toHaveBeenCalledWith(
         "insertHTML",
         false,
-        "<img src=\"cid:logo-1@inline.local\" alt=\"logo\">",
+        "<img src=\"data:image/png;base64,aa\" data-taomni-cid=\"logo-1@inline.local\" alt=\"logo\">",
+      );
+    });
+  });
+
+  it("pastes clipboard images via the parent handler", async () => {
+    const execCommand = vi.fn();
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+    const onPasteImages = vi.fn(async () => [
+      "<img src=\"data:image/png;base64,aa\" data-taomni-cid=\"paste@inline.local\" alt=\"pasted\">",
+    ]);
+    const file = new File([new Uint8Array([1, 2, 3])], "clip.png", { type: "image/png" });
+
+    render(
+      <RichMailEditor
+        html="<p>Hello</p>"
+        onChange={vi.fn()}
+        onPasteImages={onPasteImages}
+      />,
+    );
+
+    const editor = screen.getByTestId("mail-compose-editor");
+    const clipboardData = {
+      items: [{
+        type: "image/png",
+        getAsFile: () => file,
+      }],
+      files: [file],
+      getData: () => "",
+    };
+    fireEvent.paste(editor, { clipboardData });
+
+    await waitFor(() => {
+      expect(onPasteImages).toHaveBeenCalledTimes(1);
+      expect(execCommand).toHaveBeenCalledWith(
+        "insertHTML",
+        false,
+        "<img src=\"data:image/png;base64,aa\" data-taomni-cid=\"paste@inline.local\" alt=\"pasted\">",
       );
     });
   });

--- a/src/components/mail/RichMailEditor.tsx
+++ b/src/components/mail/RichMailEditor.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useRef, useState, type ClipboardEvent, type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ClipboardEvent,
+  type DragEvent as ReactDragEvent,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from "react";
 import {
   AlignCenter,
   AlignLeft,
@@ -20,6 +28,7 @@ import {
   Underline,
 } from "lucide-react";
 import { mailHtmlToPlainText, sanitizeMailComposeHtml } from "../../lib/mailHtml";
+import { isOsFileDrag, preventDefaultForOsFileDrag } from "../../lib/osFileDrop";
 import { useContextMenu, type MenuItem } from "../ContextMenu";
 
 interface RichMailEditorProps {
@@ -29,6 +38,11 @@ interface RichMailEditorProps {
   onRichFormatUsed?: () => void;
   onAttach?: () => void;
   onInlineImage?: () => string | null | Promise<string | null>;
+  /** Paste / drop image blobs → parent returns insertable HTML snippets (data URL + cid metadata). */
+  onPasteImages?: (files: File[]) => Promise<string[]>;
+  /** Non-image file drops should become regular attachments. */
+  onDropFiles?: (files: File[]) => void | Promise<void>;
+  dragActive?: boolean;
 }
 
 const PARAGRAPH_OPTIONS = [
@@ -80,9 +94,13 @@ export function RichMailEditor({
   onRichFormatUsed,
   onAttach,
   onInlineImage,
+  onPasteImages,
+  onDropFiles,
+  dragActive = false,
 }: RichMailEditorProps) {
   const editorRef = useRef<HTMLDivElement>(null);
   const [color, setColor] = useState("#1f2937");
+  const [localDrag, setLocalDrag] = useState(false);
   const editorMenu = useContextMenu();
 
   useEffect(() => {
@@ -120,6 +138,24 @@ export function RichMailEditor({
   };
 
   const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {
+    if (disabled) return;
+
+    const imageFiles = clipboardImageFiles(event.clipboardData);
+    if (imageFiles.length > 0 && onPasteImages) {
+      event.preventDefault();
+      void (async () => {
+        try {
+          const snippets = await onPasteImages(imageFiles);
+          for (const snippet of snippets) {
+            if (snippet) insertHtml(snippet, true);
+          }
+        } catch {
+          // Parent surfaces errors via compose status/error.
+        }
+      })();
+      return;
+    }
+
     event.preventDefault();
     const pastedHtml = event.clipboardData.getData("text/html");
     const pastedText = event.clipboardData.getData("text/plain");
@@ -128,6 +164,51 @@ export function RichMailEditor({
       return;
     }
     if (pastedText) insertHtml(escapeHtml(pastedText).replace(/\r?\n/g, "<br>"), false);
+  };
+
+  const handleDragOver = (event: ReactDragEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    if (!isOsFileDrag(event.dataTransfer) && !hasFilePayload(event.dataTransfer)) return;
+    preventDefaultForOsFileDrag(event);
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+    setLocalDrag(true);
+  };
+
+  const handleDragLeave = (event: ReactDragEvent<HTMLDivElement>) => {
+    if (!editorRef.current?.contains(event.relatedTarget as Node | null)) {
+      setLocalDrag(false);
+    }
+  };
+
+  const handleDrop = (event: ReactDragEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    setLocalDrag(false);
+    if (!isOsFileDrag(event.dataTransfer) && !hasFilePayload(event.dataTransfer)) return;
+    event.preventDefault();
+    const files = Array.from(event.dataTransfer.files ?? []);
+    if (files.length === 0) return;
+
+    const images = files.filter((file) => file.type.startsWith("image/"));
+    const others = files.filter((file) => !file.type.startsWith("image/"));
+
+    void (async () => {
+      if (images.length > 0 && onPasteImages) {
+        try {
+          const snippets = await onPasteImages(images);
+          for (const snippet of snippets) {
+            if (snippet) insertHtml(snippet, true);
+          }
+        } catch {
+          // Parent surfaces errors.
+        }
+      }
+      if (others.length > 0 && onDropFiles) {
+        await onDropFiles(others);
+      } else if (images.length === 0 && others.length === 0 && onDropFiles) {
+        await onDropFiles(files);
+      }
+    })();
   };
 
   const handleLink = () => {
@@ -206,8 +287,18 @@ export function RichMailEditor({
     },
   ];
 
+  const showDrag = dragActive || localDrag;
+
   return (
-    <div className="mx-3 mb-3 min-h-0 flex-1 flex flex-col border border-[var(--taomni-input-border)] rounded-md overflow-hidden bg-[var(--taomni-input-bg)]">
+    <div
+      className={`mx-3 mb-3 min-h-0 flex-1 flex flex-col border rounded-md overflow-hidden bg-[var(--taomni-input-bg)] ${
+        showDrag
+          ? "border-[var(--taomni-accent)] ring-1 ring-[var(--taomni-accent)]"
+          : "border-[var(--taomni-input-border)]"
+      }`}
+      data-testid="mail-compose-editor-shell"
+      data-drag-active={showDrag ? "true" : "false"}
+    >
       <div
         className="min-h-9 px-2 py-1 flex flex-wrap items-center gap-1 border-b border-[var(--taomni-divider)] bg-[var(--taomni-chrome-bg)]"
         data-testid="mail-compose-format-toolbar"
@@ -290,17 +381,30 @@ export function RichMailEditor({
         )}
       </div>
       {editorMenu.render}
-      <div
-        ref={editorRef}
-        className="flex-1 min-h-[240px] overflow-auto px-3 py-2 text-[13px] leading-6 outline-none bg-[var(--taomni-input-bg)] empty:before:content-['']"
-        contentEditable={!disabled}
-        suppressContentEditableWarning
-        role="textbox"
-        aria-label="Message body"
-        data-testid="mail-compose-editor"
-        onInput={emitChange}
-        onPaste={handlePaste}
-      />
+      <div className="relative flex-1 min-h-[240px] flex flex-col">
+        <div
+          ref={editorRef}
+          className="flex-1 min-h-[240px] overflow-auto px-3 py-2 text-[13px] leading-6 outline-none bg-[var(--taomni-input-bg)] empty:before:content-['']"
+          contentEditable={!disabled}
+          suppressContentEditableWarning
+          role="textbox"
+          aria-label="Message body"
+          data-testid="mail-compose-editor"
+          onInput={emitChange}
+          onPaste={handlePaste}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        />
+        {showDrag && (
+          <div
+            className="pointer-events-none absolute inset-0 flex items-center justify-center bg-[var(--taomni-accent)]/10 text-[12px] font-medium text-[var(--taomni-accent)]"
+            data-testid="mail-compose-drop-hint"
+          >
+            Drop files to attach · drop images to insert inline
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -368,6 +472,24 @@ function buildTableHtml(cols: number, rows: number): string {
   )).join("");
   const body = Array.from({ length: rows }, () => `<tr>${cells}</tr>`).join("");
   return `<table style="border-collapse: collapse;"><tbody>${body}</tbody></table><p><br></p>`;
+}
+
+function clipboardImageFiles(data: DataTransfer | null): File[] {
+  if (!data) return [];
+  const fromItems: File[] = [];
+  for (const item of Array.from(data.items ?? [])) {
+    if (!item.type.startsWith("image/")) continue;
+    const file = item.getAsFile();
+    if (file) fromItems.push(file);
+  }
+  if (fromItems.length > 0) return fromItems;
+  return Array.from(data.files ?? []).filter((file) => file.type.startsWith("image/"));
+}
+
+function hasFilePayload(data: DataTransfer | null): boolean {
+  if (!data) return false;
+  if ((data.files?.length ?? 0) > 0) return true;
+  return Array.from(data.types ?? []).some((type) => type === "Files" || type === "text/uri-list");
 }
 
 function escapeHtml(value: string): string {

--- a/src/lib/mailHtml.test.ts
+++ b/src/lib/mailHtml.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildInlineImageHtml,
   buildReplyHtml,
   hasRichMailFormatting,
+  isRemoteMailImageSrc,
+  mailHtmlHasRemoteImages,
   mailHtmlToPlainText,
   plainTextToMailHtml,
+  prepareMailHtmlForSend,
   sanitizeMailComposeHtml,
   sanitizeMailDisplayHtml,
 } from "./mailHtml";
@@ -28,30 +32,63 @@ describe("mailHtml", () => {
     expect(html).not.toContain("background-image");
   });
 
-  it("blocks remote images for display until explicitly allowed", () => {
-    const blocked = sanitizeMailDisplayHtml("<p>before<img src=\"https://example.com/a.png\" alt=\"x\">after</p>", false);
-    const allowed = sanitizeMailDisplayHtml("<p>before<img src=\"https://example.com/a.png\" alt=\"x\">after</p>", true);
+  it("blocks only remote images for display until explicitly allowed (Thunderbird-style)", () => {
+    const mixed = [
+      "<p>before",
+      "<img src=\"https://example.com/a.png\" alt=\"remote\">",
+      "<img src=\"cid:logo@inline.local\" alt=\"embedded\">",
+      "<img src=\"data:image/png;base64,aaaa\" alt=\"data\">",
+      "after</p>",
+    ].join("");
 
-    expect(blocked).toContain("[image blocked]");
-    expect(blocked).not.toContain("<img");
-    expect(allowed).toContain("<img");
+    const blocked = sanitizeMailDisplayHtml(mixed, false);
+    const allowed = sanitizeMailDisplayHtml(mixed, true);
+
+    expect(blocked).toContain("[remote image blocked]");
+    expect(blocked).not.toContain("https://example.com/a.png");
+    expect(blocked).toContain("cid:logo@inline.local");
+    expect(blocked).toContain("data:image/png;base64,aaaa");
     expect(allowed).toContain("https://example.com/a.png");
+    expect(allowed).toContain("cid:logo@inline.local");
+    expect(isRemoteMailImageSrc("https://cdn.example/x.png")).toBe(true);
+    expect(isRemoteMailImageSrc("cid:logo@inline.local")).toBe(false);
+    expect(isRemoteMailImageSrc("data:image/png;base64,aa")).toBe(false);
+    expect(mailHtmlHasRemoteImages(mixed)).toBe(true);
+    expect(mailHtmlHasRemoteImages("<p><img src=\"cid:x@y\"></p>")).toBe(false);
   });
 
-  it("preserves compose CID images and safe inserted table styles", () => {
+  it("preserves compose CID/data images and safe inserted table styles", () => {
     const html = sanitizeMailComposeHtml(`
       <p><img src="cid:logo-1@inline.local" alt="logo"></p>
+      <p><img src="data:image/png;base64,abcd" data-taomni-cid="paste-1@inline.local" alt="pasted"></p>
       <table style="border-collapse: collapse; position: fixed">
         <tbody><tr><td style="border: 1px solid #9ca3af; padding: 4px 8px; background-image: url(javascript:alert(1))">Cell</td></tr></tbody>
       </table>
     `);
 
     expect(html).toContain("src=\"cid:logo-1@inline.local\"");
+    expect(html).toContain("data:image/png;base64,abcd");
+    expect(html).toContain("data-taomni-cid=\"paste-1@inline.local\"");
     expect(html).toContain("border-collapse: collapse");
     expect(html).toContain("border: 1px solid #9ca3af");
     expect(html).toContain("padding: 4px 8px");
     expect(html).not.toContain("position");
     expect(html).not.toContain("background-image");
+  });
+
+  it("builds preview HTML and rewrites data-taomni-cid images to cid for send", () => {
+    const preview = buildInlineImageHtml({
+      contentId: "logo-1@inline.local",
+      dataUrl: "data:image/png;base64,abcd",
+      alt: "logo",
+    });
+    expect(preview).toContain("data:image/png;base64,abcd");
+    expect(preview).toContain("data-taomni-cid=\"logo-1@inline.local\"");
+
+    const forSend = prepareMailHtmlForSend(`<p>${preview}</p>`);
+    expect(forSend).toContain("src=\"cid:logo-1@inline.local\"");
+    expect(forSend).not.toContain("data:image");
+    expect(forSend).not.toContain("data-taomni-cid");
   });
 
   it("round-trips plain text through mail HTML and extracts readable text from lists and paragraphs", () => {

--- a/src/lib/mailHtml.ts
+++ b/src/lib/mailHtml.ts
@@ -9,9 +9,9 @@ const MAIL_ALLOWED_TAGS = [
 ];
 
 const MAIL_ALLOWED_ATTR = [
-  "align", "alt", "class", "color", "colspan", "face", "height", "href",
-  "lang", "name", "rel", "rowspan", "size", "src", "style", "target",
-  "title", "width",
+  "align", "alt", "class", "color", "colspan", "data-taomni-cid", "face",
+  "height", "href", "lang", "name", "rel", "rowspan", "size", "src", "style",
+  "target", "title", "width",
 ];
 
 const MAIL_PURIFY_CONFIG: DomPurifyConfig = {
@@ -20,8 +20,9 @@ const MAIL_PURIFY_CONFIG: DomPurifyConfig = {
   FORBID_TAGS: ["script", "iframe", "object", "embed", "link", "meta"],
   FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover", "onfocus"],
   ALLOW_DATA_ATTR: false,
-  ADD_ATTR: ["target"],
-  ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|cid):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+  ADD_ATTR: ["target", "data-taomni-cid"],
+  // Thunderbird-style: allow embedded cid:/data: images; remote http(s) stay for optional load.
+  ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|cid|data):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
 };
 
 const SAFE_STYLE_PROPS = new Set([
@@ -39,6 +40,8 @@ const SAFE_STYLE_PROPS = new Set([
   "text-decoration",
   "text-decoration-line",
 ]);
+
+const REMOTE_IMAGE_PLACEHOLDER = "[remote image blocked]";
 
 let hooksInstalled = false;
 
@@ -111,17 +114,47 @@ function isSafeCssColor(value: string): boolean {
   return /^rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}(\s*,\s*(0|1|0?\.\d+))?\s*\)$/.test(lower);
 }
 
-export function sanitizeMailDisplayHtml(html: string, allowImages: boolean): string {
+/** Remote content that should stay blocked until the user opts in (Thunderbird privacy model). */
+export function isRemoteMailImageSrc(src: string | null | undefined): boolean {
+  const value = (src ?? "").trim();
+  if (!value) return false;
+  if (/^(cid:|data:|blob:|file:)/i.test(value)) return false;
+  return /^(https?:|\/\/)/i.test(value);
+}
+
+export function mailHtmlHasRemoteImages(html: string | null | undefined): boolean {
+  const value = html?.trim();
+  if (!value) return false;
+  if (typeof DOMParser === "undefined") {
+    return /<img\b[^>]*\bsrc\s*=\s*["']?\s*(?:https?:|\/\/)/i.test(value);
+  }
+  const doc = new DOMParser().parseFromString(value, "text/html");
+  return Array.from(doc.querySelectorAll("img")).some((img) => isRemoteMailImageSrc(img.getAttribute("src")));
+}
+
+/**
+ * Sanitize HTML for the message reader.
+ * When allowRemoteImages is false, only remote http(s) images are blocked —
+ * embedded cid:/data: images remain visible (Thunderbird-aligned).
+ */
+export function sanitizeMailDisplayHtml(html: string, allowRemoteImages: boolean): string {
   installMailPurifyHooks();
   const sanitized = DOMPurify.sanitize(html, MAIL_PURIFY_CONFIG) as unknown as string;
-  if (allowImages) return sanitized;
+  if (allowRemoteImages) return sanitized;
   if (typeof DOMParser === "undefined") {
-    return sanitized.replace(/<img\b[^>]*>/gi, "[image blocked]");
+    return sanitized.replace(/<img\b[^>]*>/gi, (tag) => {
+      const srcMatch = /\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(tag);
+      const src = srcMatch?.[1] ?? srcMatch?.[2] ?? srcMatch?.[3] ?? "";
+      return isRemoteMailImageSrc(src) ? REMOTE_IMAGE_PLACEHOLDER : tag;
+    });
   }
   const doc = new DOMParser().parseFromString(sanitized, "text/html");
   doc.querySelectorAll("img").forEach((img) => {
+    if (!isRemoteMailImageSrc(img.getAttribute("src"))) return;
     const placeholder = doc.createElement("span");
-    placeholder.textContent = "[image blocked]";
+    placeholder.setAttribute("data-taomni-remote-image", "blocked");
+    placeholder.className = "taomni-mail-remote-image-blocked";
+    placeholder.textContent = REMOTE_IMAGE_PLACEHOLDER;
     img.replaceWith(placeholder);
   });
   return doc.body.innerHTML;
@@ -131,6 +164,38 @@ export function sanitizeMailComposeHtml(html: string): string {
   installMailPurifyHooks();
   const sanitized = DOMPurify.sanitize(html, MAIL_PURIFY_CONFIG) as unknown as string;
   return sanitized.trim() || "<p><br></p>";
+}
+
+/** Build a compose-time inline image that previews via data URL and sends as cid: */
+export function buildInlineImageHtml(opts: {
+  contentId: string;
+  dataUrl: string;
+  alt?: string;
+}): string {
+  const contentId = opts.contentId.trim();
+  const dataUrl = opts.dataUrl.trim();
+  const alt = opts.alt?.trim() || "image";
+  return `<img src="${escapeHtml(dataUrl)}" data-taomni-cid="${escapeHtml(contentId)}" alt="${escapeHtml(alt)}">`;
+}
+
+/** Rewrite compose previews (data URL + data-taomni-cid) to cid: for MIME send. */
+export function prepareMailHtmlForSend(html: string): string {
+  const sanitized = sanitizeMailComposeHtml(html);
+  if (typeof DOMParser === "undefined") {
+    return sanitized.replace(
+      /<img\b([^>]*?)\bsrc=(["'])data:[^"']*\2([^>]*?)\bdata-taomni-cid=(["'])([^"']+)\4([^>]*)>/gi,
+      (_full, before: string, _q1: string, mid: string, _q2: string, cid: string, after: string) =>
+        `<img${before}src="cid:${cid}"${mid}${after}>`.replace(/\sdata-taomni-cid=(["'])[^"']+\1/i, ""),
+    );
+  }
+  const doc = new DOMParser().parseFromString(sanitized, "text/html");
+  doc.querySelectorAll("img[data-taomni-cid]").forEach((img) => {
+    const cid = img.getAttribute("data-taomni-cid")?.trim();
+    if (!cid) return;
+    img.setAttribute("src", `cid:${cid}`);
+    img.removeAttribute("data-taomni-cid");
+  });
+  return doc.body.innerHTML.trim() || "<p><br></p>";
 }
 
 export function plainTextToMailHtml(text: string): string {


### PR DESCRIPTION
…chments

Address issue #379: remote images blocked incorrectly, no paste-to-insert, and no drag-and-drop attachments in compose.

Reader (Thunderbird privacy model):
- Only block remote http(s) images by default; keep cid:/data: embeds visible
- Rewrite MIME cid: inline images to data: URLs when parsing bodies so the webview can render them without a network fetch
- Surface a privacy banner with "Show/Block remote content" instead of a silent "[image blocked]" replacement for every img tag

Composer:
- Paste (Ctrl/Cmd+V) clipboard images into the rich editor as inline parts
- Drag-and-drop files onto the compose window/editor/attachment zone (multi-file), with progress/success feedback
- Preview inline images via data URL + data-taomni-cid; rewrite to cid: on send so SMTP multipart/related embedding still works

Tests cover remote-vs-embedded sanitization, paste insertion, send-time cid rewrite, and backend cid→data URL rewriting.