### PR TITLE
fix(code-workspace): restore IDEA-style navigate back and library go-…

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -485,6 +485,7 @@ pub fn run() {
             lsp::lsp_definition,
             lsp::lsp_type_definition,
             lsp::lsp_implementation,
+            lsp::lsp_read_uri_contents,
             lsp::lsp_references,
             lsp::lsp_document_symbols,
             lsp::lsp_completion,

--- a/src-tauri/src/lsp.rs
+++ b/src-tauri/src/lsp.rs
@@ -173,6 +173,19 @@ pub struct LspLocationsResult {
     pub locations: Vec<LspLocation>,
 }
 
+/// Contents of a library / virtual document (JDK, dependency JAR, jdt:// URI).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LspUriContentsResult {
+    pub status: LspDocumentStatus,
+    pub uri: String,
+    pub path: Option<String>,
+    pub title: String,
+    pub language_id: String,
+    pub text: String,
+    pub read_only: bool,
+}
+
 /// One entry of a flattened `textDocument/documentSymbol` tree; `depth`
 /// preserves the hierarchy for indented rendering.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -3219,6 +3232,112 @@ pub async fn lsp_implementation(
     .await
 }
 
+/// Open library / virtual LSP locations (JDK classes, dependency JARs, jdt://).
+/// Prefer a real filesystem path when the URI maps to one; otherwise ask JDT LS
+/// for decompiled or attached source via `java/classFileContents`.
+#[tauri::command]
+pub async fn lsp_read_uri_contents(
+    state: State<'_, AppState>,
+    workspace_id: String,
+    root_path: Option<String>,
+    file_path: String,
+    uri: String,
+    language_id: Option<String>,
+    server_command_id: Option<String>,
+    custom_server_command: Option<LspCustomServerCommand>,
+) -> Result<LspUriContentsResult, String> {
+    let uri = uri.trim().to_string();
+    if uri.is_empty() {
+        return Err("Missing document URI".into());
+    }
+    let document = resolve_document(workspace_id, root_path, file_path, language_id, 0)?;
+    let status = state
+        .lsp
+        .document_status(
+            &document,
+            server_command_id.as_deref(),
+            custom_server_command.as_ref(),
+        )
+        .await;
+
+    // Real file on disk (workspace sources, cargo registry, jdt extracted sources, …).
+    if let Some(path) = path_from_uri(&uri) {
+        let target = PathBuf::from(&path);
+        if target.is_file() {
+            let text = std::fs::read_to_string(&target)
+                .map_err(|e| format!("read {}: {e}", target.display()))?;
+            let language = detect_language_for_path(&target)
+                .map(|detected| detected.language_id)
+                .unwrap_or_else(|| language_id_from_uri(&uri));
+            return Ok(LspUriContentsResult {
+                status,
+                uri,
+                path: Some(path.clone()),
+                title: target
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| path.clone()),
+                language_id: language,
+                text,
+                read_only: true,
+            });
+        }
+    }
+
+    // Virtual class-file URIs from Eclipse JDT LS (JDK + third-party JARs).
+    if is_virtual_class_uri(&uri) {
+        let session = state
+            .lsp
+            .active_session(
+                &document,
+                server_command_id.as_deref(),
+                custom_server_command.as_ref(),
+            )
+            .await
+            .ok_or_else(|| {
+                "No language server session is active for this file; cannot open library source"
+                    .to_string()
+            })?;
+        let result = session
+            .request_with_timeout(
+                "java/classFileContents",
+                json!({ "uri": uri }),
+                REQUEST_TIMEOUT_SECS.max(20),
+            )
+            .await
+            .map_err(|e| format!("Failed to load class contents: {e}"))?;
+        let text = result
+            .as_str()
+            .ok_or_else(|| {
+                "Language server returned empty class file contents (attach sources or enable decompiler)"
+                    .to_string()
+            })?
+            .to_string();
+        let title = title_from_class_uri(&uri);
+        let status = state
+            .lsp
+            .document_status(
+                &document,
+                server_command_id.as_deref(),
+                custom_server_command.as_ref(),
+            )
+            .await;
+        return Ok(LspUriContentsResult {
+            status,
+            uri: uri.clone(),
+            path: None,
+            title,
+            language_id: "java".to_string(),
+            text,
+            read_only: true,
+        });
+    }
+
+    Err(format!(
+        "Cannot open location URI (not a readable file path and not a class-file URI): {uri}"
+    ))
+}
+
 #[tauri::command]
 pub async fn lsp_workspace_symbols(
     state: State<'_, AppState>,
@@ -5246,10 +5365,87 @@ fn parse_location(value: &Value) -> Option<LspLocation> {
 }
 
 fn path_from_uri(uri: &str) -> Option<String> {
+    let trimmed = uri.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // jar:file:///path/to.jar!/com/Foo.class — not a plain filesystem path.
+    // Open via java/classFileContents (or fail for non-Java servers).
+    if trimmed.to_ascii_lowercase().starts_with("jar:file:") {
+        return None;
+    }
+
+    if trimmed.starts_with("file:") {
+        return path_from_file_uri(trimmed);
+    }
+
+    // Some servers emit raw absolute paths instead of file:// URIs.
+    let path = Path::new(trimmed);
+    if path.is_absolute() {
+        return Some(normalize_os_path_string(trimmed.to_string()));
+    }
+    None
+}
+
+fn path_from_file_uri(uri: &str) -> Option<String> {
     url::Url::parse(uri)
         .ok()
+        .filter(|url| url.scheme() == "file")
         .and_then(|url| url.to_file_path().ok())
-        .map(|path| path.to_string_lossy().into_owned())
+        .map(|path| normalize_os_path_string(path.to_string_lossy().into_owned()))
+}
+
+fn normalize_os_path_string(path: String) -> String {
+    // Windows extended-length prefix breaks relativePathWithinRoot comparisons.
+    path.strip_prefix(r"\\?\")
+        .unwrap_or(path.as_str())
+        .to_string()
+}
+
+fn is_virtual_class_uri(uri: &str) -> bool {
+    let lower = uri.to_ascii_lowercase();
+    lower.starts_with("jdt:")
+        || lower.starts_with("jar:file:")
+        || lower.contains(".class?")
+        || lower.ends_with(".class")
+}
+
+fn language_id_from_uri(uri: &str) -> String {
+    let lower = uri.to_ascii_lowercase();
+    if lower.contains(".kt") {
+        "kotlin".into()
+    } else if lower.contains(".scala") {
+        "scala".into()
+    } else if lower.contains(".rs") {
+        "rust".into()
+    } else if lower.contains(".ts") {
+        "typescript".into()
+    } else if lower.contains(".js") {
+        "javascript".into()
+    } else if lower.contains(".py") {
+        "python".into()
+    } else {
+        "java".into()
+    }
+}
+
+/// Best-effort display name for jdt://contents/.../String.class?=... URIs.
+fn title_from_class_uri(uri: &str) -> String {
+    // jdt://contents/java.base/java.lang/String.class?=java.base/...
+    if let Some(after) = uri.split("://").nth(1) {
+        let path_part = after.split('?').next().unwrap_or(after);
+        if let Some(name) = path_part.rsplit('/').next() {
+            let clean = name.trim();
+            if !clean.is_empty() {
+                if clean.ends_with(".class") {
+                    return clean[..clean.len() - 6].to_string() + ".java";
+                }
+                return clean.to_string();
+            }
+        }
+    }
+    "Library Class".into()
 }
 
 fn detect_language_id(language_id: &str) -> Option<DetectedLanguage> {
@@ -6479,6 +6675,31 @@ Java(TM) SE Runtime Environment (build 17.0.4+11-LTS-179)
                 &json!({ "edits": [{ "start": 99, "deleteCount": 1 }] }),
             )
             .is_none()
+        );
+    }
+
+    #[test]
+    fn path_from_uri_maps_file_uris_and_rejects_class_uris() {
+        #[cfg(windows)]
+        {
+            let path = path_from_uri("file:///C:/Users/test/Project/Main.java").unwrap();
+            assert!(path.replace('\\', "/").ends_with("Users/test/Project/Main.java"));
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(
+                path_from_uri("file:///home/test/Project/Main.java").as_deref(),
+                Some("/home/test/Project/Main.java")
+            );
+        }
+        assert!(path_from_uri("jdt://contents/java.base/java.lang/String.class?=x").is_none());
+        assert!(path_from_uri("jar:file:///lib/foo.jar!/com/Foo.class").is_none());
+        assert!(is_virtual_class_uri(
+            "jdt://contents/java.base/java.lang/String.class?=x"
+        ));
+        assert_eq!(
+            title_from_class_uri("jdt://contents/java.base/java.lang/String.class?=x"),
+            "String.java"
         );
     }
 }

--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -70,6 +70,7 @@ import {
   lspPrepareRename,
   lspPrepareTypeHierarchy,
   lspRangeFormatting,
+  lspReadUriContents,
   lspReferences,
   lspRename,
   lspSelectionRanges,
@@ -1116,6 +1117,16 @@ export function CodeWorkspaceTab({
     ],
   );
 
+  const revealNavLocation = useCallback((key: string, position: { line: number; character: number }) => {
+    revealNonceRef.current += 1;
+    setRevealTarget({
+      key,
+      line: position.line,
+      character: position.character,
+      nonce: revealNonceRef.current,
+    });
+  }, []);
+
   const {
     navCan,
     goToFileItems,
@@ -1124,6 +1135,9 @@ export function CodeWorkspaceTab({
     openSearchEverywhere,
     openGoToFileItem,
     navigateHistory,
+    recordNavigationLocation,
+    suppressNextHistoryRecord,
+    noteCaretPosition,
     openRecentFiles,
     pickRecentFile,
   } = useWorkspaceNavigation({
@@ -1137,6 +1151,7 @@ export function CodeWorkspaceTab({
     openFilesRef,
     loadFlatFiles,
     openFile,
+    revealLocation: revealNavLocation,
     setSearchEverywhereMode,
     setSearchEverywhereOpen,
     setRecentEntries,
@@ -2950,29 +2965,182 @@ export function CodeWorkspaceTab({
     });
   }, []);
 
+  /** Inject a library/virtual buffer (JDK, dependency JAR) without reading from the workspace FS. */
+  const openVirtualBuffer = useCallback(async (
+    displayPath: string,
+    title: string,
+    text: string,
+    range: LspLocation["range"],
+    options: { groupId?: EditorGroupId; preview?: boolean } = {},
+  ) => {
+    const loose = makeLooseFile(displayPath);
+    // Prefer a stable title from the language server (e.g. String.java) over a raw URI slug.
+    const namedLoose = { ...loose, name: title || loose.name };
+    const ref: CodeWorkspaceFileRef = { kind: "loose", id: namedLoose.id, path: namedLoose.path };
+    setLooseFiles((current) => (
+      current.some((item) => item.path === namedLoose.path)
+        ? current
+        : [...current, namedLoose]
+    ));
+    const key = fileKey(ref);
+    const normalized = normalizeEditorText(text);
+    const meta = fileMeta(ref, rootsRef.current, [...looseFilesRef.current, namedLoose]);
+    suppressNextHistoryRecord();
+    setOpenFiles((current) => ({
+      ...current,
+      [key]: {
+        ref,
+        key,
+        path: meta.path,
+        title: namedLoose.name || meta.title,
+        subtitle: meta.subtitle.startsWith("jdt:") || meta.subtitle.startsWith("jar:")
+          ? `Library · ${namedLoose.name}`
+          : meta.subtitle,
+        languagePath: namedLoose.name.endsWith(".java")
+          ? namedLoose.name
+          : (meta.languagePath || namedLoose.name),
+        text: normalized.text,
+        savedText: normalized.text,
+        eol: normalized.eol,
+        hash: `virtual:${key}`,
+        mtime: Date.now(),
+        size: normalized.text.length,
+        loading: false,
+        saving: false,
+        dirty: false,
+        error: null,
+      },
+    }));
+    const currentUi = selectCodeWorkspaceUi(useCodeWorkspaceStore.getState(), workspaceInstanceId);
+    const groupId = options.groupId ?? currentUi.activeEditorGroupId;
+    updateEditorGroup(groupId, (group) => {
+      const alreadyOpen = group.openOrder.includes(key);
+      let nextOrder = group.openOrder;
+      let previewKey = group.previewKey;
+      if (!alreadyOpen) {
+        if (options.preview && previewKey && previewKey !== key && !group.pinnedKeys.includes(previewKey)) {
+          nextOrder = nextOrder.filter((entry) => entry !== previewKey);
+        }
+        nextOrder = [...nextOrder, key];
+      }
+      if (options.preview) {
+        previewKey = group.pinnedKeys.includes(key) ? null : key;
+      } else if (previewKey === key) {
+        previewKey = null;
+      }
+      return { ...group, openOrder: nextOrder, activeKey: key, previewKey };
+    });
+    if (groupId !== currentUi.activeEditorGroupId) activateEditorGroup(groupId);
+    revealEditorLocation(key, range);
+    recordNavigationLocation(ref, {
+      line: range.start.line,
+      character: range.start.character,
+    }, { replaceSameFile: false });
+    setStatusMessage(`Opened ${namedLoose.name}`);
+    return true;
+  }, [
+    activateEditorGroup,
+    recordNavigationLocation,
+    revealEditorLocation,
+    setStatusMessage,
+    suppressNextHistoryRecord,
+    updateEditorGroup,
+    workspaceInstanceId,
+  ]);
+
   const openLspLocation = useCallback(
     async (
       location: LspLocation,
       options: { groupId?: EditorGroupId; preview?: boolean } = {},
     ) => {
-      const path = location.path;
-      if (!path) return false;
-      for (const root of rootsRef.current) {
-        const relative = relativePathWithinRoot(root.path, path);
-        if (relative === null) continue;
-        const ref: CodeWorkspaceFileRef = { kind: "root", rootId: root.id, path: relative };
+      const openResolvedPath = async (path: string) => {
+        for (const root of rootsRef.current) {
+          const relative = relativePathWithinRoot(root.path, path);
+          if (relative === null) continue;
+          const ref: CodeWorkspaceFileRef = { kind: "root", rootId: root.id, path: relative };
+          suppressNextHistoryRecord();
+          revealEditorLocation(fileKey(ref), location.range);
+          await openFile(ref, options);
+          recordNavigationLocation(ref, {
+            line: location.range.start.line,
+            character: location.range.start.character,
+          }, { replaceSameFile: false });
+          return true;
+        }
+        const loose = makeLooseFile(path);
+        const ref: CodeWorkspaceFileRef = { kind: "loose", id: loose.id, path: loose.path };
+        setLooseFiles((current) => current.some((item) => item.path === loose.path) ? current : [...current, loose]);
+        suppressNextHistoryRecord();
         revealEditorLocation(fileKey(ref), location.range);
         await openFile(ref, options);
+        recordNavigationLocation(ref, {
+          line: location.range.start.line,
+          character: location.range.start.character,
+        }, { replaceSameFile: false });
         return true;
+      };
+
+      if (location.path) {
+        try {
+          return await openResolvedPath(location.path);
+        } catch (err) {
+          // Fall through to URI content fetch when the path is not readable as a workspace/loose file
+          // (e.g. missing source attachment path that still has a jdt:// URI).
+          if (!location.uri || location.uri.startsWith("file:")) {
+            setStatusMessage(errorMessage(err));
+            return false;
+          }
+        }
       }
-      const loose = makeLooseFile(path);
-      const ref: CodeWorkspaceFileRef = { kind: "loose", id: loose.id, path: loose.path };
-      setLooseFiles((current) => current.some((item) => item.path === loose.path) ? current : [...current, loose]);
-      revealEditorLocation(fileKey(ref), location.range);
-      await openFile(ref, options);
-      return true;
+
+      // JDK / third-party JAR / other virtual URIs (jdt://, jar:file:…).
+      if (!location.uri) {
+        setStatusMessage("No definition found");
+        return false;
+      }
+      const origin = activeFile
+        ?? Object.values(openFilesRef.current).find((item) => !item.loading)
+        ?? null;
+      const descriptor = origin ? lspDescriptorForFile(origin) : null;
+      if (!descriptor) {
+        setStatusMessage("Cannot open library source without an active language server document");
+        return false;
+      }
+      try {
+        const virtual = await lspReadUriContents(descriptor, location.uri);
+        updateLspStatusForFile(origin!, virtual.status);
+        if (virtual.path) {
+          try {
+            return await openResolvedPath(virtual.path);
+          } catch {
+            // Keep going and inject the text we already fetched.
+          }
+        }
+        const displayPath = virtual.path
+          ?? `library/${virtual.title || "Class.java"}`;
+        return openVirtualBuffer(
+          displayPath,
+          virtual.title,
+          virtual.text,
+          location.range,
+          options,
+        );
+      } catch (err) {
+        setStatusMessage(errorMessage(err));
+        return false;
+      }
     },
-    [openFile, revealEditorLocation],
+    [
+      activeFile,
+      lspDescriptorForFile,
+      openFile,
+      openVirtualBuffer,
+      recordNavigationLocation,
+      revealEditorLocation,
+      setStatusMessage,
+      suppressNextHistoryRecord,
+      updateLspStatusForFile,
+    ],
   );
 
   const fetchWorkspaceSymbols = useCallback(async (query: string): Promise<GoToSymbolItem[]> => {
@@ -3515,6 +3683,8 @@ export function CodeWorkspaceTab({
       title: "Navigate Back",
       category: "Navigation",
       keybinding: "Ctrl+Alt+Left",
+      // Also accept Alt+Left (common IDEA keymap variant) when history is available.
+      keybindings: ["Alt+Left"],
       when: () => navCan.back,
       run: () => navigateHistory(-1),
     },
@@ -3523,6 +3693,7 @@ export function CodeWorkspaceTab({
       title: "Navigate Forward",
       category: "Navigation",
       keybinding: "Ctrl+Alt+Right",
+      keybindings: ["Alt+Right"],
       when: () => navCan.forward,
       run: () => navigateHistory(1),
     },
@@ -4136,8 +4307,7 @@ export function CodeWorkspaceTab({
     }
     if (locations.length === 1) {
       setLocationPeek(null);
-      await openLspLocation(locations[0]);
-      return true;
+      return openLspLocation(locations[0]);
     }
     setLocationPeek({ title, locations });
     return true;
@@ -4147,6 +4317,8 @@ export function CodeWorkspaceTab({
     async (file: OpenFileState, position: LspPosition) => {
       const descriptor = lspDescriptorForFile(file);
       if (!descriptor) return false;
+      // Record the origin code focus before jumping (IDEA Navigate Back).
+      recordNavigationLocation(file.ref, position);
       try {
         const result = await lspDefinition(descriptor, position);
         updateLspStatusForFile(file, result.status);
@@ -4156,7 +4328,7 @@ export function CodeWorkspaceTab({
         return false;
       }
     },
-    [lspDescriptorForFile, navigateLocations, setStatusMessage, updateLspStatusForFile],
+    [lspDescriptorForFile, navigateLocations, recordNavigationLocation, setStatusMessage, updateLspStatusForFile],
   );
 
   const goToTypeDefinition = useCallback(
@@ -4168,6 +4340,7 @@ export function CodeWorkspaceTab({
         setStatusMessage("Type definition is not supported by this language server");
         return false;
       }
+      recordNavigationLocation(file.ref, position);
       try {
         const result = await lspTypeDefinition(descriptor, position);
         updateLspStatusForFile(file, result.status);
@@ -4177,7 +4350,7 @@ export function CodeWorkspaceTab({
         return false;
       }
     },
-    [lspDescriptorForFile, navigateLocations, setStatusMessage, updateLspStatusForFile],
+    [lspDescriptorForFile, navigateLocations, recordNavigationLocation, setStatusMessage, updateLspStatusForFile],
   );
 
   const goToImplementation = useCallback(
@@ -4189,6 +4362,7 @@ export function CodeWorkspaceTab({
         setStatusMessage("Go to implementation is not supported by this language server");
         return false;
       }
+      recordNavigationLocation(file.ref, position);
       try {
         const result = await lspImplementation(descriptor, position);
         updateLspStatusForFile(file, result.status);
@@ -4198,7 +4372,7 @@ export function CodeWorkspaceTab({
         return false;
       }
     },
-    [lspDescriptorForFile, navigateLocations, setStatusMessage, updateLspStatusForFile],
+    [lspDescriptorForFile, navigateLocations, recordNavigationLocation, setStatusMessage, updateLspStatusForFile],
   );
   goToTypeDefinitionRef.current = goToTypeDefinition;
   goToImplementationRef.current = goToImplementation;
@@ -4616,6 +4790,9 @@ export function CodeWorkspaceTab({
           if (groupId === activeEditorGroupId) {
             editorSelectionRef.current = selection;
             setEditorAiSelection(!selection.empty && selection.text.trim().length >= 2 ? selection : null);
+          }
+          if (groupFile) {
+            noteCaretPosition(groupFile.key, selection.end);
           }
           setCursorPositions((current) => ({ ...current, [groupId]: selection.end }));
         }}

--- a/src/components/editor/workspace/useWorkspaceNavigation.test.tsx
+++ b/src/components/editor/workspace/useWorkspaceNavigation.test.tsx
@@ -66,6 +66,7 @@ describe("useWorkspaceNavigation", () => {
       openFilesRef: { current: {} },
       loadFlatFiles,
       openFile: vi.fn(async () => {}),
+      revealLocation: vi.fn(),
       setSearchEverywhereMode: setMode,
       setSearchEverywhereOpen: setOpen,
       setRecentEntries: vi.fn(),
@@ -84,7 +85,7 @@ describe("useWorkspaceNavigation", () => {
     expect(setOpen).toHaveBeenCalledWith(true);
   });
 
-  it("owns recent files and back-forward navigation history", async () => {
+  it("owns recent files and back-forward navigation history with caret restore", async () => {
     const first: CodeWorkspaceFileRef = { kind: "root", rootId: "root-1", path: "src/first.ts" };
     const second: CodeWorkspaceFileRef = { kind: "root", rootId: "root-1", path: "src/second.ts" };
     const openFilesRef = { current: {
@@ -92,6 +93,7 @@ describe("useWorkspaceNavigation", () => {
       "root:root-1:src/second.ts": openState(second),
     } };
     const openFile = vi.fn(async () => {});
+    const revealLocation = vi.fn();
     const setRecentEntries = vi.fn();
     const setRecentFilesOpen = vi.fn();
     const props = {
@@ -104,6 +106,7 @@ describe("useWorkspaceNavigation", () => {
       openFilesRef,
       loadFlatFiles: vi.fn(async () => {}),
       openFile,
+      revealLocation,
       setSearchEverywhereMode: vi.fn(),
       setSearchEverywhereOpen: vi.fn(),
       setRecentEntries,
@@ -113,11 +116,13 @@ describe("useWorkspaceNavigation", () => {
       ({ activeKey }) => useWorkspaceNavigation({ ...props, activeKey }),
       { initialProps: { activeKey: "root:root-1:src/first.ts" as string | null } },
     );
+    act(() => result.current.noteCaretPosition("root:root-1:src/first.ts", { line: 10, character: 4 }));
     rerender({ activeKey: "root:root-1:src/second.ts" });
     await waitFor(() => expect(result.current.navCan.back).toBe(true));
 
     act(() => result.current.navigateHistory(-1));
     expect(openFile).toHaveBeenCalledWith(first);
+    expect(revealLocation).toHaveBeenCalledWith("root:root-1:src/first.ts", { line: 10, character: 4 });
     expect(result.current.navCan.forward).toBe(true);
 
     act(() => result.current.openRecentFiles());
@@ -126,6 +131,42 @@ describe("useWorkspaceNavigation", () => {
       expect.objectContaining({ ref: first, open: true }),
     ]);
     expect(setRecentFilesOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("records origin and destination so same-file go-to-definition can navigate back", () => {
+    const file: CodeWorkspaceFileRef = { kind: "root", rootId: "root-1", path: "src/Main.java" };
+    const openFilesRef = {
+      current: { "root:root-1:src/Main.java": openState(file) },
+    };
+    const openFile = vi.fn(async () => {});
+    const revealLocation = vi.fn();
+    const { result } = renderHook(() => useWorkspaceNavigation({
+      workspaceInstanceId: "workspace-1",
+      activeKey: "root:root-1:src/Main.java",
+      roots,
+      flatFiles: {},
+      visible: false,
+      rootsRef: { current: roots },
+      looseFilesRef: { current: [] },
+      openFilesRef,
+      loadFlatFiles: vi.fn(async () => {}),
+      openFile,
+      revealLocation,
+      setSearchEverywhereMode: vi.fn(),
+      setSearchEverywhereOpen: vi.fn(),
+      setRecentEntries: vi.fn(),
+      setRecentFilesOpen: vi.fn(),
+    }));
+
+    act(() => {
+      result.current.recordNavigationLocation(file, { line: 5, character: 2 });
+      result.current.recordNavigationLocation(file, { line: 40, character: 8 }, { replaceSameFile: false });
+    });
+    expect(result.current.navCan.back).toBe(true);
+
+    act(() => result.current.navigateHistory(-1));
+    expect(openFile).toHaveBeenCalledWith(file);
+    expect(revealLocation).toHaveBeenCalledWith("root:root-1:src/Main.java", { line: 5, character: 2 });
   });
 
   it("opens Go to File results in preview or the opposite split", () => {
@@ -142,6 +183,7 @@ describe("useWorkspaceNavigation", () => {
       openFilesRef: { current: {} },
       loadFlatFiles: vi.fn(async () => {}),
       openFile,
+      revealLocation: vi.fn(),
       setSearchEverywhereMode: vi.fn(),
       setSearchEverywhereOpen,
       setRecentEntries: vi.fn(),

--- a/src/components/editor/workspace/useWorkspaceNavigation.ts
+++ b/src/components/editor/workspace/useWorkspaceNavigation.ts
@@ -14,6 +14,18 @@ import {
   type OpenFileState,
 } from "./codeWorkspaceModel";
 
+/** One IDE navigation-history entry: file + caret (IDEA Navigate Back/Forward). */
+export interface WorkspaceNavLocation {
+  ref: CodeWorkspaceFileRef;
+  line: number;
+  character: number;
+}
+
+export interface WorkspaceNavPosition {
+  line: number;
+  character: number;
+}
+
 interface UseWorkspaceNavigationOptions {
   workspaceInstanceId: string;
   activeKey: string | null;
@@ -28,6 +40,8 @@ interface UseWorkspaceNavigationOptions {
     ref: CodeWorkspaceFileRef,
     options?: { preview?: boolean; groupId?: EditorGroupId },
   ) => Promise<void>;
+  /** Reveal caret after back/forward (same path as go-to-definition). */
+  revealLocation: (key: string, position: WorkspaceNavPosition) => void;
   setSearchEverywhereMode: (mode: SearchEverywhereMode) => void;
   setSearchEverywhereOpen: (open: boolean) => void;
   setRecentEntries: (entries: RecentFileEntry[]) => void;
@@ -42,8 +56,36 @@ export interface WorkspaceNavigationController {
   openSearchEverywhere: (mode?: SearchEverywhereMode) => void;
   openGoToFileItem: (item: GoToFileItem, options?: { split: boolean }) => void;
   navigateHistory: (delta: -1 | 1) => void;
+  /**
+   * Push an explicit (file, caret) entry — call before go-to-definition and after
+   * landing so Ctrl+Alt+Left restores the previous code focus like IDEA.
+   *
+   * - `replaceSameFile` (default true): refine the current stack entry when still
+   *   on the same file (origin caret before a jump).
+   * - `replaceSameFile: false`: always push a new entry (destination after a jump,
+   *   including same-file definition targets).
+   */
+  recordNavigationLocation: (
+    ref: CodeWorkspaceFileRef,
+    position: WorkspaceNavPosition,
+    options?: { replaceSameFile?: boolean },
+  ) => void;
+  /**
+   * Suppress the next activeKey-driven history push (pair with openFile +
+   * recordNavigationLocation when landing on a go-to-definition target).
+   */
+  suppressNextHistoryRecord: () => void;
+  /** Remember the live caret so tab switches keep accurate history positions. */
+  noteCaretPosition: (key: string, position: WorkspaceNavPosition) => void;
   openRecentFiles: () => void;
   pickRecentFile: (entry: RecentFileEntry) => void;
+}
+
+function sameNavLocation(a: WorkspaceNavLocation | undefined, b: WorkspaceNavLocation): boolean {
+  if (!a) return false;
+  return fileKey(a.ref) === fileKey(b.ref)
+    && a.line === b.line
+    && a.character === b.character;
 }
 
 export function useWorkspaceNavigation({
@@ -57,6 +99,7 @@ export function useWorkspaceNavigation({
   openFilesRef,
   loadFlatFiles,
   openFile,
+  revealLocation,
   setSearchEverywhereMode,
   setSearchEverywhereOpen,
   setRecentEntries,
@@ -65,11 +108,14 @@ export function useWorkspaceNavigation({
   const setSplitOrientation = useCodeWorkspaceStore((state) => state.setSplitOrientation);
   const [navCan, setNavCan] = useState({ back: false, forward: false });
   const navHistoryRef = useRef<{
-    stack: CodeWorkspaceFileRef[];
+    stack: WorkspaceNavLocation[];
     index: number;
+    /** Skip the next activeKey-driven push (history walk or explicit open+record). */
     suppress: boolean;
   }>({ stack: [], index: -1, suppress: false });
   const recentFilesRef = useRef<CodeWorkspaceFileRef[]>([]);
+  const caretByKeyRef = useRef<Record<string, WorkspaceNavPosition>>({});
+  const previousActiveKeyRef = useRef<string | null>(null);
 
   const openSearchEverywhere = useCallback((mode: SearchEverywhereMode = "files") => {
     rootsRef.current?.forEach((root) => void loadFlatFiles(root.id));
@@ -114,22 +160,105 @@ export function useWorkspaceNavigation({
     void openFile(ref, { preview: true });
   }, [openFile, setSearchEverywhereOpen, setSplitOrientation, workspaceInstanceId]);
 
+  const noteCaretPosition = useCallback((key: string, position: WorkspaceNavPosition) => {
+    caretByKeyRef.current[key] = {
+      line: Math.max(0, position.line),
+      character: Math.max(0, position.character),
+    };
+  }, []);
+
+  const recordNavigationLocation = useCallback((
+    ref: CodeWorkspaceFileRef,
+    position: WorkspaceNavPosition,
+    options?: { replaceSameFile?: boolean },
+  ) => {
+    const replaceSameFile = options?.replaceSameFile !== false;
+    const entry: WorkspaceNavLocation = {
+      ref,
+      line: Math.max(0, position.line),
+      character: Math.max(0, position.character),
+    };
+    caretByKeyRef.current[fileKey(ref)] = {
+      line: entry.line,
+      character: entry.character,
+    };
+    const nav = navHistoryRef.current;
+    // Explicit destination records win over a pending suppress from openFile.
+    nav.suppress = false;
+    if (sameNavLocation(nav.stack[nav.index], entry)) {
+      setNavCan({ back: nav.index > 0, forward: nav.index < nav.stack.length - 1 });
+      return;
+    }
+    const current = nav.stack[nav.index];
+    // Origin recording: keep a single refined caret for the active file.
+    if (replaceSameFile && current && fileKey(current.ref) === fileKey(ref)) {
+      nav.stack[nav.index] = entry;
+      setNavCan({ back: nav.index > 0, forward: nav.index < nav.stack.length - 1 });
+      return;
+    }
+    nav.stack = [...nav.stack.slice(0, nav.index + 1), entry].slice(-NAV_HISTORY_LIMIT);
+    nav.index = nav.stack.length - 1;
+    setNavCan({ back: nav.index > 0, forward: false });
+  }, []);
+
+  const suppressNextHistoryRecord = useCallback(() => {
+    navHistoryRef.current.suppress = true;
+  }, []);
+
   useEffect(() => {
-    if (!activeKey) return;
+    if (!activeKey) {
+      previousActiveKeyRef.current = null;
+      return;
+    }
     const ref = openFilesRef.current?.[activeKey]?.ref;
     if (!ref) return;
+
     recentFilesRef.current = [
       ref,
       ...recentFilesRef.current.filter((item) => fileKey(item) !== activeKey),
     ].slice(0, RECENT_FILES_LIMIT);
+
     const nav = navHistoryRef.current;
+    const prevKey = previousActiveKeyRef.current;
+    previousActiveKeyRef.current = activeKey;
+
+    // Before switching away, persist the previous file's live caret onto the
+    // current stack entry so Navigate Back restores the real code focus.
+    if (prevKey && prevKey !== activeKey) {
+      const prevPos = caretByKeyRef.current[prevKey];
+      const current = nav.stack[nav.index];
+      if (prevPos && current && fileKey(current.ref) === prevKey) {
+        nav.stack[nav.index] = {
+          ...current,
+          line: prevPos.line,
+          character: prevPos.character,
+        };
+      }
+    }
+
     if (nav.suppress) {
       nav.suppress = false;
       setNavCan({ back: nav.index > 0, forward: nav.index < nav.stack.length - 1 });
       return;
     }
-    if (nav.index >= 0 && nav.stack[nav.index] && fileKey(nav.stack[nav.index]) === activeKey) return;
-    nav.stack = [...nav.stack.slice(0, nav.index + 1), ref].slice(-NAV_HISTORY_LIMIT);
+
+    const pos = caretByKeyRef.current[activeKey] ?? { line: 0, character: 0 };
+    const entry: WorkspaceNavLocation = {
+      ref,
+      line: pos.line,
+      character: pos.character,
+    };
+    if (sameNavLocation(nav.stack[nav.index], entry)) {
+      setNavCan({ back: nav.index > 0, forward: nav.index < nav.stack.length - 1 });
+      return;
+    }
+    // Same file as current entry (e.g. only caret moved via explicit record) —
+    // do not double-push on re-render when keys match.
+    if (nav.index >= 0 && nav.stack[nav.index] && fileKey(nav.stack[nav.index].ref) === activeKey) {
+      setNavCan({ back: nav.index > 0, forward: nav.index < nav.stack.length - 1 });
+      return;
+    }
+    nav.stack = [...nav.stack.slice(0, nav.index + 1), entry].slice(-NAV_HISTORY_LIMIT);
     nav.index = nav.stack.length - 1;
     setNavCan({ back: nav.index > 0, forward: false });
   }, [activeKey, openFilesRef]);
@@ -138,11 +267,16 @@ export function useWorkspaceNavigation({
     const nav = navHistoryRef.current;
     const nextIndex = nav.index + delta;
     if (nextIndex < 0 || nextIndex >= nav.stack.length) return;
+    const entry = nav.stack[nextIndex];
+    if (!entry) return;
     nav.index = nextIndex;
     nav.suppress = true;
     setNavCan({ back: nextIndex > 0, forward: nextIndex < nav.stack.length - 1 });
-    void openFile(nav.stack[nextIndex]);
-  }, [openFile]);
+    const key = fileKey(entry.ref);
+    caretByKeyRef.current[key] = { line: entry.line, character: entry.character };
+    revealLocation(key, { line: entry.line, character: entry.character });
+    void openFile(entry.ref);
+  }, [openFile, revealLocation]);
 
   const openRecentFiles = useCallback(() => {
     const entries: RecentFileEntry[] = recentFilesRef.current.map((ref) => {
@@ -186,6 +320,9 @@ export function useWorkspaceNavigation({
     openSearchEverywhere,
     openGoToFileItem,
     navigateHistory,
+    recordNavigationLocation,
+    suppressNextHistoryRecord,
+    noteCaretPosition,
     openRecentFiles,
     pickRecentFile,
   };

--- a/src/components/editor/workspace/workspaceCommands.test.ts
+++ b/src/components/editor/workspace/workspaceCommands.test.ts
@@ -41,6 +41,15 @@ describe("workspaceCommands", () => {
       altKey: true,
       metaKey: false,
     })).toBe(true);
+    // Windows WebView2 can report unreliable event.key under Alt; fall back to code.
+    expect(workspaceCommandMatchesKeybinding(command({ keybinding: "Ctrl+Alt+Left" }), {
+      key: "Unidentified",
+      code: "ArrowLeft",
+      ctrlKey: true,
+      shiftKey: false,
+      altKey: true,
+      metaKey: false,
+    })).toBe(true);
   });
 
   it("dispatches the first enabled matching command and consumes the event", () => {

--- a/src/components/editor/workspace/workspaceCommands.ts
+++ b/src/components/editor/workspace/workspaceCommands.ts
@@ -32,6 +32,8 @@ export interface WorkspaceCommandRegistration {
 
 interface KeyboardEventLike {
   key: string;
+  /** Physical key code (e.g. ArrowLeft); used when `key` is unreliable under Alt. */
+  code?: string;
   ctrlKey: boolean;
   shiftKey: boolean;
   altKey: boolean;
@@ -57,6 +59,28 @@ function normalizeKey(value: string): string {
   return key;
 }
 
+/**
+ * Resolve the logical key for a keyboard event.
+ * Prefer `event.key`, but fall back to `event.code` when Alt/Ctrl combinations
+ * on Windows WebView2 yield an empty or non-arrow `key` for ArrowLeft/Right.
+ */
+export function eventLogicalKey(
+  event: Pick<KeyboardEventLike, "key"> & { code?: string },
+): string {
+  const rawKey = (event.key ?? "").trim();
+  if (rawKey && rawKey !== "Unidentified" && rawKey !== "Process") {
+    const normalized = normalizeKey(rawKey);
+    // Single printable keys and named keys (ArrowLeft, F12, …).
+    if (normalized.length > 0) return normalized;
+  }
+  const code = event.code ?? "";
+  if (!code) return normalizeKey(rawKey);
+  if (code.startsWith("Key") && code.length === 4) return code.slice(3).toLowerCase();
+  if (code.startsWith("Digit") && code.length === 6) return code.slice(5).toLowerCase();
+  if (code.startsWith("Numpad") && code.length > 6) return normalizeKey(code.slice(6));
+  return normalizeKey(code);
+}
+
 function parseKeybinding(value: string): ParsedKeybinding | null {
   const parts = value.split("+").map((part) => part.trim()).filter(Boolean);
   if (parts.length === 0) return null;
@@ -79,13 +103,16 @@ export function workspaceCommandEnabled(
 
 export function workspaceCommandMatchesKeybinding(
   command: WorkspaceCommand,
-  event: Pick<KeyboardEventLike, "key" | "ctrlKey" | "shiftKey" | "altKey" | "metaKey">,
+  event: Pick<KeyboardEventLike, "key" | "ctrlKey" | "shiftKey" | "altKey" | "metaKey"> & {
+    code?: string;
+  },
 ): boolean {
   const bindings = [command.keybinding, ...(command.keybindings ?? [])].filter((value): value is string => !!value);
+  const eventKey = eventLogicalKey(event);
   return bindings.some((value) => {
     const binding = parseKeybinding(value);
     return !!binding
-      && binding.key === normalizeKey(event.key)
+      && binding.key === eventKey
       && binding.ctrl === event.ctrlKey
       && binding.shift === event.shiftKey
       && binding.alt === event.altKey

--- a/src/lib/editor/lsp.ts
+++ b/src/lib/editor/lsp.ts
@@ -130,6 +130,17 @@ export interface LspLocationsResult {
   locations: LspLocation[];
 }
 
+/** Library / virtual document opened from jdt://, jar:, or an absolute file URI. */
+export interface LspUriContentsResult {
+  status: LspDocumentStatus;
+  uri: string;
+  path: string | null;
+  title: string;
+  languageId: string;
+  text: string;
+  readOnly: boolean;
+}
+
 export interface LspDocumentSymbol {
   name: string;
   detail: string | null;
@@ -706,6 +717,20 @@ export function lspImplementation(
     ...documentArgs(descriptor),
     line: position.line,
     character: position.character,
+  });
+}
+
+/**
+ * Load contents for a definition/reference URI that is not a workspace file
+ * (JDK classes, dependency JARs via jdtls `java/classFileContents`, or absolute paths).
+ */
+export function lspReadUriContents(
+  descriptor: LspDocumentDescriptor,
+  uri: string,
+): Promise<LspUriContentsResult> {
+  return invoke<LspUriContentsResult>("lsp_read_uri_contents", {
+    ...documentArgs(descriptor),
+    uri,
   });
 }
 

--- a/src/stubs/tauri-core.ts
+++ b/src/stubs/tauri-core.ts
@@ -1435,6 +1435,19 @@ export async function invoke<T>(cmd: string, args?: any, options?: InvokeOptions
         locations: [],
       } as T;
     }
+    case "lsp_read_uri_contents": {
+      const uri = String((args as InvokeArgs)?.uri ?? "");
+      const title = uri.split("/").pop()?.split("?")[0] || "Library.java";
+      return {
+        status: stubLspDocumentStatus(args as InvokeArgs),
+        uri,
+        path: null,
+        title: title.endsWith(".class") ? title.replace(/\.class$/, ".java") : title,
+        languageId: "java",
+        text: `// Stub library source for ${uri}\n`,
+        readOnly: true,
+      } as T;
+    }
     case "lsp_prepare_call_hierarchy":
     case "lsp_prepare_type_hierarchy":
     case "lsp_type_hierarchy_supertypes":


### PR DESCRIPTION
…to-definition

Navigate Back (Ctrl+Alt+Left) only tracked open files, so same-file definition jumps never entered history and returning dropped the previous caret. Ctrl+click also failed for JDK / third-party JAR targets because jdtls returns jdt:// and jar:file URIs that path_from_uri could not map to readable workspace paths.

Navigation history
- Store (file, line, character) entries instead of file refs alone
- Record origin caret before definition / type-definition / implementation
- Record destination after openLspLocation lands (including same-file jumps)
- Navigate Back/Forward opens the file and reveals the saved caret
- Suppress activeKey-driven double pushes during programmatic opens
- Match keybindings via event.code when Alt makes event.key unreliable
- Also bind Alt+Left / Alt+Right as IDEA-friendly alternate shortcuts

Library / JDK class navigation
- Add lsp_read_uri_contents: read real file:// paths, or request java/classFileContents from jdtls for jdt:// and jar:file class URIs
- Open decompiled or attached sources in a Library loose buffer
- Improve path_from_uri (strip Windows \\?\ prefix; reject jar class URIs)
- Wire frontend openLspLocation fallback and browser-mode stub

Tests cover caret restore, same-file history, keybinding code fallback, and URI path parsing for file vs jdt/jar locations.