### PR TITLE
fix(database): make MySQL schema/database switching work end-to-end

### DIFF
--- a/src-tauri/src/database/clickhouse.rs
+++ b/src-tauri/src/database/clickhouse.rs
@@ -2,6 +2,7 @@
 //! existing `reqwest` client. Queries are issued with `FORMAT JSONCompact` so
 //! we get column names, types, and row data in one response.
 
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use futures::StreamExt;
@@ -12,6 +13,7 @@ use super::{
     emit_query_result_stream, send_query_stream_event, ColumnDescription, ColumnInfo, DbConfig,
     DbHandle, DbObject, QueryResult, QueryStreamChannel, QueryStreamEvent, SchemaInfo, TableInfo,
 };
+use super::sql;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 15;
 const STREAM_BATCH_ROWS: usize = 100;
@@ -23,7 +25,25 @@ pub struct ClickHouseClient {
     base_url: String,
     user: Option<String>,
     password: Option<String>,
-    database: String,
+    /// Default database sent as the HTTP `database` query param. Updated when
+    /// the user runs `USE db` so subsequent queries follow the UI selection.
+    database: Arc<Mutex<String>>,
+}
+
+impl ClickHouseClient {
+    pub fn database(&self) -> String {
+        self.database
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    pub fn set_database(&self, database: String) {
+        match self.database.lock() {
+            Ok(mut guard) => *guard = database,
+            Err(poisoned) => *poisoned.into_inner() = database,
+        }
+    }
 }
 
 pub async fn connect(config: &DbConfig, password: Option<&str>) -> Result<DbHandle, String> {
@@ -56,11 +76,13 @@ pub async fn connect(config: &DbConfig, password: Option<&str>) -> Result<DbHand
         base_url,
         user: config.username.clone().filter(|u| !u.is_empty()),
         password: password.map(|p| p.to_string()),
-        database: config
-            .database
-            .clone()
-            .filter(|d| !d.is_empty())
-            .unwrap_or_else(|| "default".to_string()),
+        database: Arc::new(Mutex::new(
+            config
+                .database
+                .clone()
+                .filter(|d| !d.is_empty())
+                .unwrap_or_else(|| "default".to_string()),
+        )),
     };
     // Verify reachability eagerly so db_connect reports failures up front.
     ping(&ch).await?;
@@ -68,10 +90,11 @@ pub async fn connect(config: &DbConfig, password: Option<&str>) -> Result<DbHand
 }
 
 fn sql_request(client: &ClickHouseClient, sql: &str) -> reqwest::RequestBuilder {
+    let database = client.database();
     let mut req = client
         .client
         .post(&client.base_url)
-        .query(&[("database", client.database.as_str())])
+        .query(&[("database", database.as_str())])
         .body(sql.to_string());
     if let Some(user) = &client.user {
         req = req.header("X-ClickHouse-User", user);
@@ -223,6 +246,18 @@ pub async fn execute(
             columns,
             rows,
             rows_affected: parsed.rows,
+            duration_ms: start.elapsed().as_millis() as u64,
+            warnings: Vec::new(),
+        })
+    } else if let Some(database) = sql::parse_default_schema_switch(sql) {
+        // ClickHouse HTTP binds the default DB via the `database` query param
+        // on every request, so a server-side USE would not stick. Switch the
+        // client-side default instead.
+        client.set_database(database);
+        Ok(QueryResult {
+            columns: Vec::new(),
+            rows: Vec::new(),
+            rows_affected: 0,
             duration_ms: start.elapsed().as_millis() as u64,
             warnings: Vec::new(),
         })
@@ -418,7 +453,8 @@ pub async fn list_tables(
     client: &ClickHouseClient,
     schema: Option<&str>,
 ) -> Result<Vec<TableInfo>, String> {
-    let db = schema.unwrap_or(&client.database);
+    let default_db = client.database();
+    let db = schema.unwrap_or(default_db.as_str());
     let sql = format!(
         "SELECT name, engine, total_rows FROM system.tables WHERE database = '{}' ORDER BY name",
         db.replace('\'', "''")
@@ -458,7 +494,8 @@ pub async fn search_tables(
     prefix: &str,
     limit: usize,
 ) -> Result<Vec<TableInfo>, String> {
-    let database = schema.unwrap_or(&client.database).replace('\'', "''");
+    let default_db = client.database();
+    let database = schema.unwrap_or(default_db.as_str()).replace('\'', "''");
     let prefix = prefix.replace('\\', "\\\\").replace('\'', "''");
     let sql = format!(
         "SELECT name, engine FROM system.tables \
@@ -499,7 +536,8 @@ pub async fn list_objects(
     if kind != "dictionary" {
         return Ok(Vec::new());
     }
-    let db = schema.unwrap_or(&client.database);
+    let default_db = client.database();
+    let db = schema.unwrap_or(default_db.as_str());
     let sql = format!(
         "SELECT name FROM system.dictionaries WHERE database = '{}' ORDER BY name",
         db.replace('\'', "''")
@@ -525,7 +563,8 @@ pub async fn object_ddl(
     kind: &str,
     name: &str,
 ) -> Result<String, String> {
-    let db = schema.unwrap_or(&client.database);
+    let default_db = client.database();
+    let db = schema.unwrap_or(default_db.as_str());
     let verb = if kind == "dictionary" { "DICTIONARY" } else { "TABLE" };
     let sql = format!(
         "SHOW CREATE {verb} `{}`.`{}`",
@@ -546,7 +585,8 @@ pub async fn table_stats(
     schema: Option<&str>,
     table: &str,
 ) -> Result<QueryResult, String> {
-    let db = schema.unwrap_or(&client.database);
+    let default_db = client.database();
+    let db = schema.unwrap_or(default_db.as_str());
     let sql = format!(
         "SELECT sum(rows), sum(bytes_on_disk), count() FROM system.parts \
          WHERE database = '{}' AND table = '{}' AND active",
@@ -569,7 +609,8 @@ pub async fn describe_table(
     schema: Option<&str>,
     table: &str,
 ) -> Result<Vec<ColumnDescription>, String> {
-    let db = schema.unwrap_or(&client.database);
+    let default_db = client.database();
+    let db = schema.unwrap_or(default_db.as_str());
     let sql = format!(
         "SELECT name, type, default_expression, is_in_primary_key \
          FROM system.columns WHERE database = '{}' AND table = '{}' ORDER BY position",

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -291,6 +291,9 @@ pub enum DbHandle {
 pub struct DbSession {
     pub handle: DbHandle,
     pub cancel: AsyncMutex<CancellationToken>,
+    /// Last successful default schema/database from `USE` / `SET search_path`
+    /// etc. Shared with pool `after_connect` hooks so reconnects restore it.
+    pub active_schema: sql::ActiveSchemaSlot,
     shutdown: CancellationToken,
     keepalive: Option<JoinHandle<()>>,
     /// Loopback forwarder task when the connection is routed through a proxy /
@@ -299,12 +302,17 @@ pub struct DbSession {
 }
 
 impl DbSession {
-    fn with_forward(handle: DbHandle, forward: Option<JoinHandle<()>>) -> Self {
+    fn with_forward(
+        handle: DbHandle,
+        forward: Option<JoinHandle<()>>,
+        active_schema: sql::ActiveSchemaSlot,
+    ) -> Self {
         let shutdown = CancellationToken::new();
         let keepalive = start_keepalive(&handle, shutdown.clone());
         Self {
             handle,
             cancel: AsyncMutex::new(CancellationToken::new()),
+            active_schema,
             shutdown,
             keepalive,
             forward,
@@ -318,6 +326,18 @@ impl DbSession {
         let token = CancellationToken::new();
         *guard = token.clone();
         token
+    }
+
+    /// Record a successful session default-schema switch so reconnects and
+    /// engines with client-side default DB (ClickHouse) stay in sync.
+    async fn note_schema_switch(&self, sql: &str) {
+        let Some(schema) = sql::parse_default_schema_switch(sql) else {
+            return;
+        };
+        *self.active_schema.lock().await = Some(schema.clone());
+        if let DbHandle::ClickHouse(client) = &self.handle {
+            client.set_database(schema);
+        }
     }
 }
 
@@ -531,13 +551,20 @@ pub async fn db_connect(
         None => (config, None),
     };
 
+    let active_schema = sql::new_active_schema_slot(&config);
     let handle = match config.engine.as_str() {
-        "MySQL" => sql::connect_mysql(&config, password.as_deref()).await?,
-        "PostgreSQL" => sql::connect_postgres(&config, password.as_deref()).await?,
+        "MySQL" => {
+            sql::connect_mysql(&config, password.as_deref(), active_schema.clone()).await?
+        }
+        "PostgreSQL" => {
+            sql::connect_postgres(&config, password.as_deref(), active_schema.clone()).await?
+        }
         "PanWeiDB" => panwei::connect(&config, password.as_deref()).await?,
         "Oracle" => oracle::connect(&config, password.as_deref()).await?,
         "SQLServer" => sql::connect_sqlserver(&config, password.as_deref()).await?,
-        "StarRocks" => sql::connect_starrocks(&config, password.as_deref()).await?,
+        "StarRocks" => {
+            sql::connect_starrocks(&config, password.as_deref(), active_schema.clone()).await?
+        }
         "ClickHouse" => clickhouse::connect(&config, password.as_deref()).await?,
         "Presto" => presto::connect(&config, password.as_deref()).await?,
         "Redis" => redis_ops::connect(&config, password.as_deref()).await?,
@@ -548,7 +575,7 @@ pub async fn db_connect(
             return Err(format!("Unsupported database engine: {other}"));
         }
     };
-    let session = Arc::new(DbSession::with_forward(handle, forward_task));
+    let session = Arc::new(DbSession::with_forward(handle, forward_task, active_schema));
     let previous = {
         let mut map = state.db_connections.write().await;
         // If a stale session exists under this id, close it after releasing the map lock.
@@ -972,7 +999,7 @@ pub async fn db_execute(
 ) -> Result<QueryResult, String> {
     let session = get_session(&state, &session_id).await?;
     let token = session.fresh_cancel_token().await;
-    match &session.handle {
+    let result = match &session.handle {
         DbHandle::MySql(pool) => sql::execute_mysql(pool, &sql, &token).await,
         DbHandle::StarRocks(pool) => sql::execute_mysql(pool, &sql, &token).await,
         DbHandle::Postgres(pool) => sql::execute_postgres(pool, &sql, &token).await,
@@ -982,7 +1009,11 @@ pub async fn db_execute(
         DbHandle::ClickHouse(client) => clickhouse::execute(client, &sql, &token).await,
         DbHandle::Presto(client) => presto::execute(client, &sql, &token).await,
         DbHandle::Redis(_) => Err("Use redis_exec for Redis commands".into()),
+    };
+    if result.is_ok() {
+        session.note_schema_switch(&sql).await;
     }
+    result
 }
 
 #[tauri::command]
@@ -995,7 +1026,7 @@ pub async fn db_execute_stream(
 ) -> Result<(), String> {
     let session = get_session(&state, &session_id).await?;
     let token = session.fresh_cancel_token().await;
-    match &session.handle {
+    let result = match &session.handle {
         DbHandle::MySql(pool) => {
             sql::execute_mysql_stream(pool, &sql, max_rows, &token, &on_event).await
         }
@@ -1021,7 +1052,11 @@ pub async fn db_execute_stream(
             presto::execute_stream(client, &sql, max_rows, &token, &on_event).await
         }
         DbHandle::Redis(_) => Err("Use redis_exec for Redis commands".into()),
+    };
+    if result.is_ok() {
+        session.note_schema_switch(&sql).await;
     }
+    result
 }
 
 #[tauri::command]
@@ -1211,7 +1246,8 @@ mod live_tests {
             network_settings: None,
         };
 
-        let handle = sql::connect_postgres(&config, config.password.as_deref())
+        let active_schema = sql::new_active_schema_slot(&config);
+        let handle = sql::connect_postgres(&config, config.password.as_deref(), active_schema)
             .await
             .expect("Hologres PostgreSQL connect should succeed");
         let pool = match handle {

--- a/src-tauri/src/database/sql.rs
+++ b/src-tauri/src/database/sql.rs
@@ -12,6 +12,7 @@ use futures::TryStreamExt;
 use sqlx_core::column::Column;
 use sqlx_core::pool::Pool;
 use sqlx_core::query::query;
+use sqlx_core::raw_sql::raw_sql;
 use sqlx_core::row::Row;
 use sqlx_core::sql_str::AssertSqlSafe;
 use sqlx_core::type_info::TypeInfo;
@@ -51,7 +52,70 @@ fn timeout(config: &DbConfig) -> Duration {
 // Connect
 // ---------------------------------------------------------------------------
 
-pub async fn connect_mysql(config: &DbConfig, password: Option<&str>) -> Result<DbHandle, String> {
+/// Session default schema/database remembered across pool reconnects.
+///
+/// `USE` / `SET search_path` only affect the live connection. sqlx may recreate
+/// the single pooled connection after idle timeout or network blips; the
+/// `after_connect` hook re-applies this value so the UI "active schema" sticks.
+pub type ActiveSchemaSlot = Arc<AsyncMutex<Option<String>>>;
+
+fn initial_active_schema(config: &DbConfig) -> Option<String> {
+    config
+        .database
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+pub fn new_active_schema_slot(config: &DbConfig) -> ActiveSchemaSlot {
+    // Only engines where the connection "database" field is the default schema
+    // should seed the restore slot. Postgres/PanWei/Oracle/SQLServer use a
+    // separate schema namespace from the connect database name.
+    let initial = match config.engine.as_str() {
+        "MySQL" | "StarRocks" | "ClickHouse" | "Presto" => initial_active_schema(config),
+        _ => None,
+    };
+    Arc::new(AsyncMutex::new(initial))
+}
+
+async fn restore_mysql_schema(
+    conn: &mut sqlx_mysql::MySqlConnection,
+    active_schema: &ActiveSchemaSlot,
+) -> Result<(), SqlxError> {
+    let schema = active_schema.lock().await.clone();
+    let Some(schema) = schema.filter(|value| !value.is_empty()) else {
+        return Ok(());
+    };
+    // USE is not supported by MySQL's prepared-statement protocol (error 1295).
+    let sql = format!("USE {}", quote_mysql_ident(&schema));
+    raw_sql(AssertSqlSafe(sql)).execute(&mut *conn).await?;
+    Ok(())
+}
+
+async fn restore_postgres_schema(
+    conn: &mut sqlx_postgres::PgConnection,
+    active_schema: &ActiveSchemaSlot,
+) -> Result<(), SqlxError> {
+    let schema = active_schema.lock().await.clone();
+    let Some(schema) = schema.filter(|value| !value.is_empty()) else {
+        return Ok(());
+    };
+    // Postgres search_path is session state; re-apply after reconnect.
+    let sql = format!("SET search_path TO {}", quote_pg_ident(&schema));
+    raw_sql(AssertSqlSafe(sql)).execute(&mut *conn).await?;
+    Ok(())
+}
+
+fn quote_pg_ident(ident: &str) -> String {
+    format!("\"{}\"", ident.replace('"', "\"\""))
+}
+
+pub async fn connect_mysql(
+    config: &DbConfig,
+    password: Option<&str>,
+    active_schema: ActiveSchemaSlot,
+) -> Result<DbHandle, String> {
     let mut opts = MySqlConnectOptions::new()
         .host(&config.host)
         .port(config.port);
@@ -74,6 +138,10 @@ pub async fn connect_mysql(config: &DbConfig, password: Option<&str>) -> Result<
         .max_connections(1)
         .acquire_timeout(timeout(config))
         .test_before_acquire(true)
+        .after_connect(move |conn, _meta| {
+            let active_schema = active_schema.clone();
+            Box::pin(async move { restore_mysql_schema(conn, &active_schema).await })
+        })
         .connect_with(opts)
         .await
         .map_err(|e| format!("MySQL connect failed: {e}"))?;
@@ -83,6 +151,7 @@ pub async fn connect_mysql(config: &DbConfig, password: Option<&str>) -> Result<
 pub async fn connect_starrocks(
     config: &DbConfig,
     password: Option<&str>,
+    active_schema: ActiveSchemaSlot,
 ) -> Result<DbHandle, String> {
     let mut opts = MySqlConnectOptions::new()
         .host(&config.host)
@@ -110,6 +179,10 @@ pub async fn connect_starrocks(
         .max_connections(1)
         .acquire_timeout(timeout(config))
         .test_before_acquire(true)
+        .after_connect(move |conn, _meta| {
+            let active_schema = active_schema.clone();
+            Box::pin(async move { restore_mysql_schema(conn, &active_schema).await })
+        })
         .connect_with(opts)
         .await
         .map_err(|e| format!("StarRocks connect failed: {e}"))?;
@@ -119,6 +192,7 @@ pub async fn connect_starrocks(
 pub async fn connect_postgres(
     config: &DbConfig,
     password: Option<&str>,
+    active_schema: ActiveSchemaSlot,
 ) -> Result<DbHandle, String> {
     let mut opts = PgConnectOptions::new().host(&config.host).port(config.port);
     if let Some(user) = config.username.as_deref().filter(|u| !u.is_empty()) {
@@ -140,6 +214,10 @@ pub async fn connect_postgres(
         .max_connections(1)
         .acquire_timeout(timeout(config))
         .test_before_acquire(true)
+        .after_connect(move |conn, _meta| {
+            let active_schema = active_schema.clone();
+            Box::pin(async move { restore_postgres_schema(conn, &active_schema).await })
+        })
         .connect_with(opts)
         .await
         .map_err(|e| format!("PostgreSQL connect failed: {e}"))?;
@@ -413,14 +491,17 @@ fn sqlserver_value_to_string(row: &TdsRow, i: usize) -> Option<String> {
 }
 
 /// Heuristic: does the statement return rows? (SELECT/SHOW/DESCRIBE/WITH/...)
-fn is_query(sql: &str) -> bool {
-    let head: String = executable_sql_head(sql)
+fn sql_head_keyword(sql: &str) -> String {
+    executable_sql_head(sql)
         .chars()
         .take_while(|c| c.is_alphabetic())
         .collect::<String>()
-        .to_uppercase();
+        .to_uppercase()
+}
+
+fn is_query(sql: &str) -> bool {
     matches!(
-        head.as_str(),
+        sql_head_keyword(sql).as_str(),
         "SELECT"
             | "SHOW"
             | "DESCRIBE"
@@ -431,6 +512,89 @@ fn is_query(sql: &str) -> bool {
             | "VALUES"
             | "PRAGMA"
     )
+}
+
+/// MySQL (and StarRocks) reject some statements under the prepared-statement
+/// protocol with error 1295. Run those via the text protocol (`raw_sql`).
+fn needs_mysql_text_protocol(sql: &str) -> bool {
+    matches!(
+        sql_head_keyword(sql).as_str(),
+        "USE" | "PREPARE" | "EXECUTE" | "DEALLOCATE" | "HELP"
+    )
+}
+
+/// Parse the target of session default-schema switch statements:
+/// `USE db`, `SET search_path TO schema`, `ALTER SESSION SET CURRENT_SCHEMA = schema`.
+pub fn parse_default_schema_switch(sql: &str) -> Option<String> {
+    let head = executable_sql_head(sql);
+    let keyword = sql_head_keyword(sql);
+    match keyword.as_str() {
+        "USE" => {
+            let rest = head.get(keyword.len()..)?.trim();
+            let first = rest.split_whitespace().next().unwrap_or(rest);
+            // Presto: USE catalog.schema → keep the last component as schema.
+            let target = first.rsplit('.').next().unwrap_or(first);
+            unquote_sql_ident(target)
+        }
+        "SET" => {
+            // SET search_path TO ident  |  SET search_path = ident
+            let rest = head.get(keyword.len()..)?.trim();
+            let upper = rest.to_ascii_uppercase();
+            if !upper.starts_with("SEARCH_PATH") {
+                return None;
+            }
+            let after = rest.get("search_path".len()..)?.trim_start();
+            let after_upper = after.to_ascii_uppercase();
+            let after = if after_upper.starts_with("TO") {
+                after.get(2..).unwrap_or("").trim_start()
+            } else if after.starts_with('=') {
+                after.get(1..).unwrap_or("").trim_start()
+            } else {
+                after
+            };
+            // search_path can be a comma list; take the first entry.
+            let first = after.split(',').next().unwrap_or(after).trim();
+            unquote_sql_ident(first)
+        }
+        "ALTER" => {
+            // ALTER SESSION SET CURRENT_SCHEMA = ident
+            let upper = head.to_ascii_uppercase();
+            let marker = "CURRENT_SCHEMA";
+            let idx = upper.find(marker)?;
+            let after = head.get(idx + marker.len()..)?.trim_start();
+            let after = after.strip_prefix('=').map(str::trim).unwrap_or(after);
+            let first = after.split_whitespace().next().unwrap_or(after);
+            unquote_sql_ident(first)
+        }
+        _ => None,
+    }
+}
+
+fn unquote_sql_ident(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_end_matches(';').trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let unquoted = if (trimmed.starts_with('`') && trimmed.ends_with('`'))
+        || (trimmed.starts_with('"') && trimmed.ends_with('"'))
+        || (trimmed.starts_with('[') && trimmed.ends_with(']'))
+        || (trimmed.starts_with('\'') && trimmed.ends_with('\''))
+    {
+        let inner = &trimmed[1..trimmed.len() - 1];
+        inner
+            .replace("``", "`")
+            .replace("\"\"", "\"")
+            .replace("]]", "]")
+            .replace("''", "'")
+    } else {
+        trimmed.to_string()
+    };
+    let unquoted = unquoted.trim();
+    if unquoted.is_empty() {
+        None
+    } else {
+        Some(unquoted.to_string())
+    }
 }
 
 fn executable_sql_head(sql: &str) -> &str {
@@ -604,6 +768,21 @@ pub async fn execute_mysql(
             columns,
             rows_affected: 0,
             rows: out_rows,
+            duration_ms: start.elapsed().as_millis() as u64,
+            warnings: Vec::new(),
+        })
+    } else if needs_mysql_text_protocol(sql) {
+        // MySQL rejects USE (and a few admin commands) on COM_STMT_PREPARE with
+        // 1295 HY000. Text protocol via raw_sql is required.
+        let exec = raw_sql(AssertSqlSafe(sql)).execute(pool);
+        let res = tokio::select! {
+            _ = token.cancelled() => return Err("Query cancelled".into()),
+            r = exec => r.map_err(|e| format!("Statement failed: {e}"))?,
+        };
+        Ok(QueryResult {
+            columns: Vec::new(),
+            rows: Vec::new(),
+            rows_affected: res.rows_affected(),
             duration_ms: start.elapsed().as_millis() as u64,
             warnings: Vec::new(),
         })
@@ -784,6 +963,20 @@ pub async fn execute_mysql_stream(
                 rows_affected: 0,
                 duration_ms: start.elapsed().as_millis() as u64,
                 warnings: limit_warning(limit_reached, max_rows),
+            },
+        )
+    } else if needs_mysql_text_protocol(sql) {
+        let exec = raw_sql(AssertSqlSafe(sql)).execute(pool);
+        let res = tokio::select! {
+            _ = token.cancelled() => return Err("Query cancelled".into()),
+            r = exec => r.map_err(|e| format!("Statement failed: {e}"))?,
+        };
+        send_query_stream_event(
+            on_event,
+            QueryStreamEvent::Done {
+                rows_affected: res.rows_affected(),
+                duration_ms: start.elapsed().as_millis() as u64,
+                warnings: Vec::new(),
             },
         )
     } else {
@@ -2372,5 +2565,34 @@ mod tests {
         ));
         assert!(!is_query("-- mutate\nINSERT INTO t VALUES (1)"));
         assert!(!is_query("/* unterminated"));
+    }
+
+    #[test]
+    fn mysql_use_requires_text_protocol() {
+        assert!(needs_mysql_text_protocol("USE `app`"));
+        assert!(needs_mysql_text_protocol("-- switch\nUSE app;"));
+        assert!(!needs_mysql_text_protocol("INSERT INTO t VALUES (1)"));
+        assert!(!needs_mysql_text_protocol("SELECT 1"));
+    }
+
+    #[test]
+    fn parse_default_schema_switch_supports_common_dialects() {
+        assert_eq!(
+            parse_default_schema_switch("USE `ali-model-tools`"),
+            Some("ali-model-tools".into())
+        );
+        assert_eq!(
+            parse_default_schema_switch("use ecommerce;"),
+            Some("ecommerce".into())
+        );
+        assert_eq!(
+            parse_default_schema_switch(r#"SET search_path TO "sales""#),
+            Some("sales".into())
+        );
+        assert_eq!(
+            parse_default_schema_switch(r#"ALTER SESSION SET CURRENT_SCHEMA = "HR""#),
+            Some("HR".into())
+        );
+        assert_eq!(parse_default_schema_switch("SELECT 1"), None);
     }
 }

--- a/src/components/database/DbClientTab.tsx
+++ b/src/components/database/DbClientTab.tsx
@@ -1400,34 +1400,17 @@ export default function DbClientTab({
       }
       const panelId = activePanelId;
       const sql = schemaSwitchSql(info.engine, schema, info.catalog);
-      const panel = panels.find((p) => p.id === panelId);
-      const sheet = newResultSheet(sql, (panel?.sheets.length ?? 0) + 1, rowLimit);
-      sheet.title = "Schema";
       try {
         if (!connectionSessionId) throw new Error("Database connection is still starting.");
-        const result = await dbExecute(connectionSessionId, sql);
+        await dbExecute(connectionSessionId, sql);
+        // Update UI active schema (toolbar dropdown + tree highlight) without
+        // dumping a success result sheet on every click.
         setActiveSchema(schema);
-        setPanels((prev) =>
-          prev.map((p) =>
-            p.id === panelId
-              ? {
-                  ...p,
-                  sheets: [
-                    ...p.sheets,
-                    {
-                      ...sheet,
-                      result,
-                      warnings: result.warnings,
-                      running: false,
-                      resultTab: (result.warnings.length > 0 ? "messages" : "results") as ResultSubTab,
-                    },
-                  ].slice(-maxResultSheets),
-                  activeSheetId: sheet.id,
-                }
-              : p,
-          ),
-        );
+        setStatusMessage(`Active schema: ${schema}`);
       } catch (err) {
+        const panel = panels.find((p) => p.id === panelId);
+        const sheet = newResultSheet(sql, (panel?.sheets.length ?? 0) + 1, rowLimit);
+        sheet.title = "Schema";
         setPanels((prev) =>
           prev.map((p) =>
             p.id === panelId
@@ -1449,6 +1432,7 @@ export default function DbClientTab({
               : p,
           ),
         );
+        setStatusMessage(`Schema switch failed: ${String(err)}`);
       }
     },
     [activePanelId, activeSchema, connectionSessionId, info.catalog, info.engine, maxResultSheets, panels, rowLimit],
@@ -2341,6 +2325,7 @@ export default function DbClientTab({
                     engine={info.engine}
                     catalog={info.catalog}
                     databaseName={info.database}
+                    activeSchema={activeSchema}
                     onSelectionChange={handleSchemaSelectionChange}
                     onInsertTable={insertIntoActive}
                     onQuickSelect={quickSelect}

--- a/src/components/database/SchemaTree.test.tsx
+++ b/src/components/database/SchemaTree.test.tsx
@@ -62,6 +62,38 @@ describe("SchemaTree folder model", () => {
     expect(screen.getByText("Events")).toBeInTheDocument();
   });
 
+  it("sets the clicked database as the session default and expands it", async () => {
+    const onSetDefaultSchema = vi.fn();
+    render(
+      <SchemaTree
+        sessionId="s1"
+        engine="MySQL"
+        activeSchema="other"
+        onSetDefaultSchema={onSetDefaultSchema}
+      />,
+    );
+    fireEvent.click(await screen.findByTestId("schema-tree-db-name-ecommerce"));
+    expect(onSetDefaultSchema).toHaveBeenCalledWith("ecommerce");
+    expect(await screen.findByText("Tables")).toBeInTheDocument();
+  });
+
+  it("highlights the active database without treating expand-only as USE", async () => {
+    const onSetDefaultSchema = vi.fn();
+    render(
+      <SchemaTree
+        sessionId="s1"
+        engine="MySQL"
+        activeSchema="ecommerce"
+        onSetDefaultSchema={onSetDefaultSchema}
+      />,
+    );
+    await screen.findByText("ecommerce");
+    expect(screen.getByTestId("schema-tree-db-ecommerce")).toHaveAttribute("data-active", "true");
+    fireEvent.click(screen.getByLabelText("Expand ecommerce"));
+    expect(onSetDefaultSchema).not.toHaveBeenCalled();
+    expect(await screen.findByText("Tables")).toBeInTheDocument();
+  });
+
   it("loads tables eagerly and splits them by kind under Tables/Views", async () => {
     render(<SchemaTree sessionId="s1" engine="MySQL" />);
     fireEvent.click(await screen.findByText("ecommerce"));

--- a/src/components/database/SchemaTree.tsx
+++ b/src/components/database/SchemaTree.tsx
@@ -87,6 +87,8 @@ interface SchemaTreeProps {
   onNewQuery?: () => void;
   /** Make a schema the session default. */
   onSetDefaultSchema?: (schema: string) => void;
+  /** Currently active schema/database (highlight + toolbar sync). */
+  activeSchema?: string | null;
   /** Surface a transient status message. */
   onStatus?: (message: string) => void;
   /** Bubble up schema names for the editor toolbar selector. */
@@ -156,6 +158,7 @@ export function SchemaTree({
   onInsertSql,
   onNewQuery,
   onSetDefaultSchema,
+  activeSchema = null,
   onStatus,
   onSchemasLoaded,
   onSchemaLoaded,
@@ -246,6 +249,16 @@ export function SchemaTree({
     setExpandedDb((prev) => ({ ...prev, [db]: next }));
     // Eagerly load tables so the Tables/Views folder counts appear at once.
     if (next) void ensureTables(db);
+  };
+
+  /** Clicking the database/schema name makes it the session default (USE). */
+  const selectDatabase = (db: string) => {
+    onSetDefaultSchema?.(db);
+    // Expand so the user can browse objects in the newly active database.
+    if (!expandedDb[db]) {
+      setExpandedDb((prev) => ({ ...prev, [db]: true }));
+      void ensureTables(db);
+    }
   };
 
   const toggleCategory = (db: string, kind: ObjectKind) => {
@@ -1029,23 +1042,50 @@ export function SchemaTree({
   );
 
   const renderSchemaRows = () => (
-    visibleSchemas.map((db) => (
+    visibleSchemas.map((db) => {
+      const isActive = activeSchema === db;
+      const isExpanded = expandedDb[dbKey(db)] || filterActive;
+      return (
       <div key={db}>
-        <button
-          type="button"
+        <div
           className="taomni-tree-row w-full text-left"
-          onClick={() => toggleDb(db)}
-          onContextMenu={(e) => openMenu(e, databaseMenu(db))}
+          style={{ background: isActive ? "var(--taomni-selected)" : undefined }}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            openMenu(e, databaseMenu(db));
+          }}
+          data-testid={`schema-tree-db-${db}`}
+          data-active={isActive ? "true" : "false"}
         >
-          {expandedDb[dbKey(db)] || filterActive ? (
-            <ChevronDown className="w-3 h-3" />
-          ) : (
-            <ChevronRight className="w-3 h-3" />
-          )}
-          <Database className="w-3.5 h-3.5 text-[var(--taomni-accent)]" />
-          <span className="flex-1 truncate">{db}</span>
-        </button>
-        {(expandedDb[dbKey(db)] || filterActive) &&
+          <button
+            type="button"
+            className="h-full inline-flex items-center justify-center shrink-0 rounded hover:bg-[var(--taomni-hover)]"
+            aria-label={isExpanded ? `Collapse ${db}` : `Expand ${db}`}
+            title={isExpanded ? `Collapse ${db}` : `Expand ${db}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleDb(db);
+            }}
+          >
+            {isExpanded ? (
+              <ChevronDown className="w-3 h-3" />
+            ) : (
+              <ChevronRight className="w-3 h-3" />
+            )}
+          </button>
+          <button
+            type="button"
+            className="flex-1 min-w-0 inline-flex items-center gap-1 text-left"
+            onClick={() => selectDatabase(db)}
+            title={t("dbObjects.setDefault")}
+            aria-pressed={isActive}
+            data-testid={`schema-tree-db-name-${db}`}
+          >
+            <Database className="w-3.5 h-3.5 text-[var(--taomni-accent)] shrink-0" />
+            <span className="flex-1 truncate">{db}</span>
+          </button>
+        </div>
+        {isExpanded &&
           categories.filter((kind) => categoryVisible(db, kind)).map((kind) => {
             const meta = CATEGORY_META[kind];
             const CatIcon = meta.Icon;
@@ -1076,7 +1116,8 @@ export function SchemaTree({
             );
           })}
       </div>
-    ))
+      );
+    })
   );
 
   return (


### PR DESCRIPTION
Fixes #388 (mysql选择database失效).

Root cause
- Switching databases from the toolbar or tree ran `USE \`db\`` through sqlx prepared statements. MySQL rejects USE on the prepared-statement protocol with error 1295 (HY000): "This command is not supported in the prepared statement protocol yet".
- After a failed USE, the connection stayed on the session default database, so unqualified SQL could only hit that database even when the UI showed another schema selected.

Backend
- Execute MySQL/StarRocks USE (and a few other text-only commands) via sqlx raw_sql (text protocol) instead of query().execute().
- Remember the last successful default schema/database on DbSession and re-apply it in pool after_connect hooks so reconnects keep the UI choice for MySQL, StarRocks, and PostgreSQL search_path.
- ClickHouse HTTP binds the default DB per request; update the client-side database param on USE so subsequent queries follow the selection.
- Parse common switch statements (USE, SET search_path, ALTER SESSION SET CURRENT_SCHEMA) after successful execute/stream to keep session state in sync across engines.

Frontend
- Clicking a database/schema name in the left tree runs USE and expands it; the chevron only expands/collapses without switching.
- Highlight the active database and keep the top-right schema dropdown in sync via activeSchema.
- Successful switches update status only; failures still open a Messages sheet so errors remain visible.

Tests cover text-protocol detection, schema-switch parsing, tree click = USE, and expand-only chevron behavior.