### PR TITLE
fix(mail): paste clipboard images on Linux via native arboard fallback

### DIFF
--- a/src/components/mail/MailClientTab.tsx
+++ b/src/components/mail/MailClientTab.tsx
@@ -121,6 +121,10 @@ import {
   writeStreamOpen,
 } from "../../lib/ipc";
 import {
+  readClipboardImageFiles,
+  readNativeClipboardImagePath,
+} from "../../lib/clipboard";
+import {
   droppedFilePaths,
   droppedFiles,
   isOsFileDrag,
@@ -2240,14 +2244,40 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
 
   const handlePasteImages = useCallback(async (files: File[]): Promise<string[]> => {
     const snippets: string[] = [];
-    setAttachProgress({ done: 0, total: files.length, label: "Inserting images…" });
-    try {
-      for (let i = 0; i < files.length; i += 1) {
-        const html = await insertInlineImageFromFile(files[i]);
-        if (html) snippets.push(html);
-        setAttachProgress({ done: i + 1, total: files.length, label: "Inserting images…" });
+    // Prefer files from the paste event when present (multi-image). When the
+    // webview omits image/* (common on Linux WebKitGTK for screenshots), fall
+    // back to native arboard, then the async Clipboard API.
+    let imageFiles = files.filter((file) => (file.type || "").startsWith("image/"));
+    if (imageFiles.length === 0) {
+      const nativePath = await readNativeClipboardImagePath();
+      if (nativePath) {
+        setAttachProgress({ done: 0, total: 1, label: "Inserting images…" });
+        try {
+          const html = await insertInlineImageFromPath(nativePath);
+          if (html) {
+            setAttachProgress({ done: 1, total: 1, label: "Images inserted" });
+            setStatus("Image pasted");
+            window.setTimeout(() => setAttachProgress(null), 1200);
+            return [html];
+          }
+        } catch (e) {
+          setAttachProgress(null);
+          setError(mailClientErrorMessage(e));
+          return [];
+        }
       }
-      setAttachProgress({ done: files.length, total: files.length, label: "Images inserted" });
+      imageFiles = await readClipboardImageFiles();
+    }
+    if (imageFiles.length === 0) return [];
+
+    setAttachProgress({ done: 0, total: imageFiles.length, label: "Inserting images…" });
+    try {
+      for (let i = 0; i < imageFiles.length; i += 1) {
+        const html = await insertInlineImageFromFile(imageFiles[i]);
+        if (html) snippets.push(html);
+        setAttachProgress({ done: i + 1, total: imageFiles.length, label: "Inserting images…" });
+      }
+      setAttachProgress({ done: imageFiles.length, total: imageFiles.length, label: "Images inserted" });
       if (snippets.length > 0) {
         setStatus(snippets.length === 1 ? "Image pasted" : `${snippets.length} images pasted`);
       }
@@ -2258,7 +2288,7 @@ export function MailClientTab({ tabId, info, visible, onEditSession }: MailClien
       setError(mailClientErrorMessage(e));
       return snippets;
     }
-  }, [insertInlineImageFromFile]);
+  }, [insertInlineImageFromFile, insertInlineImageFromPath]);
 
   const handleDropComposeFiles = useCallback(async (files: File[]) => {
     if (files.length === 0) return;

--- a/src/components/mail/RichMailEditor.test.tsx
+++ b/src/components/mail/RichMailEditor.test.tsx
@@ -143,4 +143,79 @@ describe("RichMailEditor", () => {
       );
     });
   });
+
+  it("asks parent for native clipboard images when paste event has no image items", async () => {
+    const execCommand = vi.fn();
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+    const onPasteImages = vi.fn(async (files: File[]) => {
+      expect(files).toEqual([]);
+      return [
+        "<img src=\"data:image/png;base64,bb\" data-taomni-cid=\"native@inline.local\" alt=\"native\">",
+      ];
+    });
+
+    render(
+      <RichMailEditor
+        html="<p>Hello</p>"
+        onChange={vi.fn()}
+        onPasteImages={onPasteImages}
+      />,
+    );
+
+    const editor = screen.getByTestId("mail-compose-editor");
+    // Linux WebKitGTK paste of a screenshot: no image/* items, no text.
+    fireEvent.paste(editor, {
+      clipboardData: {
+        items: [],
+        files: [],
+        getData: () => "",
+      },
+    });
+
+    await waitFor(() => {
+      expect(onPasteImages).toHaveBeenCalledWith([]);
+      expect(execCommand).toHaveBeenCalledWith(
+        "insertHTML",
+        false,
+        "<img src=\"data:image/png;base64,bb\" data-taomni-cid=\"native@inline.local\" alt=\"native\">",
+      );
+    });
+  });
+
+  it("does not call native image paste when plain text is present", async () => {
+    const execCommand = vi.fn();
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+    const onPasteImages = vi.fn(async () => []);
+
+    render(
+      <RichMailEditor
+        html="<p>Hello</p>"
+        onChange={vi.fn()}
+        onPasteImages={onPasteImages}
+      />,
+    );
+
+    fireEvent.paste(screen.getByTestId("mail-compose-editor"), {
+      clipboardData: {
+        items: [],
+        files: [],
+        getData: (type: string) => (type === "text/plain" ? "hello from clipboard" : ""),
+      },
+    });
+
+    await waitFor(() => {
+      expect(execCommand).toHaveBeenCalledWith(
+        "insertHTML",
+        false,
+        "hello from clipboard",
+      );
+    });
+    expect(onPasteImages).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/mail/RichMailEditor.tsx
+++ b/src/components/mail/RichMailEditor.tsx
@@ -140,8 +140,16 @@ export function RichMailEditor({
   const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {
     if (disabled) return;
 
+    const pastedHtml = event.clipboardData?.getData("text/html") ?? "";
+    const pastedText = event.clipboardData?.getData("text/plain") ?? "";
     const imageFiles = clipboardImageFiles(event.clipboardData);
-    if (imageFiles.length > 0 && onPasteImages) {
+    // Linux WebKitGTK often omits image/* from the paste event even when the
+    // OS clipboard holds a screenshot. When there is no text/html payload,
+    // let the parent try native clipboard image read.
+    const maybeNativeImageOnly =
+      !!onPasteImages && imageFiles.length === 0 && !pastedHtml.trim() && !pastedText.trim();
+
+    if (onPasteImages && (imageFiles.length > 0 || maybeNativeImageOnly)) {
       event.preventDefault();
       void (async () => {
         try {
@@ -157,8 +165,6 @@ export function RichMailEditor({
     }
 
     event.preventDefault();
-    const pastedHtml = event.clipboardData.getData("text/html");
-    const pastedText = event.clipboardData.getData("text/plain");
     if (pastedHtml) {
       insertHtml(sanitizeMailComposeHtml(pastedHtml), true);
       return;

--- a/src/lib/clipboard.test.ts
+++ b/src/lib/clipboard.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import {
+  readClipboardImageFiles,
   readMultiFormat,
+  readNativeClipboardImagePath,
   writeMultiFormat,
   writeText,
   writeImagePng,
@@ -102,5 +104,21 @@ describe("clipboard.writeImagePng", () => {
     });
     await expect(writeImagePng(new Blob([]))).rejects.toThrow();
     if (original) (globalThis as { ClipboardItem?: unknown }).ClipboardItem = original;
+  });
+});
+
+describe("clipboard.readNativeClipboardImagePath", () => {
+  it("returns null outside Tauri", async () => {
+    await expect(readNativeClipboardImagePath()).resolves.toBeNull();
+  });
+});
+
+describe("clipboard.readClipboardImageFiles", () => {
+  it("returns empty when clipboard.read is unavailable", async () => {
+    Object.defineProperty(globalThis, "navigator", {
+      value: { clipboard: {} },
+      configurable: true,
+    });
+    await expect(readClipboardImageFiles()).resolves.toEqual([]);
   });
 });

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -139,6 +139,53 @@ export async function writeImagePng(blob: Blob): Promise<void> {
   await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
 }
 
+/**
+ * Read a system clipboard image into a temp PNG via native arboard.
+ *
+ * WebKitGTK (Linux Tauri) often omits image/* from paste events even when the
+ * OS clipboard holds a screenshot or "copy image" bitmap. Chat already uses
+ * `chat_read_clipboard_image_attachment`; mail compose reuses the same path.
+ */
+export async function readNativeClipboardImagePath(): Promise<string | null> {
+  if (!isTauriRuntime()) return null;
+  try {
+    const attachment = await invoke<{ path?: string | null } | null>(
+      "chat_read_clipboard_image_attachment",
+    );
+    const path = typeof attachment?.path === "string" ? attachment.path.trim() : "";
+    return path || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort image files from the async Clipboard API (browser / some webviews).
+ * Returns [] when unavailable or permission is denied.
+ */
+export async function readClipboardImageFiles(): Promise<File[]> {
+  if (typeof navigator === "undefined" || !navigator.clipboard?.read) return [];
+  try {
+    const items = await navigator.clipboard.read();
+    const files: File[] = [];
+    for (const item of items) {
+      for (const type of item.types) {
+        if (!type.startsWith("image/")) continue;
+        try {
+          const blob = await item.getType(type);
+          const ext = type.split("/")[1]?.split(";")[0] || "png";
+          files.push(new File([blob], `pasted-image.${ext}`, { type }));
+        } catch {
+          // Skip unreadable type.
+        }
+      }
+    }
+    return files;
+  } catch {
+    return [];
+  }
+}
+
 /** Read multi-format clipboard. Returns text plus html/rtf when available. */
 export async function readMultiFormat(): Promise<PasteResult> {
   const text = await readText();


### PR DESCRIPTION
Drag-and-drop already inserted images/attachments in the composer, but Ctrl/Cmd+V often failed on Linux desktop. WebKitGTK frequently omits image/* from the paste event even when the OS clipboard holds a screenshot or "Copy Image" bitmap, so the previous File-only path never ran.

Behavior:
- RichMailEditor still prefers paste-event image Files when present.
- If there are no image Files and also no text/html payload, it asks the parent for a native/async clipboard image (empty File list signals fallback) so text paste is not stolen.
- MailClientTab.handlePasteImages then tries, in order: 1) File blobs from the paste event (multi-image) 2) native arboard via chat_read_clipboard_image_attachment → temp PNG → existing insertInlineImageFromPath / CID inline path 3) navigator.clipboard.read() image types as a secondary fallback
- Shared helpers live in lib/clipboard.ts for reuse with chat.

Cross-platform notes: Win/macOS WebView paste usually already supplies image Files (path 1). The native path reuses the same arboard command already used for chat image paste and only runs when path 1 is empty and there is no text, so ordinary text/HTML paste should be unchanged.

Tests cover native-fallback paste, text paste not triggering image handling, and the new clipboard helpers.