### PR TITLE
feat(code-workspace): IDEA-style clickable breadcrumb path navigation

### DIFF
--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -42,6 +42,7 @@ import {
   ZoomOut,
 } from "lucide-react";
 import {
+  workspaceListDir,
   workspaceReadFile,
   workspaceReadLooseFile,
   workspaceWriteFile,
@@ -313,6 +314,7 @@ import {
   resolveLooseMarkdownLink,
   resolveRootMarkdownLink,
   rootDirKey,
+  shouldHideEntry,
   workspacePathForGitPath,
   workspaceTitle,
   writeCodeWorkspaceTreeFontSize,
@@ -323,7 +325,12 @@ import { useWorkspaceLspSession } from "./workspace/useWorkspaceLspSession";
 import { useWorkspaceGitSnapshots } from "./workspace/useWorkspaceGitSnapshots";
 import { useWorkspaceNavigation } from "./workspace/useWorkspaceNavigation";
 import { useWorkspaceFileActions } from "./workspace/useWorkspaceFileActions";
-import { Breadcrumbs, type BreadcrumbPathSegment } from "./workspace/Breadcrumbs";
+import {
+  Breadcrumbs,
+  type BreadcrumbPathAction,
+  type BreadcrumbPathChild,
+  type BreadcrumbPathSegment,
+} from "./workspace/Breadcrumbs";
 import {
   TerminalDockPanel,
   type TerminalDockHandle,
@@ -1308,6 +1315,171 @@ export function CodeWorkspaceTab({
       .then(() => setStatusMessage(`Opened ${absolute}`))
       .catch((err) => setStatusMessage(errorMessage(err)));
   }, [revealInExplorer, setStatusMessage]);
+
+  /**
+   * IDEA-style breadcrumb: list children of a directory/root segment, or siblings
+   * when the file segment is clicked. Marks the trail's next segment as active.
+   */
+  const loadBreadcrumbPathChildren = useCallback(async (
+    segment: BreadcrumbPathSegment,
+    file: OpenFileState,
+    trail: BreadcrumbPathSegment[],
+  ): Promise<BreadcrumbPathChild[]> => {
+    const segmentIndex = trail.findIndex((item) =>
+      item.path === segment.path && item.kind === segment.kind && item.label === segment.label
+    );
+    const nextSegment = segmentIndex >= 0 ? trail[segmentIndex + 1] ?? null : null;
+    const activeChildPath = nextSegment && nextSegment.kind !== "root" ? nextSegment.path : null;
+
+    const toChildren = (
+      entries: Array<{ name: string; path: string; fileType: string; isHidden?: boolean }>,
+      pathOf: (entry: { name: string; path: string }) => string,
+    ): BreadcrumbPathChild[] => entries
+      .filter((entry) => entry.fileType === "file" || entry.fileType === "dir")
+      .filter((entry) => !shouldHideEntry({
+        name: entry.name,
+        path: entry.path,
+        fileType: entry.fileType as "file" | "dir" | "symlink" | "other",
+        size: 0,
+        mtime: 0,
+        isHidden: entry.isHidden ?? false,
+      }))
+      .map((entry) => {
+        const path = pathOf(entry);
+        const kind = entry.fileType === "dir" ? "directory" as const : "file" as const;
+        return {
+          label: entry.name,
+          path,
+          kind,
+          active: activeChildPath === path,
+        };
+      });
+
+    if (file.ref.kind === "root") {
+      const rootId = file.ref.rootId;
+      const root = rootsRef.current.find((item) => item.id === rootId);
+      if (!root) return [];
+      // File segment → siblings in parent; directory/root → children of that path.
+      const listPath = segment.kind === "file" ? parentPath(segment.path) : segment.path;
+      void loadDir(rootId, listPath);
+      const entries = await workspaceListDir(root.path, listPath);
+      return toChildren(entries, (entry) => entry.path);
+    }
+
+    // Loose file: list an absolute directory via workspace_list_dir(dir, "").
+    const absolute = normalizeFsPath(segment.path);
+    const dirToList = segment.kind === "file" ? parentPath(absolute) : absolute;
+    if (!dirToList) return [];
+    const entries = await workspaceListDir(dirToList, "");
+    return toChildren(entries, (entry) =>
+      normalizeFsPath(`${dirToList.replace(/[/\\]+$/, "")}/${entry.name}`)
+    );
+  }, [loadDir]);
+
+  const navigateBreadcrumbPathChild = useCallback((
+    child: BreadcrumbPathChild,
+    file: OpenFileState,
+  ) => {
+    if (file.ref.kind === "root") {
+      const rootId = file.ref.rootId;
+      if (child.kind === "directory") {
+        setSelected({ kind: "dir", rootId, path: child.path });
+        setExpandedRoots((current) => new Set(current).add(rootId));
+        setExpandedDirs((current) => {
+          const next = new Set(current);
+          let acc = "";
+          for (const part of child.path.split("/").filter(Boolean)) {
+            acc = acc ? `${acc}/${part}` : part;
+            next.add(rootDirKey(rootId, acc));
+          }
+          return next;
+        });
+        void loadDir(rootId, child.path);
+        treePaneRef.current?.focus();
+        return;
+      }
+      void openFile({ kind: "root", rootId, path: child.path });
+      return;
+    }
+    // Loose file sibling/parent navigation: open absolute path as a loose file.
+    if (child.kind === "file") {
+      void addLooseFilePath(child.path);
+      return;
+    }
+    setStatusMessage(`Folder: ${child.path}`);
+  }, [addLooseFilePath, loadDir, openFile, setStatusMessage]);
+
+  const breadcrumbPathActions = useCallback((
+    segment: BreadcrumbPathSegment,
+    file: OpenFileState,
+  ): BreadcrumbPathAction[] => {
+    const actions: BreadcrumbPathAction[] = [];
+    actions.push({
+      id: "reveal-tree",
+      label: "Select in Project Tree",
+      onSelect: () => {
+        if (file.ref.kind !== "root") {
+          setSelected({ kind: "file", ref: file.ref });
+          treePaneRef.current?.focus();
+          return;
+        }
+        const rootId = file.ref.rootId;
+        if (segment.kind === "root") {
+          setSelected({ kind: "root", rootId });
+          setExpandedRoots((current) => new Set(current).add(rootId));
+        } else if (segment.kind === "directory") {
+          setSelected({ kind: "dir", rootId, path: segment.path });
+          setExpandedRoots((current) => new Set(current).add(rootId));
+          setExpandedDirs((current) => new Set(current).add(rootDirKey(rootId, segment.path)));
+          void loadDir(rootId, segment.path);
+        } else {
+          setSelected({ kind: "file", ref: file.ref });
+          revealEditorTabInTree(file.key);
+          return;
+        }
+        treePaneRef.current?.focus();
+      },
+    });
+    if (file.ref.kind === "root") {
+      const rootId = file.ref.rootId;
+      actions.push({
+        id: "copy-path",
+        label: "Copy Path",
+        onSelect: () => { void copyTreePath(rootId, segment.path, true); },
+      });
+      actions.push({
+        id: "copy-relative",
+        label: "Copy Relative Path",
+        onSelect: () => { void copyTreePath(rootId, segment.path, false); },
+      });
+      actions.push({
+        id: "reveal-explorer",
+        label: "Reveal in Explorer",
+        onSelect: () => { void revealInExplorer(rootId, segment.path); },
+      });
+    } else {
+      const absolute = normalizeFsPath(segment.path);
+      actions.push({
+        id: "copy-path",
+        label: "Copy Path",
+        onSelect: () => {
+          void writeText(absolute)
+            .then(() => setStatusMessage(`Copied ${absolute}`))
+            .catch((err) => setStatusMessage(errorMessage(err)));
+        },
+      });
+      actions.push({
+        id: "reveal-explorer",
+        label: "Reveal in Explorer",
+        onSelect: () => {
+          void invoke("sftp_open_path", { path: absolute })
+            .then(() => setStatusMessage(`Opened ${absolute}`))
+            .catch((err) => setStatusMessage(errorMessage(err)));
+        },
+      });
+    }
+    return actions;
+  }, [copyTreePath, loadDir, revealEditorTabInTree, revealInExplorer, setStatusMessage]);
 
   const openEditorTabInTerminal = useCallback((key: string) => {
     const file = openFilesRef.current[key];
@@ -4240,7 +4412,13 @@ export function CodeWorkspaceTab({
             pathSegments={groupBreadcrumbSegments}
             symbols={breadcrumbSymbolsByGroup[groupId]}
             position={cursorPositions[groupId]}
+            loadPathChildren={(segment) =>
+              loadBreadcrumbPathChildren(segment, groupFile, groupBreadcrumbSegments)
+            }
+            onPathNavigate={(child) => navigateBreadcrumbPathChild(child, groupFile)}
+            pathActionsForSegment={(segment) => breadcrumbPathActions(segment, groupFile)}
             onPathClick={(segment) => {
+              // Fallback when listing is unavailable: reveal the segment in the tree.
               if (groupFile.ref.kind !== "root") return;
               const rootId = groupFile.ref.rootId;
               if (segment.kind === "root") {

--- a/src/components/editor/workspace/Breadcrumbs.test.tsx
+++ b/src/components/editor/workspace/Breadcrumbs.test.tsx
@@ -1,7 +1,30 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { LspDocumentSymbol } from "../../../lib/editor/lsp";
-import { Breadcrumbs, collapsedBreadcrumbItems, symbolChainAtPosition } from "./Breadcrumbs";
+import {
+  Breadcrumbs,
+  collapsedBreadcrumbItems,
+  symbolChainAtPosition,
+  symbolSiblingsAt,
+} from "./Breadcrumbs";
+
+afterEach(() => {
+  cleanup();
+});
+
+function breadcrumbNav() {
+  return screen.getByTestId("code-workspace-breadcrumbs");
+}
+
+function clickPathSegment(kind: "root" | "directory" | "file", label: RegExp | string) {
+  const buttons = within(breadcrumbNav()).getAllByTestId(`code-workspace-breadcrumb-path-${kind}`);
+  const match = buttons.find((button) => label instanceof RegExp
+    ? label.test(button.textContent ?? "")
+    : (button.textContent ?? "").includes(label));
+  if (!match) throw new Error(`No ${kind} breadcrumb matching ${label}`);
+  fireEvent.click(match);
+  return match;
+}
 
 const symbols: LspDocumentSymbol[] = [
   {
@@ -13,12 +36,28 @@ const symbols: LspDocumentSymbol[] = [
     selectionRange: { start: { line: 0, character: 6 }, end: { line: 0, character: 9 } },
   },
   {
+    name: "Helper",
+    detail: null,
+    kind: 5,
+    depth: 0,
+    range: { start: { line: 21, character: 0 }, end: { line: 30, character: 0 } },
+    selectionRange: { start: { line: 21, character: 6 }, end: { line: 21, character: 12 } },
+  },
+  {
     name: "render",
     detail: null,
     kind: 6,
     depth: 1,
     range: { start: { line: 5, character: 2 }, end: { line: 10, character: 3 } },
     selectionRange: { start: { line: 5, character: 2 }, end: { line: 5, character: 8 } },
+  },
+  {
+    name: "mount",
+    detail: null,
+    kind: 6,
+    depth: 1,
+    range: { start: { line: 11, character: 2 }, end: { line: 15, character: 3 } },
+    selectionRange: { start: { line: 11, character: 2 }, end: { line: 11, character: 7 } },
   },
 ];
 
@@ -31,8 +70,9 @@ describe("Breadcrumbs", () => {
       { label: "java", path: "src/main/java", kind: "directory" as const },
       { label: "App.java", path: "src/main/java/App.java", kind: "file" as const },
     ];
+    const chain = symbolChainAtPosition(symbols, { line: 7, character: 1 });
 
-    expect(collapsedBreadcrumbItems(segments, symbols).map((item) => {
+    expect(collapsedBreadcrumbItems(segments, chain).map((item) => {
       if (item.type === "collapsed") return "…";
       return item.type === "symbol" ? item.value.name : item.value.label;
     })).toEqual(["repo", "…", "java", "App.java", "…", "render"]);
@@ -41,11 +81,107 @@ describe("Breadcrumbs", () => {
   it("derives the nested symbol chain at the cursor", () => {
     expect(symbolChainAtPosition(symbols, { line: 7, character: 1 }).map((item) => item.name))
       .toEqual(["App", "render"]);
-    expect(symbolChainAtPosition(symbols, { line: 15, character: 1 }).map((item) => item.name))
+    expect(symbolChainAtPosition(symbols, { line: 18, character: 1 }).map((item) => item.name))
       .toEqual(["App"]);
   });
 
-  it("renders path and symbol segments and routes clicks", () => {
+  it("lists sibling symbols under the same parent", () => {
+    const render = symbols.find((item) => item.name === "render")!;
+    expect(symbolSiblingsAt(symbols, render).map((item) => item.name)).toEqual(["render", "mount"]);
+    const app = symbols.find((item) => item.name === "App")!;
+    expect(symbolSiblingsAt(symbols, app).map((item) => item.name)).toEqual(["App", "Helper"]);
+  });
+
+  it("opens an IDEA-style path popup with children and actions on segment click", async () => {
+    const loadPathChildren = vi.fn().mockResolvedValue([
+      { label: "App.tsx", path: "src/App.tsx", kind: "file", active: true },
+      { label: "lib", path: "src/lib", kind: "directory" },
+    ]);
+    const onPathNavigate = vi.fn();
+    const onCopy = vi.fn();
+    render(
+      <Breadcrumbs
+        pathSegments={[
+          { label: "repo", path: "", kind: "root" },
+          { label: "src", path: "src", kind: "directory" },
+          { label: "App.tsx", path: "src/App.tsx", kind: "file" },
+        ]}
+        symbols={symbols}
+        position={{ line: 7, character: 1 }}
+        loadPathChildren={loadPathChildren}
+        onPathNavigate={onPathNavigate}
+        pathActionsForSegment={(segment) => [
+          {
+            id: "copy-path",
+            label: "Copy Path",
+            onSelect: () => onCopy(segment.path),
+          },
+        ]}
+      />,
+    );
+
+    clickPathSegment("directory", /src/);
+    expect(loadPathChildren).toHaveBeenCalledWith(expect.objectContaining({ path: "src" }));
+
+    const popup = await screen.findByTestId("code-workspace-breadcrumb-popup");
+    expect(popup).toBeTruthy();
+    expect(await within(popup).findByRole("option", { name: /lib/ })).toBeTruthy();
+    expect(within(popup).getByRole("option", { name: /App\.tsx/ })).toBeTruthy();
+
+    fireEvent.click(within(popup).getByRole("option", { name: /lib/ }));
+    expect(onPathNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "src/lib", kind: "directory" }),
+      expect.objectContaining({ path: "src" }),
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("code-workspace-breadcrumb-popup")).toBeNull();
+    });
+  });
+
+  it("runs path actions from the segment popup footer", async () => {
+    const onCopy = vi.fn();
+    render(
+      <Breadcrumbs
+        pathSegments={[
+          { label: "repo", path: "", kind: "root" },
+          { label: "src", path: "src", kind: "directory" },
+        ]}
+        symbols={[]}
+        position={{ line: 0, character: 0 }}
+        loadPathChildren={vi.fn().mockResolvedValue([])}
+        pathActionsForSegment={(segment) => [
+          { id: "copy-path", label: "Copy Path", onSelect: () => onCopy(segment.path) },
+        ]}
+      />,
+    );
+
+    clickPathSegment("directory", /src/);
+    const action = await screen.findByTestId("code-workspace-breadcrumb-action-copy-path");
+    fireEvent.click(action);
+    expect(onCopy).toHaveBeenCalledWith("src");
+  });
+
+  it("opens a sibling-symbol popup when a symbol segment is clicked", async () => {
+    const onSymbolClick = vi.fn();
+    render(
+      <Breadcrumbs
+        pathSegments={[{ label: "App.tsx", path: "App.tsx", kind: "file" }]}
+        symbols={symbols}
+        position={{ line: 7, character: 1 }}
+        onSymbolClick={onSymbolClick}
+      />,
+    );
+
+    const symbolButtons = within(breadcrumbNav()).getAllByTestId("code-workspace-breadcrumb-symbol");
+    const renderBtn = symbolButtons.find((button) => /render/.test(button.textContent ?? ""));
+    expect(renderBtn).toBeTruthy();
+    fireEvent.click(renderBtn!);
+    const popup = await screen.findByTestId("code-workspace-breadcrumb-popup");
+    fireEvent.click(within(popup).getByRole("option", { name: /mount/ }));
+    expect(onSymbolClick).toHaveBeenCalledWith(expect.objectContaining({ name: "mount" }));
+  });
+
+  it("falls back to onPathClick when loadPathChildren is not provided", () => {
     const onPathClick = vi.fn();
     const onSymbolClick = vi.fn();
     render(
@@ -62,9 +198,12 @@ describe("Breadcrumbs", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /src/ }));
+    clickPathSegment("directory", /src/);
     expect(onPathClick).toHaveBeenCalledWith(expect.objectContaining({ path: "src" }));
-    fireEvent.click(screen.getByRole("button", { name: /render/ }));
-    expect(onSymbolClick).toHaveBeenCalledWith(expect.objectContaining({ name: "render" }));
+    const symbolButtons = within(breadcrumbNav()).getAllByTestId("code-workspace-breadcrumb-symbol");
+    const appBtn = symbolButtons.find((button) => (button.textContent ?? "").trim() === "App");
+    expect(appBtn).toBeTruthy();
+    fireEvent.click(appBtn!);
+    expect(screen.getByTestId("code-workspace-breadcrumb-popup")).toBeTruthy();
   });
 });

--- a/src/components/editor/workspace/Breadcrumbs.tsx
+++ b/src/components/editor/workspace/Breadcrumbs.tsx
@@ -1,4 +1,14 @@
-import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import { createPortal } from "react-dom";
 import { ChevronRight, File, Folder, Hash, MoreHorizontal } from "lucide-react";
 import type { LspDocumentSymbol, LspPosition } from "../../../lib/editor/lsp";
 
@@ -8,18 +18,69 @@ export interface BreadcrumbPathSegment {
   kind: "root" | "directory" | "file";
 }
 
+/** Child/sibling entry shown in a path-segment dropdown (IDEA-style). */
+export interface BreadcrumbPathChild {
+  label: string;
+  path: string;
+  kind: "directory" | "file";
+  /** True when this entry is the next segment on the current trail. */
+  active?: boolean;
+}
+
+export interface BreadcrumbPathAction {
+  id: string;
+  label: string;
+  disabled?: boolean;
+  danger?: boolean;
+  onSelect: () => void;
+}
+
 type BreadcrumbItem =
   | { type: "path"; value: BreadcrumbPathSegment }
   | { type: "symbol"; value: LspDocumentSymbol }
-  | { type: "collapsed" };
+  | { type: "collapsed"; hiddenPaths: BreadcrumbPathSegment[] };
 
 interface BreadcrumbsProps {
   pathSegments: BreadcrumbPathSegment[];
   symbols: LspDocumentSymbol[];
   position: LspPosition;
+  /**
+   * Load children of a directory/root, or siblings of a file (parent listing).
+   * When provided, path segment clicks open an IDEA-style navigation popup.
+   */
+  loadPathChildren?: (segment: BreadcrumbPathSegment) => Promise<BreadcrumbPathChild[]>;
+  /** Navigate to a child/sibling picked from the path dropdown. */
+  onPathNavigate?: (child: BreadcrumbPathChild, fromSegment: BreadcrumbPathSegment) => void;
+  /** Context / footer actions for a path segment (copy path, reveal, …). */
+  pathActionsForSegment?: (segment: BreadcrumbPathSegment) => BreadcrumbPathAction[];
+  /**
+   * Fallback simple click when `loadPathChildren` is not provided
+   * (e.g. reveal the segment in the project tree).
+   */
   onPathClick?: (segment: BreadcrumbPathSegment) => void;
   onSymbolClick?: (symbol: LspDocumentSymbol) => void;
 }
+
+type OpenPopup =
+  | {
+      kind: "path";
+      segment: BreadcrumbPathSegment;
+      anchor: DOMRect;
+      children: BreadcrumbPathChild[];
+      loading: boolean;
+      error: string | null;
+    }
+  | {
+      kind: "symbol";
+      symbol: LspDocumentSymbol;
+      siblings: LspDocumentSymbol[];
+      anchor: DOMRect;
+    }
+  | {
+      kind: "collapsed";
+      segments: BreadcrumbPathSegment[];
+      anchor: DOMRect;
+    };
 
 function positionWithin(symbol: LspDocumentSymbol, position: LspPosition): boolean {
   const { start, end } = symbol.range;
@@ -38,6 +99,34 @@ export function symbolChainAtPosition(
     .sort((left, right) => left.depth - right.depth);
 }
 
+/**
+ * Siblings of `target` under the same enclosing parent symbol (or top-level
+ * peers when depth is 0). Matches IDEA breadcrumb symbol dropdown behavior.
+ */
+export function symbolSiblingsAt(
+  symbols: LspDocumentSymbol[],
+  target: LspDocumentSymbol,
+): LspDocumentSymbol[] {
+  const parent = symbols
+    .filter((symbol) =>
+      symbol.depth === target.depth - 1 && positionWithin(symbol, target.selectionRange.start)
+    )
+    .sort((left, right) => right.depth - left.depth)[0] ?? null;
+
+  return symbols
+    .filter((symbol) => {
+      if (symbol.depth !== target.depth) return false;
+      if (!parent) return target.depth === 0;
+      return positionWithin(parent, symbol.selectionRange.start);
+    })
+    .sort((left, right) => {
+      if (left.range.start.line !== right.range.start.line) {
+        return left.range.start.line - right.range.start.line;
+      }
+      return left.range.start.character - right.range.start.character;
+    });
+}
+
 /** Keep the root, the active file, and the nearest parent visible in narrow panes. */
 export function collapsedBreadcrumbItems(
   pathSegments: BreadcrumbPathSegment[],
@@ -46,21 +135,330 @@ export function collapsedBreadcrumbItems(
   const compactPath: BreadcrumbItem[] = pathSegments.length > 3
     ? [
         { type: "path", value: pathSegments[0]! },
-        { type: "collapsed" },
+        { type: "collapsed", hiddenPaths: pathSegments.slice(1, -2) },
         ...pathSegments.slice(-2).map((value) => ({ type: "path" as const, value })),
       ]
     : pathSegments.map((value) => ({ type: "path" as const, value }));
   const compactSymbols: BreadcrumbItem[] = symbols.length > 1
-    ? [{ type: "collapsed" }, { type: "symbol", value: symbols.at(-1)! }]
+    ? [{ type: "collapsed", hiddenPaths: [] }, { type: "symbol", value: symbols.at(-1)! }]
     : symbols.map((value) => ({ type: "symbol" as const, value }));
 
   return [...compactPath, ...compactSymbols];
+}
+
+function sortPathChildren(entries: BreadcrumbPathChild[]): BreadcrumbPathChild[] {
+  return [...entries].sort((left, right) => {
+    if (left.kind !== right.kind) return left.kind === "directory" ? -1 : 1;
+    return left.label.localeCompare(right.label, undefined, { sensitivity: "base" });
+  });
+}
+
+function filterByQuery<T>(items: T[], query: string, labelOf: (item: T) => string): T[] {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return items;
+  return items.filter((item) => labelOf(item).toLowerCase().includes(trimmed));
+}
+
+interface SegmentPopupProps {
+  open: OpenPopup;
+  query: string;
+  selectedIndex: number;
+  actions: BreadcrumbPathAction[];
+  onQueryChange: (value: string) => void;
+  onSelectedIndexChange: (index: number) => void;
+  onClose: () => void;
+  onPickPathChild: (child: BreadcrumbPathChild) => void;
+  onPickSymbol: (symbol: LspDocumentSymbol) => void;
+  onPickCollapsedSegment: (segment: BreadcrumbPathSegment) => void;
+  onAction: (action: BreadcrumbPathAction) => void;
+}
+
+function SegmentPopup({
+  open,
+  query,
+  selectedIndex,
+  actions,
+  onQueryChange,
+  onSelectedIndexChange,
+  onClose,
+  onPickPathChild,
+  onPickSymbol,
+  onPickCollapsedSegment,
+  onAction,
+}: SegmentPopupProps) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const [coords, setCoords] = useState({ left: open.anchor.left, top: open.anchor.bottom + 2 });
+
+  const pathChildren = open.kind === "path" ? sortPathChildren(open.children) : [];
+  const filteredPath = open.kind === "path"
+    ? filterByQuery(pathChildren, query, (item) => item.label)
+    : [];
+  const filteredSymbols = open.kind === "symbol"
+    ? filterByQuery(open.siblings, query, (item) => item.name)
+    : [];
+  const filteredCollapsed = open.kind === "collapsed"
+    ? filterByQuery(open.segments, query, (item) => item.label)
+    : [];
+
+  const itemCount = open.kind === "path"
+    ? filteredPath.length
+    : open.kind === "symbol"
+      ? filteredSymbols.length
+      : filteredCollapsed.length;
+  const actionStart = itemCount;
+  const totalCount = itemCount + actions.length;
+  const safeIndex = totalCount === 0 ? 0 : Math.min(selectedIndex, totalCount - 1);
+
+  useLayoutEffect(() => {
+    const el = panelRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const margin = 6;
+    const left = Math.min(
+      Math.max(margin, open.anchor.left),
+      Math.max(margin, window.innerWidth - rect.width - margin),
+    );
+    const preferBelow = open.anchor.bottom + 2;
+    const top = preferBelow + rect.height + margin > window.innerHeight
+      ? Math.max(margin, open.anchor.top - rect.height - 2)
+      : preferBelow;
+    setCoords({ left, top });
+  }, [open, query, itemCount, actions.length]);
+
+  useEffect(() => {
+    const id = window.setTimeout(() => inputRef.current?.focus(), 0);
+    return () => window.clearTimeout(id);
+  }, [open.kind, open.kind === "path" ? open.segment.path : open.kind === "symbol" ? open.symbol.name : "collapsed"]);
+
+  useEffect(() => {
+    const onMouseDown = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (panelRef.current && target && !panelRef.current.contains(target)) {
+        onClose();
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onClose]);
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const active = list.querySelector<HTMLElement>(`[data-popup-index="${safeIndex}"]`);
+    if (active && typeof active.scrollIntoView === "function") {
+      active.scrollIntoView({ block: "nearest" });
+    }
+  }, [safeIndex]);
+
+  const activate = (index: number) => {
+    if (index < itemCount) {
+      if (open.kind === "path") {
+        const child = filteredPath[index];
+        if (child) onPickPathChild(child);
+      } else if (open.kind === "symbol") {
+        const symbol = filteredSymbols[index];
+        if (symbol) onPickSymbol(symbol);
+      } else {
+        const segment = filteredCollapsed[index];
+        if (segment) onPickCollapsedSegment(segment);
+      }
+      return;
+    }
+    const action = actions[index - itemCount];
+    if (action && !action.disabled) onAction(action);
+  };
+
+  const onKeyDown = (event: ReactKeyboardEvent) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (totalCount > 0) onSelectedIndexChange((safeIndex + 1) % totalCount);
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      if (totalCount > 0) onSelectedIndexChange((safeIndex - 1 + totalCount) % totalCount);
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      activate(safeIndex);
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+    }
+  };
+
+  const title = open.kind === "path"
+    ? open.segment.label
+    : open.kind === "symbol"
+      ? open.symbol.name
+      : "Path";
+
+  return createPortal(
+    <div
+      ref={panelRef}
+      role="listbox"
+      aria-label={`${title} breadcrumb menu`}
+      data-testid="code-workspace-breadcrumb-popup"
+      data-taomni-context-menu="true"
+      className="fixed z-[500] flex max-h-[min(360px,50vh)] w-[min(320px,calc(100vw-12px))] flex-col overflow-hidden rounded border border-[var(--taomni-code-border)] bg-[var(--taomni-code-tooltip-bg)] text-[11px] text-[var(--taomni-code-text)] shadow-xl"
+      style={{ left: coords.left, top: coords.top }}
+      onKeyDown={onKeyDown}
+    >
+      <div className="border-b border-[var(--taomni-code-border)] px-2 py-1.5">
+        <input
+          ref={inputRef}
+          data-testid="code-workspace-breadcrumb-popup-filter"
+          aria-label="Filter breadcrumb entries"
+          className="taomni-input h-6 w-full text-[11px]"
+          placeholder={open.kind === "path" && open.loading ? "Loading…" : "Type to filter"}
+          value={query}
+          onChange={(event) => onQueryChange(event.target.value)}
+        />
+      </div>
+      <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto py-1">
+        {open.kind === "path" && open.loading && (
+          <div className="px-2 py-1.5 text-[var(--taomni-code-muted)]">Loading…</div>
+        )}
+        {open.kind === "path" && open.error && (
+          <div className="px-2 py-1.5 text-red-400">{open.error}</div>
+        )}
+        {open.kind === "path" && !open.loading && !open.error && filteredPath.length === 0 && (
+          <div className="px-2 py-1.5 text-[var(--taomni-code-muted)]">
+            {query.trim() ? "No matching entries" : "Empty folder"}
+          </div>
+        )}
+        {open.kind === "path" && filteredPath.map((child, index) => (
+          <button
+            key={`${child.kind}:${child.path}`}
+            type="button"
+            role="option"
+            aria-selected={index === safeIndex}
+            data-popup-index={index}
+            data-active={child.active || undefined}
+            data-testid={`code-workspace-breadcrumb-entry-${child.kind}`}
+            className={`flex w-full items-center gap-1.5 px-2 py-1 text-left hover:bg-[var(--taomni-code-active-line-bg)] ${
+              index === safeIndex ? "bg-[var(--taomni-code-active-line-bg)]" : ""
+            } ${child.active ? "text-[var(--taomni-code-text)] font-medium" : "text-[var(--taomni-code-muted)]"}`}
+            onMouseEnter={() => onSelectedIndexChange(index)}
+            onClick={() => activate(index)}
+          >
+            {child.kind === "directory" ? (
+              <Folder className="h-3 w-3 shrink-0 text-[#d59d32]" />
+            ) : (
+              <File className="h-3 w-3 shrink-0" />
+            )}
+            <span className="min-w-0 truncate">{child.label}</span>
+          </button>
+        ))}
+        {open.kind === "symbol" && filteredSymbols.length === 0 && (
+          <div className="px-2 py-1.5 text-[var(--taomni-code-muted)]">
+            {query.trim() ? "No matching symbols" : "No symbols"}
+          </div>
+        )}
+        {open.kind === "symbol" && filteredSymbols.map((symbol, index) => {
+          const current = symbol === open.symbol
+            || (symbol.name === open.symbol.name
+              && symbol.selectionRange.start.line === open.symbol.selectionRange.start.line
+              && symbol.selectionRange.start.character === open.symbol.selectionRange.start.character);
+          return (
+            <button
+              key={`${symbol.name}:${symbol.selectionRange.start.line}:${symbol.selectionRange.start.character}`}
+              type="button"
+              role="option"
+              aria-selected={index === safeIndex}
+              data-popup-index={index}
+              data-testid="code-workspace-breadcrumb-entry-symbol"
+              className={`flex w-full items-center gap-1.5 px-2 py-1 text-left hover:bg-[var(--taomni-code-active-line-bg)] ${
+                index === safeIndex ? "bg-[var(--taomni-code-active-line-bg)]" : ""
+              } ${current ? "text-[var(--taomni-code-text)] font-medium" : "text-[var(--taomni-code-muted)]"}`}
+              onMouseEnter={() => onSelectedIndexChange(index)}
+              onClick={() => activate(index)}
+            >
+              <Hash className="h-3 w-3 shrink-0 text-[var(--taomni-accent)]" />
+              <span className="min-w-0 truncate">{symbol.name}</span>
+              {symbol.detail && (
+                <span className="ml-auto min-w-0 max-w-[40%] truncate text-[10px] text-[var(--taomni-code-muted)]">
+                  {symbol.detail}
+                </span>
+              )}
+            </button>
+          );
+        })}
+        {open.kind === "collapsed" && filteredCollapsed.map((segment, index) => (
+          <button
+            key={`collapsed:${segment.path}:${segment.label}`}
+            type="button"
+            role="option"
+            aria-selected={index === safeIndex}
+            data-popup-index={index}
+            data-testid="code-workspace-breadcrumb-entry-collapsed"
+            className={`flex w-full items-center gap-1.5 px-2 py-1 text-left text-[var(--taomni-code-muted)] hover:bg-[var(--taomni-code-active-line-bg)] ${
+              index === safeIndex ? "bg-[var(--taomni-code-active-line-bg)]" : ""
+            }`}
+            onMouseEnter={() => onSelectedIndexChange(index)}
+            onClick={() => activate(index)}
+          >
+            {segment.kind === "file" ? (
+              <File className="h-3 w-3 shrink-0" />
+            ) : (
+              <Folder className="h-3 w-3 shrink-0 text-[#d59d32]" />
+            )}
+            <span className="min-w-0 truncate">{segment.label}</span>
+          </button>
+        ))}
+      </div>
+      {actions.length > 0 && (
+        <div className="border-t border-[var(--taomni-code-border)] py-1">
+          {actions.map((action, offset) => {
+            const index = actionStart + offset;
+            return (
+              <button
+                key={action.id}
+                type="button"
+                role="option"
+                aria-selected={index === safeIndex}
+                data-popup-index={index}
+                data-testid={`code-workspace-breadcrumb-action-${action.id}`}
+                disabled={action.disabled}
+                className={`flex w-full items-center px-2 py-1 text-left hover:bg-[var(--taomni-code-active-line-bg)] disabled:opacity-40 ${
+                  index === safeIndex ? "bg-[var(--taomni-code-active-line-bg)]" : ""
+                } ${action.danger ? "text-red-400" : "text-[var(--taomni-code-text)]"}`}
+                onMouseEnter={() => onSelectedIndexChange(index)}
+                onClick={() => activate(index)}
+              >
+                {action.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>,
+    document.body,
+  );
 }
 
 export function Breadcrumbs({
   pathSegments,
   symbols,
   position,
+  loadPathChildren,
+  onPathNavigate,
+  pathActionsForSegment,
   onPathClick,
   onSymbolClick,
 }: BreadcrumbsProps) {
@@ -68,6 +466,11 @@ export function Breadcrumbs({
   const navRef = useRef<HTMLElement | null>(null);
   const fullPathMeasureRef = useRef<HTMLDivElement | null>(null);
   const [collapsed, setCollapsed] = useState(false);
+  const [popup, setPopup] = useState<OpenPopup | null>(null);
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const loadGenerationRef = useRef(0);
+
   const fullItems = useMemo<BreadcrumbItem[]>(() => [
     ...pathSegments.map((value) => ({ type: "path" as const, value })),
     ...symbolChain.map((value) => ({ type: "symbol" as const, value })),
@@ -94,42 +497,193 @@ export function Breadcrumbs({
     return () => observer.disconnect();
   }, [fullItems]);
 
-  const renderItems = (items: BreadcrumbItem[], compact: boolean) => items.map((item, index) => {
+  // Close popup when the active trail changes (file switch / cursor jump).
+  useEffect(() => {
+    setPopup(null);
+    setQuery("");
+    setSelectedIndex(0);
+  }, [pathSegments, position.line, position.character]);
+
+  const closePopup = useCallback(() => {
+    loadGenerationRef.current += 1;
+    setPopup(null);
+    setQuery("");
+    setSelectedIndex(0);
+  }, []);
+
+  const actionsForOpen = useMemo(() => {
+    if (!popup || popup.kind !== "path" || !pathActionsForSegment) return [];
+    return pathActionsForSegment(popup.segment);
+  }, [pathActionsForSegment, popup]);
+
+  const openPathPopup = useCallback(async (
+    segment: BreadcrumbPathSegment,
+    anchorEl: HTMLElement,
+  ) => {
+    const anchor = anchorEl.getBoundingClientRect();
+    if (!loadPathChildren) {
+      onPathClick?.(segment);
+      return;
+    }
+    const generation = ++loadGenerationRef.current;
+    setQuery("");
+    setSelectedIndex(0);
+    setPopup({
+      kind: "path",
+      segment,
+      anchor,
+      children: [],
+      loading: true,
+      error: null,
+    });
+    try {
+      const children = await loadPathChildren(segment);
+      if (generation !== loadGenerationRef.current) return;
+      const activeIndex = Math.max(0, children.findIndex((child) => child.active));
+      setSelectedIndex(activeIndex);
+      setPopup({
+        kind: "path",
+        segment,
+        anchor,
+        children,
+        loading: false,
+        error: null,
+      });
+    } catch (error) {
+      if (generation !== loadGenerationRef.current) return;
+      setPopup({
+        kind: "path",
+        segment,
+        anchor,
+        children: [],
+        loading: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, [loadPathChildren, onPathClick]);
+
+  const openSymbolPopup = useCallback((
+    symbol: LspDocumentSymbol,
+    anchorEl: HTMLElement,
+  ) => {
+    const siblings = symbolSiblingsAt(symbols, symbol);
+    if (siblings.length <= 1) {
+      onSymbolClick?.(symbol);
+      return;
+    }
+    const anchor = anchorEl.getBoundingClientRect();
+    const activeIndex = Math.max(0, siblings.findIndex((item) =>
+      item.name === symbol.name
+      && item.selectionRange.start.line === symbol.selectionRange.start.line
+      && item.selectionRange.start.character === symbol.selectionRange.start.character
+    ));
+    setQuery("");
+    setSelectedIndex(activeIndex);
+    setPopup({ kind: "symbol", symbol, siblings, anchor });
+  }, [onSymbolClick, symbols]);
+
+  const openCollapsedPopup = useCallback((
+    segments: BreadcrumbPathSegment[],
+    anchorEl: HTMLElement,
+  ) => {
+    if (segments.length === 0) return;
+    setQuery("");
+    setSelectedIndex(0);
+    setPopup({
+      kind: "collapsed",
+      segments,
+      anchor: anchorEl.getBoundingClientRect(),
+    });
+  }, []);
+
+  const handlePathContextMenu = useCallback((
+    event: ReactMouseEvent,
+    segment: BreadcrumbPathSegment,
+  ) => {
+    const actions = pathActionsForSegment?.(segment) ?? [];
+    if (actions.length === 0 && !loadPathChildren) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const anchorEl = event.currentTarget as HTMLElement;
+    void openPathPopup(segment, anchorEl);
+  }, [loadPathChildren, openPathPopup, pathActionsForSegment]);
+
+  const renderItems = (items: BreadcrumbItem[], compact: boolean, interactive: boolean) => items.map((item, index) => {
     const path = item.type === "path" ? item.value : null;
     const symbol = item.type === "symbol" ? item.value : null;
     const label = path?.label ?? symbol?.name ?? "";
     const flexible = compact && (path?.kind === "file" || !!symbol);
+    const icon = path?.kind === "root" || path?.kind === "directory" ? (
+      <Folder className="h-3 w-3 shrink-0 text-[#d59d32]" />
+    ) : path?.kind === "file" ? (
+      <File className="h-3 w-3 shrink-0" />
+    ) : item.type === "collapsed" ? (
+      <MoreHorizontal className="h-3 w-3" />
+    ) : (
+      <Hash className="h-3 w-3 shrink-0 text-[var(--taomni-accent)]" />
+    );
+
     if (item.type === "collapsed") {
       return (
         <span key={`collapsed:${index}`} className="inline-flex shrink-0 items-center">
           {index > 0 && <ChevronRight className="mx-0.5 h-3 w-3" />}
-          <MoreHorizontal className="mx-1 h-3 w-3" aria-label="Hidden breadcrumb segments" />
+          {interactive ? (
+            <button
+              type="button"
+              className="inline-flex h-5 items-center rounded px-1 hover:bg-[var(--taomni-code-active-line-bg)] hover:text-[var(--taomni-code-text)]"
+              aria-label="Hidden breadcrumb segments"
+              data-testid="code-workspace-breadcrumb-collapsed"
+              onClick={(event) => {
+                if (item.hiddenPaths.length > 0) {
+                  openCollapsedPopup(item.hiddenPaths, event.currentTarget);
+                }
+              }}
+            >
+              {icon}
+            </button>
+          ) : (
+            <span className="inline-flex h-5 items-center rounded px-1">{icon}</span>
+          )}
         </span>
       );
     }
+
+    const content = (
+      <>
+        {icon}
+        <span className={flexible ? "truncate" : undefined}>{label}</span>
+      </>
+    );
+
     return (
       <span
         key={`${item.type}:${label}:${index}`}
         className={`inline-flex min-w-0 items-center ${flexible ? "flex-1" : "shrink-0"}`}
       >
         {index > 0 && <ChevronRight className="mx-0.5 h-3 w-3 shrink-0" />}
-        <button
-          type="button"
-          className={`inline-flex h-5 min-w-0 items-center gap-1 rounded px-1 hover:bg-[var(--taomni-code-active-line-bg)] hover:text-[var(--taomni-code-text)] ${flexible ? "flex-1" : ""}`}
-          onClick={() => {
-            if (path) onPathClick?.(path);
-            if (symbol) onSymbolClick?.(symbol);
-          }}
-        >
-          {path?.kind === "root" || path?.kind === "directory" ? (
-            <Folder className="h-3 w-3 shrink-0 text-[#d59d32]" />
-          ) : path?.kind === "file" ? (
-            <File className="h-3 w-3 shrink-0" />
-          ) : (
-            <Hash className="h-3 w-3 shrink-0 text-[var(--taomni-accent)]" />
-          )}
-          <span className={flexible ? "truncate" : undefined}>{label}</span>
-        </button>
+        {interactive ? (
+          <button
+            type="button"
+            className={`inline-flex h-5 min-w-0 items-center gap-1 rounded px-1 hover:bg-[var(--taomni-code-active-line-bg)] hover:text-[var(--taomni-code-text)] ${flexible ? "flex-1" : ""}`}
+            aria-haspopup="listbox"
+            data-testid={path
+              ? `code-workspace-breadcrumb-path-${path.kind}`
+              : "code-workspace-breadcrumb-symbol"}
+            onClick={(event) => {
+              if (path) void openPathPopup(path, event.currentTarget);
+              if (symbol) openSymbolPopup(symbol, event.currentTarget);
+            }}
+            onContextMenu={(event) => {
+              if (path) handlePathContextMenu(event, path);
+            }}
+          >
+            {content}
+          </button>
+        ) : (
+          <span className={`inline-flex h-5 min-w-0 items-center gap-1 rounded px-1 ${flexible ? "flex-1" : ""}`}>
+            {content}
+          </span>
+        )}
       </span>
     );
   });
@@ -146,11 +700,84 @@ export function Breadcrumbs({
         aria-hidden="true"
         className="pointer-events-none absolute invisible w-max whitespace-nowrap"
       >
-        {renderItems(fullItems, false)}
+        {renderItems(fullItems, false, false)}
       </div>
       <div className="flex min-w-0 flex-1 items-center overflow-hidden">
-        {renderItems(visibleItems, collapsed)}
+        {renderItems(visibleItems, collapsed, true)}
       </div>
+      {popup && (
+        <SegmentPopup
+          open={popup}
+          query={query}
+          selectedIndex={selectedIndex}
+          actions={actionsForOpen}
+          onQueryChange={(value) => {
+            setQuery(value);
+            setSelectedIndex(0);
+          }}
+          onSelectedIndexChange={setSelectedIndex}
+          onClose={closePopup}
+          onPickPathChild={(child) => {
+            if (popup.kind === "path") {
+              onPathNavigate?.(child, popup.segment);
+            }
+            closePopup();
+          }}
+          onPickSymbol={(symbol) => {
+            onSymbolClick?.(symbol);
+            closePopup();
+          }}
+          onPickCollapsedSegment={(segment) => {
+            // Swap the collapsed list for that intermediate segment's children menu.
+            const anchor = popup.kind === "collapsed"
+              ? popup.anchor
+              : navRef.current?.getBoundingClientRect() ?? new DOMRect(8, 8, 0, 0);
+            if (!loadPathChildren) {
+              onPathClick?.(segment);
+              closePopup();
+              return;
+            }
+            const generation = ++loadGenerationRef.current;
+            setQuery("");
+            setSelectedIndex(0);
+            setPopup({
+              kind: "path",
+              segment,
+              anchor,
+              children: [],
+              loading: true,
+              error: null,
+            });
+            void loadPathChildren(segment).then((children) => {
+              if (generation !== loadGenerationRef.current) return;
+              const activeIndex = Math.max(0, children.findIndex((child) => child.active));
+              setSelectedIndex(activeIndex);
+              setPopup({
+                kind: "path",
+                segment,
+                anchor,
+                children,
+                loading: false,
+                error: null,
+              });
+            }).catch((error) => {
+              if (generation !== loadGenerationRef.current) return;
+              setPopup({
+                kind: "path",
+                segment,
+                anchor,
+                children: [],
+                loading: false,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            });
+          }}
+          onAction={(action) => {
+            action.onSelect();
+            closePopup();
+          }}
+        />
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
Make editor breadcrumbs behave like IntelliJ IDEA: each path/symbol segment opens a popup with navigable peers and segment actions, instead of only selecting the path in the project tree.

UI (Breadcrumbs.tsx):
- Click a root/directory segment to list its children; click a file segment to list siblings in the parent directory
- Click a symbol segment to list sibling symbols under the same parent
- Click collapsed "…" to pick intermediate path segments
- Popup supports type-to-filter, keyboard ↑↓/Enter/Esc, and highlights the active trail child
- Path popup footer actions: Select in Project Tree, Copy Path, Copy Relative Path, Reveal in Explorer
- Right-click on a path segment opens the same navigation menu
- Width-measure clone renders non-interactive spans so a11y queries only see the live breadcrumb buttons

Wiring (CodeWorkspaceTab.tsx):
- loadBreadcrumbPathChildren lists via workspaceListDir (and warms the tree cache), hides heavy dirs via shouldHideEntry, and marks the next trail segment active
- onPathNavigate opens files or expands/selects directories in the tree; loose-file roots list absolute parents and open siblings as loose files
- pathActionsForSegment reuses copyTreePath / revealInExplorer (and clipboard / sftp_open_path for loose paths)

Tests cover path popup navigation, footer actions, symbol siblings, collapsed trail helpers, and the loadPathChildren fallback.