### PR TITLE
feat(sftp): add global local double-click open/upload preference

### DIFF
--- a/src/components/filebrowser/FileBrowser.tsx
+++ b/src/components/filebrowser/FileBrowser.tsx
@@ -34,6 +34,7 @@ import { useAppStore } from "../../stores/appStore";
 import { useT, type TranslateFn } from "../../lib/i18n";
 import { useConfirmDialog, useTextInputDialog } from "../sidebar/ConfirmDialog";
 import { loadResizableLayout, saveResizableLayout } from "../../lib/resizableLayout";
+import { loadSftpPreferences } from "../../lib/sftpPreferences";
 
 type Orientation = "horizontal" | "vertical";
 
@@ -335,6 +336,14 @@ export function FileBrowser(props: FileBrowserProps) {
         setDownloadPrompt(entry);
         return;
       }
+      // Local file: open or upload based on global SFTP preference (default: open).
+      const { localDoubleClickAction } = loadSftpPreferences();
+      if (localDoubleClickAction === "upload") {
+        const remoteDir = session?.remote.path ?? "/";
+        const mappedRemote = resolveRemoteByMapping(entry.path, mappings);
+        void controller.upload(entry, mappedRemote ?? remoteDir);
+        return;
+      }
       try {
         const { sftpOpenPath } = await import("../../lib/sftp");
         await sftpOpenPath(entry.path);
@@ -342,7 +351,16 @@ export function FileBrowser(props: FileBrowserProps) {
         setStatus(t("fileBrowser.statusFailedToOpen", { name: entry.name, error: String(err) }));
       }
     },
-    [navigate, props.sessionId, props.onTerminalSync, setStatus, t],
+    [
+      controller,
+      mappings,
+      navigate,
+      props.sessionId,
+      props.onTerminalSync,
+      session?.remote.path,
+      setStatus,
+      t,
+    ],
   );
 
   const handleDownloadConfirmed = useCallback(

--- a/src/components/filebrowser/FileToolbarWiring.test.tsx
+++ b/src/components/filebrowser/FileToolbarWiring.test.tsx
@@ -8,6 +8,10 @@ import { useSftpStore, type PaneState } from "../../stores/sftpStore";
 import { NATIVE_FILE_DROP_EVENT } from "../../lib/osFileDrop";
 import type { FileEntry } from "../../lib/sftp";
 import { setLocale } from "../../lib/i18n";
+import {
+  saveSftpPreferences,
+  SFTP_PREFERENCES_STORAGE_KEY,
+} from "../../lib/sftpPreferences";
 
 const controllerMocks = vi.hoisted(() => ({
   upload: vi.fn(async () => undefined),
@@ -35,6 +39,7 @@ const sftpMocks = vi.hoisted(() => ({
     fileType: "file",
     isHidden: false,
   })),
+  sftpOpenPath: vi.fn(async () => undefined),
 }));
 
 vi.mock("../../lib/sftpController", () => ({
@@ -52,6 +57,7 @@ vi.mock("../../lib/sftp", async () => {
     sftpDetach: vi.fn(async () => undefined),
     sftpRealpath: vi.fn(async (_sid: string, p: string) => p),
     sftpStat: sftpMocks.sftpStat,
+    sftpOpenPath: sftpMocks.sftpOpenPath,
   };
 });
 
@@ -129,6 +135,7 @@ afterEach(() => {
   cleanup();
   useSftpStore.setState({ sessions: {} });
   setLocale("en");
+  localStorage.removeItem(SFTP_PREFERENCES_STORAGE_KEY);
   vi.clearAllMocks();
 });
 
@@ -583,6 +590,36 @@ describe("FileBrowser → FilePanel toolbar wiring", () => {
     expect(uploadArgs[0]).toMatchObject({
       path: "/work/notes.txt",
     });
+  });
+
+  it("double-clicks a local file to open it by default", async () => {
+    seedSession();
+    renderBrowser();
+
+    const localPanel = screen.getByText("LOCAL").closest("div.h-full") as HTMLElement;
+    fireEvent.doubleClick(within(localPanel).getByText("notes.txt"));
+
+    await waitFor(() => {
+      expect(sftpMocks.sftpOpenPath).toHaveBeenCalledWith("/work/notes.txt");
+    });
+    expect(controllerMocks.upload).not.toHaveBeenCalled();
+  });
+
+  it("double-clicks a local file to upload when the preference is upload", async () => {
+    saveSftpPreferences({ localDoubleClickAction: "upload" });
+    seedSession();
+    renderBrowser();
+
+    const localPanel = screen.getByText("LOCAL").closest("div.h-full") as HTMLElement;
+    fireEvent.doubleClick(within(localPanel).getByText("notes.txt"));
+
+    await waitFor(() => {
+      expect(controllerMocks.upload).toHaveBeenCalledWith(
+        expect.objectContaining({ path: "/work/notes.txt", name: "notes.txt" }),
+        "/work",
+      );
+    });
+    expect(sftpMocks.sftpOpenPath).not.toHaveBeenCalled();
   });
 
   it("uploads OS-dropped files to the current remote directory", async () => {

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -61,6 +61,7 @@ import { TerminalAppearanceSettings } from "../terminal/TerminalAppearanceSettin
 import { SqlCompletionSettings } from "./SqlCompletionSettings";
 import { SqlExecutionSettings } from "./SqlExecutionSettings";
 import { LanguageServersSettings } from "./LanguageServersSettings";
+import { SftpSettings } from "./SftpSettings";
 import { FontPickerSelect, type FontPickerOption } from "../terminal/FontPickerPanel";
 import {
   consumePendingSettingsSection,
@@ -715,7 +716,10 @@ export function SettingsPanel() {
             matchCount={matchCountByGroup.terminal ?? 0}
             searching={searching}
           >
-            <SettingsAnchor id="terminal-defaults">
+            <SettingsAnchor id="sftp">
+              <SftpSettings />
+            </SettingsAnchor>
+            <SettingsAnchor id="terminal-defaults" className="mt-4">
               <div className="mb-4 flex items-center gap-3">
                 <Terminal className="w-4 h-4 text-[var(--taomni-accent)]" />
                 <div>

--- a/src/components/settings/SftpSettings.test.tsx
+++ b/src/components/settings/SftpSettings.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { SftpSettings } from "./SftpSettings";
+import {
+  loadSftpPreferences,
+  SFTP_PREFERENCES_STORAGE_KEY,
+} from "../../lib/sftpPreferences";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe("SftpSettings", () => {
+  it("renders with open selected by default and can switch to upload", () => {
+    render(<SftpSettings />);
+
+    const openBtn = screen.getByTestId("sftp-local-double-click-open");
+    const uploadBtn = screen.getByTestId("sftp-local-double-click-upload");
+
+    expect(openBtn).toHaveAttribute("aria-checked", "true");
+    expect(uploadBtn).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(uploadBtn);
+
+    expect(uploadBtn).toHaveAttribute("aria-checked", "true");
+    expect(openBtn).toHaveAttribute("aria-checked", "false");
+    expect(loadSftpPreferences().localDoubleClickAction).toBe("upload");
+    expect(JSON.parse(localStorage.getItem(SFTP_PREFERENCES_STORAGE_KEY) ?? "{}"))
+      .toEqual({ localDoubleClickAction: "upload" });
+  });
+
+  it("resets to default open action", () => {
+    localStorage.setItem(
+      SFTP_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({ localDoubleClickAction: "upload" }),
+    );
+    render(<SftpSettings />);
+
+    expect(screen.getByTestId("sftp-local-double-click-upload"))
+      .toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(screen.getByTestId("sftp-settings-reset"));
+
+    expect(screen.getByTestId("sftp-local-double-click-open"))
+      .toHaveAttribute("aria-checked", "true");
+    expect(loadSftpPreferences().localDoubleClickAction).toBe("open");
+  });
+});

--- a/src/components/settings/SftpSettings.tsx
+++ b/src/components/settings/SftpSettings.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useState, type ReactNode } from "react";
+import {
+  Check,
+  ExternalLink,
+  FolderSync,
+  RotateCcw,
+  Upload,
+} from "lucide-react";
+import { useT } from "../../lib/i18n";
+import {
+  DEFAULT_SFTP_PREFERENCES,
+  loadSftpPreferences,
+  normalizeSftpPreferences,
+  saveSftpPreferences,
+  subscribeSftpPreferences,
+  type SftpLocalDoubleClickAction,
+  type SftpPreferences,
+} from "../../lib/sftpPreferences";
+
+const ACTIONS: Array<{
+  value: SftpLocalDoubleClickAction;
+  labelKey: string;
+  hintKey: string;
+  testId: string;
+  icon: ReactNode;
+  isDefault?: boolean;
+}> = [
+  {
+    value: "open",
+    labelKey: "settings.sftpLocalDoubleClickOpen",
+    hintKey: "settings.sftpLocalDoubleClickOpenHint",
+    testId: "sftp-local-double-click-open",
+    icon: <ExternalLink className="h-4 w-4" />,
+    isDefault: true,
+  },
+  {
+    value: "upload",
+    labelKey: "settings.sftpLocalDoubleClickUpload",
+    hintKey: "settings.sftpLocalDoubleClickUploadHint",
+    testId: "sftp-local-double-click-upload",
+    icon: <Upload className="h-4 w-4" />,
+  },
+];
+
+export function SftpSettings() {
+  const t = useT();
+  const [preferences, setPreferences] = useState(loadSftpPreferences);
+
+  useEffect(() => subscribeSftpPreferences(setPreferences), []);
+
+  const updatePreferences = (patch: Partial<SftpPreferences>) => {
+    const next = normalizeSftpPreferences({ ...preferences, ...patch });
+    setPreferences(next);
+    saveSftpPreferences(next);
+  };
+
+  return (
+    <section
+      data-testid="sftp-settings"
+      className="mb-5 overflow-hidden rounded-lg border border-[var(--taomni-divider)] bg-[var(--taomni-panel-bg)]"
+    >
+      {/* Header */}
+      <div className="flex items-start gap-3 border-b border-[var(--taomni-divider)] px-3.5 py-3">
+        <div
+          className="mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-md"
+          style={{
+            background: "color-mix(in srgb, var(--taomni-accent) 14%, transparent)",
+            color: "var(--taomni-accent)",
+          }}
+        >
+          <FolderSync className="h-4 w-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-[14px] font-semibold leading-tight">
+            {t("settings.sftpTitle")}
+          </div>
+          <div className="mt-0.5 text-[12px] leading-snug text-[var(--taomni-text-muted)]">
+            {t("settings.sftpSubtitle")}
+          </div>
+        </div>
+        <button
+          type="button"
+          data-testid="sftp-settings-reset"
+          className="taomni-btn ml-1 h-7 shrink-0 px-2.5 inline-flex items-center gap-1 text-[11px]"
+          onClick={() => {
+            setPreferences(DEFAULT_SFTP_PREFERENCES);
+            saveSftpPreferences(DEFAULT_SFTP_PREFERENCES);
+          }}
+          title={t("settings.sftpResetTitle")}
+        >
+          <RotateCcw className="h-3.5 w-3.5" />
+          {t("settings.reset")}
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="space-y-3 px-3.5 py-3.5">
+        <div>
+          <div className="text-[12px] font-medium">
+            {t("settings.sftpLocalDoubleClickLabel")}
+          </div>
+          <div className="mt-0.5 text-[11px] leading-snug text-[var(--taomni-text-muted)]">
+            {t("settings.sftpLocalDoubleClickHint")}
+          </div>
+        </div>
+
+        <div
+          role="radiogroup"
+          aria-label={t("settings.sftpLocalDoubleClickLabel")}
+          className="grid grid-cols-1 gap-2.5 sm:grid-cols-2"
+        >
+          {ACTIONS.map((action) => {
+            const active = preferences.localDoubleClickAction === action.value;
+            return (
+              <button
+                key={action.value}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                data-testid={action.testId}
+                data-active={active || undefined}
+                onClick={() => updatePreferences({ localDoubleClickAction: action.value })}
+                className="group relative flex h-full flex-col gap-2.5 rounded-lg border px-3 py-3 text-left transition-all duration-150 outline-none focus-visible:ring-2 focus-visible:ring-[var(--taomni-accent)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--taomni-panel-bg)]"
+                style={
+                  active
+                    ? {
+                        borderColor: "var(--taomni-accent)",
+                        background:
+                          "color-mix(in srgb, var(--taomni-accent) 12%, var(--taomni-panel-bg))",
+                        boxShadow:
+                          "0 0 0 1px color-mix(in srgb, var(--taomni-accent) 40%, transparent)",
+                      }
+                    : {
+                        borderColor: "var(--taomni-divider)",
+                        background: "var(--taomni-bg)",
+                      }
+                }
+                onMouseEnter={(e) => {
+                  if (active) return;
+                  e.currentTarget.style.borderColor =
+                    "color-mix(in srgb, var(--taomni-accent) 45%, var(--taomni-divider))";
+                  e.currentTarget.style.background =
+                    "color-mix(in srgb, var(--taomni-accent) 6%, var(--taomni-bg))";
+                }}
+                onMouseLeave={(e) => {
+                  if (active) return;
+                  e.currentTarget.style.borderColor = "var(--taomni-divider)";
+                  e.currentTarget.style.background = "var(--taomni-bg)";
+                }}
+              >
+                <div className="flex items-start gap-2.5">
+                  <span
+                    className="grid h-8 w-8 shrink-0 place-items-center rounded-md transition-colors"
+                    style={
+                      active
+                        ? {
+                            background:
+                              "color-mix(in srgb, var(--taomni-accent) 22%, transparent)",
+                            color: "var(--taomni-accent)",
+                          }
+                        : {
+                            background: "var(--taomni-panel-bg)",
+                            color: "var(--taomni-text-muted)",
+                            border: "1px solid var(--taomni-divider)",
+                          }
+                    }
+                    aria-hidden
+                  >
+                    {action.icon}
+                  </span>
+                  <div className="min-w-0 flex-1 pt-0.5">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className="text-[12.5px] font-semibold leading-tight">
+                        {t(action.labelKey)}
+                      </span>
+                      {action.isDefault ? (
+                        <span
+                          className="rounded px-1.5 py-px text-[10px] font-medium leading-4"
+                          style={{
+                            background: active
+                              ? "color-mix(in srgb, var(--taomni-accent) 18%, transparent)"
+                              : "var(--taomni-panel-bg)",
+                            color: active
+                              ? "var(--taomni-accent)"
+                              : "var(--taomni-text-muted)",
+                            border: "1px solid var(--taomni-divider)",
+                          }}
+                        >
+                          {t("common.default")}
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                  <span
+                    className="mt-0.5 grid shrink-0 place-items-center rounded-full border transition-colors"
+                    style={
+                      active
+                        ? {
+                            borderColor: "var(--taomni-accent)",
+                            background: "var(--taomni-accent)",
+                            color: "var(--taomni-panel-bg)",
+                            width: 18,
+                            height: 18,
+                          }
+                        : {
+                            borderColor: "var(--taomni-divider)",
+                            background: "transparent",
+                            width: 18,
+                            height: 18,
+                          }
+                    }
+                    aria-hidden
+                  >
+                    {active ? <Check className="h-3 w-3" strokeWidth={3} /> : null}
+                  </span>
+                </div>
+                <p className="text-[11px] leading-snug text-[var(--taomni-text-muted)]">
+                  {t(action.hintKey)}
+                </p>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/settings/settingsSearch.test.ts
+++ b/src/components/settings/settingsSearch.test.ts
@@ -29,6 +29,13 @@ describe("settingsSearch groups", () => {
     expect(matchingGroupIds(ids)).toEqual(["network", "ai"]);
   });
 
+  it("matches the sftp double-click settings entry under the terminal group", () => {
+    // terms match via term.includes(query); identity `t` skips titleKeys.
+    const ids = matchingIds("double click", t);
+    expect(ids).toEqual(["sftp"]);
+    expect(groupIdForEntry("sftp")).toBe("terminal");
+  });
+
   it("preserves group order even when entry list is reordered", () => {
     expect(matchingGroupIds(["ai-acp", "app-proxy", "language"])).toEqual([
       "ai",

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -87,6 +87,20 @@ export const SETTINGS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     ],
   },
   {
+    id: "sftp",
+    titleKeys: [
+      "settings.sftpTitle",
+      "settings.sftpLocalDoubleClickLabel",
+      "settings.sftpLocalDoubleClickOpen",
+      "settings.sftpLocalDoubleClickUpload",
+    ],
+    terms: [
+      "sftp", "file browser", "double click", "upload", "open local file", "local pane",
+      "sftp pane", "sidebar sftp", "transfer",
+      "双击", "上传", "打开本地文件", "本地面板", "侧边 sftp", "文件传输", "文件浏览器",
+    ],
+  },
+  {
     id: "terminal-defaults",
     titleKeys: ["settings.terminalDefaultsTitle", "terminalAppearance.behaviorHeading"],
     terms: [
@@ -194,7 +208,7 @@ export const SETTINGS_GROUPS: SettingsGroupDef[] = [
   {
     id: "terminal",
     titleKey: "settings.groupTerminal",
-    entryIds: ["terminal-defaults"],
+    entryIds: ["sftp", "terminal-defaults"],
   },
   {
     id: "security",

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1866,6 +1866,17 @@ const dict = {
     sqlExecutionShortcutInvalid: "Use a modifier plus a key, or a function key such as F8.",
     sqlExecutionShortcutReserved: "That shortcut is already used by an SQL editor or completion command.",
     sqlExecutionConflict: "Shortcut conflicts with {shortcut}.",
+    sftpTitle: "SFTP File Browser",
+    sftpSubtitle: "Global behavior for dedicated SFTP sessions and the sidebar SFTP pane",
+    sftpResetTitle: "Reset SFTP settings",
+    sftpLocalDoubleClickLabel: "Double-click local file",
+    sftpLocalDoubleClickHint:
+      "Applies to the local pane in dual-pane SFTP (standalone SFTP tab and terminal-attached SFTP sidebar).",
+    sftpLocalDoubleClickOpen: "Open with system default app",
+    sftpLocalDoubleClickOpenHint: "Current default. Opens the file the same way as the toolbar Open button.",
+    sftpLocalDoubleClickUpload: "Upload to remote",
+    sftpLocalDoubleClickUploadHint:
+      "Uploads the file into the current remote directory (uses path mappings when available).",
     localTerminalDefaultsTitle: "Terminal Defaults",
     localTerminalDefaultsSubtitle: "Default appearance, behavior, history, and command assistance for new terminal sessions",
     resetLocalTerminalDefaults: "Reset terminal defaults",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -1862,6 +1862,17 @@ export const zhCN: DeepPartial<typeof en> = {
     sqlExecutionShortcutInvalid: "请使用修饰键加普通按键，或使用 F8 等功能键。",
     sqlExecutionShortcutReserved: "该快捷键已被 SQL 编辑器或补全命令占用。",
     sqlExecutionConflict: "快捷键与「{shortcut}」冲突。",
+    sftpTitle: "SFTP 文件浏览器",
+    sftpSubtitle: "适用于独立 SFTP 会话与侧边 SFTP 面板的全局行为",
+    sftpResetTitle: "重置 SFTP 设置",
+    sftpLocalDoubleClickLabel: "双击本地文件时",
+    sftpLocalDoubleClickHint:
+      "作用于双栏 SFTP 的本地面板（独立 SFTP 标签页与终端侧边 SFTP 面板）。",
+    sftpLocalDoubleClickOpen: "用系统默认应用打开",
+    sftpLocalDoubleClickOpenHint: "默认行为。与工具栏「打开」按钮相同。",
+    sftpLocalDoubleClickUpload: "上传到远端",
+    sftpLocalDoubleClickUploadHint:
+      "上传到当前远端目录（若有路径映射则优先使用映射）。",
     localTerminalDefaultsTitle: "终端默认设置",
     localTerminalDefaultsSubtitle: "设置新建终端会话默认使用的外观、行为、历史与命令辅助",
     resetLocalTerminalDefaults: "重置终端默认设置",

--- a/src/lib/sftpPreferences.test.ts
+++ b/src/lib/sftpPreferences.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_SFTP_PREFERENCES,
+  loadSftpPreferences,
+  normalizeSftpPreferences,
+  saveSftpPreferences,
+  SFTP_PREFERENCES_EVENT,
+  SFTP_PREFERENCES_STORAGE_KEY,
+  subscribeSftpPreferences,
+} from "./sftpPreferences";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("sftpPreferences", () => {
+  it("defaults local double-click to open", () => {
+    expect(DEFAULT_SFTP_PREFERENCES.localDoubleClickAction).toBe("open");
+    expect(normalizeSftpPreferences(undefined).localDoubleClickAction).toBe("open");
+    expect(loadSftpPreferences().localDoubleClickAction).toBe("open");
+  });
+
+  it("normalizes valid and invalid stored values", () => {
+    expect(normalizeSftpPreferences({ localDoubleClickAction: "upload" }))
+      .toEqual({ localDoubleClickAction: "upload" });
+    expect(normalizeSftpPreferences({ localDoubleClickAction: "open" }))
+      .toEqual({ localDoubleClickAction: "open" });
+    expect(normalizeSftpPreferences({ localDoubleClickAction: "delete" }))
+      .toEqual(DEFAULT_SFTP_PREFERENCES);
+    expect(normalizeSftpPreferences({ localDoubleClickAction: 1 }))
+      .toEqual(DEFAULT_SFTP_PREFERENCES);
+    expect(normalizeSftpPreferences(null)).toEqual(DEFAULT_SFTP_PREFERENCES);
+  });
+
+  it("persists and reloads preferences", () => {
+    saveSftpPreferences({ localDoubleClickAction: "upload" });
+    expect(JSON.parse(localStorage.getItem(SFTP_PREFERENCES_STORAGE_KEY) ?? "{}"))
+      .toEqual({ localDoubleClickAction: "upload" });
+    expect(loadSftpPreferences()).toEqual({ localDoubleClickAction: "upload" });
+  });
+
+  it("notifies subscribers on save and storage events", () => {
+    const listener = vi.fn();
+    const unsub = subscribeSftpPreferences(listener);
+
+    saveSftpPreferences({ localDoubleClickAction: "upload" });
+    expect(listener).toHaveBeenCalledWith({ localDoubleClickAction: "upload" });
+
+    // storage handler re-reads localStorage (other-tab write path).
+    localStorage.setItem(
+      SFTP_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({ localDoubleClickAction: "open" }),
+    );
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: SFTP_PREFERENCES_STORAGE_KEY,
+        newValue: JSON.stringify({ localDoubleClickAction: "open" }),
+      }),
+    );
+    expect(listener).toHaveBeenLastCalledWith({ localDoubleClickAction: "open" });
+
+    // Unrelated storage keys are ignored.
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: "other", newValue: "x" }),
+    );
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsub();
+    window.dispatchEvent(
+      new CustomEvent(SFTP_PREFERENCES_EVENT, {
+        detail: { localDoubleClickAction: "upload" },
+      }),
+    );
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/sftpPreferences.ts
+++ b/src/lib/sftpPreferences.ts
@@ -1,0 +1,89 @@
+/**
+ * Global SFTP UI preferences (localStorage-backed).
+ *
+ * Currently covers local-pane double-click behavior for dual-pane SFTP
+ * (dedicated SFTP sessions + sidebar SFTP pane). Default keeps the historical
+ * "open with system default app" behavior.
+ */
+
+export type SftpLocalDoubleClickAction = "open" | "upload";
+
+export interface SftpPreferences {
+  /** Double-click a local file: open in OS, or upload to the remote pane. */
+  localDoubleClickAction: SftpLocalDoubleClickAction;
+}
+
+export const DEFAULT_SFTP_PREFERENCES: SftpPreferences = {
+  localDoubleClickAction: "open",
+};
+
+export const SFTP_PREFERENCES_STORAGE_KEY = "taomni.sftpPreferences.v1";
+export const SFTP_PREFERENCES_EVENT = "taomni:sftp-preferences-changed";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function normalizeSftpPreferences(input: unknown): SftpPreferences {
+  const source = isRecord(input) ? input : {};
+  const action = source.localDoubleClickAction;
+  return {
+    localDoubleClickAction:
+      action === "open" || action === "upload"
+        ? action
+        : DEFAULT_SFTP_PREFERENCES.localDoubleClickAction,
+  };
+}
+
+export function loadSftpPreferences(): SftpPreferences {
+  if (typeof window === "undefined") return DEFAULT_SFTP_PREFERENCES;
+  try {
+    const raw = window.localStorage.getItem(SFTP_PREFERENCES_STORAGE_KEY);
+    return normalizeSftpPreferences(raw ? JSON.parse(raw) : undefined);
+  } catch {
+    return DEFAULT_SFTP_PREFERENCES;
+  }
+}
+
+export function saveSftpPreferences(preferences: SftpPreferences): void {
+  if (typeof window === "undefined") return;
+  const normalized = normalizeSftpPreferences(preferences);
+  try {
+    window.localStorage.setItem(
+      SFTP_PREFERENCES_STORAGE_KEY,
+      JSON.stringify(normalized),
+    );
+  } catch {
+    // localStorage unavailable
+  }
+  try {
+    window.dispatchEvent(
+      new CustomEvent(SFTP_PREFERENCES_EVENT, { detail: normalized }),
+    );
+  } catch {
+    // CustomEvent unavailable
+  }
+}
+
+export function subscribeSftpPreferences(
+  listener: (preferences: SftpPreferences) => void,
+): () => void {
+  if (typeof window === "undefined") return () => {};
+  const onCustom = (event: Event) => {
+    listener(
+      normalizeSftpPreferences(
+        (event as CustomEvent<SftpPreferences>).detail,
+      ),
+    );
+  };
+  const onStorage = (event: StorageEvent) => {
+    if (event.key !== null && event.key !== SFTP_PREFERENCES_STORAGE_KEY) return;
+    listener(loadSftpPreferences());
+  };
+  window.addEventListener(SFTP_PREFERENCES_EVENT, onCustom as EventListener);
+  window.addEventListener("storage", onStorage);
+  return () => {
+    window.removeEventListener(SFTP_PREFERENCES_EVENT, onCustom as EventListener);
+    window.removeEventListener("storage", onStorage);
+  };
+}


### PR DESCRIPTION
Addresses #378 by making dual-pane SFTP local-file double-click configurable instead of hard-coding "open with system default app".

Why
- Users often double-click a local file intending to upload it to the remote pane; the previous always-open behavior was surprising.
- Keep the historical default (open) so existing muscle memory stays intact, while letting power users opt into upload.

What
- Persist a global preference (localStorage) with: localDoubleClickAction: "open" | "upload" (default "open")
- Apply the preference in FileBrowser local-pane double-click handling for both dedicated SFTP sessions and the terminal sidebar SFTP pane. Upload path still respects deployment path mappings when present.
- Add Settings → Terminal → SFTP File Browser panel with side-by-side option cards, default badge, reset, and searchable settings entry.
- i18n for en and zh-CN.

Tests
- Unit coverage for preference load/save/normalize/subscribe
- Settings panel interaction and reset
- FileBrowser double-click open (default) vs upload preference
- Settings search group registration for the new entry