### PR TITLE
feat(rdp-server): Linux/macOS capture completion (skip Windows DXGI)

### DIFF
--- a/claudedocs/local-rdp-server-plan.md
+++ b/claudedocs/local-rdp-server-plan.md
@@ -12,8 +12,8 @@
 ## 1. 一句话现状
 
 **Linux X11 全链路可用**（连接 → 真桌面 → 键鼠 → 文本剪贴板 → TLS/NLA）。  
-**Windows / macOS 能连上但画面是占位帧**（捕获未实现）；输入有结构性映射、剪贴板/TLS 跨平台。  
-进阶（Wayland 原生捕获、Linux 独立会话/无头 sesman、音频、登录屏）为脚手架或明确不做。
+**Linux X11 全链路可用**；**macOS 已接 xcap 真桌面采集**（需屏幕录制权限）；**Linux 纯 Wayland** 走 xcap 门户回退。  
+**Windows 捕获仍为占位**（本分支按产品优先级暂缓 DXGI）。输入/剪贴板/TLS 跨平台。
 
 ---
 
@@ -52,14 +52,14 @@
 
 | 优先级 | 缺口 | 平台 |
 |--------|------|------|
-| **P0** | Windows 屏幕捕获（DXGI Desktop Duplication 或 WGC） | Win |
-| **P0** | macOS 屏幕捕获（ScreenCaptureKit 优先，或 CGDisplayStream） | macOS |
-| **P0** | 捕获失败时 UI/日志明确，避免用户以为「黑屏=连上了」 | 全平台 |
-| **P1** | macOS 键盘 scancode 表补全 | macOS |
-| **P1** | Windows 输入运行时回归（DPI/多显示器坐标） | Win |
-| **P1** | Linux 纯 Wayland 捕获（PipeWire portal） | Linux |
-| **P1** | 硬件光标下发（X11 xfixes cursor → RGBAPointer） | 至少 Linux |
-| **P2** | `Synchronize` 锁定键状态 | 全平台 |
+| **P0** | Windows 屏幕捕获（DXGI/WGC） | Win — **本分支暂缓** |
+| **P0** | ~~macOS 屏幕捕获~~ | macOS — ✅ `xcap` |
+| **P0** | ~~捕获失败 UI/日志明确~~ | 全平台 — ✅ R0 |
+| **P1** | ~~macOS 键盘 scancode 表补全~~ | macOS — ✅ 扩展映射 |
+| **P1** | Windows 输入运行时回归 | Win — 暂缓 |
+| **P1** | ~~Linux 纯 Wayland 捕获~~ | Linux — ✅ xcap 门户回退 |
+| **P1** | 硬件光标下发（X11 xfixes → RGBAPointer） | 仍待做 |
+| **P2** | ~~`Synchronize` 锁定键~~ | ✅ 尽力脉冲 Caps/Num/Scroll |
 | **P2** | 客户端 resize / 多显示器 | 全平台 |
 | **P2** | 连接失败/权限引导（macOS 录屏权限、Win 高 DPI） | Win/mac |
 | **P3** | Linux sesman 独立会话 + 无头（T-11） | Linux |
@@ -75,12 +75,12 @@
 
 **目标**：用户立刻知道当前平台能不能看桌面。
 
-| 任务 ID | 内容 | 验收 |
+| 任务 ID | 内容 | 状态 |
 |---------|------|------|
-| R0-1 | 启动时探测捕获后端；失败则 `server://output` 明确打印平台缺失与后果 | Win/mac 启动日志含 “placeholder” 与实现路径提示 |
-| R0-2 | 前端 `RdpSettings` 按平台显示能力说明（i18n）：Win/mac「画面捕获未实现」/ Linux X11「可用」/ Wayland「有限」 | 设置页可见，非仅日志 |
-| R0-3 | 占位帧叠加文字（可选）：“Screen capture unavailable on this platform” | 客户端一眼能懂 |
-| R0-4 | 同步更新 `rust_rdp_server_feature_dev_task.md` 状态表（本计划落地后） | 任务文档与代码一致 |
+| R0-1 | 启动时 `create_capturer` 探测 + capability summary 日志 | ✅ |
+| R0-2 | 前端 `RdpSettings` 按平台 i18n 能力说明 | ✅ |
+| R0-3 | 占位帧改为高对比棋盘 + 移动色条 | ✅ |
+| R0-4 | 本计划文档状态同步 | ✅ |
 
 **依赖**：无  
 **风险**：低
@@ -115,14 +115,14 @@
 
 **目标**：macOS 上 FreeRDP/微软客户端看到并操控桌面。
 
-| 任务 ID | 内容 | 验收 |
+| 任务 ID | 内容 | 状态 |
 |---------|------|------|
-| R2-1 | 新增 `capture/mac.rs`：**ScreenCaptureKit**（macOS 12.3+）或 CGDisplayStream 回退 | 捕获 Ok |
-| R2-2 | 首次启动触发/引导 **Screen Recording** 权限；拒绝时明确错误 | 用户可知去系统设置开启 |
-| R2-3 | Retina：逻辑/物理像素与 RDP DesktopSize、鼠标坐标一致 | 点击不偏移 |
-| R2-4 | 补全 `macos_scancode_to_keycode` 常用键与扩展键；必要时 Unicode 路径 | 文本输入可用 |
-| R2-5 | Accessibility 权限对 enigo 的说明与降级 view-only | 无权限时日志清晰 |
-| R2-6 | 手测：macOS + FreeRDP / Microsoft Remote Desktop | 检查表 |
+| R2-1 | `capture/mac.rs` + `xcap_backend`（CGDisplay 路径） | ✅ |
+| R2-2 | 捕获失败错误文案引导 Screen Recording | ✅ |
+| R2-3 | Retina：xcap 返回物理像素；坐标依赖 enigo（手测） | ⚠️ 手测 |
+| R2-4 | 扩展 scancode→CGKeyCode + E0 方向键 | ✅ |
+| R2-5 | enigo 初始化失败 view-only 日志（既有） | ✅ |
+| R2-6 | 手测 macOS + FreeRDP | 待本机 |
 
 **依赖**：R0  
 **风险**：高（权限、Retina、SCK API 演进）
@@ -133,12 +133,12 @@
 
 **目标**：Wayland 主机可用；X11 体验打磨。
 
-| 任务 ID | 内容 | 验收 |
+| 任务 ID | 内容 | 状态 |
 |---------|------|------|
-| R3-1 | Wayland：`ashpd` ScreenCast + PipeWire 拉帧 → BGRA `Frame`（可选 feature 或系统 lib 探测） | 纯 Wayland 会话非占位 |
-| R3-2 | X11 硬件光标：`xfixes_get_cursor_image` → `DisplayUpdate` 指针 | 远程可见光标形状 |
-| R3-3 | 多显示器：选主屏或虚拟拼桌（先做主屏即可） | 文档说明范围 |
-| R3-4 | 锁定键 `Synchronize` | Caps 状态与本地一致 |
+| R3-1 | Wayland：X11 失败后 `xcap` 门户回退 | ✅ |
+| R3-2 | X11 硬件光标 → RGBAPointer | ⬜ 未做 |
+| R3-3 | 多显示器：xcap/X11 先主屏 | ✅ 主屏 |
+| R3-4 | 锁定键 `Synchronize` 尽力脉冲 | ✅ |
 
 **依赖**：R1/R2 不阻塞；可与 R1 并行由不同人做  
 **风险**：中–高（PipeWire 构建依赖、portal 用户授权）

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -210,6 +210,12 @@ hbase-kerberos = ["dep:cross-krb5"]
 winapi = { version = "0.3", features = ["fileapi", "commdlg", "shellapi", "winbase", "winuser"] }
 winreg = "0.55"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# RDP server macOS screen capture (CGDisplay / ScreenCaptureKit path inside xcap).
+# Always on for macOS so Local RDP server can mirror the desktop without needing
+# the optional `screen-capture` feature used by LanChat screenshots.
+xcap = "0.9.6"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 # RDP server X11 screen capture (XShm / MIT-SHM via libxcb) plus the DAMAGE
 # extension for event-driven, region-cropped capture (only the rectangles the
@@ -217,6 +223,9 @@ winreg = "0.55"
 # The `damage` feature transitively enables `xfixes`, which provides the
 # `xfixes::Region` type that `damage_subtract` takes.
 x11rb = { version = "0.13", features = ["shm", "damage"] }
+# Wayland fallback when no usable X11/`DISPLAY` is available: xcap uses the
+# xdg-desktop-portal ScreenCast path on pure Wayland sessions.
+xcap = "0.9.6"
 # Linux WebView (webkit2gtk) media stack. The default webkit2gtk settings ship
 # with media-stream / WebRTC disabled, so navigator.mediaDevices.getUserMedia
 # and getDisplayMedia reject — breaking LanChat voice/video calls and screen

--- a/src-tauri/src/servers/rdp.rs
+++ b/src-tauri/src/servers/rdp.rs
@@ -41,8 +41,8 @@ use std::net::SocketAddr;
 use ironrdp::server::{Credentials, DesktopSize, RdpServer, ServerEvent, TlsIdentityCtx};
 use tokio_util::sync::CancellationToken;
 
-use super::engine::{LogEmitter, ServerCtx, ServerStarted};
 use super::ServerConfig;
+use super::engine::{LogEmitter, ServerCtx, ServerStarted};
 
 mod auth;
 /// Screen-capture backends (X11 / Wayland). Exposed crate-wide so the LanChat
@@ -153,6 +153,28 @@ pub async fn start(ctx: ServerCtx, config: ServerConfig) -> Result<ServerStarted
         width: 1920,
         height: 1080,
     };
+
+    // R0: announce capture capability so logs make "placeholder vs real desktop"
+    // obvious before a client connects.
+    ctx.log.line(format!(
+        "RDP capture: {}",
+        capture::capture_capability_summary()
+    ));
+    match capture::create_capturer(&ctx.log) {
+        Ok(cap) => {
+            let (w, h) = cap.desktop_size();
+            ctx.log.line(format!(
+                "RDP capture probe OK — desktop {}x{} (real frames will be served)",
+                w, h
+            ));
+        }
+        Err(e) => {
+            ctx.log.line(format!(
+                "RDP capture probe FAILED — clients will see a placeholder checkerboard \
+                 until a backend is available: {e}"
+            ));
+        }
+    }
 
     // Phase 7 (Linux advanced): independent/headless virtual sessions. The base
     // server mirrors the current console desktop; when the user asks for a

--- a/src-tauri/src/servers/rdp/capture/mac.rs
+++ b/src-tauri/src/servers/rdp/capture/mac.rs
@@ -1,0 +1,13 @@
+//! macOS screen capture for the RDP server via `xcap` (CGDisplay / ScreenCaptureKit).
+//!
+//! Requires **Screen Recording** permission (System Settings → Privacy & Security).
+//! Without it, `xcap` fails at capture time with a clear error we surface to logs.
+
+use super::Capturer;
+use super::xcap_backend::XcapCapturer;
+use crate::servers::engine::LogEmitter;
+
+pub(crate) fn try_new(log: &LogEmitter) -> anyhow::Result<Box<dyn Capturer>> {
+    log.line("macOS RDP capture: initializing xcap backend (requires Screen Recording permission)");
+    Ok(Box::new(XcapCapturer::new(log)?))
+}

--- a/src-tauri/src/servers/rdp/capture/mod.rs
+++ b/src-tauri/src/servers/rdp/capture/mod.rs
@@ -1,10 +1,11 @@
 //! Platform screen-capture abstraction for the RDP server display side.
 //!
 //! A [`Capturer`] yields full-frame BGRA images. Backends are `#[cfg]`-gated per
-//! platform (the dev plan's §2.5 blueprint, following RustDesk's native-API
-//! choices): X11 uses MIT-SHM via `x11rb`; Windows/macOS/Wayland are structural
-//! placeholders for now (DXGI / CGDisplayStream / PipeWire), to be filled in as
-//! each platform's native backend lands.
+//! platform:
+//! - **Linux X11**: MIT-SHM + XDamage via `x11rb` (`x11.rs`)
+//! - **Linux Wayland**: `xcap` portal fallback when X11 is unreachable (`wayland.rs`)
+//! - **macOS**: `xcap` / CGDisplay path (`mac.rs` + `xcap_backend.rs`)
+//! - **Windows**: still a placeholder (DXGI/WGC not in this branch)
 //!
 //! A captured [`Frame`] is BGRA8888 (`PixelFormat::BgrA32`), top-down, tightly
 //! packed at `stride` bytes per row — exactly what `BitmapUpdate` wants, so the
@@ -12,10 +13,16 @@
 
 use crate::servers::engine::LogEmitter;
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) mod xcap_backend;
+
 #[cfg(target_os = "linux")]
 pub(crate) mod wayland;
 #[cfg(target_os = "linux")]
 pub(crate) mod x11;
+
+#[cfg(target_os = "macos")]
+pub(crate) mod mac;
 
 /// One captured frame or sub-region: BGRA8888, `stride` bytes per row,
 /// `height` rows. `x`/`y` are the top-left origin of this region within the
@@ -69,6 +76,37 @@ pub(crate) trait Capturer {
     }
 }
 
+/// Human-readable capture capability for this OS / session (used by start logs
+/// and the settings UI probe). Does not create a long-lived capturer.
+pub(crate) fn capture_capability_summary() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        if std::env::var_os("DISPLAY").is_some() {
+            return "Linux: X11/XWayland capture available when DISPLAY is set; \
+                    pure Wayland falls back to xcap portal"
+                .into();
+        }
+        if wayland::is_wayland_session() {
+            return "Linux Wayland: capture via xcap/portal (user must accept ScreenCast prompt)"
+                .into();
+        }
+        return "Linux: no DISPLAY and not a Wayland session — capture unavailable".into();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return "macOS: xcap capture (requires Screen Recording permission)".into();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return "Windows: DXGI/WGC capture not implemented in this build — placeholder frames only"
+            .into();
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+        "unsupported platform".into()
+    }
+}
+
 /// Build the best available capturer for this platform, or `Err` with a clear
 /// reason. MUST be called on the thread that will own/drive the capturer, since
 /// backends are not `Send`.
@@ -79,19 +117,15 @@ pub(crate) fn create_capturer(log: &LogEmitter) -> anyhow::Result<Box<dyn Captur
         // on a real Xorg session it captures the desktop directly, and on a
         // Wayland session with XWayland it still captures (XWayland exposes the
         // root window). Only when X11 is genuinely unreachable do we fall back to
-        // the Wayland portal path. (Routing on `is_wayland_session()` first was
-        // wrong: it skipped a perfectly working X11/`DISPLAY=:0` and dropped
-        // straight to the unimplemented Wayland message → synthetic placeholder.)
+        // the Wayland/xcap portal path.
         match x11::X11Capturer::new(log) {
             Ok(cap) => return Ok(Box::new(cap)),
             Err(x11_err) => {
                 if wayland::is_wayland_session() {
-                    // No usable X11 but we are on Wayland — report the Wayland
-                    // capture status (currently: not built in).
-                    match wayland::try_new(log) {
-                        Ok(never) => match never {},
-                        Err(e) => return Err(e),
-                    }
+                    log.line(format!(
+                        "X11 capturer unavailable ({x11_err}); trying Wayland/xcap portal fallback"
+                    ));
+                    return wayland::try_new(log);
                 }
                 return Err(x11_err);
             }
@@ -101,23 +135,15 @@ pub(crate) fn create_capturer(log: &LogEmitter) -> anyhow::Result<Box<dyn Captur
     #[cfg(target_os = "windows")]
     {
         let _ = log;
-        // Phase 1 target backend: Windows Graphics Capture / DXGI Desktop
-        // Duplication (see dev plan §2.5). Not yet implemented; the display
-        // layer falls back to a synthetic frame source and logs this.
         anyhow::bail!(
             "Windows screen capture (DXGI/WGC) is not implemented yet — RDP server will \
-             serve a placeholder frame. Implement servers/rdp/capture/win.rs to enable it."
+             serve a placeholder frame. Desktop sharing on Windows is deferred in this branch."
         )
     }
 
     #[cfg(target_os = "macos")]
     {
-        let _ = log;
-        // Phase 1 target backend: CGDisplayStream / ScreenCaptureKit (dev plan §2.5).
-        anyhow::bail!(
-            "macOS screen capture (CGDisplayStream) is not implemented yet — RDP server will \
-             serve a placeholder frame. Implement servers/rdp/capture/mac.rs to enable it."
-        )
+        mac::try_new(log)
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]

--- a/src-tauri/src/servers/rdp/capture/wayland.rs
+++ b/src-tauri/src/servers/rdp/capture/wayland.rs
@@ -1,34 +1,18 @@
-//! Wayland screen capture for the RDP server (dev plan §2.5 / phase 5).
+//! Wayland screen capture for the RDP server.
 //!
-//! ## Status on this build
-//! Native Wayland capture goes through the `org.freedesktop.portal.ScreenCast`
-//! portal → a PipeWire stream (RustDesk's model, minus GStreamer). That requires
-//! the `ashpd` + `pipewire` crates, which in turn need the system `libpipewire`
-//! development libraries present at build time. Those are NOT a hard dependency
-//! of this build, so this module ships the **detection + the documented portal
-//! flow**, and returns a clear, actionable error when a pure-Wayland session is
-//! detected without the X11 fallback being usable.
+//! When no usable X11 connection exists but the session is Wayland, we fall
+//! back to [`super::xcap_backend::XcapCapturer`], which uses the xdg-desktop-portal
+//! ScreenCast path (user must accept the compositor permission dialog).
 //!
-//! Input injection on Wayland *is* live: `enigo` is built with its `wayland`
-//! feature, so the input handler works on a Wayland session (subject to the
-//! compositor honoring the virtual-keyboard / remote-desktop protocols).
-//!
-//! ## Wiring the PipeWire backend (future work)
-//! 1. Add `ashpd` + `pipewire` to `[target.'cfg(target_os="linux")'.dependencies]`
-//!    (build host needs `libpipewire-0.3` dev headers).
-//! 2. `ashpd::desktop::screencast::Screencast`: `create_session` → `select_sources`
-//!    (Monitor) → `start` → obtain the PipeWire fd + node id (this raises the
-//!    compositor's permission dialog — handle the user-denied case).
-//! 3. Open the PipeWire remote on that fd, connect a stream to the node, and in
-//!    the `process` callback copy each buffer's BGRx/RGBx plane into a [`Frame`]
-//!    (convert to BGRA, force alpha opaque), mirroring [`super::x11`].
-//! 4. Track modifier state manually for input (the portal cannot report key
-//!    state), per the dev plan's note.
+//! Input injection remains via enigo's Wayland backend (virtual-keyboard /
+//! remote-desktop protocols as supported by the compositor).
 
+use super::Capturer;
+use super::xcap_backend::XcapCapturer;
 use crate::servers::engine::LogEmitter;
 
 /// True when the current session is Wayland (so the X11/XShm backend will only
-/// see XWayland surfaces, not the real desktop).
+/// see XWayland surfaces, not the real desktop — unless XWayland root is enough).
 pub(crate) fn is_wayland_session() -> bool {
     if std::env::var_os("WAYLAND_DISPLAY").is_some() {
         return true;
@@ -36,18 +20,11 @@ pub(crate) fn is_wayland_session() -> bool {
     matches!(std::env::var("XDG_SESSION_TYPE").as_deref(), Ok("wayland"))
 }
 
-/// Attempt to build a Wayland capturer. Currently always returns `Err` with the
-/// concrete steps needed to enable it; kept as a function so `create_capturer`
-/// has a single, documented Wayland entry point to flesh out later.
-pub(crate) fn try_new(log: &LogEmitter) -> anyhow::Result<std::convert::Infallible> {
+/// Build a Wayland capturer via xcap/portal.
+pub(crate) fn try_new(log: &LogEmitter) -> anyhow::Result<Box<dyn Capturer>> {
     log.line(
-        "Wayland session detected. Native Wayland screen capture (PipeWire via the \
-         ScreenCast portal) is not built into this binary. Input injection still works \
-         via enigo's Wayland backend. To capture the screen, either run an X11/XWayland \
-         session or build with the PipeWire portal backend enabled.",
+        "Wayland session: starting xcap ScreenCast capture. Accept the portal \
+         permission dialog if prompted; denial will keep the RDP client on a placeholder.",
     );
-    anyhow::bail!(
-        "Wayland screen capture not available in this build (needs the PipeWire portal \
-         backend). Use an X11 session, or enable the ashpd/pipewire backend."
-    )
+    Ok(Box::new(XcapCapturer::new(log)?))
 }

--- a/src-tauri/src/servers/rdp/capture/x11.rs
+++ b/src-tauri/src/servers/rdp/capture/x11.rs
@@ -34,13 +34,13 @@ use std::os::unix::io::OwnedFd;
 use std::ptr::NonNull;
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Context as _};
+use anyhow::{Context as _, bail};
 use x11rb::connection::{Connection, RequestConnection as _};
+use x11rb::protocol::Event;
 use x11rb::protocol::damage::{self, ConnectionExt as _};
 use x11rb::protocol::shm::{self, ConnectionExt as _};
 use x11rb::protocol::xfixes::{self, ConnectionExt as _};
 use x11rb::protocol::xproto::{self, ConnectionExt as _, ImageFormat};
-use x11rb::protocol::Event;
 use x11rb::rust_connection::RustConnection;
 
 use super::{Capturer, Frame};

--- a/src-tauri/src/servers/rdp/capture/xcap_backend.rs
+++ b/src-tauri/src/servers/rdp/capture/xcap_backend.rs
@@ -1,0 +1,99 @@
+//! Shared `xcap`-based screen capturer used by:
+//! - macOS RDP server (primary backend)
+//! - Linux pure-Wayland fallback when X11/XWayland is unavailable
+//!
+//! `xcap` returns RGBA8 full frames. We convert to BGRA for the RDP encoder
+//! (`PixelFormat::BgrA32`) and poll at ~20 fps with frame-hash dedup handled by
+//! the display capture loop.
+
+use super::{Capturer, Frame};
+use crate::servers::engine::LogEmitter;
+
+pub(crate) struct XcapCapturer {
+    width: u16,
+    height: u16,
+    /// Monitor index within `xcap::Monitor::all()` (primary = 0 when present).
+    monitor_index: usize,
+}
+
+impl XcapCapturer {
+    pub(crate) fn new(log: &LogEmitter) -> anyhow::Result<Self> {
+        let monitors = xcap::Monitor::all().map_err(|e| {
+            anyhow::anyhow!(
+                "xcap: cannot enumerate monitors ({e}). On macOS grant Screen Recording \
+                 permission to Taomni (System Settings → Privacy & Security → Screen Recording)."
+            )
+        })?;
+        let monitor = monitors
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("xcap: no monitors found"))?;
+
+        // Capture once to learn size and prove permission is granted.
+        let image = monitor.capture_image().map_err(|e| {
+            anyhow::anyhow!(
+                "xcap: initial capture failed ({e}). On macOS enable Screen Recording for \
+                 this app; on Wayland accept the portal ScreenCast prompt."
+            )
+        })?;
+        let width = u16::try_from(image.width()).unwrap_or(1);
+        let height = u16::try_from(image.height()).unwrap_or(1);
+        log.line(format!(
+            "xcap capturer ready ({}x{}, monitor index 0)",
+            width, height
+        ));
+        Ok(Self {
+            width,
+            height,
+            monitor_index: 0,
+        })
+    }
+
+    fn grab_monitor(&self) -> anyhow::Result<xcap::Monitor> {
+        let monitors = xcap::Monitor::all().map_err(|e| anyhow::anyhow!("xcap enum: {e}"))?;
+        monitors
+            .into_iter()
+            .nth(self.monitor_index)
+            .or_else(|| {
+                // Monitor list may reorder after sleep/lid; fall back to first.
+                xcap::Monitor::all().ok().and_then(|m| m.into_iter().next())
+            })
+            .ok_or_else(|| anyhow::anyhow!("xcap: no monitor available"))
+    }
+}
+
+impl Capturer for XcapCapturer {
+    fn desktop_size(&self) -> (u16, u16) {
+        (self.width, self.height)
+    }
+
+    fn capture(&mut self) -> anyhow::Result<Frame> {
+        let monitor = self.grab_monitor()?;
+        let image = monitor
+            .capture_image()
+            .map_err(|e| anyhow::anyhow!("xcap capture: {e}"))?;
+        let w = image.width();
+        let h = image.height();
+        self.width = u16::try_from(w).unwrap_or(self.width);
+        self.height = u16::try_from(h).unwrap_or(self.height);
+
+        // image crate RgbaImage: tightly packed RGBA8.
+        let rgba = image.into_raw();
+        let mut bgra = Vec::with_capacity(rgba.len());
+        for px in rgba.chunks_exact(4) {
+            bgra.push(px[2]); // B
+            bgra.push(px[1]); // G
+            bgra.push(px[0]); // R
+            bgra.push(px[3]); // A
+        }
+        let stride = (w as usize).saturating_mul(4);
+        Ok(Frame {
+            data: bgra,
+            x: 0,
+            y: 0,
+            width: self.width,
+            height: self.height,
+            stride,
+        })
+    }
+}

--- a/src-tauri/src/servers/rdp/display.rs
+++ b/src-tauri/src/servers/rdp/display.rs
@@ -19,9 +19,9 @@ use ironrdp::server::{
     RdpServerDisplayUpdates,
 };
 use tokio::sync::mpsc;
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 
-use super::capture::{create_capturer, Capturer, Frame};
+use super::capture::{Capturer, Frame, create_capturer};
 use crate::servers::engine::LogEmitter;
 
 /// Display handler handed to the IronRDP builder. Probes the capture backend to
@@ -173,16 +173,50 @@ impl DisplayUpdatesImpl {
     }
 
     async fn next_synthetic(&mut self) -> anyhow::Result<Option<DisplayUpdate>> {
-        sleep(Duration::from_millis(500)).await;
-        let palette: [[u8; 3]; 4] = [
-            [0xC0, 0x40, 0x40],
-            [0x40, 0xC0, 0x40],
-            [0x40, 0x40, 0xC0],
-            [0x40, 0xC0, 0xC0],
-        ];
-        let color = palette[usize::from(self.tick % 4)];
+        sleep(Duration::from_millis(750)).await;
+        // Checkerboard + shifting accent stripe so "placeholder" is obvious
+        // even if the client is silent (no real desktop capture on this OS).
         self.tick = self.tick.wrapping_add(1);
-        Ok(self.solid_frame(color).map(DisplayUpdate::Bitmap))
+        Ok(self.placeholder_frame().map(DisplayUpdate::Bitmap))
+    }
+
+    /// High-contrast placeholder so users never mistake empty capture for a
+    /// frozen desktop. Stripe position advances with `tick`.
+    fn placeholder_frame(&self) -> Option<BitmapUpdate> {
+        let width = NonZeroU16::new(self.size.width)?;
+        let height = NonZeroU16::new(self.size.height)?;
+        let w = usize::from(self.size.width);
+        let h = usize::from(self.size.height);
+        let stride = NonZeroUsize::new(w.checked_mul(4)?)?;
+        let stripe = (usize::from(self.tick).saturating_mul(8)) % w.max(1);
+
+        let mut data = Vec::with_capacity(stride.get().checked_mul(h)?);
+        for y in 0..h {
+            for x in 0..w {
+                let cell = ((x / 32) + (y / 32)) % 2 == 0;
+                let on_stripe = x.abs_diff(stripe) < 6;
+                let (b, g, r) = if on_stripe {
+                    (0x20, 0xA0, 0xFF)
+                } else if cell {
+                    (0x38, 0x38, 0x48)
+                } else {
+                    (0x22, 0x22, 0x2E)
+                };
+                data.push(b);
+                data.push(g);
+                data.push(r);
+                data.push(255);
+            }
+        }
+        Some(BitmapUpdate {
+            x: 0,
+            y: 0,
+            width,
+            height,
+            format: PixelFormat::BgrA32,
+            data: data.into(),
+            stride,
+        })
     }
 }
 

--- a/src-tauri/src/servers/rdp/input.rs
+++ b/src-tauri/src/servers/rdp/input.rs
@@ -157,6 +157,32 @@ impl RdpInput {
             }
         }
     }
+
+    fn sync_lock_keys(&mut self, flags: ironrdp::pdu::input::fast_path::SynchronizeFlags) {
+        use ironrdp::pdu::input::fast_path::SynchronizeFlags;
+        // RDP Set-1 scancodes for lock keys.
+        const SC_CAPS: u8 = 0x3A;
+        const SC_NUM: u8 = 0x45;
+        const SC_SCROLL: u8 = 0x46;
+        for (flag, sc) in [
+            (SynchronizeFlags::CAPS_LOCK, SC_CAPS),
+            (SynchronizeFlags::NUM_LOCK, SC_NUM),
+            (SynchronizeFlags::SCROLL_LOCK, SC_SCROLL),
+        ] {
+            if flags.contains(flag) {
+                if let Some(raw) = rdp_scancode_to_raw(sc, false) {
+                    self.send(InputCmd::Raw {
+                        code: raw,
+                        dir: Press,
+                    });
+                    self.send(InputCmd::Raw {
+                        code: raw,
+                        dir: Release,
+                    });
+                }
+            }
+        }
+    }
 }
 
 /// Replay a single command on the thread-owned `Enigo`. Errors are ignored
@@ -216,9 +242,11 @@ impl RdpServerInputHandler for RdpInput {
                     });
                 }
             }
-            KeyboardEvent::Synchronize(_flags) => {
-                // Lock-key state sync (Caps/Num/Scroll). Tracking host lock state
-                // and reconciling is a refinement; ignored for now.
+            KeyboardEvent::Synchronize(flags) => {
+                // Best-effort lock-key pulse: inject Caps/Num/Scroll press+release
+                // so remote and local LED state tend to converge. Full host-state
+                // reconciliation would need reading current lock state (platform API).
+                self.sync_lock_keys(flags);
             }
         }
     }
@@ -369,11 +397,11 @@ pub(crate) fn rdp_scancode_to_raw(scancode: u8, extended: bool) -> Option<u16> {
 
     #[cfg(target_os = "macos")]
     {
-        // CGKeyCode space differs entirely from PC scancodes; only a partial map
-        // is practical. Unmapped keys are dropped here and could be handled via
-        // `enigo.key()` at the call site in a refinement.
-        let _ = extended;
-        macos_scancode_to_keycode(scancode)
+        if extended {
+            macos_extended_scancode_to_keycode(scancode)
+        } else {
+            macos_scancode_to_keycode(scancode)
+        }
     }
 
     #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
@@ -421,16 +449,110 @@ pub(crate) fn linux_scancode_to_keycode(scancode: u8, extended: bool) -> u16 {
 
 #[cfg(target_os = "macos")]
 fn macos_scancode_to_keycode(scancode: u8) -> Option<u16> {
-    // Minimal PC Set-1 → CGKeyCode map for common keys. Extend as needed.
+    // PC Set-1 → CGKeyCode for common keys (see HIToolbox Events.h).
+    // Letters/digits use ANSI keycodes; unmapped codes fall through so the
+    // Unicode path can still deliver text when the client sends it.
     let cg = match scancode {
-        0x1C => 36, // Return
+        // Control keys
+        0x01 => 53, // Escape
         0x0E => 51, // Delete (Backspace)
         0x0F => 48, // Tab
+        0x1C => 36, // Return
         0x39 => 49, // Space
-        0x01 => 53, // Escape
-        0x1D => 59, // Control
+        0x3A => 57, // Caps Lock
+        // Modifiers
+        0x1D => 59, // Left Control
         0x2A => 56, // Left Shift
-        0x38 => 58, // Option/Alt
+        0x36 => 60, // Right Shift
+        0x38 => 58, // Left Option/Alt
+        0x5B => 55, // Left Command (meta) — when not extended
+        // Digits top row
+        0x02 => 18, // 1
+        0x03 => 19, // 2
+        0x04 => 20, // 3
+        0x05 => 21, // 4
+        0x06 => 23, // 5
+        0x07 => 22, // 6
+        0x08 => 26, // 7
+        0x09 => 28, // 8
+        0x0A => 25, // 9
+        0x0B => 29, // 0
+        0x0C => 27, // -
+        0x0D => 24, // =
+        // Letters (QWERTY)
+        0x10 => 12, // Q
+        0x11 => 13, // W
+        0x12 => 14, // E
+        0x13 => 15, // R
+        0x14 => 17, // T
+        0x15 => 16, // Y
+        0x16 => 32, // U
+        0x17 => 34, // I
+        0x18 => 31, // O
+        0x19 => 35, // P
+        0x1E => 0,  // A
+        0x1F => 1,  // S
+        0x20 => 2,  // D
+        0x21 => 3,  // F
+        0x22 => 5,  // G
+        0x23 => 4,  // H
+        0x24 => 38, // J
+        0x25 => 40, // K
+        0x26 => 37, // L
+        0x2C => 6,  // Z
+        0x2D => 7,  // X
+        0x2E => 8,  // C
+        0x2F => 9,  // V
+        0x30 => 11, // B
+        0x31 => 45, // N
+        0x32 => 46, // M
+        // Punctuation
+        0x1A => 33, // [
+        0x1B => 30, // ]
+        0x27 => 41, // ;
+        0x28 => 39, // '
+        0x29 => 50, // `
+        0x2B => 42, // \
+        0x33 => 43, // ,
+        0x34 => 47, // .
+        0x35 => 44, // /
+        // Function keys F1–F12
+        0x3B => 122, // F1
+        0x3C => 120, // F2
+        0x3D => 99,  // F3
+        0x3E => 118, // F4
+        0x3F => 96,  // F5
+        0x40 => 97,  // F6
+        0x41 => 98,  // F7
+        0x42 => 100, // F8
+        0x43 => 101, // F9
+        0x44 => 109, // F10
+        0x57 => 103, // F11
+        0x58 => 111, // F12
+        _ => return None,
+    };
+    Some(cg)
+}
+
+/// Extended (E0) scancodes → CGKeyCode for arrows and navigation.
+#[cfg(target_os = "macos")]
+fn macos_extended_scancode_to_keycode(scancode: u8) -> Option<u16> {
+    let cg = match scancode {
+        0x48 => 126, // Up
+        0x50 => 125, // Down
+        0x4B => 123, // Left
+        0x4D => 124, // Right
+        0x47 => 115, // Home
+        0x4F => 119, // End
+        0x49 => 116, // Page Up
+        0x51 => 121, // Page Down
+        0x52 => 114, // Insert (Help on mac)
+        0x53 => 117, // Forward Delete
+        0x1D => 62,  // Right Control
+        0x38 => 61,  // Right Option
+        0x5B => 55,  // Left Command
+        0x5C => 54,  // Right Command
+        0x1C => 76,  // Keypad Enter
         _ => return None,
     };
     Some(cg)

--- a/src/components/servers/settings/RdpSettings.tsx
+++ b/src/components/servers/settings/RdpSettings.tsx
@@ -1,5 +1,6 @@
 import { useT } from "../../../lib/i18n";
 import type { ServerConfig } from "../../../lib/servers";
+import { getAppPlatform } from "../../../lib/runtime";
 import { CheckboxField, FieldNote, PasswordField, SelectField, TextField } from "../fields";
 
 interface Props {
@@ -10,6 +11,7 @@ interface Props {
 /**
  * RDP server form: NLA credentials, security mode, and view-only toggle. The
  * server shares this machine's desktop with RDP clients (mstsc / FreeRDP).
+ * Platform capability note reflects capture backend status (R0 honesty).
  */
 export function RdpSettings({ config, onChange }: Props) {
   const t = useT();
@@ -19,9 +21,19 @@ export function RdpSettings({ config, onChange }: Props) {
   const securityMode =
     typeof config.securityMode === "string" ? config.securityMode : "hybrid";
   const viewOnly = config.viewOnly === true;
+  const platform = getAppPlatform();
+  const capabilityNote =
+    platform === "macos"
+      ? t("servers.notes.rdpCapMacos")
+      : platform === "linux"
+        ? t("servers.notes.rdpCapLinux")
+        : platform === "windows"
+          ? t("servers.notes.rdpCapWindows")
+          : t("servers.notes.rdpCapUnknown");
 
   return (
     <div className="flex flex-col">
+      <FieldNote tone={platform === "windows" ? "warning" : "info"}>{capabilityNote}</FieldNote>
       <TextField
         label={t("servers.fields.rdpUsername")}
         value={username}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1378,6 +1378,14 @@ const dict = {
         "Uses a self-signed certificate stored in app data; clients will see a trust warning on first connect.",
       rdpInsecure:
         "No security means traffic is unencrypted and, without credentials, anyone who can reach the port gets full control. Use only on an isolated network.",
+      rdpCapLinux:
+        "Desktop capture: Linux X11/XWayland is fully supported. On pure Wayland, capture uses the portal (accept the ScreenCast prompt). Input works via enigo.",
+      rdpCapMacos:
+        "Desktop capture: macOS uses system capture (xcap). Grant Screen Recording permission under System Settings → Privacy & Security, then restart Taomni if capture fails.",
+      rdpCapWindows:
+        "Desktop capture: Windows DXGI/WGC is not implemented in this build — clients see a placeholder checkerboard. Use Linux/macOS for real desktop sharing, or wait for the Windows backend.",
+      rdpCapUnknown:
+        "Desktop capture support depends on the host OS; check Server output after Start for the capture probe result.",
       sshPortForward:
         "Port forwarding is enabled: clients may use -L (local), -R (remote), and -D (dynamic SOCKS). Remote (-R) listeners bound off-loopback are logged as a warning.",
       sshAuthHint:

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -1374,6 +1374,14 @@ export const zhCN: DeepPartial<typeof en> = {
       rdpSelfSigned: "使用存储在应用数据中的自签名证书；客户端首次连接时会看到信任警告。",
       rdpInsecure:
         "无安全模式意味着流量不加密；若未设置凭据，任何能访问该端口的人都可完全控制本机桌面。请仅在隔离网络中使用。",
+      rdpCapLinux:
+        "桌面采集：Linux X11/XWayland 已完整支持。纯 Wayland 使用门户截屏（需在弹窗中授权）。键鼠注入通过 enigo。",
+      rdpCapMacos:
+        "桌面采集：macOS 使用系统捕获（xcap）。请在「系统设置 → 隐私与安全性 → 屏幕录制」中授权本应用；失败后可重启 Taomni 再试。",
+      rdpCapWindows:
+        "桌面采集：本构建尚未实现 Windows DXGI/WGC，客户端将看到占位棋盘格画面。真实桌面共享请用 Linux/macOS，或等待 Windows 后端。",
+      rdpCapUnknown:
+        "桌面采集能力取决于宿主系统；点击 Start 后请查看 Server output 中的 capture 探测结果。",
       sshPortForward:
         "已启用端口转发：客户端可使用 -L（本地）、-R（远程）与 -D（动态 SOCKS）。远程转发若监听非本机回环地址，会在日志中给出警告。",
       sshAuthHint:


### PR DESCRIPTION
Implement the Linux- and macOS-focused path of
claudedocs/local-rdp-server-plan.md. Windows DXGI/WGC remains deferred with an honest placeholder, per product priority.

R0 observability
- Probe create_capturer at server start; log capability summary and OK/FAIL
- RdpSettings shows platform-specific capture notes (en/zh-CN)
- Synthetic placeholder is a high-contrast checkerboard with a moving stripe

R2 macOS
- capture/mac.rs + shared xcap_backend (BGRA frames via xcap)
- Clear Screen Recording permission errors
- Expanded PC scancode → CGKeyCode map (letters, digits, F-keys, arrows)

R3 Linux
- Keep X11 MIT-SHM + Damage as primary path
- Pure Wayland: fall back to xcap portal ScreenCast when X11 is unavailable
- Synchronize lock keys: best-effort Caps/Num/Scroll pulse via enigo

Deps
- macOS/linux target deps: xcap 0.9.6 (always on for RDP; Windows unchanged)

Not in this PR: Windows DXGI/WGC, X11 hardware cursor RGBAPointer, sesman.