### PR TITLE
fix(ci): make beforeBundleCommand cross-platform for Windows bundling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 /.gitattributes text eol=lf
 src-tauri/Cargo.toml text eol=lf
+# Shell hooks run via git-bash on the Windows CI runner; CRLF breaks them.
+*.sh text eol=lf

--- a/scripts/before-bundle.sh
+++ b/scripts/before-bundle.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Tauri beforeBundleCommand dispatcher (runs post-compile, pre-bundle).
+#
+# Tauri runs beforeBundleCommand through the *platform* shell: /bin/sh on
+# macOS/Linux, but cmd.exe on Windows. Inline POSIX `if`/`[ ]`/`$(...)` syntax
+# therefore breaks on Windows — cmd.exe reports `"$(uname -s)" was unexpected
+# at this time.` and fails the bundle. Keeping this a single
+# `bash scripts/before-bundle.sh` invocation means cmd.exe only ever sees one
+# program name, and all platform branching happens here in bash (git-bash is
+# available on the Windows CI runner, same as the other bash-based hooks).
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+case "$(uname -s)" in
+  Darwin)
+    # Rewrite the compiled binary's krb5 load commands to @rpath + re-sign.
+    bash scripts/bundle-krb5-macos.sh fixbin
+    ;;
+  Linux)
+    bash scripts/stage-sockscap-linux.sh --check
+    ;;
+  MINGW* | MSYS* | CYGWIN* | Windows_NT)
+    pwsh -File scripts/stage-sockscap-windows.ps1 --check
+    ;;
+  *)
+    echo "before-bundle: no bundle preflight for $(uname -s), skipping."
+    ;;
+esac

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
     "devUrl": "http://localhost:1980",
     "beforeDevCommand": "bash scripts/bundle-krb5-macos.sh stage && pnpm dev",
     "beforeBuildCommand": "pnpm build && bash scripts/bundle-krb5-macos.sh stage",
-    "beforeBundleCommand": "bash scripts/bundle-krb5-macos.sh fixbin && bash scripts/stage-sockscap-linux.sh --check && if [ \"$(uname -s)\" = \"Windows_NT\" ]; then pwsh -File scripts/stage-sockscap-windows.ps1 --check; fi"
+    "beforeBundleCommand": "bash scripts/before-bundle.sh"
   },
   "app": {
     "withGlobalTauri": true,


### PR DESCRIPTION
Tauri runs beforeBundleCommand through the platform shell — /bin/sh on macOS/Linux but cmd.exe on Windows. The inline POSIX guard `if [ "$(uname -s)" = "Windows_NT" ]; then pwsh ... fi` is not valid cmd.exe syntax, so on the Windows runner it failed with `"$(uname -s)" was unexpected at this time.` and aborted `tauri build`. (That guard was also dead on macOS/Linux: uname never reports "Windows_NT", and git-bash reports MINGW*.)

Move the logic into scripts/before-bundle.sh and invoke it as a single `bash scripts/before-bundle.sh` — cmd.exe then only sees one program name, and platform branching happens in bash. macOS/Linux behavior is unchanged (krb5 fixbin / linux sockscap --check); Windows now actually runs the sockscap preflight instead of erroring.

Pin *.sh to eol=lf so a runner defaulting to autocrlf can't inject CRLF that would break git-bash execution.