### PR TITLE
fix: resolve E0282 type ambiguity in sockscap_start

### DIFF
--- a/src-tauri/src/servers/ssh.rs
+++ b/src-tauri/src/servers/ssh.rs
@@ -920,12 +920,12 @@ impl SshConnection {
 fn exec_command_launch(command: &str, login_shell: bool) -> (String, Vec<String>) {
     let launch = crate::terminal::pty::resolve_shell(None);
     let program = launch.program;
-    let lower = program.to_ascii_lowercase();
+    let _lower = program.to_ascii_lowercase();
 
     #[cfg(windows)]
     {
         let _ = login_shell;
-        if lower.contains("pwsh") || lower.contains("powershell") {
+        if _lower.contains("pwsh") || _lower.contains("powershell") {
             let mut args = launch.args;
             args.extend([
                 "-NoProfile".into(),

--- a/src-tauri/src/sockscap/helper.rs
+++ b/src-tauri/src/sockscap/helper.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
-use tauri::{AppHandle, Manager, State};
+use tauri::{AppHandle, State};
 
 use crate::sockscap::paths::{
     resolve_helper_exe, resolve_windivert_dir, windivert_missing_hint,

--- a/src-tauri/src/sockscap/mod.rs
+++ b/src-tauri/src/sockscap/mod.rs
@@ -398,15 +398,17 @@ pub async fn sockscap_start(
     let caps = capture::capabilities();
     let journal_path = data_dir(&app)?.join("recovery.json");
 
-    #[cfg(windows)]
-    let status = start_windows_capture(&app, &state, &cfg, &caps).await;
+    let status: Result<SocksCapStatus, String> = {
+        #[cfg(windows)]
+        start_windows_capture(&app, &state, &cfg, &caps).await
 
-    #[cfg(not(windows))]
-    let status = {
-        let mut orch = state.sockscap.orch.write().await;
-        orch.apply_config(cfg.clone());
-        let _ = orch.start_stub(&caps);
-        Ok(orch.status())
+        #[cfg(not(windows))]
+        {
+            let mut orch = state.sockscap.orch.write().await;
+            orch.apply_config(cfg.clone());
+            let _ = orch.start_stub(&caps);
+            Ok(orch.status())
+        }
     };
 
     match &status {


### PR DESCRIPTION
The conditional let status block used duplicate variable names across #[cfg] arms, causing Rust to fail with type annotation needed. Added explicit return type annotation on the outer let (Result<SocksCapStatus, String>). This matches the compiler suggestion and keeps original logic intact.