### PR TITLE
feat(git): polish log branch filter and commit message hover UX

### DIFF
--- a/src/components/git/CommitLog.tsx
+++ b/src/components/git/CommitLog.tsx
@@ -12,6 +12,8 @@ import {
 } from "../../lib/git";
 import { buildGraph, graphColor, type GraphRow } from "../../lib/gitGraph";
 import { DiffViewer } from "./DiffViewer";
+import { BranchFilterSelect, type BranchFilterOption } from "./shared/BranchFilterSelect";
+import { CommitMessageHover } from "./shared/CommitMessageHover";
 
 const ROW_H = 88;
 const LANE_W = 14;
@@ -165,6 +167,15 @@ export function CommitLog({ repoRoot, headOid, branches = [], busy, onContextMen
 
   const graph = useMemo(() => buildGraph(entries), [entries]);
   const maxWidth = useMemo(() => graph.reduce((m, r) => Math.max(m, r.width), 1), [graph]);
+  const branchOptions = useMemo<BranchFilterOption[]>(
+    () => branches.map((branch) => ({
+      value: branch.name,
+      name: branch.name,
+      date: branch.date,
+      label: branch.current ? `${branch.name} (current)` : branch.name,
+    })),
+    [branches],
+  );
   const diffEmptyLabel =
     files.length > AUTO_PREVIEW_FILE_LIMIT && !filePath
       ? `Large commit (${files.length} files). Select a file to preview its diff.`
@@ -201,19 +212,12 @@ export function CommitLog({ repoRoot, headOid, branches = [], busy, onContextMen
           </div>
           <label className="flex items-center gap-1 text-[12px] select-none whitespace-nowrap">
             Branch
-            <select
-              className="taomni-input h-7 w-40"
+            <BranchFilterSelect
               value={branchFilter}
-              onChange={(event) => setBranchFilter(event.target.value)}
-            >
-              <option value="__current__">Current branch</option>
-              <option value="__all__">All branches</option>
-              {branches.map((branch) => (
-                <option key={branch.fullName} value={branch.name}>
-                  {branch.name}{branch.current ? " (current)" : ""}
-                </option>
-              ))}
-            </select>
+              onChange={setBranchFilter}
+              branches={branchOptions}
+              aria-label="Branch"
+            />
           </label>
           {loading && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
         </div>
@@ -224,45 +228,55 @@ export function CommitLog({ repoRoot, headOid, branches = [], busy, onContextMen
             </div>
           ) : (
             entries.map((entry, i) => (
-              <div
+              <CommitMessageHover
                 key={entry.oid}
-                role="button"
-                tabIndex={0}
-                style={{ height: ROW_H }}
-                title={commitTooltip(entry)}
+                content={commitHoverContent(entry)}
                 className={`w-full flex items-start gap-2 pr-2 overflow-hidden cursor-pointer border-b border-[var(--taomni-divider)] ${
                   selectedOid === entry.oid ? "bg-[var(--taomni-hover)]" : "hover:bg-[var(--taomni-hover)]"
                 }`}
-                onClick={() => setSelectedOid(entry.oid)}
-                onContextMenu={(e) => {
-                  e.preventDefault();
-                  setSelectedOid(entry.oid);
-                  onContextMenu(entry, e.clientX, e.clientY);
-                }}
               >
-                <GraphCell row={graph[i]} maxWidth={maxWidth} />
-                <div className="min-w-0 flex-1 py-2">
-                  <div className="flex items-start gap-1 min-w-0">
-                    {entry.refs.map((ref) => (
-                      <span
-                        key={ref}
-                        className="shrink-0 mt-0.5 text-[10px] px-1 rounded bg-[var(--taomni-accent)]/15 text-[var(--taomni-accent)] border border-[var(--taomni-accent)]/30"
-                      >
-                        {ref}
-                      </span>
-                    ))}
-                    <span className="min-w-0 text-[12px] leading-4 font-medium line-clamp-2">{entry.subject}</span>
-                  </div>
-                  {commitBodyPreview(entry) && (
-                    <div className="mt-0.5 text-[11px] leading-4 text-[var(--taomni-text-muted)] line-clamp-1">
-                      {commitBodyPreview(entry)}
+                <div
+                  role="button"
+                  tabIndex={0}
+                  style={{ height: ROW_H }}
+                  className="w-full flex items-start gap-2 overflow-hidden"
+                  onClick={() => setSelectedOid(entry.oid)}
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    setSelectedOid(entry.oid);
+                    onContextMenu(entry, e.clientX, e.clientY);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setSelectedOid(entry.oid);
+                    }
+                  }}
+                >
+                  <GraphCell row={graph[i]} maxWidth={maxWidth} />
+                  <div className="min-w-0 flex-1 py-2">
+                    <div className="flex items-start gap-1 min-w-0">
+                      {entry.refs.map((ref) => (
+                        <span
+                          key={ref}
+                          className="shrink-0 mt-0.5 text-[10px] px-1 rounded bg-[var(--taomni-accent)]/15 text-[var(--taomni-accent)] border border-[var(--taomni-accent)]/30"
+                        >
+                          {ref}
+                        </span>
+                      ))}
+                      <span className="min-w-0 text-[12px] leading-4 font-medium line-clamp-2">{entry.subject}</span>
                     </div>
-                  )}
-                  <div className="mt-1 text-[11px] text-[var(--taomni-text-muted)] truncate">
-                    <span className="taomni-mono text-[var(--taomni-accent)]">{entry.shortOid}</span> · {entry.authorName} · {formatDate(entry.date)}
+                    {commitBodyPreview(entry) && (
+                      <div className="mt-0.5 text-[11px] leading-4 text-[var(--taomni-text-muted)] line-clamp-1">
+                        {commitBodyPreview(entry)}
+                      </div>
+                    )}
+                    <div className="mt-1 text-[11px] text-[var(--taomni-text-muted)] truncate">
+                      <span className="taomni-mono text-[var(--taomni-accent)]">{entry.shortOid}</span> · {entry.authorName} · {formatDate(entry.date)}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </CommitMessageHover>
             ))
           )}
           {entries.length >= limit && (
@@ -284,21 +298,6 @@ export function CommitLog({ repoRoot, headOid, branches = [], busy, onContextMen
             <div className="h-8 shrink-0 flex items-center px-3 border-b border-[var(--taomni-divider)] text-[12px] font-semibold">
               {selected ? `${selected.shortOid} · ${files.length} file(s)` : "Commit"}
             </div>
-            {selected && (
-              <div className="shrink-0 px-3 py-2 border-b border-[var(--taomni-divider)]">
-                <div className="text-[12px] leading-5 font-semibold text-[var(--taomni-text)] whitespace-pre-wrap">
-                  {selected.subject}
-                </div>
-                {selected.body.trim() && (
-                  <div className="mt-1 max-h-28 overflow-auto whitespace-pre-wrap text-[11px] leading-4 text-[var(--taomni-text-muted)]">
-                    {selected.body.trim()}
-                  </div>
-                )}
-                <div className="mt-1 text-[11px] text-[var(--taomni-text-muted)] truncate">
-                  {selected.authorName} &lt;{selected.authorEmail}&gt; · {formatDate(selected.date)}
-                </div>
-              </div>
-            )}
             <div className="flex-1 min-h-0 overflow-auto">
               {files.length === 0 ? (
                 <div className="h-full min-h-16 flex items-center justify-center text-[12px] text-[var(--taomni-text-muted)]">
@@ -353,9 +352,12 @@ function commitBodyPreview(entry: GitLogEntry): string {
   return entry.body.trim().replace(/\s+/g, " ");
 }
 
-function commitTooltip(entry: GitLogEntry): string {
-  const message = [entry.subject, entry.body.trim()].filter(Boolean).join("\n\n");
-  return `${message}\n\n${entry.shortOid} · ${entry.authorName} · ${formatDate(entry.date)}`;
+function commitHoverContent(entry: GitLogEntry) {
+  return {
+    subject: entry.subject,
+    body: entry.body,
+    meta: `${entry.shortOid} · ${entry.authorName} <${entry.authorEmail}> · ${formatDate(entry.date)}`,
+  };
 }
 
 function formatDate(value: string): string {

--- a/src/components/git/WorkspaceCommitLog.tsx
+++ b/src/components/git/WorkspaceCommitLog.tsx
@@ -11,8 +11,11 @@ import {
   type GitSnapshot,
 } from "../../lib/git";
 import { buildGraph, graphColor, type GraphRow } from "../../lib/gitGraph";
+import { dateMs } from "../../lib/gitRefList";
 import type { GitWorkspaceRootInfo } from "../../types";
 import { DiffViewer } from "./DiffViewer";
+import { BranchFilterSelect, type BranchFilterOption } from "./shared/BranchFilterSelect";
+import { CommitMessageHover } from "./shared/CommitMessageHover";
 
 const ROW_H = 88;
 const LANE_W = 14;
@@ -219,19 +222,12 @@ export function WorkspaceCommitLog({ roots, snapshots, busy }: WorkspaceCommitLo
                 onChange={(event) => setQuery(event.target.value)}
               />
             </div>
-            <select
-              className="taomni-input h-7 w-40"
+            <BranchFilterSelect
               value={branchFilter}
-              onChange={(event) => setBranchFilter(event.target.value)}
-            >
-              <option value="__current__">Current branch</option>
-              <option value="__all__">All branches</option>
-              {branchOptions.map((branch) => (
-                <option key={branch.name} value={branch.name}>
-                  {branch.name}{branch.count > 1 ? ` (${branch.count})` : ""}
-                </option>
-              ))}
-            </select>
+              onChange={setBranchFilter}
+              branches={branchOptions}
+              aria-label="Branch"
+            />
             {loading && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
           </div>
           {error && (
@@ -253,43 +249,53 @@ export function WorkspaceCommitLog({ roots, snapshots, busy }: WorkspaceCommitLo
                 width: 1,
               };
               return (
-              <div
+              <CommitMessageHover
                 key={entryKey(entry)}
-                role="button"
-                tabIndex={0}
-                style={{ height: ROW_H }}
+                content={commitHoverContent(entry)}
                 className={`w-full flex items-start gap-2 pr-2 text-left overflow-hidden cursor-pointer border-b border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] ${
                   selectedKey === entryKey(entry) ? "bg-[var(--taomni-hover)]" : ""
                 }`}
-                title={commitTooltip(entry)}
-                onClick={() => setSelectedKey(entryKey(entry))}
               >
-                <GraphCell row={graphRow} maxWidth={maxGraphWidth} />
-                <div className="min-w-0 flex-1 py-2">
-                  <div className="flex items-start gap-1 min-w-0">
-                    <span className="shrink-0 mt-0.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-quick-bg)] px-1 text-[10px] text-[var(--taomni-text-muted)]">
-                      {entry.repoName}
-                    </span>
-                    {entry.refs.slice(0, 3).map((ref) => (
-                      <span
-                        key={ref}
-                        className="shrink-0 mt-0.5 text-[10px] px-1 rounded bg-[var(--taomni-accent)]/15 text-[var(--taomni-accent)] border border-[var(--taomni-accent)]/30"
-                      >
-                        {ref}
+                <div
+                  role="button"
+                  tabIndex={0}
+                  style={{ height: ROW_H }}
+                  className="w-full flex items-start gap-2 overflow-hidden"
+                  onClick={() => setSelectedKey(entryKey(entry))}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setSelectedKey(entryKey(entry));
+                    }
+                  }}
+                >
+                  <GraphCell row={graphRow} maxWidth={maxGraphWidth} />
+                  <div className="min-w-0 flex-1 py-2">
+                    <div className="flex items-start gap-1 min-w-0">
+                      <span className="shrink-0 mt-0.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-quick-bg)] px-1 text-[10px] text-[var(--taomni-text-muted)]">
+                        {entry.repoName}
                       </span>
-                    ))}
-                    <span className="min-w-0 text-[12px] leading-4 font-medium line-clamp-2">{entry.subject}</span>
-                  </div>
-                  {commitBodyPreview(entry) && (
-                    <div className="mt-0.5 text-[11px] leading-4 text-[var(--taomni-text-muted)] line-clamp-1">
-                      {commitBodyPreview(entry)}
+                      {entry.refs.slice(0, 3).map((ref) => (
+                        <span
+                          key={ref}
+                          className="shrink-0 mt-0.5 text-[10px] px-1 rounded bg-[var(--taomni-accent)]/15 text-[var(--taomni-accent)] border border-[var(--taomni-accent)]/30"
+                        >
+                          {ref}
+                        </span>
+                      ))}
+                      <span className="min-w-0 text-[12px] leading-4 font-medium line-clamp-2">{entry.subject}</span>
                     </div>
-                  )}
-                  <div className="mt-1 text-[11px] text-[var(--taomni-text-muted)] truncate">
-                    <span className="taomni-mono text-[var(--taomni-accent)]">{entry.shortOid}</span> · {entry.authorName} · {formatDate(entry.date)}
+                    {commitBodyPreview(entry) && (
+                      <div className="mt-0.5 text-[11px] leading-4 text-[var(--taomni-text-muted)] line-clamp-1">
+                        {commitBodyPreview(entry)}
+                      </div>
+                    )}
+                    <div className="mt-1 text-[11px] text-[var(--taomni-text-muted)] truncate">
+                      <span className="taomni-mono text-[var(--taomni-accent)]">{entry.shortOid}</span> · {entry.authorName} · {formatDate(entry.date)}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </CommitMessageHover>
               );
             })}
             {entries.length >= limit && (
@@ -318,21 +324,6 @@ export function WorkspaceCommitLog({ roots, snapshots, busy }: WorkspaceCommitLo
                   </>
                 ) : "Commit"}
               </div>
-              {selected && (
-                <div className="shrink-0 px-3 py-2 border-b border-[var(--taomni-divider)]">
-                  <div className="text-[12px] leading-5 font-semibold text-[var(--taomni-text)] whitespace-pre-wrap">
-                    {selected.subject}
-                  </div>
-                  {selected.body.trim() && (
-                    <div className="mt-1 max-h-28 overflow-auto whitespace-pre-wrap text-[11px] leading-4 text-[var(--taomni-text-muted)]">
-                      {selected.body.trim()}
-                    </div>
-                  )}
-                  <div className="mt-1 text-[11px] text-[var(--taomni-text-muted)] truncate">
-                    {selected.authorName} &lt;{selected.authorEmail}&gt; · {formatDate(selected.date)}
-                  </div>
-                </div>
-              )}
               <div className="flex-1 min-h-0 overflow-auto">
                 {files.length === 0 ? (
                   <div className="h-full min-h-16 flex items-center justify-center text-[12px] text-[var(--taomni-text-muted)]">
@@ -370,28 +361,31 @@ function entryKey(entry: WorkspaceCommit): string {
   return `${entry.repoRoot}\u0000${entry.oid}`;
 }
 
-interface WorkspaceBranchOption {
-  name: string;
-  count: number;
-}
-
 function workspaceBranchOptions(
   roots: GitWorkspaceRootInfo[],
   snapshots: Record<string, { snapshot: GitSnapshot | null } | undefined>,
-): WorkspaceBranchOption[] {
-  const counts = new Map<string, number>();
+): BranchFilterOption[] {
+  const byName = new Map<string, { count: number; date: string | null }>();
   for (const root of roots) {
     const branches = snapshots[root.repoRoot]?.snapshot?.branches ?? [];
     const seenInRepo = new Set<string>();
     for (const branch of branches) {
       if (seenInRepo.has(branch.name)) continue;
       seenInRepo.add(branch.name);
-      counts.set(branch.name, (counts.get(branch.name) ?? 0) + 1);
+      const prev = byName.get(branch.name);
+      const nextCount = (prev?.count ?? 0) + 1;
+      const prevMs = dateMs(prev?.date);
+      const branchMs = dateMs(branch.date);
+      const nextDate = branchMs >= prevMs ? (branch.date ?? prev?.date ?? null) : (prev?.date ?? null);
+      byName.set(branch.name, { count: nextCount, date: nextDate });
     }
   }
-  return [...counts.entries()]
-    .map(([name, count]) => ({ name, count }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  return [...byName.entries()].map(([name, info]) => ({
+    value: name,
+    name,
+    date: info.date,
+    label: info.count > 1 ? `${name} (${info.count})` : name,
+  }));
 }
 
 function workspaceGraphRows(entries: WorkspaceCommit[], roots: GitWorkspaceRootInfo[]): Map<string, GraphRow> {
@@ -430,9 +424,12 @@ function commitBodyPreview(entry: GitLogEntry): string {
   return entry.body.trim().replace(/\s+/g, " ");
 }
 
-function commitTooltip(entry: WorkspaceCommit): string {
-  const message = [entry.subject, entry.body.trim()].filter(Boolean).join("\n\n");
-  return `${entry.repoName} · ${message}\n\n${entry.shortOid} · ${entry.authorName} · ${formatDate(entry.date)}`;
+function commitHoverContent(entry: WorkspaceCommit) {
+  return {
+    subject: entry.subject,
+    body: entry.body,
+    meta: `${entry.repoName} · ${entry.shortOid} · ${entry.authorName} <${entry.authorEmail}> · ${formatDate(entry.date)}`,
+  };
 }
 
 function formatDate(value: string): string {

--- a/src/components/git/shared/BranchFilterSelect.test.tsx
+++ b/src/components/git/shared/BranchFilterSelect.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BranchFilterSelect } from "./BranchFilterSelect";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BranchFilterSelect", () => {
+  it("opens a searchable menu and filters branches", () => {
+    const onChange = vi.fn();
+    render(
+      <BranchFilterSelect
+        value="__current__"
+        onChange={onChange}
+        branches={[
+          { value: "main", name: "main", date: "2026-01-01T00:00:00Z" },
+          { value: "feature/ui", name: "feature/ui", date: "2026-03-01T00:00:00Z" },
+          { value: "hotfix", name: "hotfix", date: "2026-02-01T00:00:00Z" },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Branch" }));
+    const menu = screen.getByTestId("git-branch-filter-menu");
+    expect(menu).toBeInTheDocument();
+
+    // Sorted by date desc: feature/ui, hotfix, main (after specials)
+    const options = screen.getAllByTestId("git-branch-filter-option");
+    expect(options.map((el) => el.getAttribute("data-value"))).toEqual([
+      "__current__",
+      "__all__",
+      "feature/ui",
+      "hotfix",
+      "main",
+    ]);
+
+    fireEvent.change(screen.getByLabelText("Filter branches"), { target: { value: "hot" } });
+    const filtered = screen.getAllByTestId("git-branch-filter-option");
+    expect(filtered.map((el) => el.getAttribute("data-value"))).toEqual(["hotfix"]);
+
+    fireEvent.click(filtered[0]!);
+    expect(onChange).toHaveBeenCalledWith("hotfix");
+    expect(screen.queryByTestId("git-branch-filter-menu")).not.toBeInTheDocument();
+  });
+
+  it("closes on Escape", () => {
+    render(
+      <BranchFilterSelect
+        value="__all__"
+        onChange={() => {}}
+        branches={[{ value: "main", name: "main" }]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("combobox", { name: "Branch" }));
+    expect(screen.getByTestId("git-branch-filter-menu")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByTestId("git-branch-filter-menu")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/git/shared/BranchFilterSelect.tsx
+++ b/src/components/git/shared/BranchFilterSelect.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown, Search } from "lucide-react";
+import { sortByDateThenName, type DatedNamed } from "../../../lib/gitRefList";
+
+export interface BranchFilterOption extends DatedNamed {
+  /** Option value (branch name, or special keys). */
+  value: string;
+  /** Display label; defaults to `name` / `value`. */
+  label?: string;
+}
+
+export interface BranchFilterSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  /** Branch options (special Current/All are always prepended). */
+  branches: readonly BranchFilterOption[];
+  className?: string;
+  /** Width class for the trigger; default `w-44`. */
+  widthClass?: string;
+  "aria-label"?: string;
+  testId?: string;
+}
+
+const SPECIALS: BranchFilterOption[] = [
+  { value: "__current__", name: "Current branch", label: "Current branch" },
+  { value: "__all__", name: "All branches", label: "All branches" },
+];
+
+export function BranchFilterSelect({
+  value,
+  onChange,
+  branches,
+  className = "",
+  widthClass = "w-44",
+  "aria-label": ariaLabel = "Branch",
+  testId = "git-branch-filter",
+}: BranchFilterSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const rootRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const sortedBranches = useMemo(
+    () => sortByDateThenName(branches),
+    [branches],
+  );
+
+  const selectedLabel = useMemo(() => {
+    const special = SPECIALS.find((item) => item.value === value);
+    if (special) return special.label ?? special.name;
+    const branch = sortedBranches.find((item) => item.value === value);
+    return branch?.label ?? branch?.name ?? value;
+  }, [sortedBranches, value]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const list = [...SPECIALS, ...sortedBranches];
+    if (!q) return list;
+    return list.filter((item) => {
+      const hay = `${item.label ?? ""} ${item.name} ${item.value}`.toLowerCase();
+      return hay.includes(q);
+    });
+  }, [query, sortedBranches]);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      return;
+    }
+    const timer = window.setTimeout(() => inputRef.current?.focus(), 0);
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node) || !rootRef.current?.contains(target)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.clearTimeout(timer);
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className={`relative inline-flex min-w-0 ${widthClass} ${className}`}>
+      <button
+        type="button"
+        role="combobox"
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        data-testid={testId}
+        className="taomni-input h-7 w-full px-2 text-left inline-flex items-center gap-1"
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span className="min-w-0 flex-1 truncate text-[12px]">{selectedLabel}</span>
+        <ChevronDown className="w-3.5 h-3.5 shrink-0 text-[var(--taomni-text-muted)]" />
+      </button>
+      {open && (
+        <div
+          role="listbox"
+          data-testid={`${testId}-menu`}
+          className="absolute right-0 top-full z-50 mt-1 w-[min(280px,max(100%,220px))] max-h-64 flex flex-col overflow-hidden rounded border border-[var(--taomni-divider)] bg-[var(--taomni-panel-bg)] shadow-lg"
+        >
+          <div className="shrink-0 border-b border-[var(--taomni-divider)] p-1.5">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--taomni-text-muted)]" />
+              <input
+                ref={inputRef}
+                type="search"
+                className="taomni-input h-7 w-full pl-7 text-[12px]"
+                placeholder="Filter branches"
+                aria-label="Filter branches"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Escape") {
+                    event.stopPropagation();
+                    setOpen(false);
+                  }
+                }}
+              />
+            </div>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto p-0.5">
+            {filtered.length === 0 ? (
+              <div className="px-2 py-3 text-center text-[11px] text-[var(--taomni-text-muted)]">
+                No matching branches
+              </div>
+            ) : (
+              filtered.map((item) => {
+                const isSelected = item.value === value;
+                const isSpecial = item.value === "__current__" || item.value === "__all__";
+                return (
+                  <button
+                    key={item.value}
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    data-testid={`${testId}-option`}
+                    data-value={item.value}
+                    className={`w-full h-7 px-2 text-left text-[12px] rounded flex items-center gap-1 cursor-pointer outline-none ${
+                      isSelected
+                        ? "bg-[var(--taomni-accent)]/15 text-[var(--taomni-accent)]"
+                        : "hover:bg-[var(--taomni-hover)]"
+                    } ${isSpecial ? "font-medium" : ""}`}
+                    onClick={() => {
+                      onChange(item.value);
+                      setOpen(false);
+                    }}
+                  >
+                    <span className="min-w-0 flex-1 truncate">{item.label ?? item.name}</span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/git/shared/CommitMessageHover.test.tsx
+++ b/src/components/git/shared/CommitMessageHover.test.tsx
@@ -1,0 +1,76 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CommitMessageHover } from "./CommitMessageHover";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("CommitMessageHover", () => {
+  it("shows a selectable sticky popup on hover and closes on Escape", () => {
+    render(
+      <CommitMessageHover
+        openDelayMs={100}
+        closeDelayMs={50}
+        content={{
+          subject: "Fix branch filter",
+          body: "Add search and sort.",
+          meta: "abc1234 · Ada · yesterday",
+        }}
+      >
+        <button type="button">commit row</button>
+      </CommitMessageHover>,
+    );
+
+    fireEvent.mouseEnter(screen.getByText("commit row").parentElement!);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    const popup = screen.getByTestId("commit-message-hover");
+    expect(popup).toBeInTheDocument();
+    expect(popup).toHaveTextContent("Fix branch filter");
+    expect(popup).toHaveTextContent("Add search and sort.");
+    expect(popup.querySelector(".select-text")).toBeTruthy();
+
+    // Moving onto the popup keeps it open past the close delay.
+    fireEvent.mouseLeave(screen.getByText("commit row").parentElement!);
+    fireEvent.mouseEnter(popup);
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.getByTestId("commit-message-hover")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByTestId("commit-message-hover")).not.toBeInTheDocument();
+  });
+
+  it("closes when clicking outside", () => {
+    render(
+      <div>
+        <CommitMessageHover
+          openDelayMs={0}
+          closeDelayMs={50}
+          content={{ subject: "Hello" }}
+        >
+          <span>row</span>
+        </CommitMessageHover>
+        <button type="button">outside</button>
+      </div>,
+    );
+
+    fireEvent.mouseEnter(screen.getByText("row").parentElement!);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(screen.getByTestId("commit-message-hover")).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByText("outside"));
+    expect(screen.queryByTestId("commit-message-hover")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/git/shared/CommitMessageHover.tsx
+++ b/src/components/git/shared/CommitMessageHover.tsx
@@ -1,0 +1,209 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+
+export interface CommitMessageHoverContent {
+  subject: string;
+  body?: string;
+  meta?: string;
+}
+
+export interface CommitMessageHoverProps {
+  content: CommitMessageHoverContent;
+  children: ReactNode;
+  className?: string;
+  /** Delay before showing (ms). Default 350. */
+  openDelayMs?: number;
+  /** Delay before hiding when pointer leaves (ms). Default 180. */
+  closeDelayMs?: number;
+}
+
+interface PopupPos {
+  top: number;
+  left: number;
+  maxWidth: number;
+  maxHeight: number;
+}
+
+const VIEW_PAD = 8;
+const POPUP_GAP = 6;
+
+/**
+ * Hoverable commit message that becomes a sticky, selectable popup.
+ * Pointer can move from the trigger onto the popup; Esc / outside click closes.
+ */
+export function CommitMessageHover({
+  content,
+  children,
+  className = "",
+  openDelayMs = 350,
+  closeDelayMs = 180,
+}: CommitMessageHoverProps) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<PopupPos | null>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
+  const openTimer = useRef<number | null>(null);
+  const closeTimer = useRef<number | null>(null);
+  const popupId = useId();
+
+  const clearTimers = useCallback(() => {
+    if (openTimer.current != null) {
+      window.clearTimeout(openTimer.current);
+      openTimer.current = null;
+    }
+    if (closeTimer.current != null) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  }, []);
+
+  const scheduleOpen = useCallback(() => {
+    clearTimers();
+    openTimer.current = window.setTimeout(() => setOpen(true), openDelayMs);
+  }, [clearTimers, openDelayMs]);
+
+  const scheduleClose = useCallback(() => {
+    clearTimers();
+    closeTimer.current = window.setTimeout(() => setOpen(false), closeDelayMs);
+  }, [clearTimers, closeDelayMs]);
+
+  const keepOpen = useCallback(() => {
+    clearTimers();
+    setOpen(true);
+  }, [clearTimers]);
+
+  useEffect(() => () => clearTimers(), [clearTimers]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        clearTimers();
+        setOpen(false);
+      }
+    };
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (triggerRef.current?.contains(target) || popupRef.current?.contains(target)) return;
+      clearTimers();
+      setOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    document.addEventListener("mousedown", onPointerDown, true);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("mousedown", onPointerDown, true);
+    };
+  }, [open, clearTimers]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setPos(null);
+      return;
+    }
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+
+    const place = () => {
+      const rect = trigger.getBoundingClientRect();
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const maxWidth = Math.min(420, vw - VIEW_PAD * 2);
+      const maxHeight = Math.min(280, vh - VIEW_PAD * 2);
+
+      // Prefer below the row; flip above if not enough space.
+      let top = rect.bottom + POPUP_GAP;
+      if (top + 120 > vh - VIEW_PAD) {
+        top = Math.max(VIEW_PAD, rect.top - POPUP_GAP - Math.min(maxHeight, 160));
+      }
+      let left = rect.left;
+      if (left + maxWidth > vw - VIEW_PAD) {
+        left = Math.max(VIEW_PAD, vw - VIEW_PAD - maxWidth);
+      }
+      if (left < VIEW_PAD) left = VIEW_PAD;
+
+      setPos({ top, left, maxWidth, maxHeight });
+    };
+
+    place();
+    window.addEventListener("scroll", place, true);
+    window.addEventListener("resize", place);
+    return () => {
+      window.removeEventListener("scroll", place, true);
+      window.removeEventListener("resize", place);
+    };
+  }, [open, content.subject, content.body, content.meta]);
+
+  const body = content.body?.trim() ?? "";
+
+  return (
+    <div
+      ref={triggerRef}
+      className={className}
+      onMouseEnter={scheduleOpen}
+      onMouseLeave={scheduleClose}
+      onFocus={scheduleOpen}
+      onBlur={(event) => {
+        const next = event.relatedTarget;
+        if (next instanceof Node && (triggerRef.current?.contains(next) || popupRef.current?.contains(next))) {
+          return;
+        }
+        scheduleClose();
+      }}
+      aria-describedby={open ? popupId : undefined}
+    >
+      {children}
+      {open && pos && createPortal(
+        <div
+          ref={popupRef}
+          id={popupId}
+          role="dialog"
+          aria-label="Commit message"
+          data-testid="commit-message-hover"
+          className="fixed z-[600] rounded-md border border-[var(--taomni-divider)] bg-[var(--taomni-panel-bg)] text-[var(--taomni-text)] shadow-xl"
+          style={{
+            top: pos.top,
+            left: pos.left,
+            maxWidth: pos.maxWidth,
+            maxHeight: pos.maxHeight,
+            width: "max-content",
+            minWidth: 220,
+          }}
+          onMouseEnter={keepOpen}
+          onMouseLeave={scheduleClose}
+        >
+          <div
+            className="overflow-auto p-3 select-text cursor-text"
+            style={{ maxHeight: pos.maxHeight }}
+          >
+            <div className="text-[12px] leading-5 font-semibold whitespace-pre-wrap break-words">
+              {content.subject}
+            </div>
+            {body ? (
+              <div className="mt-1.5 text-[11px] leading-4 text-[var(--taomni-text-muted)] whitespace-pre-wrap break-words">
+                {body}
+              </div>
+            ) : null}
+            {content.meta ? (
+              <div className="mt-2 pt-2 border-t border-[var(--taomni-divider)] text-[11px] text-[var(--taomni-text-muted)] select-text">
+                {content.meta}
+              </div>
+            ) : null}
+          </div>
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Improve Git Log usability for both single-repo and workspace views.

Branch filter dropdown:
- Replace the native select with a searchable combobox (BranchFilterSelect) so long branch lists can be filtered by name.
- Sort branch options by tip commit date (newest first), then by name A-Z, reusing sortByDateThenName / dateMs from gitRefList.
- Keep Current branch / All branches pinned at the top; workspace multi-repo options still show shared-branch counts and use the newest tip date across repos.

Right-side message pane:
- Remove the selected-commit subject/body/author block above the file list in CommitLog and WorkspaceCommitLog. Full message is already available via hover, so reclaim vertical space for the files list and diff.

Commit message hover:
- Replace the browser title tooltip with CommitMessageHover: a sticky, portal- rendered dialog that opens on row hover, stays open when the pointer moves onto the popup, allows text selection/copy, and closes on outside click or Esc.

Tests cover BranchFilterSelect filtering/sort/Escape and CommitMessageHover sticky open / Escape / outside-click behavior.