### PR TITLE
fix(code-workspace): make Ctrl+click jump into JDK and dependency JAR…

### DIFF
--- a/src-tauri/src/lsp.rs
+++ b/src-tauri/src/lsp.rs
@@ -181,6 +181,8 @@ pub struct LspUriContentsResult {
     pub uri: String,
     pub path: Option<String>,
     pub title: String,
+    /// Human label for where the source came from (package · jar/module).
+    pub container: Option<String>,
     pub language_id: String,
     pub text: String,
     pub read_only: bool,
@@ -527,6 +529,7 @@ struct LspSession {
     stderr_tail: Mutex<String>,
 }
 
+#[derive(Clone)]
 struct ResolvedDocument {
     path: PathBuf,
     uri: String,
@@ -2621,13 +2624,17 @@ pub async fn lsp_hover(
     workspace_id: String,
     root_path: Option<String>,
     file_path: String,
+    document_uri: Option<String>,
     line: u32,
     character: u32,
     language_id: Option<String>,
     server_command_id: Option<String>,
     custom_server_command: Option<LspCustomServerCommand>,
 ) -> Result<LspHoverResult, String> {
-    let document = resolve_document(workspace_id, root_path, file_path, language_id, 0)?;
+    let document = with_document_uri(
+        resolve_document(workspace_id, root_path, file_path, language_id, 0)?,
+        document_uri,
+    );
     let session = match state
         .lsp
         .active_session(
@@ -2685,6 +2692,7 @@ pub async fn lsp_definition(
     workspace_id: String,
     root_path: Option<String>,
     file_path: String,
+    document_uri: Option<String>,
     line: u32,
     character: u32,
     language_id: Option<String>,
@@ -2696,6 +2704,7 @@ pub async fn lsp_definition(
         workspace_id,
         root_path,
         file_path,
+        document_uri,
         line,
         character,
         language_id,
@@ -2713,6 +2722,7 @@ pub async fn lsp_references(
     workspace_id: String,
     root_path: Option<String>,
     file_path: String,
+    document_uri: Option<String>,
     line: u32,
     character: u32,
     include_declaration: Option<bool>,
@@ -2725,6 +2735,7 @@ pub async fn lsp_references(
         workspace_id,
         root_path,
         file_path,
+        document_uri,
         line,
         character,
         language_id,
@@ -2745,6 +2756,7 @@ async fn lsp_location_request(
     workspace_id: String,
     root_path: Option<String>,
     file_path: String,
+    document_uri: Option<String>,
     line: u32,
     character: u32,
     language_id: Option<String>,
@@ -2753,7 +2765,10 @@ async fn lsp_location_request(
     method: &str,
     mut extra: Value,
 ) -> Result<LspLocationsResult, String> {
-    let document = resolve_document(workspace_id, root_path, file_path, language_id, 0)?;
+    let document = with_document_uri(
+        resolve_document(workspace_id, root_path, file_path, language_id, 0)?,
+        document_uri,
+    );
     let session = match state
         .lsp
         .active_session(
@@ -2802,11 +2817,15 @@ pub async fn lsp_document_symbols(
     workspace_id: String,
     root_path: Option<String>,
     file_path: String,
+    document_uri: Option<String>,
     language_id: Option<String>,
     server_command_id: Option<String>,
     custom_server_command: Option<LspCustomServerCommand>,
 ) -> Result<LspDocumentSymbolsResult, String> {
-    let document = resolve_document(workspace_id, root_path, file_path, language_id, 0)?;
+    let document = with_document_uri(
+        resolve_document(workspace_id, root_path, file_path, language_id, 0)?,
+        document_uri,
+    );
     let session = match state
         .lsp
         .active_session(
@@ -3182,6 +3201,7 @@ pub async fn lsp_type_definition(
     workspace_id: String,
     root_path: Option<String>,
     file_path: String,
+    document_uri: Option<String>,
     line: u32,
     character: u32,
     language_id: Option<String>,
@@ -3193,6 +3213,7 @@ pub async fn lsp_type_definition(
         workspace_id,
         root_path,
         file_path,
+        document_uri,
         line,
         character,
         language_id,
@@ -3210,6 +3231,7 @@ pub async fn lsp_implementation(
     workspace_id: String,
     root_path: Option<String>,
     file_path: String,
+    document_uri: Option<String>,
     line: u32,
     character: u32,
     language_id: Option<String>,
@@ -3221,6 +3243,7 @@ pub async fn lsp_implementation(
         workspace_id,
         root_path,
         file_path,
+        document_uri,
         line,
         character,
         language_id,
@@ -3277,6 +3300,9 @@ pub async fn lsp_read_uri_contents(
                     .file_name()
                     .map(|name| name.to_string_lossy().into_owned())
                     .unwrap_or_else(|| path.clone()),
+                container: target
+                    .parent()
+                    .map(|parent| parent.to_string_lossy().into_owned()),
                 language_id: language,
                 text,
                 read_only: true,
@@ -3306,27 +3332,29 @@ pub async fn lsp_read_uri_contents(
             )
             .await
             .map_err(|e| format!("Failed to load class contents: {e}"))?;
+        // jdtls answers with an empty string when neither attached sources nor the
+        // bundled decompiler could produce anything for this class.
         let text = result
             .as_str()
+            .filter(|text| !text.trim().is_empty())
             .ok_or_else(|| {
-                "Language server returned empty class file contents (attach sources or enable decompiler)"
-                    .to_string()
+                format!(
+                    "{} returned no source for {}: attach a sources JAR or install a decompiler",
+                    document
+                        .preset
+                        .as_ref()
+                        .map(|preset| preset.display_name.clone())
+                        .unwrap_or_else(|| "The language server".to_string()),
+                    title_from_class_uri(&uri),
+                )
             })?
             .to_string();
-        let title = title_from_class_uri(&uri);
-        let status = state
-            .lsp
-            .document_status(
-                &document,
-                server_command_id.as_deref(),
-                custom_server_command.as_ref(),
-            )
-            .await;
         return Ok(LspUriContentsResult {
             status,
             uri: uri.clone(),
             path: None,
-            title,
+            title: title_from_class_uri(&uri),
+            container: container_from_class_uri(&uri),
             language_id: "java".to_string(),
             text,
             read_only: true,
@@ -4229,6 +4257,22 @@ fn resolve_document(
     })
 }
 
+/// Retarget a resolved document at a virtual URI (a `jdt://` library buffer) while
+/// keeping the origin file's path for session / SDK selection: library sources have
+/// no project of their own, so requests must ride the origin project's session.
+fn with_document_uri(
+    mut document: ResolvedDocument,
+    document_uri: Option<String>,
+) -> ResolvedDocument {
+    if let Some(uri) = document_uri
+        .map(|uri| uri.trim().to_string())
+        .filter(|uri| !uri.is_empty())
+    {
+        document.uri = uri;
+    }
+    document
+}
+
 fn resolve_file_path(root_path: Option<&str>, file_path: &str) -> Result<PathBuf, String> {
     let file = Path::new(file_path);
     let path = if file.is_absolute() {
@@ -4283,6 +4327,14 @@ fn lsp_initialization_options(
                     "runtimes": runtimes
                 }
             }
+        },
+        // JDT LS drops every location that resolves into a `.class` file unless the
+        // client declares `classFileContentsSupport` (JDTUtils#toUri(IClassFile)
+        // returns null otherwise). Without it, Ctrl+click on a JDK or dependency
+        // type silently resolves to nothing. It also widens workspace symbol search
+        // to application/system libraries and enables decompiled-source lookups.
+        "extendedClientCapabilities": {
+            "classFileContentsSupport": true
         }
     })
 }
@@ -5448,6 +5500,43 @@ fn title_from_class_uri(uri: &str) -> String {
     "Library Class".into()
 }
 
+/// Where a library class came from, shown as the editor tab subtitle:
+/// `java.lang · java.base` for jdt:// URIs, `com.foo · lib.jar` for jar: URIs.
+fn container_from_class_uri(uri: &str) -> Option<String> {
+    let after = uri.split("://").nth(1)?;
+    let path = after.split('?').next().unwrap_or(after);
+    if uri.to_ascii_lowercase().starts_with("jar:file:") {
+        // /path/to/lib.jar!/com/foo/Bar.class
+        let (archive, entry) = path.split_once("!/")?;
+        let jar = archive.rsplit('/').next().unwrap_or(archive);
+        let package = entry
+            .rsplit_once('/')
+            .map(|(dir, _)| dir.replace('/', "."))
+            .unwrap_or_default();
+        return Some(if package.is_empty() {
+            jar.to_string()
+        } else {
+            format!("{package} · {jar}")
+        });
+    }
+    // contents/java.base/java.lang/String.class
+    let segments: Vec<&str> = path.split('/').collect();
+    if segments.len() < 4 {
+        return None;
+    }
+    let jar = segments[1].trim();
+    let package = segments[2].trim();
+    let package = if package.is_empty() {
+        "(default package)"
+    } else {
+        package
+    };
+    if jar.is_empty() {
+        return Some(package.to_string());
+    }
+    Some(format!("{package} · {jar}"))
+}
+
 fn detect_language_id(language_id: &str) -> Option<DetectedLanguage> {
     let language_id = language_id.trim();
     let preset_id = match language_id {
@@ -5839,6 +5928,11 @@ mod tests {
         assert_eq!(
             options["settings"]["java"]["configuration"]["runtimes"][0],
             json!({ "name": "JavaSE-17", "path": "/sdk/jdk-17", "default": true })
+        );
+        // Required for jdt:// definitions into the JDK and dependency JARs.
+        assert_eq!(
+            options["extendedClientCapabilities"]["classFileContentsSupport"],
+            json!(true)
         );
         assert_eq!(lsp_initialization_options(false, &environment), Value::Null);
     }
@@ -6701,5 +6795,53 @@ Java(TM) SE Runtime Environment (build 17.0.4+11-LTS-179)
             title_from_class_uri("jdt://contents/java.base/java.lang/String.class?=x"),
             "String.java"
         );
+    }
+
+    #[test]
+    fn container_from_class_uri_labels_package_and_archive() {
+        assert_eq!(
+            container_from_class_uri("jdt://contents/java.base/java.lang/String.class?=x")
+                .as_deref(),
+            Some("java.lang · java.base")
+        );
+        let jar_class = concat!(
+            "jdt://contents/commons-lang3-3.12.0.jar/",
+            "org.apache.commons.lang3/StringUtils.class?=y"
+        );
+        assert_eq!(
+            container_from_class_uri(jar_class).as_deref(),
+            Some("org.apache.commons.lang3 · commons-lang3-3.12.0.jar")
+        );
+        assert_eq!(
+            container_from_class_uri("jar:file:///libs/foo.jar!/com/acme/Bar.class").as_deref(),
+            Some("com.acme · foo.jar")
+        );
+        assert!(container_from_class_uri("jdt://contents/String.class").is_none());
+    }
+
+    #[test]
+    fn with_document_uri_overrides_only_when_present() {
+        let document = ResolvedDocument {
+            path: PathBuf::from(if cfg!(windows) {
+                r"C:\repo\src\Main.java"
+            } else {
+                "/repo/src/Main.java"
+            }),
+            uri: "file:///repo/src/Main.java".to_string(),
+            root_path: PathBuf::from(if cfg!(windows) { r"C:\repo" } else { "/repo" }),
+            workspace_id: "workspace".to_string(),
+            preset: find_preset("java"),
+            language_id: Some("java".to_string()),
+            version: 0,
+        };
+        let untouched = with_document_uri(document.clone(), Some("   ".to_string()));
+        assert_eq!(untouched.uri, "file:///repo/src/Main.java");
+        let library = with_document_uri(
+            document,
+            Some("jdt://contents/java.base/java.lang/String.class?=x".to_string()),
+        );
+        assert_eq!(library.uri, "jdt://contents/java.base/java.lang/String.class?=x");
+        // Session / SDK resolution still keys off the origin project file.
+        assert!(library.path.ends_with("Main.java"));
     }
 }

--- a/src/components/editor/CodeWorkspaceTab.test.tsx
+++ b/src/components/editor/CodeWorkspaceTab.test.tsx
@@ -41,6 +41,7 @@ const lspMocks = vi.hoisted(() => ({
   lspGetDiagnostics: vi.fn(),
   lspHover: vi.fn(),
   lspDefinition: vi.fn(),
+  lspReadUriContents: vi.fn(),
   lspReferences: vi.fn(),
   lspPrepareCallHierarchy: vi.fn(),
   lspCallHierarchyIncoming: vi.fn(),
@@ -237,6 +238,7 @@ describe("CodeWorkspaceTab", () => {
     lspMocks.lspGetDiagnostics.mockReset();
     lspMocks.lspHover.mockReset();
     lspMocks.lspDefinition.mockReset();
+    lspMocks.lspReadUriContents.mockReset();
     lspMocks.lspReferences.mockReset();
     lspMocks.lspPrepareCallHierarchy.mockReset();
     lspMocks.lspCallHierarchyIncoming.mockReset();
@@ -483,6 +485,7 @@ describe("CodeWorkspaceTab", () => {
           workspaceId: "instance-multi",
           rootPath: "/repo/app",
           filePath: "src/Program.cs",
+          documentUri: null,
           serverCommandId: null,
           customServerCommand: null,
           javaHome: null,
@@ -1632,6 +1635,118 @@ describe("CodeWorkspaceTab", () => {
     await waitFor(() => expect(lspMocks.lspPrepareTypeHierarchy).toHaveBeenCalled());
     expect(screen.getByRole("tab", { name: "Type Hierarchy", selected: true })).toBeInTheDocument();
     expect(screen.getByTestId("code-workspace-type-hierarchy-panel")).toHaveTextContent("Base");
+  });
+
+  it("opens a JDK / dependency class as a read-only library buffer", async () => {
+    const workspace: CodeWorkspaceTabInfo = {
+      repoRoot: "/repo/app",
+      workspaceId: "ws-library-goto",
+      workspaceInstanceId: "instance-library-goto",
+      name: "Library goto",
+      roots: [{ id: "app", name: "app", path: "/repo/app", kind: "git" }],
+      looseFiles: [],
+      initialFile: { kind: "root", rootId: "app", path: "src/Main.java" },
+    };
+    const activeStatus = documentStatus({
+      path: "/repo/app/src/Main.java",
+      uri: "file:///repo/app/src/Main.java",
+      presetId: "java",
+      languageId: "java",
+      displayName: "Java",
+      available: true,
+      active: true,
+    });
+    const classUri = "jdt://contents/java.base/java.lang/String.class?=java.base";
+    workspaceMocks.workspaceReadFile.mockResolvedValue(
+      file("src/Main.java", "class Main { String value; }"),
+    );
+    lspMocks.lspOpenDocument.mockResolvedValue(activeStatus);
+    lspMocks.lspChangeDocument.mockResolvedValue(activeStatus);
+    lspMocks.lspGetDiagnostics.mockResolvedValue({ status: activeStatus, diagnostics: [] });
+    // jdtls answers binary targets with a jdt:// URI and no filesystem path.
+    lspMocks.lspDefinition.mockResolvedValue({
+      status: activeStatus,
+      locations: [{
+        uri: classUri,
+        path: null,
+        range: {
+          start: { line: 3, character: 13 },
+          end: { line: 3, character: 19 },
+        },
+      }],
+    });
+    const charSequenceUri = "jdt://contents/java.base/java.lang/CharSequence.class?=java.base";
+    lspMocks.lspReadUriContents.mockImplementation(async (_descriptor: unknown, uri: string) => (
+      uri === charSequenceUri
+        ? {
+          status: activeStatus,
+          uri,
+          path: null,
+          title: "CharSequence.java",
+          container: "java.lang · java.base",
+          languageId: "java",
+          text: "package java.lang;\n\npublic interface CharSequence {}\n",
+          readOnly: true,
+        }
+        : {
+          status: activeStatus,
+          uri,
+          path: null,
+          title: "String.java",
+          container: "java.lang · java.base",
+          languageId: "java",
+          text: "package java.lang;\n\npublic final class String implements CharSequence {}\n",
+          readOnly: true,
+        }
+    ));
+
+    const rendered = renderWorkspace(workspace);
+    await screen.findByTitle("app / src/Main.java");
+    const content = rendered.container.querySelector<HTMLElement>(".cm-content");
+    expect(content).not.toBeNull();
+
+    fireEvent.keyDown(content!, { key: "F12" });
+
+    await waitFor(() => expect(lspMocks.lspReadUriContents).toHaveBeenCalledWith(
+      expect.objectContaining({ rootPath: "/repo/app", filePath: "src/Main.java" }),
+      classUri,
+    ));
+    const libraryTab = await screen.findByTitle("java.lang · java.base · String.java");
+    expect(libraryTab).toBeInTheDocument();
+    // Library sources never touch the file system, and never open a server document.
+    expect(workspaceMocks.workspaceReadLooseFile).not.toHaveBeenCalled();
+    expect(lspMocks.lspOpenDocument).not.toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: classUri }),
+      expect.anything(),
+      expect.anything(),
+    );
+
+    await waitFor(() => expect(useAppStore.getState().statusMessage)
+      .toBe("Opened java.lang · java.base · String.java (read-only)"));
+
+    // Jumping again from inside the library buffer rides the origin project's
+    // session, and a URI reported as a "path" is never read from disk.
+    lspMocks.lspDefinition.mockResolvedValue({
+      status: activeStatus,
+      locations: [{
+        uri: charSequenceUri,
+        path: charSequenceUri,
+        range: {
+          start: { line: 2, character: 17 },
+          end: { line: 2, character: 29 },
+        },
+      }],
+    });
+    fireEvent.keyDown(rendered.container.querySelector<HTMLElement>(".cm-content")!, { key: "F12" });
+
+    await waitFor(() => expect(lspMocks.lspReadUriContents).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: "src/Main.java", documentUri: classUri }),
+      charSequenceUri,
+    ));
+    expect(await screen.findByTitle("java.lang · java.base · CharSequence.java")).toBeInTheDocument();
+    expect(workspaceMocks.workspaceReadLooseFile).not.toHaveBeenCalled();
+    expect(workspaceMocks.workspaceWriteLooseFile).not.toHaveBeenCalled();
+    expect(workspaceMocks.workspaceWriteFile).not.toHaveBeenCalled();
   });
 
   it("requests usage highlights, viewport inlay hints, and semantic selection ranges", async () => {

--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -230,6 +230,15 @@ function breadcrumbSegmentsForFile(
   file: OpenFileState,
   roots: CodeWorkspaceRootInfo[],
 ): BreadcrumbPathSegment[] {
+  // Library sources have no directory trail — show where the class came from.
+  if (file.library) {
+    const trail: BreadcrumbPathSegment[] = [];
+    if (file.library.container) {
+      trail.push({ label: file.library.container, path: "", kind: "root" });
+    }
+    trail.push({ label: file.title, path: file.path, kind: "file" });
+    return trail;
+  }
   if (file.ref.kind === "root") {
     const rootId = file.ref.rootId;
     const root = roots.find((candidate) => candidate.id === rootId);
@@ -281,6 +290,7 @@ const LSP_DOCUMENT_SYMBOLS_IDLE_DELAY_MS = 650;
 const EDITOR_TEXT_COMMIT_IDLE_DELAY_MS = 220;
 
 import {
+  type LibraryBufferInfo,
   type LspFileState,
   type MarkdownViewMode,
   type OpenFileState,
@@ -312,8 +322,10 @@ import {
   isLspFeatureReady,
   isMarkdownPath,
   applyEditorEol,
+  looksLikeDocumentUri,
   shouldLiveSyncLsp,
   shouldProbeLsp,
+  makeLibraryFile,
   makeLoadingFile,
   makeLooseFile,
   normalizeEditorText,
@@ -767,6 +779,9 @@ export function CodeWorkspaceTab({
   }, [workspaceInstanceId]);
   const rootsRef = useRef(roots);
   const looseFilesRef = useRef(looseFiles);
+  // Library sources opened from the language server (JDK / dependency classes),
+  // keyed by editor key so a closed tab can be re-fetched from history.
+  const libraryBuffersRef = useRef<Record<string, LibraryBufferInfo>>({});
   const codeViewProfileRef = useRef(codeViewProfile);
   const treeFontSizeRef = useRef(treeFontSize);
   const gitHeadRequestsRef = useRef(new Set<string>());
@@ -804,6 +819,7 @@ export function CodeWorkspaceTab({
   const runPanelRef = useRef<RunPanelHandle | null>(null);
   const {
     descriptorForFile: lspDescriptorForFile,
+    descriptorForPath: lspDescriptorForPath,
     isDocumentSynced: isLspDocumentSynced,
     syncDocument: syncLspDocument,
     saveDocument: saveLspDocument,
@@ -1049,6 +1065,42 @@ export function CodeWorkspaceTab({
       });
       if (groupId !== currentUi.activeEditorGroupId) activateEditorGroup(groupId);
       if (openFilesRef.current[key] && !openFilesRef.current[key].loading) return;
+      // Library sources (JDK / dependency classes) have no file to read: ask the
+      // language server again so history and Recent Files can reopen them.
+      const library = libraryBuffersRef.current[key];
+      if (library) {
+        setOpenFiles((current) => ({
+          ...current,
+          [key]: current[key] ?? { ...makeLibraryFile(library, ""), loading: true },
+        }));
+        try {
+          const contents = await lspReadUriContents(
+            lspDescriptorForPath(library.originRootPath, library.originFilePath),
+            library.uri,
+          );
+          const info: LibraryBufferInfo = {
+            ...library,
+            title: contents.title || library.title,
+            container: contents.container ?? library.container,
+            languageId: contents.languageId || library.languageId,
+          };
+          libraryBuffersRef.current[key] = info;
+          setOpenFiles((current) => ({ ...current, [key]: makeLibraryFile(info, contents.text) }));
+          setStatusMessage(`Opened ${info.title}`);
+        } catch (err) {
+          const message = errorMessage(err);
+          setOpenFiles((current) => ({
+            ...current,
+            [key]: {
+              ...(current[key] ?? makeLibraryFile(library, "")),
+              loading: false,
+              error: message,
+            },
+          }));
+          setStatusMessage(message);
+        }
+        return;
+      }
       setOpenFiles((current) => ({
         ...current,
         [key]: current[key] ?? makeLoadingFile(ref, rootsRef.current, looseFilesRef.current),
@@ -1111,6 +1163,7 @@ export function CodeWorkspaceTab({
       activateEditorGroup,
       findRoot,
       flushPendingEditorText,
+      lspDescriptorForPath,
       setStatusMessage,
       updateEditorGroup,
       workspaceInstanceId,
@@ -1221,6 +1274,22 @@ export function CodeWorkspaceTab({
   useEffect(() => {
     if (!workspaceInstanceId) return;
     const timer = window.setTimeout(() => {
+      // Library buffers come from a live language server, so they cannot be
+      // restored on the next launch — keep them out of the persisted layout.
+      const persistableGroups = Object.fromEntries(
+        (Object.entries(editorGroups) as Array<[EditorGroupId, typeof editorGroups.primary]>)
+          .map(([groupId, group]) => [groupId, {
+            ...group,
+            openOrder: group.openOrder.filter((key) => !libraryBuffersRef.current[key]),
+            pinnedKeys: group.pinnedKeys.filter((key) => !libraryBuffersRef.current[key]),
+            activeKey: group.activeKey && libraryBuffersRef.current[group.activeKey]
+              ? null
+              : group.activeKey,
+            previewKey: group.previewKey && libraryBuffersRef.current[group.previewKey]
+              ? null
+              : group.previewKey,
+          }]),
+      ) as typeof editorGroups;
       writeWorkspaceLayoutSnapshot(workspaceInstanceId, snapshotFromWorkspaceUi({
         bottomDockOpen,
         bottomDockTab,
@@ -1231,7 +1300,7 @@ export function CodeWorkspaceTab({
         activeEditorGroupId,
         expandedRootIds,
         expandedDirKeys,
-        editorGroups,
+        editorGroups: persistableGroups,
       }));
     }, 250);
     return () => window.clearTimeout(timer);
@@ -1348,6 +1417,10 @@ export function CodeWorkspaceTab({
   const revealEditorTabInExplorer = useCallback((key: string) => {
     const file = openFilesRef.current[key];
     if (!file) return;
+    if (file.library) {
+      setStatusMessage(`${file.title} is a library source with no file on disk`);
+      return;
+    }
     if (file.ref.kind === "root") {
       void revealInExplorer(file.ref.rootId, file.ref.path);
       return;
@@ -1370,6 +1443,8 @@ export function CodeWorkspaceTab({
     const segmentIndex = trail.findIndex((item) =>
       item.path === segment.path && item.kind === segment.kind && item.label === segment.label
     );
+    // Nothing to browse inside a JAR / decompiled class.
+    if (file.library) return [];
     const nextSegment = segmentIndex >= 0 ? trail[segmentIndex + 1] ?? null : null;
     const activeChildPath = nextSegment && nextSegment.kind !== "root" ? nextSegment.path : null;
 
@@ -1455,6 +1530,8 @@ export function CodeWorkspaceTab({
     segment: BreadcrumbPathSegment,
     file: OpenFileState,
   ): BreadcrumbPathAction[] => {
+    // Copy path / reveal / open-in-terminal make no sense for a class inside a JAR.
+    if (file.library) return [];
     const actions: BreadcrumbPathAction[] = [];
     actions.push({
       id: "reveal-tree",
@@ -1526,6 +1603,10 @@ export function CodeWorkspaceTab({
   const openEditorTabInTerminal = useCallback((key: string) => {
     const file = openFilesRef.current[key];
     if (!file) return;
+    if (file.library) {
+      setStatusMessage(`${file.title} is a library source with no directory on disk`);
+      return;
+    }
     if (file.ref.kind === "root") {
       openTerminalAt(file.ref.rootId, file.ref.path, true);
       return;
@@ -1534,7 +1615,7 @@ export function CodeWorkspaceTab({
     setBottomDockTab("terminal");
     setBottomDockOpen(true);
     terminalDockRef.current?.openAt(cwd, basename(cwd));
-  }, [openTerminalAt]);
+  }, [openTerminalAt, setStatusMessage]);
 
   const handleTreeKeyDown = useCallback((event: React.KeyboardEvent<HTMLElement>) => {
     const pane = treePaneRef.current;
@@ -1795,6 +1876,8 @@ export function CodeWorkspaceTab({
   }, [flushPendingEditorText, scheduleLiveLspSync]);
 
   const absolutePathForOpenFile = useCallback((file: OpenFileState): string | null => {
+    // Library sources live inside a JAR / the language server, not on disk.
+    if (file.library) return null;
     if (file.ref.kind === "loose") return normalizeFsPath(file.ref.path);
     const root = findRoot(file.ref.rootId);
     if (!root) return null;
@@ -1813,7 +1896,9 @@ export function CodeWorkspaceTab({
     if (!file) return;
     const absolute = absolutePathForOpenFile(file);
     if (!absolute) {
-      setStatusMessage("Cannot resolve path for local history");
+      setStatusMessage(file.library
+        ? `${file.title} is a library source with no local history`
+        : "Cannot resolve path for local history");
       return;
     }
     setLocalHistoryTarget({ key, path: absolute });
@@ -1912,6 +1997,9 @@ export function CodeWorkspaceTab({
     const file = openFilesRef.current[key];
     if (!file || file.loading) {
       throw new Error("Open buffer is not available to save");
+    }
+    if (file.library) {
+      throw new Error(`${file.title} is a read-only library source`);
     }
     setOpenFiles((current) => ({
       ...current,
@@ -2057,6 +2145,10 @@ export function CodeWorkspaceTab({
       if (!key) return;
       const file = openFilesRef.current[key];
       if (!file) return;
+      if (file.library) {
+        setStatusMessage(`${file.title} is a read-only library source`);
+        return;
+      }
       if (file.dirty) {
         const confirmed = await confirmAppDialog({
           title: "Reload file",
@@ -2374,8 +2466,12 @@ export function CodeWorkspaceTab({
   const activeFileKey = activeFile?.key ?? null;
   const activeFileLoading = activeFile?.loading ?? false;
   const activeFileLanguagePath = activeFile?.languagePath ?? null;
+  // Library buffers are served by the origin project's session and never opened as
+  // documents, so they must not start a server of their own.
+  const activeFileIsLibrary = !!activeFile?.library;
   useEffect(() => {
     if (!visible || !activeFileKey || activeFileLoading || !activeFileLanguagePath) return;
+    if (activeFileIsLibrary) return;
     const lspState = lspFilesRef.current[activeFileKey];
     if (!shouldProbeLsp(activeFileLanguagePath, lspState)) return;
     if (lspState?.status?.active) {
@@ -2389,6 +2485,7 @@ export function CodeWorkspaceTab({
     }, 0);
     return () => window.clearTimeout(timer);
   }, [
+    activeFileIsLibrary,
     activeFileKey,
     activeFileLanguagePath,
     activeFileLoading,
@@ -2965,52 +3062,24 @@ export function CodeWorkspaceTab({
     });
   }, []);
 
-  /** Inject a library/virtual buffer (JDK, dependency JAR) without reading from the workspace FS. */
-  const openVirtualBuffer = useCallback(async (
-    displayPath: string,
-    title: string,
+  /**
+   * Open a language-server library source (JDK class, dependency JAR) as a
+   * read-only buffer. Nothing is read from or written to disk, and the buffer is
+   * not registered as a loose workspace file — it only exists while open (plus in
+   * the library registry so history can reopen it).
+   */
+  const openLibraryBuffer = useCallback(async (
+    info: LibraryBufferInfo,
     text: string,
     range: LspLocation["range"],
     options: { groupId?: EditorGroupId; preview?: boolean } = {},
   ) => {
-    const loose = makeLooseFile(displayPath);
-    // Prefer a stable title from the language server (e.g. String.java) over a raw URI slug.
-    const namedLoose = { ...loose, name: title || loose.name };
-    const ref: CodeWorkspaceFileRef = { kind: "loose", id: namedLoose.id, path: namedLoose.path };
-    setLooseFiles((current) => (
-      current.some((item) => item.path === namedLoose.path)
-        ? current
-        : [...current, namedLoose]
-    ));
-    const key = fileKey(ref);
-    const normalized = normalizeEditorText(text);
-    const meta = fileMeta(ref, rootsRef.current, [...looseFilesRef.current, namedLoose]);
+    const file = makeLibraryFile(info, text);
+    const ref = file.ref;
+    const key = file.key;
+    libraryBuffersRef.current[key] = info;
     suppressNextHistoryRecord();
-    setOpenFiles((current) => ({
-      ...current,
-      [key]: {
-        ref,
-        key,
-        path: meta.path,
-        title: namedLoose.name || meta.title,
-        subtitle: meta.subtitle.startsWith("jdt:") || meta.subtitle.startsWith("jar:")
-          ? `Library · ${namedLoose.name}`
-          : meta.subtitle,
-        languagePath: namedLoose.name.endsWith(".java")
-          ? namedLoose.name
-          : (meta.languagePath || namedLoose.name),
-        text: normalized.text,
-        savedText: normalized.text,
-        eol: normalized.eol,
-        hash: `virtual:${key}`,
-        mtime: Date.now(),
-        size: normalized.text.length,
-        loading: false,
-        saving: false,
-        dirty: false,
-        error: null,
-      },
-    }));
+    setOpenFiles((current) => ({ ...current, [key]: file }));
     const currentUi = selectCodeWorkspaceUi(useCodeWorkspaceStore.getState(), workspaceInstanceId);
     const groupId = options.groupId ?? currentUi.activeEditorGroupId;
     updateEditorGroup(groupId, (group) => {
@@ -3036,7 +3105,7 @@ export function CodeWorkspaceTab({
       line: range.start.line,
       character: range.start.character,
     }, { replaceSameFile: false });
-    setStatusMessage(`Opened ${namedLoose.name}`);
+    setStatusMessage(`Opened ${file.subtitle} (read-only)`);
     return true;
   }, [
     activateEditorGroup,
@@ -3061,6 +3130,8 @@ export function CodeWorkspaceTab({
           suppressNextHistoryRecord();
           revealEditorLocation(fileKey(ref), location.range);
           await openFile(ref, options);
+          // openFile reports read failures on the buffer instead of throwing.
+          if (openFilesRef.current[fileKey(ref)]?.error) return false;
           recordNavigationLocation(ref, {
             line: location.range.start.line,
             character: location.range.start.character,
@@ -3073,6 +3144,8 @@ export function CodeWorkspaceTab({
         suppressNextHistoryRecord();
         revealEditorLocation(fileKey(ref), location.range);
         await openFile(ref, options);
+        // openFile reports read failures on the buffer instead of throwing.
+        if (openFilesRef.current[fileKey(ref)]?.error) return false;
         recordNavigationLocation(ref, {
           line: location.range.start.line,
           character: location.range.start.character,
@@ -3080,17 +3153,20 @@ export function CodeWorkspaceTab({
         return true;
       };
 
-      if (location.path) {
+      // Workspace-symbol hits fall back to the URI when the server reports no path,
+      // and a URI string is never readable from disk.
+      const diskPath = location.path && !looksLikeDocumentUri(location.path) ? location.path : null;
+      if (diskPath) {
         try {
-          return await openResolvedPath(location.path);
+          if (await openResolvedPath(diskPath)) return true;
         } catch (err) {
-          // Fall through to URI content fetch when the path is not readable as a workspace/loose file
-          // (e.g. missing source attachment path that still has a jdt:// URI).
-          if (!location.uri || location.uri.startsWith("file:")) {
+          if (!location.uri) {
             setStatusMessage(errorMessage(err));
             return false;
           }
         }
+        // Path unreadable (missing source attachment, JAR entry): try the URI below.
+        if (!location.uri) return false;
       }
 
       // JDK / third-party JAR / other virtual URIs (jdt://, jar:file:…).
@@ -3098,30 +3174,37 @@ export function CodeWorkspaceTab({
         setStatusMessage("No definition found");
         return false;
       }
+      // Library sources ride the origin project's language-server session: prefer the
+      // active buffer, and fall back to the origin project of a library buffer.
       const origin = activeFile
         ?? Object.values(openFilesRef.current).find((item) => !item.loading)
         ?? null;
       const descriptor = origin ? lspDescriptorForFile(origin) : null;
-      if (!descriptor) {
+      if (!origin || !descriptor) {
         setStatusMessage("Cannot open library source without an active language server document");
         return false;
       }
       try {
-        const virtual = await lspReadUriContents(descriptor, location.uri);
-        updateLspStatusForFile(origin!, virtual.status);
-        if (virtual.path) {
+        const contents = await lspReadUriContents(descriptor, location.uri);
+        updateLspStatusForFile(origin, contents.status);
+        // Attached sources that exist on disk open as a normal editable-looking file.
+        if (contents.path) {
           try {
-            return await openResolvedPath(virtual.path);
+            if (await openResolvedPath(contents.path)) return true;
           } catch {
             // Keep going and inject the text we already fetched.
           }
         }
-        const displayPath = virtual.path
-          ?? `library/${virtual.title || "Class.java"}`;
-        return openVirtualBuffer(
-          displayPath,
-          virtual.title,
-          virtual.text,
+        return openLibraryBuffer(
+          {
+            uri: contents.uri || location.uri,
+            title: contents.title,
+            container: contents.container,
+            languageId: contents.languageId,
+            originRootPath: descriptor.rootPath ?? null,
+            originFilePath: descriptor.filePath,
+          },
+          contents.text,
           location.range,
           options,
         );
@@ -3134,7 +3217,7 @@ export function CodeWorkspaceTab({
       activeFile,
       lspDescriptorForFile,
       openFile,
-      openVirtualBuffer,
+      openLibraryBuffer,
       recordNavigationLocation,
       revealEditorLocation,
       setStatusMessage,

--- a/src/components/editor/workspace/CodeMirrorHost.test.tsx
+++ b/src/components/editor/workspace/CodeMirrorHost.test.tsx
@@ -116,6 +116,23 @@ describe("CodeMirrorHost search", () => {
     await waitFor(() => expect(onChange).toHaveBeenLastCalledWith("one\ntwo"));
   });
 
+  it("rejects edits in read-only buffers but keeps navigation working", async () => {
+    const onChange = vi.fn();
+    const onDefinition = vi.fn(async () => true);
+    const { content } = renderEditor("one\ntwo", onChange, { readOnly: true, onDefinition });
+
+    // Editing commands are no-ops on library / decompiled sources.
+    fireEvent.keyDown(content, { key: "d", code: "KeyD", ctrlKey: true });
+    fireEvent.keyDown(content, { key: "y", code: "KeyY", ctrlKey: true });
+    await waitFor(() => expect(onDefinition).not.toHaveBeenCalled());
+    expect(onChange).not.toHaveBeenCalled();
+
+    // Go to definition still jumps out of a read-only buffer.
+    fireEvent.keyDown(content, { key: "F12" });
+    await waitFor(() => expect(onDefinition).toHaveBeenCalled());
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it("moves selected lines with Alt+Shift+Arrow", async () => {
     const onChange = vi.fn();
     const { content } = renderEditor("one\ntwo", onChange);

--- a/src/components/editor/workspace/CodeMirrorHost.tsx
+++ b/src/components/editor/workspace/CodeMirrorHost.tsx
@@ -91,6 +91,8 @@ interface CodeMirrorHostProps {
   gitChanges?: GitLineChange[];
   gitBlame?: GitBlameLine | null;
   reveal: EditorRevealTarget | null;
+  /** Block edits (library / decompiled sources that have no file to write back to). */
+  readOnly?: boolean;
   onChange: (doc: string) => void;
   onSave: () => void;
   onHover: (position: LspPosition) => Promise<string | null>;
@@ -128,6 +130,14 @@ export interface EditorContextMenuRequest {
   cut: () => void;
   copy: () => void;
   paste: () => void;
+}
+
+/**
+ * Read-only buffers keep the caret, selection, search, and Ctrl+click navigation —
+ * only document changes are rejected (IDEA's decompiled-source behaviour).
+ */
+function readOnlyExtension(readOnly: boolean): Extension {
+  return readOnly ? EditorState.readOnly.of(true) : [];
 }
 
 const WORKSPACE_EDITOR_STYLE = EditorView.theme({
@@ -278,6 +288,7 @@ export function CodeMirrorHost({
   gitChanges = EMPTY_GIT_CHANGES,
   gitBlame = null,
   reveal,
+  readOnly = false,
   onChange,
   onSave,
   onHover,
@@ -303,6 +314,7 @@ export function CodeMirrorHost({
   const semanticTokensCompartment = useRef(new Compartment());
   const gitCompartment = useRef(new Compartment());
   const signatureCompartment = useRef(new Compartment());
+  const readOnlyCompartment = useRef(new Compartment());
   const signatureShownRef = useRef(false);
   /** True while applying a prop-driven doc replace so it is not treated as a user edit. */
   const applyingExternalDocRef = useRef(false);
@@ -569,6 +581,7 @@ export function CodeMirrorHost({
           (change) => onGitChangeClickRef.current?.(change),
         )),
         signatureCompartment.current.of([]),
+        readOnlyCompartment.current.of(readOnlyExtension(readOnly)),
         ...lspInteractionExtensions(onHoverRef, onDefinitionRef, onReferencesRef),
         ...codeViewExtensions(),
         WORKSPACE_EDITOR_STYLE,
@@ -728,6 +741,12 @@ export function CodeMirrorHost({
       cancelled = true;
     };
   }, [path]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({ effects: readOnlyCompartment.current.reconfigure(readOnlyExtension(readOnly)) });
+  }, [readOnly]);
 
   useEffect(() => {
     const view = viewRef.current;

--- a/src/components/editor/workspace/EditorGroup.tsx
+++ b/src/components/editor/workspace/EditorGroup.tsx
@@ -483,6 +483,8 @@ export function EditorGroup({
                         gitChanges={activeGitChanges}
                         gitBlame={activeGitBlame}
                         reveal={revealTarget?.key === activeFile.key ? revealTarget : null}
+                        // Library sources (JDK / dependency classes) cannot be written back.
+                        readOnly={!!activeFile.library}
                         onChange={(doc) => {
                           if (previewKey === activeFile.key) onPromotePreview(activeFile.key);
                           onChangeText(activeFile.key, doc);

--- a/src/components/editor/workspace/codeWorkspaceModel.ts
+++ b/src/components/editor/workspace/codeWorkspaceModel.ts
@@ -208,6 +208,86 @@ export function looseIdForPath(path: string): string {
   return `loose-${hashString(path)}`;
 }
 
+/**
+ * A JDK / dependency source delivered by the language server instead of the file
+ * system (jdtls answers `java/classFileContents` for `jdt://` class URIs).
+ */
+export interface LibraryBufferInfo {
+  uri: string;
+  /** Display name, e.g. `String.java`. */
+  title: string;
+  /** `package · jar/module` label for the tab subtitle. */
+  container: string | null;
+  languageId: string;
+  /** Project file the jump started from; selects the language-server session. */
+  originFilePath: string;
+  originRootPath: string | null;
+}
+
+const LIBRARY_LANGUAGE_EXTENSIONS: Record<string, string> = {
+  java: "java",
+  kotlin: "kt",
+  scala: "scala",
+  groovy: "groovy",
+};
+
+/**
+ * True when a location "path" is really a document URI (`jdt://`, `jar:file:`,
+ * `file://`, …) rather than a filesystem path. Language servers and our own
+ * symbol mapping both fall back to the URI when there is no path, and reading
+ * such a string from disk always fails.
+ */
+export function looksLikeDocumentUri(candidate: string): boolean {
+  const match = /^([A-Za-z][A-Za-z0-9+.-]*):/.exec(candidate.trim());
+  if (!match) return false;
+  // A single letter before the colon is a Windows drive (C:\src\Main.java).
+  return match[1]!.length > 1;
+}
+
+/** Library buffers are keyed by URI so same-named classes never collide. */
+export function libraryFileRef(uri: string): CodeWorkspaceFileRef {
+  return { kind: "loose", id: looseIdForPath(uri), path: uri };
+}
+
+/** File name used only for syntax highlighting of a library buffer. */
+export function libraryLanguagePath(info: LibraryBufferInfo): string {
+  const title = info.title.trim();
+  if (title.includes(".")) return title;
+  const extension = LIBRARY_LANGUAGE_EXTENSIONS[info.languageId] ?? "txt";
+  return `${title || "Library"}.${extension}`;
+}
+
+/** Read-only open-buffer view model for a library source (never touches disk). */
+export function makeLibraryFile(info: LibraryBufferInfo, text: string): OpenFileState {
+  const ref = libraryFileRef(info.uri);
+  const normalized = normalizeEditorText(text);
+  const title = info.title.trim() || pathName(info.uri, "Library");
+  return {
+    ref,
+    key: fileKey(ref),
+    path: info.uri,
+    title,
+    subtitle: info.container ? `${info.container} · ${title}` : title,
+    languagePath: libraryLanguagePath(info),
+    text: normalized.text,
+    savedText: normalized.text,
+    eol: normalized.eol,
+    hash: `library:${hashString(info.uri)}`,
+    mtime: 0,
+    size: normalized.text.length,
+    loading: false,
+    saving: false,
+    dirty: false,
+    error: null,
+    library: {
+      uri: info.uri,
+      container: info.container,
+      originFilePath: info.originFilePath,
+      originRootPath: info.originRootPath,
+    },
+  };
+}
+
 export function makeRoot(path: string, kind: CodeWorkspaceRootInfo["kind"] = "folder"): CodeWorkspaceRootInfo {
   const normalized = path.trim();
   return {

--- a/src/components/editor/workspace/editorGroupTypes.ts
+++ b/src/components/editor/workspace/editorGroupTypes.ts
@@ -3,6 +3,21 @@ import type { CodeWorkspaceFileRef } from "../../../types";
 /** On-disk line ending style preserved across the LF-normalized editor buffer. */
 export type OpenFileEol = "LF" | "CRLF" | "CR";
 
+/**
+ * A buffer that has no file on disk: JDK / dependency sources delivered by the
+ * language server (`jdt://` class contents). Read-only, never written, and its LSP
+ * requests ride the origin project's session with `uri` as the document URI.
+ */
+export interface OpenFileLibrarySource {
+  uri: string;
+  /** `package · jar/module` origin label, shown instead of a directory trail. */
+  container: string | null;
+  /** Project root of the file the jump started from (null for loose-file origins). */
+  originRootPath: string | null;
+  /** File the jump started from; selects the language-server session. */
+  originFilePath: string;
+}
+
 /** View-model for an open buffer as seen by EditorGroup (presentation only). */
 export interface OpenFileViewModel {
   ref: CodeWorkspaceFileRef;
@@ -24,4 +39,6 @@ export interface OpenFileViewModel {
   saving: boolean;
   dirty: boolean;
   error: string | null;
+  /** Set for language-server-provided library sources (read-only, no file on disk). */
+  library?: OpenFileLibrarySource | null;
 }

--- a/src/components/editor/workspace/projectTreeModel.test.ts
+++ b/src/components/editor/workspace/projectTreeModel.test.ts
@@ -11,9 +11,13 @@ import {
   gitDirectoryChangeCount,
   isFlatViewSourceFile,
   languageSourceRootFor,
+  libraryLanguagePath,
+  looksLikeDocumentUri,
+  makeLibraryFile,
   matchesTreeFilter,
   normalizeEditorText,
   shouldHideEntry,
+  type LibraryBufferInfo,
 } from "./codeWorkspaceModel";
 
 const entry = (name: string, path: string): WorkspaceEntry => ({
@@ -92,5 +96,49 @@ describe("project tree model helpers", () => {
     expect(gitDirectoryChangeCount(map, "root1", "src")).toBe(1);
     expect(gitDirectoryChangeCount(map, "root1", "")).toBe(1);
     expect(gitDirectoryChangeCount(map, "other", "")).toBe(0);
+  });
+
+  it("makeLibraryFile builds a clean read-only buffer keyed by class URI", () => {
+    const info: LibraryBufferInfo = {
+      uri: "jdt://contents/java.base/java.lang/String.class?=java.base",
+      title: "String.java",
+      container: "java.lang · java.base",
+      languageId: "java",
+      originFilePath: "src/Main.java",
+      originRootPath: "/repo",
+    };
+    const file = makeLibraryFile(info, "public class String {}\r\n");
+
+    expect(file.path).toBe(info.uri);
+    expect(file.title).toBe("String.java");
+    expect(file.subtitle).toBe("java.lang · java.base · String.java");
+    expect(file.languagePath).toBe("String.java");
+    expect(file.text).toBe("public class String {}\n");
+    expect(file.dirty).toBe(false);
+    expect(file.library).toEqual({
+      uri: info.uri,
+      container: "java.lang · java.base",
+      originFilePath: "src/Main.java",
+      originRootPath: "/repo",
+    });
+
+    // Same-named classes from different packages must not share a buffer.
+    const other = makeLibraryFile({
+      ...info,
+      uri: "jdt://contents/other.jar/com.acme/String.class?=other",
+      container: "com.acme · other.jar",
+    }, "class String {}");
+    expect(other.key).not.toBe(file.key);
+
+    expect(libraryLanguagePath({ ...info, title: "String", languageId: "kotlin" })).toBe("String.kt");
+  });
+
+  it("looksLikeDocumentUri separates URIs from filesystem paths", () => {
+    expect(looksLikeDocumentUri("jdt://contents/java.base/java.lang/String.class?=x")).toBe(true);
+    expect(looksLikeDocumentUri("jar:file:///libs/foo.jar!/com/acme/Bar.class")).toBe(true);
+    expect(looksLikeDocumentUri("file:///repo/src/Main.java")).toBe(true);
+    expect(looksLikeDocumentUri("C:\\repo\\src\\Main.java")).toBe(false);
+    expect(looksLikeDocumentUri("/repo/src/Main.java")).toBe(false);
+    expect(looksLikeDocumentUri("src/Main.java")).toBe(false);
   });
 });

--- a/src/components/editor/workspace/useWorkspaceLspSession.test.tsx
+++ b/src/components/editor/workspace/useWorkspaceLspSession.test.tsx
@@ -145,6 +145,47 @@ describe("useWorkspaceLspSession", () => {
     );
   });
 
+  it("routes library sources through the origin project session and never syncs them", async () => {
+    const libraryFile: OpenFileState = {
+      ...file,
+      key: "loose:loose-jdt-string",
+      ref: { kind: "loose", id: "loose-jdt-string", path: "jdt://contents/java.base/java.lang/String.class?=x" },
+      title: "String.java",
+      subtitle: "java.lang · java.base · String.java",
+      path: "jdt://contents/java.base/java.lang/String.class?=x",
+      languagePath: "String.java",
+      library: {
+        uri: "jdt://contents/java.base/java.lang/String.class?=x",
+        container: "java.lang · java.base",
+        originRootPath: "/repo",
+        originFilePath: "src/Main.java",
+      },
+    };
+    const openFilesRef = { current: { [libraryFile.key]: libraryFile } };
+    const { result } = renderHook(() => useWorkspaceLspSession({
+      workspaceInstanceId: "workspace-1",
+      roots,
+      openFilesRef,
+      updateLspFiles: vi.fn(),
+      onError: vi.fn(),
+    }));
+
+    await waitFor(() => expect(lspMocks.lspDetectServers).toHaveBeenCalled());
+    // Requests must ride the origin project's session but target the class URI.
+    expect(result.current.descriptorForFile(libraryFile)).toMatchObject({
+      rootPath: "/repo",
+      filePath: "src/Main.java",
+      documentUri: "jdt://contents/java.base/java.lang/String.class?=x",
+    });
+
+    await act(async () => result.current.syncDocument(libraryFile, "open"));
+    await act(async () => result.current.saveDocument(libraryFile, "text"));
+    act(() => result.current.closeDocument(libraryFile));
+    expect(lspMocks.lspOpenDocument).not.toHaveBeenCalled();
+    expect(lspMocks.lspSaveDocument).not.toHaveBeenCalled();
+    expect(lspMocks.lspCloseDocument).not.toHaveBeenCalled();
+  });
+
   it("does not commit an async response after its buffer was closed", async () => {
     let resolveOpen!: (value: LspDocumentStatus) => void;
     lspMocks.lspOpenDocument.mockImplementation(() => new Promise<LspDocumentStatus>((resolve) => {

--- a/src/components/editor/workspace/useWorkspaceLspSession.ts
+++ b/src/components/editor/workspace/useWorkspaceLspSession.ts
@@ -114,6 +114,15 @@ export interface WorkspaceLspSessionController {
   updateCommandPref: (presetId: string, commandId: string) => void;
   updateCustomCommand: (presetId: string, patch: Partial<LspCustomCommandConfig>) => void;
   descriptorForFile: (file: OpenFileState) => LspDocumentDescriptor | null;
+  /**
+   * Descriptor for a path that has no open buffer (library sources re-fetched from
+   * the server). `documentUri` retargets the request at a virtual document.
+   */
+  descriptorForPath: (
+    rootPath: string | null,
+    filePath: string,
+    documentUri?: string | null,
+  ) => LspDocumentDescriptor;
   /** True when the language server has the given buffer and no didChange is in flight. */
   isDocumentSynced: (key: string, text: string) => boolean;
   syncDocument: (file: OpenFileState, mode: "open" | "change") => Promise<void>;
@@ -249,36 +258,47 @@ export function useWorkspaceLspSession({
     invalidateSyncedText();
   }, [invalidateSyncedText]);
 
-  const descriptorForFile = useCallback((file: OpenFileState): LspDocumentDescriptor | null => {
-    const presetId = lspPresetIdForPath(file.languagePath);
+  const descriptorForPath = useCallback((
+    rootPath: string | null,
+    filePath: string,
+    documentUri: string | null = null,
+  ): LspDocumentDescriptor => {
+    const presetId = lspPresetIdForPath(filePath);
     const commandPref = presetId ? commandPrefs[presetId] ?? null : null;
     const serverCommandId = commandPref && commandPref !== CUSTOM_LSP_COMMAND_ID ? commandPref : null;
     const customServerCommand = presetId && commandPref === CUSTOM_LSP_COMMAND_ID
       ? customServerCommandFromConfig(customCommands[presetId])
       : null;
-    const configuredJavaHome = javaHome.trim() || null;
+    return {
+      workspaceId: workspaceInstanceId,
+      rootPath,
+      filePath,
+      documentUri,
+      serverCommandId,
+      customServerCommand,
+      javaHome: javaHome.trim() || null,
+    };
+  }, [commandPrefs, customCommands, javaHome, workspaceInstanceId]);
+
+  const descriptorForFile = useCallback((file: OpenFileState): LspDocumentDescriptor | null => {
+    // Library sources (jdt:// JDK / JAR classes) have no file of their own: keep the
+    // origin project's path so the request lands on that project's session, and let
+    // the server resolve the class from the virtual URI.
+    if (file.library) {
+      return descriptorForPath(
+        file.library.originRootPath,
+        file.library.originFilePath,
+        file.library.uri,
+      );
+    }
     if (file.ref.kind === "root") {
       const rootId = file.ref.rootId;
       const root = rootsRef.current.find((candidate) => candidate.id === rootId);
       if (!root) return null;
-      return {
-        workspaceId: workspaceInstanceId,
-        rootPath: root.path,
-        filePath: file.ref.path,
-        serverCommandId,
-        customServerCommand,
-        javaHome: configuredJavaHome,
-      };
+      return descriptorForPath(root.path, file.ref.path);
     }
-    return {
-      workspaceId: workspaceInstanceId,
-      rootPath: null,
-      filePath: file.ref.path,
-      serverCommandId,
-      customServerCommand,
-      javaHome: configuredJavaHome,
-    };
-  }, [commandPrefs, customCommands, javaHome, workspaceInstanceId]);
+    return descriptorForPath(null, file.ref.path);
+  }, [descriptorForPath]);
 
   const updateStatus = useCallback((file: OpenFileState, status: LspDocumentStatus) => {
     if (!mountedRef.current) return;
@@ -302,6 +322,8 @@ export function useWorkspaceLspSession({
   }, [updateLspFiles]);
 
   const refreshDiagnostics = useCallback(async (file: OpenFileState) => {
+    // Library sources are never opened on the server, so they publish no diagnostics.
+    if (file.library) return;
     const descriptor = descriptorForFile(file);
     if (!descriptor) return;
     try {
@@ -375,6 +397,8 @@ export function useWorkspaceLspSession({
 
   const syncDocument = useCallback(async (file: OpenFileState, mode: "open" | "change") => {
     if (file.loading) return;
+    // Library sources are owned by the server, not by us: no didOpen/didChange.
+    if (file.library) return;
     // No language-server preset for this extension → never open an IPC path.
     if (!lspPresetIdForPath(file.languagePath)) return;
     // didChange without an active session (and not mid-open) is a no-op.
@@ -539,6 +563,7 @@ export function useWorkspaceLspSession({
   }, [descriptorForFile, openFilesRef, scheduleDiagnostics, updateLspFiles]);
 
   const saveDocument = useCallback(async (file: OpenFileState, text: string) => {
+    if (file.library) return;
     const descriptor = descriptorForFile(file);
     if (!descriptor) return;
     try {
@@ -586,7 +611,8 @@ export function useWorkspaceLspSession({
       queue.pending = null;
       delete syncQueuesRef.current[file.key];
     }
-    const descriptor = descriptorForFile(file);
+    // Never opened by us (library source) → nothing to close on the server.
+    const descriptor = file.library ? null : descriptorForFile(file);
     if (descriptor) void lspCloseDocument(descriptor);
     forgetDocument(file.key);
   }, [descriptorForFile, forgetDocument]);
@@ -599,6 +625,7 @@ export function useWorkspaceLspSession({
     updateCommandPref,
     updateCustomCommand,
     descriptorForFile,
+    descriptorForPath,
     isDocumentSynced,
     syncDocument,
     saveDocument,

--- a/src/components/editor/workspace/useWorkspaceNavigation.ts
+++ b/src/components/editor/workspace/useWorkspaceNavigation.ts
@@ -281,13 +281,15 @@ export function useWorkspaceNavigation({
   const openRecentFiles = useCallback(() => {
     const entries: RecentFileEntry[] = recentFilesRef.current.map((ref) => {
       const key = fileKey(ref);
+      const open = openFilesRef.current?.[key];
       const meta = fileMeta(ref, rootsRef.current ?? [], looseFilesRef.current ?? []);
       return {
         key,
         ref,
-        title: meta.title,
-        subtitle: meta.subtitle,
-        open: !!openFilesRef.current?.[key],
+        // Open buffers carry their own labels; library sources have no path to derive them from.
+        title: open?.title || meta.title,
+        subtitle: open?.subtitle || meta.subtitle,
+        open: !!open,
       };
     });
     setRecentEntries(entries);

--- a/src/lib/editor/lsp.ts
+++ b/src/lib/editor/lsp.ts
@@ -136,6 +136,8 @@ export interface LspUriContentsResult {
   uri: string;
   path: string | null;
   title: string;
+  /** Package · jar/module label for the tab subtitle. */
+  container: string | null;
   languageId: string;
   text: string;
   readOnly: boolean;
@@ -207,6 +209,12 @@ export interface LspDocumentDescriptor {
   workspaceId: string;
   rootPath?: string | null;
   filePath: string;
+  /**
+   * Virtual document URI to request instead of `filePath`'s own file URI, used by
+   * library buffers (JDK / dependency `jdt://` sources). `filePath` still selects
+   * the language-server session, so it must point at a file in the origin project.
+   */
+  documentUri?: string | null;
   languageId?: string | null;
   serverCommandId?: string | null;
   customServerCommand?: LspCustomServerCommand | null;
@@ -219,6 +227,7 @@ function documentArgs(descriptor: LspDocumentDescriptor) {
     workspaceId: descriptor.workspaceId,
     rootPath: descriptor.rootPath ?? null,
     filePath: descriptor.filePath,
+    documentUri: descriptor.documentUri?.trim() || null,
     languageId: descriptor.languageId ?? null,
     serverCommandId: descriptor.serverCommandId ?? null,
     customServerCommand: descriptor.customServerCommand ?? null,

--- a/src/stubs/tauri-core.ts
+++ b/src/stubs/tauri-core.ts
@@ -1443,6 +1443,7 @@ export async function invoke<T>(cmd: string, args?: any, options?: InvokeOptions
         uri,
         path: null,
         title: title.endsWith(".class") ? title.replace(/\.class$/, ".java") : title,
+        container: uri.split("/").slice(-3, -1).reverse().join(" · ") || null,
         languageId: "java",
         text: `// Stub library source for ${uri}\n`,
         readOnly: true,


### PR DESCRIPTION
… classes

Ctrl+click / F12 on a JDK type or a class from a third-party JAR resolved to nothing, while same-project targets jumped fine. Root cause was in the jdtls handshake, not the frontend: Eclipse JDT LS drops every definition/reference that resolves into a `.class` file unless the client declares `classFileContentsSupport`. JDTUtils#toUri(IClassFile) returns null without it, so textDocument/definition answered with an empty location list and the editor showed "No definition found". The jdt:// read path added previously was correct but never received a jdt:// location to act on.

Backend (lsp.rs)
- Declare extendedClientCapabilities.classFileContentsSupport in the jdtls initialize options. This unblocks jdt:// locations for JDK/JAR classes, and also widens workspace/symbol scope to application/system libraries and enables decompiled-source lookups.
- Thread an optional document_uri through definition / typeDefinition / implementation / references / hover / documentSymbol. Library sources have no project of their own, so requests keep the origin file's path (to select the session + SDK) while targeting the jdt:// URI as the document. jdtls resolves the class from the URI handle, so no didOpen is required.
- lsp_read_uri_contents now returns a `container` label (e.g. "java.lang · java.base" or "org.apache.commons.lang3 · commons-lang3-3.12.0.jar") for the tab subtitle, and treats empty class contents as an actionable error (attach a sources JAR or install a decompiler) instead of a silent success.

Frontend
- Model library buffers as a first-class read-only OpenFile with a `library` descriptor (uri + origin file/root). Keyed by URI so same-named classes from different packages never collide; not registered as loose workspace files so the project tree stays clean.
- Editor uses EditorState.readOnly for library buffers: caret, selection, search, and Ctrl+click navigation all keep working, only edits are rejected (IDEA decompiled-source behaviour). Save / reload / local history / reveal in explorer / open in terminal report a clear "read-only library source" message instead of acting on a fake path.
- LSP session hook routes library buffers through the origin project's session via descriptorForPath and never issues didOpen/didChange/didSave/diagnostics for them; go-to-definition from inside a library buffer works the same way.
- Closed library tabs stay in a registry so Navigate Back / Recent Files re-fetch their contents from jdtls; they are excluded from the persisted layout snapshot since a live server cannot restore them on next launch.
- Fix a related path: workspace-symbol hits that fall back to a URI when the server reports no path used to be read from disk (opening a broken jdt:// tab); looksLikeDocumentUri now routes them through the URI content channel.
- Breadcrumbs show the library container (package · jar/module) instead of splitting the URI into junk segments.

Tests
- Rust: classFileContentsSupport asserted in the initialize options, container_from_class_uri for jdt/jar URIs, with_document_uri override rules.
- TS: tab-level go-to-definition opening a JDK class as a read-only buffer plus a second jump from inside it, CodeMirror read-only rejects edits but keeps navigation, LSP session library routing skips didOpen/save/close, makeLibraryFile / libraryLanguagePath / looksLikeDocumentUri unit coverage.

tsc -b clean; vitest 1608 passing; cargo test --lib lsp:: 39 passing. Not yet exercised against a live jdtls (no Java project on hand). Note: the capability is sent at initialize, so a running jdtls session must be restarted to take effect.