### PR TITLE
fix(sockscap): fix release build cfg parsing

### DIFF
--- a/src-tauri/src/sockscap/mod.rs
+++ b/src-tauri/src/sockscap/mod.rs
@@ -398,17 +398,16 @@ pub async fn sockscap_start(
     let caps = capture::capabilities();
     let journal_path = data_dir(&app)?.join("recovery.json");
 
-    let status: Result<SocksCapStatus, String> = {
-        #[cfg(windows)]
-        start_windows_capture(&app, &state, &cfg, &caps).await
+    #[cfg(windows)]
+    let status: Result<SocksCapStatus, String> =
+        start_windows_capture(&app, &state, &cfg, &caps).await;
 
-        #[cfg(not(windows))]
-        {
-            let mut orch = state.sockscap.orch.write().await;
-            orch.apply_config(cfg.clone());
-            let _ = orch.start_stub(&caps);
-            Ok(orch.status())
-        }
+    #[cfg(not(windows))]
+    let status: Result<SocksCapStatus, String> = {
+        let mut orch = state.sockscap.orch.write().await;
+        orch.apply_config(cfg.clone());
+        let _ = orch.start_stub(&caps);
+        Ok(orch.status())
     };
 
     match &status {


### PR DESCRIPTION
Move the Windows and non-Windows SocksCap startup result initialization out of a single expression block. The previous adjacent cfg-gated expressions left the Windows await expression unterminated while Rust still parsed the following attribute, producing an unexpected-token error.

Because sockscap_start then failed to compile, Tauri could not generate its command symbols and reported missing __tauri_command_name_sockscap_start and __cmd__sockscap_start items. Use mutually exclusive cfg-gated let statements so each target compiles one complete status initialization while retaining the existing Windows capture and non-Windows stub behavior.

Validated with cargo check and git diff --check.