### PR TITLE
fix(sftp): recover dropped SFTP sessions instead of wedging on "sessi…

### DIFF
--- a/src-tauri/src/filebrowser/sftp.rs
+++ b/src-tauri/src/filebrowser/sftp.rs
@@ -46,25 +46,67 @@ pub struct FileEntryDto {
     pub group: Option<String>,
 }
 
+/// Everything needed to re-establish a dropped SFTP session without any
+/// frontend round-trip. Auth credentials were already resolved to plaintext
+/// (vault refs dereferenced, proxy/jump creds filled in) by `sftp_attach`
+/// before `open_sftp` was called, so a reconnect can reuse them verbatim.
+struct ReconnectParams {
+    host: String,
+    port: u16,
+    username: String,
+    auth: SshAuth,
+    /// Effective network settings (keep-alive already forced on — see
+    /// `network_with_keepalive`).
+    network: NetworkSettings,
+}
+
 pub struct ActiveSftp {
     pub sftp: Arc<Mutex<SftpSession>>,
     pub home: String,
     /// The parent SSH handle is kept alive for the lifetime of the SFTP
-    /// session: dropping it would close the underlying connection.
-    pub _handle: client::Handle<SshHandler>,
+    /// session: dropping it would close the underlying connection. Held in a
+    /// `Mutex` so `reconnect` can swap in a fresh handle after the old
+    /// connection dies.
+    _handle: Mutex<client::Handle<SshHandler>>,
+    /// Credentials + endpoint for transparent reconnect. `None` disables
+    /// auto-reconnect (not currently used, but keeps the door open for
+    /// sessions where re-auth would need a human, e.g. an agent-only setup).
+    reconnect: Option<ReconnectParams>,
+    /// Serializes reconnect attempts so a burst of failing operations triggers
+    /// a single re-handshake rather than a thundering herd.
+    reconnect_lock: Mutex<()>,
 }
 
-pub async fn open_sftp(
-    host: &str,
-    port: u16,
-    username: &str,
-    auth: SshAuth,
-    network: Option<&NetworkSettings>,
+/// Force an SSH keep-alive onto SFTP connections. An idle SFTP channel with no
+/// keep-alive is silently reaped by server-side idle timeouts / NAT / firewalls;
+/// when that happens every later operation fails with "session closed". A
+/// periodic keep-alive keeps the channel warm. Respects an explicit user
+/// interval when one is set; otherwise defaults to 30s.
+fn network_with_keepalive(network: Option<&NetworkSettings>) -> NetworkSettings {
+    let mut n = network.cloned().unwrap_or_default();
+    n.keep_alive = true;
+    if n.keep_alive_interval_secs == 0 {
+        n.keep_alive_interval_secs = 30;
+    }
+    n
+}
+
+/// Open one SSH connection, request the sftp subsystem, and complete the SFTP
+/// handshake. Returns the live session plus the handle that owns the
+/// connection's lifetime. Shared by the initial attach and every reconnect.
+async fn connect_sftp(
+    params: &ReconnectParams,
     prompter: Option<&KbdInteractivePrompter>,
-) -> Result<ActiveSftp, String> {
-    let handle =
-        connect_ssh_authenticated_with_prompter(host, port, username, auth, network, prompter)
-            .await?;
+) -> Result<(SftpSession, client::Handle<SshHandler>), String> {
+    let handle = connect_ssh_authenticated_with_prompter(
+        &params.host,
+        params.port,
+        &params.username,
+        params.auth.clone(),
+        Some(&params.network),
+        prompter,
+    )
+    .await?;
     let channel = handle
         .channel_open_session()
         .await
@@ -77,6 +119,44 @@ pub async fn open_sftp(
     let sftp = SftpSession::new(channel.into_stream())
         .await
         .map_err(|e| format!("SFTP handshake failed: {}", e))?;
+    Ok((sftp, handle))
+}
+
+/// True when an error string indicates the transport died (dropped connection,
+/// closed channel, EOF, timeout) rather than a normal per-file failure like
+/// "No such file" or "Permission denied". Used to decide whether an operation
+/// is worth retrying after a reconnect. Kept deliberately conservative so we
+/// never loop on a genuine, reproducible error.
+pub(crate) fn is_disconnect_error(err: &str) -> bool {
+    let e = err.to_lowercase();
+    e.contains("session closed")
+        || e.contains("sender dropped")
+        || e.contains("connection closed")
+        || e.contains("connection reset")
+        || e.contains("channel closed")
+        || e.contains("broken pipe")
+        || e.contains("unexpected eof")
+        || e.contains("not connected")
+        || e.contains("timeout")
+        || e.contains("timed out")
+}
+
+pub async fn open_sftp(
+    host: &str,
+    port: u16,
+    username: &str,
+    auth: SshAuth,
+    network: Option<&NetworkSettings>,
+    prompter: Option<&KbdInteractivePrompter>,
+) -> Result<ActiveSftp, String> {
+    let params = ReconnectParams {
+        host: host.to_string(),
+        port,
+        username: username.to_string(),
+        auth,
+        network: network_with_keepalive(network),
+    };
+    let (sftp, handle) = connect_sftp(&params, prompter).await?;
 
     let home = sftp
         .canonicalize(".")
@@ -86,12 +166,79 @@ pub async fn open_sftp(
     Ok(ActiveSftp {
         sftp: Arc::new(Mutex::new(sftp)),
         home,
-        _handle: handle,
+        _handle: Mutex::new(handle),
+        reconnect: Some(params),
+        reconnect_lock: Mutex::new(()),
     })
 }
 
+/// Run an `ActiveSftp` operation, and if it fails because the transport died,
+/// reconnect once and retry it. `$op` is re-evaluated verbatim after the
+/// reconnect, so it must be a self-contained call (a `*_once` helper) — no `?`
+/// may escape into the surrounding function between the two attempts.
+macro_rules! retry_reconnect {
+    ($self:ident, $op:expr) => {{
+        match $op {
+            Err(e) if is_disconnect_error(&e) => {
+                tracing::warn!("SFTP operation failed ({e}); attempting reconnect");
+                match $self.reconnect().await {
+                    Ok(()) => $op,
+                    // Reconnect failed (e.g. the server demands an interactive
+                    // second factor we can't answer here). Surface the original
+                    // transport error, not the handshake error: it's the true
+                    // cause and reliably drives the frontend's reconnect banner,
+                    // where a human can re-auth.
+                    Err(reconnect_err) => {
+                        tracing::warn!("SFTP reconnect failed: {reconnect_err}");
+                        Err(e)
+                    }
+                }
+            }
+            other => other,
+        }
+    }};
+}
+
 impl ActiveSftp {
+    /// Re-establish the SSH + SFTP connection in place after it dropped. Swaps
+    /// a fresh session and handle into the existing `Mutex`es, so every
+    /// outstanding `Arc<Mutex<SftpSession>>` clone keeps working transparently.
+    /// Serialized by `reconnect_lock`; callers that queue behind a winning
+    /// attempt re-probe and skip the redundant handshake.
+    ///
+    /// Auto-reconnect runs without a keyboard-interactive prompter, so a server
+    /// that demands an interactive second factor (MFA) on every login fails
+    /// here and falls back to the frontend's manual reconnect, which re-prompts.
+    async fn reconnect(&self) -> Result<(), String> {
+        let params = self
+            .reconnect
+            .as_ref()
+            .ok_or("SFTP session is not reconnectable")?;
+        let _guard = self.reconnect_lock.lock().await;
+        // A prior waiter may have healed the session while we queued on the
+        // lock. Probe cheaply; if it responds now, skip the re-handshake.
+        if self
+            .sftp
+            .lock()
+            .await
+            .canonicalize(".".to_string())
+            .await
+            .is_ok()
+        {
+            return Ok(());
+        }
+        let (sftp, handle) = connect_sftp(params, None).await?;
+        *self.sftp.lock().await = sftp;
+        *self._handle.lock().await = handle;
+        tracing::info!("SFTP session reconnected to {}:{}", params.host, params.port);
+        Ok(())
+    }
+
     pub async fn list_dir(&self, path: &str) -> Result<Vec<FileEntryDto>, String> {
+        retry_reconnect!(self, self.list_dir_once(path).await)
+    }
+
+    async fn list_dir_once(&self, path: &str) -> Result<Vec<FileEntryDto>, String> {
         let dir_entries = {
             let sftp = self.sftp.lock().await;
             sftp.read_dir(path.to_string())
@@ -135,6 +282,10 @@ impl ActiveSftp {
     }
 
     pub async fn read_link(&self, path: &str) -> Result<String, String> {
+        retry_reconnect!(self, self.read_link_once(path).await)
+    }
+
+    async fn read_link_once(&self, path: &str) -> Result<String, String> {
         let sftp = self.sftp.lock().await;
         sftp.read_link(path.to_string())
             .await
@@ -142,6 +293,10 @@ impl ActiveSftp {
     }
 
     pub async fn stat(&self, path: &str) -> Result<FileEntryDto, String> {
+        retry_reconnect!(self, self.stat_once(path).await)
+    }
+
+    async fn stat_once(&self, path: &str) -> Result<FileEntryDto, String> {
         let sftp = self.sftp.lock().await;
         let attrs = sftp
             .metadata(path.to_string())
@@ -152,6 +307,10 @@ impl ActiveSftp {
     }
 
     pub async fn mkdir(&self, path: &str) -> Result<(), String> {
+        retry_reconnect!(self, self.mkdir_once(path).await)
+    }
+
+    async fn mkdir_once(&self, path: &str) -> Result<(), String> {
         let sftp = self.sftp.lock().await;
         sftp.create_dir(path.to_string())
             .await
@@ -159,6 +318,10 @@ impl ActiveSftp {
     }
 
     pub async fn remove(&self, path: &str, recursive: bool) -> Result<(), String> {
+        retry_reconnect!(self, self.remove_once(path, recursive).await)
+    }
+
+    async fn remove_once(&self, path: &str, recursive: bool) -> Result<(), String> {
         let sftp = self.sftp.lock().await;
         let attrs = sftp
             .metadata(path.to_string())
@@ -199,6 +362,10 @@ impl ActiveSftp {
     }
 
     pub async fn rename(&self, from: &str, to: &str) -> Result<(), String> {
+        retry_reconnect!(self, self.rename_once(from, to).await)
+    }
+
+    async fn rename_once(&self, from: &str, to: &str) -> Result<(), String> {
         let sftp = self.sftp.lock().await;
         sftp.rename(from.to_string(), to.to_string())
             .await
@@ -206,6 +373,10 @@ impl ActiveSftp {
     }
 
     pub async fn chmod(&self, path: &str, mode: u32) -> Result<(), String> {
+        retry_reconnect!(self, self.chmod_once(path, mode).await)
+    }
+
+    async fn chmod_once(&self, path: &str, mode: u32) -> Result<(), String> {
         let sftp = self.sftp.lock().await;
         let mut attrs = sftp
             .metadata(path.to_string())
@@ -218,6 +389,10 @@ impl ActiveSftp {
     }
 
     pub async fn realpath(&self, path: &str) -> Result<String, String> {
+        retry_reconnect!(self, self.realpath_once(path).await)
+    }
+
+    async fn realpath_once(&self, path: &str) -> Result<String, String> {
         let sftp = self.sftp.lock().await;
         sftp.canonicalize(path.to_string())
             .await
@@ -225,6 +400,10 @@ impl ActiveSftp {
     }
 
     pub async fn read_bytes(&self, path: &str, max_bytes: u64) -> Result<Vec<u8>, String> {
+        retry_reconnect!(self, self.read_bytes_once(path, max_bytes).await)
+    }
+
+    async fn read_bytes_once(&self, path: &str, max_bytes: u64) -> Result<Vec<u8>, String> {
         let (size, mut file) = {
             let sftp = self.sftp.lock().await;
             let attrs = sftp
@@ -252,6 +431,10 @@ impl ActiveSftp {
     }
 
     pub async fn write_bytes(&self, path: &str, data: &[u8]) -> Result<(), String> {
+        retry_reconnect!(self, self.write_bytes_once(path, data).await)
+    }
+
+    async fn write_bytes_once(&self, path: &str, data: &[u8]) -> Result<(), String> {
         let mut file = {
             let sftp = self.sftp.lock().await;
             sftp.open_with_flags(
@@ -818,5 +1001,55 @@ fn remote_basename(path: &str) -> &str {
     match trimmed.rsplit_once('/') {
         Some((_, name)) => name,
         None => trimmed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disconnect_errors_are_classified_for_retry() {
+        // The exact string from issue #425 (russh-sftp UnexpectedBehavior,
+        // wrapped by list_dir's "Failed to read {path}: {e}").
+        assert!(is_disconnect_error(
+            "Failed to read /data/users/x/scripts: session closed"
+        ));
+        assert!(is_disconnect_error("sender dropped"));
+        assert!(is_disconnect_error("Unexpected EOF on stream"));
+        assert!(is_disconnect_error("connection reset by peer"));
+        assert!(is_disconnect_error("Broken pipe"));
+        assert!(is_disconnect_error("Timeout"));
+    }
+
+    #[test]
+    fn genuine_file_errors_are_not_retried() {
+        assert!(!is_disconnect_error("stat /x: No such file or directory"));
+        assert!(!is_disconnect_error("mkdir /x: Permission denied"));
+        assert!(!is_disconnect_error("File is 999 bytes, exceeds preview limit"));
+    }
+
+    #[test]
+    fn keepalive_is_forced_on_for_sftp() {
+        // No settings at all → synthesize a keep-alive.
+        let n = network_with_keepalive(None);
+        assert!(n.keep_alive);
+        assert_eq!(n.keep_alive_interval_secs, 30);
+
+        // keep_alive on but interval unset (the Rust default) → fill a default.
+        let mut base = NetworkSettings::default();
+        base.keep_alive = true;
+        base.keep_alive_interval_secs = 0;
+        let n = network_with_keepalive(Some(&base));
+        assert_eq!(n.keep_alive_interval_secs, 30);
+
+        // Explicit user interval is preserved.
+        base.keep_alive_interval_secs = 60;
+        let n = network_with_keepalive(Some(&base));
+        assert_eq!(n.keep_alive_interval_secs, 60);
+
+        // A synthesized default must not accidentally select a proxy.
+        let n = network_with_keepalive(None);
+        assert!(n.proxy_kind.is_empty() || n.proxy_kind == "none");
     }
 }

--- a/src-tauri/src/terminal/ssh.rs
+++ b/src-tauri/src/terminal/ssh.rs
@@ -97,6 +97,7 @@ impl client::Handler for SshHandler {
     }
 }
 
+#[derive(Clone)]
 pub enum SshAuth {
     Password(String),
     PrivateKey(String),

--- a/src/stores/sftpStore.test.ts
+++ b/src/stores/sftpStore.test.ts
@@ -126,6 +126,23 @@ describe("sftpStore", () => {
     expect(s.remote.error).toBe("socket closed");
   });
 
+  it("escalates 'session closed' (russh-sftp dropped transport) to session level error", async () => {
+    // Regression for #425: a dropped SFTP transport surfaces as
+    // "Failed to read <path>: session closed". Previously this did not match
+    // isConnectionError, so no reconnect banner appeared and the pane stayed
+    // wedged on every click.
+    vi.mocked(sftpListRemote).mockRejectedValue(
+      new Error("Failed to read /data/users/x/scripts: session closed"),
+    );
+
+    await useSftpStore.getState().navigate("sid", "remote", "/some/path");
+
+    const s = useSftpStore.getState().sessions.sid;
+    expect(s.attached).toBe(false);
+    expect(s.error).toContain("session closed");
+    expect(s.remote.error).toContain("session closed");
+  });
+
   it("does not escalate non-connection errors on remote navigation", async () => {
     vi.mocked(sftpListRemote).mockRejectedValue(new Error("Permission denied"));
 

--- a/src/stores/sftpStore.ts
+++ b/src/stores/sftpStore.ts
@@ -173,8 +173,15 @@ export function isConnectionError(err: unknown): boolean {
     msg.includes("connection closed") ||
     msg.includes("socket closed") ||
     msg.includes("channel closed") ||
+    // russh-sftp raises this once its background I/O task ends (dropped
+    // connection / idle timeout); the backend attempts a transparent
+    // reconnect, but if that fails we still want the reconnect banner.
+    msg.includes("session closed") ||
+    msg.includes("sender dropped") ||
     msg.includes("broken pipe") ||
+    msg.includes("connection reset") ||
     msg.includes("not attached") ||
+    msg.includes("not connected") ||
     msg.includes("ssh error") ||
     msg.includes("io error") ||
     msg.includes("timed out") ||


### PR DESCRIPTION
…on closed"

Fixes #425 — SFTP 报错 "Failed to read <path>: session closed"，之后不管 点哪里都失败，只能关掉重开标签页。

## 根因

SFTP 走的是一条独立于终端的 SSH 连接（sftp_attach -> open_sftp）， 单条长连接存在 state.sftp_sessions 里复用。当这条连接空闲被对端 /
中间设备（服务器 idle timeout、NAT、防火墙）回收后：

- russh-sftp 后台 I/O 任务读到 UnexpectedEof 退出，写半边随之取消， 内部 tx 关闭。此后任何一次操作在 rawsession.rs 里都直接返回 UnexpectedBehavior("session closed")（该 variant Display 无前缀， 故最终呈现为 "...: session closed"，与 issue 截图一致）。
- 后端 get_session 只是从 map 里 clone 出这条已死的会话，没有存活 检测、没有重连，于是每次 sftp_list_remote 都复现同一错误。
- 前端 isConnectionError 的匹配白名单里没有 "session closed" （只有 channel/connection/socket closed 等），因此不会把会话标记为 detached、不设置 session.error、attached 仍为 true —— 重连横幅与 重试按钮都不出现，UI 以为一切正常，用户每点一次目录就再撞一次死 会话。这正是“不管点哪里都不行”的直接原因。

## 修复（三层，防御 + 自愈 + 兜底）

1. 后端透明重连（src-tauri/src/filebrowser/sftp.rs）
   - ActiveSftp 保存重连所需参数（host/port/user/auth/network，凭据在 attach 阶段已解析为明文），SSH handle 改放进 Mutex 以便原地替换。
   - 新增 reconnect()：用存好的参数重跑 SSH+SFTP 握手，把新的 session / handle 原地换进现有 Arc<Mutex<>>，所有持有克隆的调用方无感知继续 工作。用 reconnect_lock 串行化；排队者先用 canonicalize(".") 轻量 探活，若已被前一个赢家治愈则跳过重复握手。
   - 新增 retry_reconnect! 宏，包裹交互路径方法（list_dir / stat / read_link / realpath / mkdir / remove / rename / chmod / read_bytes / write_bytes）：命中传输层错误时重连一次并重试。 is_disconnect_error() 保守判定（session closed / sender dropped / eof / connection reset / broken pipe / timeout 等），确保绝不会 在 "No such file" / "Permission denied" 这类真实错误上空转。
   - 自动重连失败时（例如服务器每次登录都要交互式 MFA），宏返回“原始” 的传输错误而非握手错误 —— 它才是真因，且能可靠触发前端重连横幅， 交由人工重新认证。

2. 默认给 SFTP 连接打开 keepalive（同文件 network_with_keepalive）
   - 空闲的 SFTP 通道没有 keepalive 时会被服务器/NAT/防火墙静默回收， 这是本 bug 的诱因。此处强制打开 keepalive（默认 30s，尊重用户 显式设置的间隔），把连接“焐热”，从源头减少掉线。这是预防层， reconnect 是恢复层。

3. 前端兜底（src/stores/sftpStore.ts）
   - isConnectionError 增加 session closed / sender dropped / connection reset / not connected 匹配。即便后端自愈失败，会话也会 被标记 detached，重连横幅与重试按钮照常出现。

## 取舍与边界

- 自动重连复用缓存凭据且不带 prompter，故“每次登录都需交互式 MFA”的 服务器不会自愈，会优雅降级到前端手动重连按钮（该路径会重新弹出认证）。
- 重连重试只覆盖交互/元数据/轻量写操作；长传输在传输中掉线仍会失败 （由用户重试），但其内部的 list_dir / dir_size 已受覆盖。
- 网络黑洞（相对于干净关闭）场景下，探活可能等到 ~10s SFTP 请求超时 后才重连；keepalive 让这种情况变得少见。

## 测试

- Rust 新增 3 个单测：is_disconnect_error 分类、真实文件错误不重试、 network_with_keepalive 强制 keepalive 且不误选代理。cargo check --lib / --tests 通过（仅存量 warning）。
- 前端 5 个测试通过，含一条复现 #425 精确错误串的回归用例，断言会话 升级为 detached 并出现横幅。
- 未在真实“掉线服务器”上做端到端验证；重连/重试路径由逻辑级单测 + 干净编译覆盖，真实 idle-timeout 服务器的端到端行为仍需 GUI 手验。

变更文件：
- src-tauri/src/terminal/ssh.rs：SshAuth 加 #[derive(Clone)]（重连需复用）
- src-tauri/src/filebrowser/sftp.rs：重连 + keepalive + 重试宏 + 单测
- src/stores/sftpStore.ts：isConnectionError 扩充
- src/stores/sftpStore.test.ts：#425 回归用例