### PR TITLE
fix(sockscap): import Manager for Windows helper startup

### DIFF
--- a/src-tauri/src/sockscap/helper.rs
+++ b/src-tauri/src/sockscap/helper.rs
@@ -10,6 +10,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, State};
+#[cfg(windows)]
+use tauri::Manager;
 
 use crate::sockscap::paths::{
     resolve_helper_exe, resolve_windivert_dir, windivert_missing_hint,


### PR DESCRIPTION
Import tauri::Manager behind cfg(windows) in the SocksCap helper module. AppHandle::path() is supplied by that trait and is used by the Windows-only UAC helper startup branch.

Without this import, the Windows release build fails with E0599 while Linux and macOS succeed because they do not compile that branch. The conditional import keeps non-Windows builds free of an additional unused-import warning.

Validation: cargo check --quiet.