### PR TITLE
fix(ci): repair SocksCap release gates on Linux and Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,11 +175,59 @@ jobs:
           cargo test --manifest-path src-tauri/Cargo.toml --lib sockscap::capture::linux
           bash scripts/stage-sockscap-linux.sh --check
 
+      - name: Fetch WinDivert redistributable (Windows)
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $dest = "src-tauri/resources/sockscap/windows"
+          New-Item -ItemType Directory -Force -Path $dest | Out-Null
+          if (Test-Path (Join-Path $dest "WinDivert.dll")) {
+            Write-Host "WinDivert already present in $dest, skipping download."
+            exit 0
+          }
+          # WinDivert redistributable (LGPLv3/GPLv2) — loaded dynamically by the
+          # elevated helper only. reqrypt.org is canonical; GitHub release is a mirror.
+          $version = "2.2.2"
+          $zip = Join-Path $env:RUNNER_TEMP "WinDivert-$version-A.zip"
+          $extract = Join-Path $env:RUNNER_TEMP "WinDivert-extract"
+          $urls = @(
+            "https://reqrypt.org/download/WinDivert-$version-A.zip",
+            "https://github.com/basil00/WinDivert/releases/download/v$version/WinDivert-$version-A.zip"
+          )
+          $ok = $false
+          foreach ($url in $urls) {
+            for ($i = 1; $i -le 3; $i++) {
+              try {
+                Write-Host "Downloading $url (attempt $i)..."
+                Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+                $ok = $true; break
+              } catch {
+                Write-Warning "Download failed: $($_.Exception.Message)"
+                Start-Sleep -Seconds 5
+              }
+            }
+            if ($ok) { break }
+          }
+          if (-not $ok) { throw "Unable to download WinDivert $version from any mirror." }
+          if (Test-Path $extract) { Remove-Item -Recurse -Force $extract }
+          Expand-Archive -Path $zip -DestinationPath $extract -Force
+          $x64 = Join-Path $extract "WinDivert-$version-A\x64"
+          Copy-Item -Force (Join-Path $x64 "WinDivert.dll") $dest
+          Copy-Item -Force (Join-Path $x64 "WinDivert64.sys") $dest
+          Write-Host "WinDivert $version staged into ${dest}:"
+          Get-ChildItem $dest | Select-Object Name, Length
+
       - name: Verify Windows SocksCap helper and preflight
         if: matrix.platform == 'windows-latest'
+        shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
+          # Make each native command's non-zero exit fatal so a failing test can't be
+          # masked by a later command's exit code (default pwsh only checks the last).
+          $PSNativeCommandUseErrorActionPreference = $true
           pwsh scripts/stage-sockscap-windows.ps1
-          cargo test --manifest-path src-tauri/Cargo.toml --lib sockscap::policy sockscap::config
+          cargo test --manifest-path src-tauri/Cargo.toml --lib -- sockscap::policy sockscap::config
           pwsh scripts/stage-sockscap-windows.ps1 --check
 
       - name: Resolve release version

--- a/src-tauri/src/sockscap/capture/linux/pid_filter.rs
+++ b/src-tauri/src/sockscap/capture/linux/pid_filter.rs
@@ -111,10 +111,11 @@ mod tests {
     #[test]
     fn handles_symlink_selectors_correctly() {
         let target = std::env::current_exe().unwrap();
-        let symlink = target.with_file_name("grok-symlink");
-        // Simulate symlink selector
-        std::fs::copy(&target, &symlink).unwrap();
-        // On Linux, we can make it a symlink
+        // Use a per-test-process unique name so parallel/repeated runs never collide.
+        let symlink = target.with_file_name(format!("grok-symlink-{}", std::process::id()));
+        // Clear any stale entry from a previous aborted run before creating the symlink.
+        let _ = std::fs::remove_file(&symlink);
+        // A selector pointing at a symlink of the process's real exe must still match.
         std::os::unix::fs::symlink(&target, &symlink).unwrap();
         assert!(selector_matches_process_path(
             target.to_str().unwrap(),


### PR DESCRIPTION
Three independent failures blocked the Release Bundle workflow:

- Linux: pid_filter symlink test copied a file then tried to symlink the same path, failing with EEXIST. Drop the copy, use a per-process-unique name, and remove any stale entry before creating the symlink.
- Windows: `cargo test` rejected two positional filters (`sockscap::policy sockscap::config`); move both after `--` so libtest applies them as OR filters.
- Windows: WinDivert.dll (gitignored, LGPLv3/GPLv2) was no longer provisioned after the old install script was removed, so the preflight `--check` failed. Add a Fetch WinDivert step (reqrypt.org + GitHub mirror, retries) that stages it into resources/sockscap/windows before verify and bundling. Also set $PSNativeCommandUseErrorActionPreference so a failing test can no longer be masked by a later command's exit code.