### PR TITLE
feat(dap): mature Java debugging to IDEA parity — resume/output/verif…

### DIFF
--- a/src-tauri/src/dap.rs
+++ b/src-tauri/src/dap.rs
@@ -451,6 +451,12 @@ pub async fn dap_start_session(
     tokio::spawn(run_reader(reader, pending, session_id.clone(), emit));
 
     // DAP handshake: initialize, then hand the launch/attach config to the adapter.
+    // `supportsConfigurationDoneRequest: true` is REQUIRED — without it, adapters
+    // (java-debug) do not wait for `configurationDone` and resume the debuggee
+    // immediately after launch, so breakpoints set after the `initialized` event
+    // are armed too late and never hit. `supportsRunInTerminalRequest: false`:
+    // we do not implement the `runInTerminal` reverse request, so adapters must
+    // launch the debuggee themselves (console: internalConsole).
     let init = session
         .request(
             "initialize",
@@ -461,7 +467,11 @@ pub async fn dap_start_session(
                 "linesStartAt1": true,
                 "columnsStartAt1": true,
                 "pathFormat": "path",
-                "supportsRunInTerminalRequest": true,
+                "supportsConfigurationDoneRequest": true,
+                "supportsRunInTerminalRequest": false,
+                // Ask adapters to include `type` on variables/evaluate results
+                // (the variables view shows it as a tooltip).
+                "supportsVariableType": true,
             }),
         )
         .await?;

--- a/src-tauri/src/java_debug_adapter.rs
+++ b/src-tauri/src/java_debug_adapter.rs
@@ -135,13 +135,28 @@ fn build_launch_arguments(
         "projectName": project_name,
         "modulePaths": modulepaths,
         "classPaths": classpaths,
-        "console": cfg.get("console").and_then(Value::as_str).unwrap_or("integratedTerminal"),
+        // internalConsole: java-debug launches the debuggee itself and streams
+        // stdout/stderr via `output` events. We do NOT use integratedTerminal
+        // because that requires answering the `runInTerminal` reverse request,
+        // which the DAP kernel does not implement (see initialize capabilities).
+        "console": cfg.get("console").and_then(Value::as_str).unwrap_or("internalConsole"),
     });
     // Optional passthroughs from the caller.
     for key in ["args", "vmArgs", "cwd", "env", "noDebug", "stepFilters"] {
         if let Some(value) = cfg.get(key) {
             args[key] = value.clone();
         }
+    }
+    // IDEA-like stepping defaults when the caller does not override: step-into
+    // skips JDK internals, synthetic/bridge methods, and static initializers
+    // ("$JDK" is java-debug's magic token for the JDK class set).
+    if args.get("stepFilters").is_none() {
+        args["stepFilters"] = json!({
+            "skipClasses": ["$JDK"],
+            "skipSynthetics": true,
+            "skipStaticInitializers": true,
+            "skipConstructors": false,
+        });
     }
     if let Some(java_exec) = java_exec.filter(|s| !s.is_empty()) {
         args["javaExec"] = json!(java_exec);
@@ -300,8 +315,22 @@ mod tests {
         assert_eq!(args["vmArgs"], "-Xmx1g");
         assert_eq!(args["cwd"], "/repo");
         assert_eq!(args["javaExec"], "/jdk/bin/java");
-        // Default console when unset.
-        assert_eq!(args["console"], "integratedTerminal");
+        // Default console when unset: internalConsole (the kernel does not
+        // implement the `runInTerminal` reverse request).
+        assert_eq!(args["console"], "internalConsole");
+    }
+
+    #[test]
+    fn defaults_idea_like_step_filters_and_honors_overrides() {
+        let args = build_launch_arguments(&json!({}), "App", "demo", &[], &[], None);
+        assert_eq!(args["stepFilters"]["skipClasses"], json!(["$JDK"]));
+        assert_eq!(args["stepFilters"]["skipSynthetics"], json!(true));
+        assert_eq!(args["stepFilters"]["skipStaticInitializers"], json!(true));
+        assert_eq!(args["stepFilters"]["skipConstructors"], json!(false));
+
+        let cfg = json!({ "stepFilters": { "skipClasses": [], "skipSynthetics": false } });
+        let overridden = build_launch_arguments(&cfg, "App", "demo", &[], &[], None);
+        assert_eq!(overridden["stepFilters"], cfg["stepFilters"]);
     }
 
     #[test]

--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -4739,6 +4739,19 @@ export function CodeWorkspaceTab({
         clientX: request.clientX,
         clientY: request.clientY,
         lspAvailable,
+        // Read through the ref: the debug hook is declared later in this
+        // component, and menu construction happens at click time.
+        debug: (() => {
+          const session = debugRef.current;
+          if (!session?.state || session.state.status === "terminated") return null;
+          return {
+            canRunToCursor: session.state.status === "stopped",
+            runToCursor: () => {
+              const absolute = absolutePathForOpenFile(file);
+              if (absolute) session.runToCursor(normalizeFsPath(absolute), request.position.line + 1);
+            },
+          };
+        })(),
         actions: {
           goToDefinition: () => { void goToDefinition(file, request.position); },
           goToTypeDefinition: () => { void goToTypeDefinition(file, request.position); },
@@ -4763,6 +4776,7 @@ export function CodeWorkspaceTab({
       }),
     );
   }, [
+    absolutePathForOpenFile,
     findReferences,
     formatActiveFile,
     goToDefinition,
@@ -4992,12 +5006,20 @@ export function CodeWorkspaceTab({
   const debugRef = useRef(debug);
   debugRef.current = debug;
   const activeFileAbsPath = activeFile ? absolutePathForOpenFile(activeFile) : null;
+  const debugSessionActive = !!debug.state && debug.state.status !== "terminated";
   const activeDebugBreakpoints = useMemo<DebugBreakpointMarker[]>(() => {
     if (!activeFileAbsPath) return [];
     const key = normalizeFsPath(activeFileAbsPath);
     const list = debug.breakpoints[key] ?? debug.breakpoints[activeFileAbsPath] ?? [];
-    return list.map((bp) => ({ line: bp.line, conditional: !!(bp.condition || bp.logMessage) }));
-  }, [activeFileAbsPath, debug.breakpoints]);
+    const runtime = debug.breakpointRuntime[key] ?? debug.breakpointRuntime[activeFileAbsPath] ?? {};
+    return list.map((bp) => ({
+      line: bp.line,
+      conditional: !!(bp.condition || bp.hitCondition),
+      logpoint: !!bp.logMessage,
+      // Grey out breakpoints the adapter could not bind (only meaningful in-session).
+      verified: !debugSessionActive || runtime[bp.line] !== false,
+    }));
+  }, [activeFileAbsPath, debug.breakpoints, debug.breakpointRuntime, debugSessionActive]);
   const activeDebugCurrentLine = useMemo<number | null>(() => {
     const loc = debug.currentLocation;
     if (!loc || !activeFileAbsPath) return null;
@@ -5021,6 +5043,13 @@ export function CodeWorkspaceTab({
         allowEmpty: true,
       });
       if (condition === null) return; // cancelled
+      const hitCondition = await promptAppDialog({
+        title: `Breakpoint at line ${line}`,
+        label: "Hit count (e.g. 5 breaks on the 5th hit) — blank for none",
+        initialValue: existing?.hitCondition ?? "",
+        allowEmpty: true,
+      });
+      if (hitCondition === null) return;
       const logMessage = await promptAppDialog({
         title: `Breakpoint at line ${line}`,
         label: "Logpoint message (logs instead of breaking; {expr} interpolates) — blank for none",
@@ -5030,6 +5059,7 @@ export function CodeWorkspaceTab({
       if (logMessage === null) return;
       debug.setBreakpointOptions(key, line, {
         condition: condition.trim() || undefined,
+        hitCondition: hitCondition.trim() || undefined,
         logMessage: logMessage.trim() || undefined,
       });
     })();
@@ -5054,13 +5084,28 @@ export function CodeWorkspaceTab({
     setBottomDockOpen(true);
   }, [activeKey, debug, findRoot, lspDescriptorForFile, absolutePathForOpenFile, setBottomDockOpen, setBottomDockTab, workspaceInstanceId]);
 
-  const openDebugFrame = useCallback((frame: DebugStackFrame) => {
+  const openDebugFrame = useCallback((frame: Pick<DebugStackFrame, "path" | "line">) => {
     if (!frame.path) return;
     const ref = problemPathToRef(frame.path);
     if (!ref) return;
     const range = { start: { line: frame.line - 1, character: 0 }, end: { line: frame.line - 1, character: 0 } };
     void openFile(ref).then(() => revealEditorLocation(fileKey(ref), range));
   }, [openFile, problemPathToRef, revealEditorLocation]);
+
+  // IDEA-style: jump to the stopped location (breakpoint hit / step landing)
+  // automatically, once per distinct location.
+  const debugRevealRef = useRef<string | null>(null);
+  useEffect(() => {
+    const loc = debug.currentLocation;
+    if (!loc || debug.state?.status !== "stopped") {
+      debugRevealRef.current = null;
+      return;
+    }
+    const key = `${loc.path}:${loc.line}`;
+    if (debugRevealRef.current === key) return;
+    debugRevealRef.current = key;
+    openDebugFrame({ path: loc.path, line: loc.line });
+  }, [debug.currentLocation, debug.state?.status, openDebugFrame]);
 
   const activeFileDebuggable = !!activeFileIsJava && !!activeFile && activeFile.ref.kind === "root";
 

--- a/src/components/editor/workspace/dapDebugModel.test.ts
+++ b/src/components/editor/workspace/dapDebugModel.test.ts
@@ -1,16 +1,36 @@
 import { describe, expect, it } from "vitest";
 import {
+  appendConsoleLine,
   buildSetBreakpointsArgs,
   currentLocation,
   initialDebugState,
+  markResumed,
+  parseBreakpointEvent,
+  parseEvaluate,
+  parseExceptionInfo,
+  parseSetBreakpointsResponse,
   parseStackFrames,
   parseThreads,
+  reconcileBreakpointLines,
   reduceDebugEvent,
   selectExceptionFilters,
+  sortedBreakpoints,
   stepCommandFor,
+  toAdapterSourcePath,
 } from "./dapDebugModel";
 
 describe("dapDebugModel", () => {
+  it("converts Windows drive paths to lowercase drive + backslashes for the adapter", () => {
+    // java-debug leaves breakpoints unverified unless the source path matches
+    // JDT's native form (lowercase drive + backslashes).
+    expect(toAdapterSourcePath("D:/code/ads/ique/src/App.java")).toBe("d:\\code\\ads\\ique\\src\\App.java");
+    expect(toAdapterSourcePath("C:/Users/x/Main.java")).toBe("c:\\Users\\x\\Main.java");
+  });
+
+  it("leaves POSIX absolute paths unchanged", () => {
+    expect(toAdapterSourcePath("/home/user/project/src/App.java")).toBe("/home/user/project/src/App.java");
+  });
+
   it("maps step actions to DAP commands", () => {
     expect(stepCommandFor("continue")).toBe("continue");
     expect(stepCommandFor("stepOver")).toBe("next");
@@ -19,18 +39,63 @@ describe("dapDebugModel", () => {
     expect(stepCommandFor("pause")).toBe("pause");
   });
 
-  it("builds setBreakpoints args sorted, with condition + logMessage (D5)", () => {
+  it("builds setBreakpoints args sorted, with condition + hitCondition + logMessage", () => {
     const args = buildSetBreakpointsArgs("/repo/src/App.java", [
       { line: 20 },
       { line: 5, condition: " x > 1 " },
       { line: 12, logMessage: "hit {x}" },
+      { line: 8, hitCondition: " 5 " },
     ]);
     expect(args.source).toEqual({ path: "/repo/src/App.java", name: "App.java" });
     expect(args.breakpoints).toEqual([
       { line: 5, condition: "x > 1" },
+      { line: 8, hitCondition: "5" },
       { line: 12, logMessage: "hit {x}" },
       { line: 20 },
     ]);
+  });
+
+  it("parses setBreakpoints responses aligned to the sorted request order", () => {
+    const requested = sortedBreakpoints([{ line: 9 }, { line: 3 }]);
+    const bindings = parseSetBreakpointsResponse(requested, {
+      breakpoints: [
+        { id: 1, verified: true, line: 4 },
+        { id: 2, verified: false },
+      ],
+    });
+    expect(bindings).toEqual([
+      { id: 1, verified: true, line: 4 },
+      { id: 2, verified: false, line: 9 },
+    ]);
+    // Missing/short response arrays leave breakpoints unverified on their line.
+    expect(parseSetBreakpointsResponse(requested, null)).toEqual([
+      { id: null, verified: false, line: 3 },
+      { id: null, verified: false, line: 9 },
+    ]);
+  });
+
+  it("adopts adapter-adjusted breakpoint lines and drops collapsed duplicates", () => {
+    const requested = sortedBreakpoints([{ line: 3, condition: "x" }, { line: 5 }]);
+    // The adapter moved line 3 → 5 (line 3 was not executable): both collapse to 5.
+    const moved = reconcileBreakpointLines(requested, [
+      { id: 1, verified: true, line: 5 },
+      { id: 2, verified: true, line: 5 },
+    ]);
+    expect(moved).toEqual([{ line: 5, condition: "x" }]);
+    // Unverified bindings do not move the breakpoint.
+    const kept = reconcileBreakpointLines(requested, [
+      { id: 1, verified: false, line: 7 },
+      { id: 2, verified: true, line: 5 },
+    ]);
+    expect(kept).toEqual([{ line: 3, condition: "x" }, { line: 5 }]);
+  });
+
+  it("parses breakpoint events (verification changes as classes load)", () => {
+    expect(parseBreakpointEvent({
+      body: { reason: "changed", breakpoint: { id: 7, verified: true, line: 12 } },
+    })).toEqual({ reason: "changed", id: 7, verified: true, line: 12 });
+    expect(parseBreakpointEvent({ body: {} })).toBeNull();
+    expect(parseBreakpointEvent(null)).toBeNull();
   });
 
   it("selects only exception filters the adapter advertises", () => {
@@ -58,11 +123,33 @@ describe("dapDebugModel", () => {
     expect(frames[1].path).toBeNull();
   });
 
-  it("derives the current highlight location from the top frame with a path", () => {
-    expect(currentLocation([
+  it("parses exceptionInfo and evaluate responses", () => {
+    expect(parseExceptionInfo({
+      exceptionId: "java.lang.NullPointerException",
+      description: "boom",
+      details: { stackTrace: "at App.main(App.java:9)" },
+    })).toEqual({
+      exceptionId: "java.lang.NullPointerException",
+      description: "boom",
+      details: "at App.main(App.java:9)",
+    });
+    expect(parseExceptionInfo({})).toBeNull();
+
+    expect(parseEvaluate({ result: "42", variablesReference: 5, type: "int" }))
+      .toEqual({ value: "42", variablesReference: 5, type: "int" });
+    expect(parseEvaluate(null)).toEqual({ value: "", variablesReference: 0, type: null });
+  });
+
+  it("derives the current highlight location from the selected frame, else the top frame", () => {
+    const frames = [
       { id: 1, name: "native", path: null, line: 0, column: 0 },
       { id: 2, name: "App.main", path: "/repo/App.java", line: 9, column: 1 },
-    ])).toEqual({ path: "/repo/App.java", line: 9 });
+      { id: 3, name: "App.run", path: "/repo/Run.java", line: 30, column: 1 },
+    ];
+    expect(currentLocation(frames)).toEqual({ path: "/repo/App.java", line: 9 });
+    expect(currentLocation(frames, 3)).toEqual({ path: "/repo/Run.java", line: 30 });
+    // A pathless selected frame falls back to the top frame with a path.
+    expect(currentLocation(frames, 1)).toEqual({ path: "/repo/App.java", line: 9 });
     expect(currentLocation([])).toBeNull();
   });
 
@@ -71,17 +158,51 @@ describe("dapDebugModel", () => {
     state = reduceDebugEvent(state, "stopped", { body: { threadId: 7, reason: "breakpoint" } });
     expect(state.status).toBe("stopped");
     expect(state.stoppedThreadId).toBe(7);
+    expect(state.selectedThreadId).toBe(7);
     expect(state.stoppedReason).toBe("breakpoint");
 
-    state = reduceDebugEvent(state, "output", { body: { output: "hello\n" } });
-    expect(state.output).toEqual(["hello\n"]);
+    state = reduceDebugEvent(state, "output", { body: { output: "hello\n", category: "stderr" } });
+    expect(state.output).toEqual([{ category: "stderr", text: "hello\n" }]);
 
     state = reduceDebugEvent(state, "continued", { body: {} });
     expect(state.status).toBe("running");
     expect(state.stoppedThreadId).toBeNull();
+    expect(state.frames).toEqual([]);
 
     state = reduceDebugEvent(state, "terminated", {});
     expect(state.status).toBe("terminated");
+  });
+
+  it("marks resumed state: clears stack, selection, and exception details", () => {
+    const stopped = {
+      ...initialDebugState("s1"),
+      status: "stopped" as const,
+      stoppedThreadId: 1,
+      stoppedReason: "breakpoint",
+      frames: [{ id: 9, name: "f", path: "/a.java", line: 1, column: 1 }],
+      selectedThreadId: 1,
+      selectedFrameId: 9,
+      exceptionInfo: { exceptionId: "E", description: "", details: null },
+    };
+    const resumed = markResumed(stopped);
+    expect(resumed.status).toBe("running");
+    expect(resumed.frames).toEqual([]);
+    expect(resumed.selectedFrameId).toBeNull();
+    expect(resumed.exceptionInfo).toBeNull();
+  });
+
+  it("logs the process exit code on the exited event (IDEA-style)", () => {
+    const state = reduceDebugEvent(initialDebugState("s1"), "exited", { body: { exitCode: 3 } });
+    expect(state.status).toBe("terminated");
+    expect(state.output.at(-1)?.text).toContain("exit code 3");
+  });
+
+  it("appends client console lines and skips telemetry output", () => {
+    let state = initialDebugState("s1");
+    state = appendConsoleLine(state, "repl", "> 1 + 1\n");
+    expect(state.output).toEqual([{ category: "repl", text: "> 1 + 1\n" }]);
+    expect(appendConsoleLine(state, "repl", "")).toBe(state);
+    expect(reduceDebugEvent(state, "output", { body: { output: "x", category: "telemetry" } })).toBe(state);
   });
 
   it("ignores unknown events and empty output", () => {

--- a/src/components/editor/workspace/dapDebugModel.ts
+++ b/src/components/editor/workspace/dapDebugModel.ts
@@ -2,7 +2,8 @@
  * Pure debug-session model (M9). Argument builders, response parsers, and event
  * reducers for the DAP flow — all side-effect-free so they unit-test without a
  * live adapter. The orchestration hook (useCodeDebugSession) wires these to the
- * kernel commands + events.
+ * kernel commands + events. Everything here is DAP-standard and language-agnostic;
+ * language-specific behavior stays in the Rust adapters.
  */
 
 /** A user breakpoint on a source line (1-based), with optional D5 extras. */
@@ -10,6 +11,8 @@ export interface DebugBreakpoint {
   line: number;
   /** D5: only break when this expression is true. */
   condition?: string;
+  /** Break only when the hit count matches (DAP `hitCondition`, e.g. "5"). */
+  hitCondition?: string;
   /** D5: logpoint — log this message (with `{expr}` interpolation) instead of breaking. */
   logMessage?: string;
 }
@@ -30,6 +33,29 @@ export interface DebugThread {
 
 export type DebugStatus = "starting" | "running" | "stopped" | "terminated";
 
+/** One console line: a debuggee `output` event or a client-side REPL echo. */
+export interface DebugConsoleLine {
+  /** DAP output category (`stdout`/`stderr`/`console`…) or client-side `repl`/`result`. */
+  category: string;
+  text: string;
+}
+
+/** Parsed `exceptionInfo` response (shown when stopped on an exception). */
+export interface DebugExceptionInfo {
+  exceptionId: string;
+  description: string;
+  /** Full stack trace text when the adapter provides one. */
+  details: string | null;
+}
+
+/** Result of `evaluate` (and `setVariable`): display value + expandable ref. */
+export interface EvaluateResult {
+  value: string;
+  /** Non-zero when the value is structured and expandable via `variables`. */
+  variablesReference: number;
+  type: string | null;
+}
+
 export interface DebugSessionState {
   sessionId: string;
   status: DebugStatus;
@@ -38,8 +64,14 @@ export interface DebugSessionState {
   stoppedReason: string | null;
   threads: DebugThread[];
   frames: DebugStackFrame[];
-  /** Console/stdout/stderr lines from `output` events. */
-  output: string[];
+  /** Thread whose stack is displayed (defaults to the stopped thread). */
+  selectedThreadId: number | null;
+  /** Frame that variables / watches / evaluate target (defaults to the top frame). */
+  selectedFrameId: number | null;
+  /** Populated via `exceptionInfo` when stopped on an exception. */
+  exceptionInfo: DebugExceptionInfo | null;
+  /** Console lines from `output` events + client-side REPL echoes. */
+  output: DebugConsoleLine[];
 }
 
 export function initialDebugState(sessionId: string): DebugSessionState {
@@ -50,8 +82,43 @@ export function initialDebugState(sessionId: string): DebugSessionState {
     stoppedReason: null,
     threads: [],
     frames: [],
+    selectedThreadId: null,
+    selectedFrameId: null,
+    exceptionInfo: null,
     output: [],
   };
+}
+
+/**
+ * State transition when the debuggee resumes. Also applied optimistically after
+ * a successful continue/step response: adapters are not required to emit a
+ * `continued` event for explicit resumes, so waiting for one leaves the UI
+ * frozen on a stale stack.
+ */
+export function markResumed(state: DebugSessionState): DebugSessionState {
+  return {
+    ...state,
+    status: "running",
+    stoppedThreadId: null,
+    stoppedReason: null,
+    frames: [],
+    selectedThreadId: null,
+    selectedFrameId: null,
+    exceptionInfo: null,
+  };
+}
+
+/** Cap retained console lines so a chatty debuggee cannot grow the store unbounded. */
+const MAX_CONSOLE_LINES = 2000;
+
+/** Append a console line (no-op for empty text). */
+export function appendConsoleLine(
+  state: DebugSessionState,
+  category: string,
+  text: string,
+): DebugSessionState {
+  if (!text) return state;
+  return { ...state, output: [...state.output, { category, text }].slice(-MAX_CONSOLE_LINES) };
 }
 
 /** DAP `stepIn`/`stepOut`/`next`/`continue`/`pause` for a UI step action. */
@@ -66,21 +133,110 @@ export function stepCommandFor(action: DebugStepAction): string {
     case "stepOut": return "stepOut";
   }
 }
-/** Build DAP `setBreakpoints` arguments for one source file. */
+/**
+ * Normalize a source path to the OS-native form the debug adapter expects.
+ * On Windows, java-debug matches breakpoint source paths against JDT's records,
+ * which use a lowercase drive letter and backslashes — a forward-slash /
+ * uppercase-drive path (our internal normalized form) leaves breakpoints
+ * `verified: false` and they never bind. Detected by a `X:` drive prefix, so
+ * POSIX absolute paths (`/…`) are returned unchanged.
+ */
+export function toAdapterSourcePath(path: string): string {
+  if (!/^[A-Za-z]:/.test(path)) return path; // not a Windows drive path
+  return path
+    .replace(/^([A-Za-z]):/, (_m, drive) => `${drive.toLowerCase()}:`)
+    .replace(/\//g, "\\");
+}
+
+/** Breakpoints in the exact order sent to the adapter (sorted by line). */
+export function sortedBreakpoints(list: DebugBreakpoint[]): DebugBreakpoint[] {
+  return list.slice().sort((a, b) => a.line - b.line);
+}
+
+/**
+ * Build DAP `setBreakpoints` arguments for one source file. Entries are sorted
+ * by line; the response's `breakpoints` array corresponds 1:1, in order, to
+ * this sorted list (see parseSetBreakpointsResponse).
+ */
 export function buildSetBreakpointsArgs(path: string, breakpoints: DebugBreakpoint[]) {
   return {
     source: { path, name: path.split(/[\\/]/).pop() ?? path },
-    breakpoints: breakpoints
-      .slice()
-      .sort((a, b) => a.line - b.line)
-      .map((bp) => {
-        const entry: Record<string, unknown> = { line: bp.line };
-        if (bp.condition && bp.condition.trim()) entry.condition = bp.condition.trim();
-        if (bp.logMessage && bp.logMessage.trim()) entry.logMessage = bp.logMessage.trim();
-        return entry;
-      }),
+    breakpoints: sortedBreakpoints(breakpoints).map((bp) => {
+      const entry: Record<string, unknown> = { line: bp.line };
+      if (bp.condition && bp.condition.trim()) entry.condition = bp.condition.trim();
+      if (bp.hitCondition && bp.hitCondition.trim()) entry.hitCondition = bp.hitCondition.trim();
+      if (bp.logMessage && bp.logMessage.trim()) entry.logMessage = bp.logMessage.trim();
+      return entry;
+    }),
     // Ask the adapter to re-verify from source lines.
     sourceModified: false,
+  };
+}
+
+/** Adapter-reported binding of one requested breakpoint. */
+export interface BreakpointBinding {
+  /** Adapter breakpoint id (routes later `breakpoint` events), or null. */
+  id: number | null;
+  verified: boolean;
+  /** Line the adapter actually bound (requested line when it reports none). */
+  line: number;
+}
+
+/**
+ * Parse a `setBreakpoints` response. Per the DAP spec the response array
+ * corresponds 1:1, in order, to the requested breakpoints — `sortedRequested`
+ * must be the same sorted list the arguments were built from.
+ */
+export function parseSetBreakpointsResponse(
+  sortedRequested: DebugBreakpoint[],
+  body: unknown,
+): BreakpointBinding[] {
+  const reported = asRecord(body).breakpoints;
+  const list = Array.isArray(reported) ? reported : [];
+  return sortedRequested.map((bp, i) => {
+    const rec = asRecord(list[i]);
+    return {
+      id: typeof rec.id === "number" ? rec.id : null,
+      verified: rec.verified === true,
+      line: typeof rec.line === "number" && rec.line > 0 ? rec.line : bp.line,
+    };
+  });
+}
+
+/**
+ * Adopt adapter-adjusted lines: a breakpoint on a non-executable line gets
+ * moved to the line the adapter actually bound (IDEA/VS Code behavior). Only
+ * verified bindings move a breakpoint; entries collapsing onto an already-used
+ * line are dropped.
+ */
+export function reconcileBreakpointLines(
+  sortedRequested: DebugBreakpoint[],
+  bindings: BreakpointBinding[],
+): DebugBreakpoint[] {
+  const out: DebugBreakpoint[] = [];
+  const seen = new Set<number>();
+  sortedRequested.forEach((bp, i) => {
+    const binding = bindings[i];
+    const line = binding && binding.verified ? binding.line : bp.line;
+    if (seen.has(line)) return;
+    seen.add(line);
+    out.push(line === bp.line ? bp : { ...bp, line });
+  });
+  return out;
+}
+
+/** Parse a `breakpoint` event (adapters re-verify bindings as classes load). */
+export function parseBreakpointEvent(
+  message: unknown,
+): { reason: string; id: number | null; verified: boolean; line: number | null } | null {
+  const body = asRecord(asRecord(message).body);
+  const bp = asRecord(body.breakpoint);
+  if (Object.keys(bp).length === 0) return null;
+  return {
+    reason: typeof body.reason === "string" ? body.reason : "changed",
+    id: typeof bp.id === "number" ? bp.id : null,
+    verified: bp.verified === true,
+    line: typeof bp.line === "number" ? bp.line : null,
   };
 }
 
@@ -133,8 +289,42 @@ export function parseStackFrames(body: unknown): DebugStackFrame[] {
   });
 }
 
-/** The source location to highlight as "current" — the top frame that has a path. */
-export function currentLocation(frames: DebugStackFrame[]): { path: string; line: number } | null {
+/** Parse an `exceptionInfo` response body (null when the adapter has nothing). */
+export function parseExceptionInfo(body: unknown): DebugExceptionInfo | null {
+  const rec = asRecord(body);
+  const exceptionId = typeof rec.exceptionId === "string" ? rec.exceptionId : "";
+  const description = typeof rec.description === "string" ? rec.description : "";
+  if (!exceptionId && !description) return null;
+  const details = asRecord(rec.details);
+  return {
+    exceptionId: exceptionId || "Exception",
+    description,
+    details: typeof details.stackTrace === "string" ? details.stackTrace : null,
+  };
+}
+
+/** Parse an `evaluate` response body into display value + expandable ref. */
+export function parseEvaluate(body: unknown): EvaluateResult {
+  const rec = asRecord(body);
+  return {
+    value: typeof rec.result === "string" ? rec.result : "",
+    variablesReference: typeof rec.variablesReference === "number" ? rec.variablesReference : 0,
+    type: typeof rec.type === "string" ? rec.type : null,
+  };
+}
+
+/**
+ * The source location to highlight as "current" — the selected frame when set,
+ * else the top frame that has a path.
+ */
+export function currentLocation(
+  frames: DebugStackFrame[],
+  selectedFrameId?: number | null,
+): { path: string; line: number } | null {
+  if (selectedFrameId != null) {
+    const selected = frames.find((f) => f.id === selectedFrameId);
+    if (selected?.path) return { path: selected.path, line: selected.line };
+  }
   const frame = frames.find((f) => f.path);
   return frame && frame.path ? { path: frame.path, line: frame.line } : null;
 }
@@ -153,23 +343,43 @@ export function reduceDebugEvent(
         ...state,
         status: "stopped",
         stoppedThreadId: threadId,
+        selectedThreadId: threadId,
         stoppedReason: typeof body.reason === "string" ? body.reason : "stopped",
+        exceptionInfo: null,
       };
     }
     case "continued":
-      return { ...state, status: "running", stoppedThreadId: null, stoppedReason: null, frames: [] };
+      return markResumed(state);
+    case "exited": {
+      const next: DebugSessionState = {
+        ...state,
+        status: "terminated",
+        stoppedThreadId: null,
+        selectedThreadId: null,
+        selectedFrameId: null,
+        frames: [],
+      };
+      // IDEA-style closing line with the process exit code.
+      return typeof body.exitCode === "number"
+        ? appendConsoleLine(next, "console", `\nProcess finished with exit code ${body.exitCode}\n`)
+        : next;
+    }
     case "terminated":
-    case "exited":
-      return { ...state, status: "terminated", stoppedThreadId: null, frames: [] };
+      return {
+        ...state,
+        status: "terminated",
+        stoppedThreadId: null,
+        selectedThreadId: null,
+        selectedFrameId: null,
+        frames: [],
+      };
     case "output": {
       const text = typeof body.output === "string" ? body.output : "";
-      if (!text) return state;
-      // Cap retained output so a chatty debuggee cannot grow the store unbounded.
-      const output = [...state.output, text].slice(-2000);
-      return { ...state, output };
+      const category = typeof body.category === "string" && body.category ? body.category : "stdout";
+      if (!text || category === "telemetry") return state;
+      return appendConsoleLine(state, category, text);
     }
     default:
       return state;
   }
 }
-

--- a/src/components/editor/workspace/debugEditorChrome.ts
+++ b/src/components/editor/workspace/debugEditorChrome.ts
@@ -17,19 +17,31 @@ import {
 export interface DebugBreakpointMarker {
   line: number; // 1-based
   conditional: boolean;
+  /** Logpoint (logs instead of breaking) — rendered as a diamond. */
+  logpoint?: boolean;
+  /** False when the adapter could not bind the line (grey hollow marker). */
+  verified?: boolean;
 }
 
 class BreakpointGutterMarker extends GutterMarker {
-  constructor(private readonly conditional: boolean) {
+  constructor(private readonly marker: DebugBreakpointMarker | null) {
     super();
   }
 
   override toDOM(): Node {
     const dot = document.createElement("span");
-    dot.textContent = "●";
-    dot.style.color = this.conditional ? "#f59e0b" : "#ef4444";
+    const marker = this.marker ?? { line: 0, conditional: false };
+    const verified = marker.verified !== false;
+    dot.textContent = marker.logpoint ? "◆" : verified ? "●" : "○";
+    dot.style.color = !verified ? "#9ca3af" : marker.conditional ? "#f59e0b" : "#ef4444";
     dot.style.fontSize = "12px";
-    dot.title = this.conditional ? "Conditional breakpoint" : "Breakpoint";
+    dot.title = !verified
+      ? "Breakpoint not bound (line not executable or class not loaded yet)"
+      : marker.logpoint
+        ? "Logpoint"
+        : marker.conditional
+          ? "Conditional breakpoint"
+          : "Breakpoint";
     return dot;
   }
 }
@@ -52,9 +64,9 @@ export function createDebugEditorChrome(
       lineMarker: (view, lineBlock) => {
         const line = view.state.doc.lineAt(lineBlock.from).number;
         const marker = byLine.get(line);
-        return marker ? new BreakpointGutterMarker(marker.conditional) : null;
+        return marker ? new BreakpointGutterMarker(marker) : null;
       },
-      initialSpacer: () => new BreakpointGutterMarker(false),
+      initialSpacer: () => new BreakpointGutterMarker(null),
       domEventHandlers: {
         mousedown: (view, lineBlock, event) => {
           const line = view.state.doc.lineAt(lineBlock.from).number;

--- a/src/components/editor/workspace/editorContextMenu.test.ts
+++ b/src/components/editor/workspace/editorContextMenu.test.ts
@@ -76,4 +76,18 @@ describe("buildEditorContextMenuItems", () => {
     items.find((i) => i.testId === "editor-context-code-actions")?.onClick?.();
     expect(actions.codeActions).toHaveBeenCalledWith(42, 84);
   });
+
+  it("adds Run to Cursor only while a debug session is active, enabled when stopped", () => {
+    const base = { capabilities: null, hasSelection: false, clientX: 0, clientY: 0, actions };
+    expect(buildEditorContextMenuItems(base).find((i) => i.testId === "editor-context-run-to-cursor"))
+      .toBeUndefined();
+    const runToCursor = vi.fn();
+    const items = buildEditorContextMenuItems({ ...base, debug: { canRunToCursor: true, runToCursor } });
+    const item = items.find((i) => i.testId === "editor-context-run-to-cursor");
+    expect(item?.disabled).toBe(false);
+    item?.onClick?.();
+    expect(runToCursor).toHaveBeenCalledTimes(1);
+    const running = buildEditorContextMenuItems({ ...base, debug: { canRunToCursor: false, runToCursor } });
+    expect(running.find((i) => i.testId === "editor-context-run-to-cursor")?.disabled).toBe(true);
+  });
 });

--- a/src/components/editor/workspace/editorContextMenu.ts
+++ b/src/components/editor/workspace/editorContextMenu.ts
@@ -39,6 +39,8 @@ export interface BuildEditorContextMenuInput {
   actions: EditorContextMenuActions;
   /** When true, LSP navigation items stay enabled even if capabilities are unknown. */
   lspAvailable?: boolean;
+  /** Present while a debug session is active — adds Run to Cursor (IDEA Alt+F9). */
+  debug?: { canRunToCursor: boolean; runToCursor: () => void } | null;
 }
 
 function capEnabled(
@@ -58,6 +60,19 @@ function capEnabled(
 export function buildEditorContextMenuItems(input: BuildEditorContextMenuInput): MenuItem[] {
   const { capabilities, hasSelection, clientX, clientY, actions } = input;
   const lspAvailable = input.lspAvailable ?? true;
+
+  const debugItems: MenuItem[] = input.debug
+    ? [
+      { separator: true, label: "" },
+      {
+        label: "Run to Cursor",
+        shortcut: "Alt+F9",
+        testId: "editor-context-run-to-cursor",
+        disabled: !input.debug.canRunToCursor,
+        onClick: input.debug.runToCursor,
+      },
+    ]
+    : [];
 
   return [
     {
@@ -132,6 +147,7 @@ export function buildEditorContextMenuItems(input: BuildEditorContextMenuInput):
         && !capEnabled(capabilities, "rangeFormatting", lspAvailable),
       onClick: actions.format,
     },
+    ...debugItems,
     { separator: true, label: "" },
     {
       label: "Cut",

--- a/src/components/editor/workspace/panels/DebugPanel.test.tsx
+++ b/src/components/editor/workspace/panels/DebugPanel.test.tsx
@@ -8,15 +8,28 @@ function makeSession(overrides: Partial<CodeDebugSession> = {}): CodeDebugSessio
   return {
     state: null,
     breakpoints: {},
+    breakpointRuntime: {},
+    capabilities: {},
     availableExceptionFilters: [],
     enabledExceptionFilters: [],
+    watchExpressions: [],
     startDebug: vi.fn().mockResolvedValue(undefined),
+    restart: vi.fn(),
+    canRestart: false,
     toggleBreakpoint: vi.fn(),
     setBreakpointOptions: vi.fn(),
     setExceptionFilters: vi.fn(),
+    addWatchExpression: vi.fn(),
+    removeWatchExpression: vi.fn(),
     step: vi.fn(),
+    runToCursor: vi.fn(),
+    selectThread: vi.fn(),
+    selectFrame: vi.fn(),
+    restartFrame: vi.fn(),
     hotReload: vi.fn(),
-    evaluate: vi.fn().mockResolvedValue(""),
+    evaluate: vi.fn().mockResolvedValue({ value: "", variablesReference: 0, type: null }),
+    setVariable: vi.fn().mockResolvedValue(null),
+    logConsole: vi.fn(),
     fetchVariables: vi.fn().mockResolvedValue({ variables: [] }),
     fetchScopes: vi.fn().mockResolvedValue({ scopes: [] }),
     terminate: vi.fn(),
@@ -31,8 +44,10 @@ function stoppedState(): DebugSessionState {
     status: "stopped",
     stoppedThreadId: 1,
     stoppedReason: "breakpoint",
-    threads: [{ id: 1, name: "main" }],
+    threads: [{ id: 1, name: "main" }, { id: 2, name: "worker" }],
     frames: [{ id: 10, name: "App.main", path: "/repo/App.java", line: 9, column: 1 }],
+    selectedThreadId: 1,
+    selectedFrameId: 10,
   };
 }
 
@@ -49,24 +64,109 @@ describe("DebugPanel", () => {
 
   it("renders the call stack and dispatches step controls when stopped", () => {
     const step = vi.fn();
+    const selectFrame = vi.fn();
     const onOpenFrame = vi.fn();
     render(
       <DebugPanel
-        debug={makeSession({ state: stoppedState(), step })}
+        debug={makeSession({ state: stoppedState(), step, selectFrame })}
         onStart={null}
         onOpenFrame={onOpenFrame}
       />,
     );
-    // Frame shows and is clickable (has a path).
+    // Clicking a frame selects it (variables context) and reveals its source.
     fireEvent.click(screen.getByTestId("debug-frame-10"));
+    expect(selectFrame).toHaveBeenCalledWith(10);
     expect(onOpenFrame).toHaveBeenCalledWith(expect.objectContaining({ id: 10, path: "/repo/App.java" }));
     // Step controls dispatch DAP actions.
     fireEvent.click(screen.getByTestId("debug-continue"));
     expect(step).toHaveBeenCalledWith("continue");
     fireEvent.click(screen.getByTestId("debug-step-over"));
     expect(step).toHaveBeenCalledWith("stepOver");
-    fireEvent.click(screen.getByTestId("debug-stop"));
-    expect(makeSession().terminate).not.toBe(step); // sanity: distinct mocks
+  });
+
+  it("renders debuggee output in the console with categories", () => {
+    const state = {
+      ...stoppedState(),
+      output: [
+        { category: "stdout", text: "hello\n" },
+        { category: "stderr", text: "boom\n" },
+      ],
+    };
+    render(<DebugPanel debug={makeSession({ state })} onStart={null} onOpenFrame={vi.fn()} />);
+    const console = screen.getByTestId("debug-console-output");
+    expect(console.textContent).toContain("hello");
+    expect(console.textContent).toContain("boom");
+  });
+
+  it("selects a thread from the threads section", () => {
+    const selectThread = vi.fn();
+    render(
+      <DebugPanel debug={makeSession({ state: stoppedState(), selectThread })} onStart={null} onOpenFrame={vi.fn()} />,
+    );
+    // The threads section is collapsed by default — open it first.
+    fireEvent.click(screen.getByText(/Threads \(2\)/));
+    fireEvent.click(screen.getByTestId("debug-thread-2"));
+    expect(selectThread).toHaveBeenCalledWith(2);
+  });
+
+  it("shows the exception banner when stopped on an exception", () => {
+    const state = {
+      ...stoppedState(),
+      exceptionInfo: {
+        exceptionId: "java.lang.NullPointerException",
+        description: "boom",
+        details: "at App.main(App.java:9)",
+      },
+    };
+    render(<DebugPanel debug={makeSession({ state })} onStart={null} onOpenFrame={vi.fn()} />);
+    const banner = screen.getByTestId("debug-exception-info");
+    expect(banner.textContent).toContain("NullPointerException");
+    expect(banner.textContent).toContain("boom");
+  });
+
+  it("gates restart-frame on the adapter capability and restarts the frame", () => {
+    const restartFrame = vi.fn();
+    const { rerender } = render(
+      <DebugPanel debug={makeSession({ state: stoppedState(), restartFrame })} onStart={null} onOpenFrame={vi.fn()} />,
+    );
+    expect(screen.queryByTestId("debug-restart-frame-10")).toBeNull();
+    rerender(
+      <DebugPanel
+        debug={makeSession({
+          state: stoppedState(),
+          restartFrame,
+          capabilities: { supportsRestartFrame: true },
+        })}
+        onStart={null}
+        onOpenFrame={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("debug-restart-frame-10"));
+    expect(restartFrame).toHaveBeenCalledWith(10);
+  });
+
+  it("adds a watch expression through the session", () => {
+    const addWatchExpression = vi.fn();
+    render(
+      <DebugPanel
+        debug={makeSession({ state: stoppedState(), addWatchExpression })}
+        onStart={null}
+        onOpenFrame={vi.fn()}
+      />,
+    );
+    const input = screen.getByTestId("debug-watch-input");
+    fireEvent.change(input, { target: { value: "x + 1" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(addWatchExpression).toHaveBeenCalledWith("x + 1");
+  });
+
+  it("offers a rerun button when a previous launch config exists", () => {
+    const restart = vi.fn();
+    render(
+      <DebugPanel debug={makeSession({ canRestart: true, restart })} onStart={null} onOpenFrame={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByTestId("debug-restart"));
+    expect(restart).toHaveBeenCalledTimes(1);
   });
 
   it("toggles an exception filter through the session", () => {

--- a/src/components/editor/workspace/panels/DebugPanel.tsx
+++ b/src/components/editor/workspace/panels/DebugPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ArrowDownToLine,
   ArrowRightToLine,
@@ -9,6 +9,7 @@ import {
   CirclePlay,
   FlameKindling,
   Pause,
+  RotateCcw,
   Square,
 } from "lucide-react";
 import type { CodeDebugSession } from "../useCodeDebugSession";
@@ -26,12 +27,15 @@ interface DebugPanelProps {
 interface VarNode {
   name: string;
   value: string;
+  type: string | null;
   variablesReference: number;
+  /** `variablesReference` of the container (scope/object) this node lives in. */
+  parentRef: number;
   children: VarNode[] | null; // null = not yet loaded
   expanded: boolean;
 }
 
-function parseVariables(body: unknown): VarNode[] {
+function parseVariables(body: unknown, parentRef: number): VarNode[] {
   const list = body && typeof body === "object" ? (body as { variables?: unknown }).variables : null;
   if (!Array.isArray(list)) return [];
   return list.flatMap((v) => {
@@ -40,26 +44,57 @@ function parseVariables(body: unknown): VarNode[] {
     return [{
       name: rec.name,
       value: typeof rec.value === "string" ? rec.value : "",
+      type: typeof rec.type === "string" ? rec.type : null,
       variablesReference: typeof rec.variablesReference === "number" ? rec.variablesReference : 0,
+      parentRef,
       children: null,
       expanded: false,
     }];
   });
 }
+
+/** Immutable tree update: replace `target` (by identity) via `update`. */
+function updateNode(nodes: VarNode[], target: VarNode, update: (n: VarNode) => VarNode): VarNode[] {
+  return nodes.map((n) => {
+    if (n === target) return update(n);
+    return n.children ? { ...n, children: updateNode(n.children, target, update) } : n;
+  });
+}
+
+interface VarEditState {
+  node: VarNode | null;
+  value: string;
+}
+
 function VariableRow({
   node,
   depth,
   onExpand,
+  onStartEdit,
+  edit,
+  onEditChange,
+  onEditSubmit,
+  onEditCancel,
+  onRemove,
 }: {
   node: VarNode;
   depth: number;
   onExpand: (node: VarNode) => void;
+  /** Present when the value is editable (DAP setVariable). */
+  onStartEdit?: (node: VarNode) => void;
+  edit?: VarEditState;
+  onEditChange?: (value: string) => void;
+  onEditSubmit?: () => void;
+  onEditCancel?: () => void;
+  /** Present on watch roots: remove the watch expression. */
+  onRemove?: () => void;
 }) {
   const expandable = node.variablesReference > 0;
+  const editing = edit?.node === node;
   return (
     <>
       <div
-        className="flex items-start gap-1 py-0.5 pr-2 hover:bg-[var(--taomni-hover-bg)]"
+        className="group flex items-start gap-1 py-0.5 pr-2 hover:bg-[var(--taomni-hover-bg)]"
         style={{ paddingLeft: `${8 + depth * 12}px` }}
       >
         {expandable ? (
@@ -69,35 +104,102 @@ function VariableRow({
         ) : (
           <span className="inline-block w-3 shrink-0" />
         )}
-        <span className="shrink-0 text-[var(--taomni-text)]">{node.name}</span>
-        <span className="truncate text-[var(--taomni-text-muted)]">= {node.value}</span>
+        <span className="shrink-0 text-[var(--taomni-text)]" title={node.type ?? undefined}>{node.name}</span>
+        {editing ? (
+          <input
+            autoFocus
+            data-testid="debug-variable-edit-input"
+            className="min-w-0 flex-1 rounded border border-[var(--taomni-input-border)] bg-[var(--taomni-input-bg)] px-1 font-mono text-[11px] outline-none"
+            value={edit?.value ?? ""}
+            onChange={(e) => onEditChange?.(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onEditSubmit?.();
+              else if (e.key === "Escape") onEditCancel?.();
+            }}
+            onBlur={() => onEditCancel?.()}
+          />
+        ) : (
+          <span
+            className="truncate text-[var(--taomni-text-muted)]"
+            title={onStartEdit ? "Double-click to change the value" : undefined}
+            onDoubleClick={onStartEdit ? () => onStartEdit(node) : undefined}
+          >
+            = {node.value}
+          </span>
+        )}
+        {onRemove && (
+          <button
+            type="button"
+            className="ml-auto shrink-0 text-[var(--taomni-text-muted)] opacity-0 group-hover:opacity-100"
+            onClick={onRemove}
+            title="Remove watch"
+          >
+            ×
+          </button>
+        )}
       </div>
-      {node.expanded && node.children?.map((child) => (
-        <VariableRow key={`${child.name}:${child.variablesReference}`} node={child} depth={depth + 1} onExpand={onExpand} />
+      {node.expanded && node.children?.map((child, i) => (
+        <VariableRow
+          key={`${child.name}:${i}`}
+          node={child}
+          depth={depth + 1}
+          onExpand={onExpand}
+          onStartEdit={onStartEdit}
+          edit={edit}
+          onEditChange={onEditChange}
+          onEditSubmit={onEditSubmit}
+          onEditCancel={onEditCancel}
+        />
       ))}
     </>
   );
+}
+
+function consoleLineClass(category: string): string {
+  switch (category) {
+    case "stderr":
+    case "error":
+      return "text-rose-500 dark:text-rose-400";
+    case "repl":
+      return "text-sky-600 dark:text-sky-400";
+    case "console":
+    case "important":
+      return "text-[var(--taomni-text-muted)] italic";
+    default:
+      return "text-[var(--taomni-text)]";
+  }
 }
 
 export function DebugPanel({ debug, onStart, onOpenFrame }: DebugPanelProps) {
   const { state } = debug;
   const running = !!state && state.status !== "terminated";
   const stopped = state?.status === "stopped";
+  const canSetVariable = debug.capabilities.supportsSetVariable === true;
+  const canRestartFrame = debug.capabilities.supportsRestartFrame === true;
   const [variables, setVariables] = useState<VarNode[]>([]);
-  const [watch, setWatch] = useState<{ expr: string; value: string }[]>([]);
+  const [watchNodes, setWatchNodes] = useState<VarNode[]>([]);
+  const [watchTick, setWatchTick] = useState(0);
   const [watchInput, setWatchInput] = useState("");
   const [consoleInput, setConsoleInput] = useState("");
+  const [edit, setEdit] = useState<VarEditState>({ node: null, value: "" });
+  const consoleRef = useRef<HTMLDivElement | null>(null);
 
-  // On each stop, load the top frame's scopes → variables (D4).
-  const topFrameId = stopped ? state?.frames[0]?.id ?? null : null;
+  // Stable hook callbacks (useCallback in useCodeDebugSession) — effects key on
+  // these instead of the per-render `debug` object so a parent re-render does
+  // not re-fetch scopes / re-evaluate watches against the adapter.
+  const { fetchScopes, fetchVariables, evaluate, setVariable: sessionSetVariable } = debug;
+
+  // On each stop, load the selected frame's scopes → variables (D4).
+  const frameId = stopped ? state?.selectedFrameId ?? state?.frames[0]?.id ?? null : null;
   useEffect(() => {
-    if (topFrameId == null) {
+    setEdit({ node: null, value: "" });
+    if (frameId == null) {
       setVariables([]);
       return;
     }
     let cancelled = false;
     void (async () => {
-      const scopesBody = await debug.fetchScopes(topFrameId);
+      const scopesBody = await fetchScopes(frameId);
       const scopes = (scopesBody && typeof scopesBody === "object"
         ? (scopesBody as { scopes?: unknown }).scopes
         : null);
@@ -111,120 +213,229 @@ export function DebugPanel({ debug, onStart, onOpenFrame }: DebugPanelProps) {
         : [];
       const roots: VarNode[] = [];
       for (const scope of refs) {
-        const vars = parseVariables(await debug.fetchVariables(scope.ref));
-        roots.push({ name: scope.name, value: "", variablesReference: scope.ref, children: vars, expanded: true });
+        const vars = parseVariables(await fetchVariables(scope.ref), scope.ref);
+        roots.push({
+          name: scope.name,
+          value: "",
+          type: null,
+          variablesReference: scope.ref,
+          parentRef: 0,
+          children: vars,
+          expanded: true,
+        });
       }
       if (!cancelled) setVariables(roots);
     })();
     return () => { cancelled = true; };
-  }, [debug, topFrameId]);
+  }, [fetchScopes, fetchVariables, frameId]);
 
-  // Re-evaluate watch expressions whenever we stop on a new frame.
+  // Re-evaluate watch expressions on each stop / frame change / edit.
+  const watchExpressions = debug.watchExpressions;
   useEffect(() => {
-    if (!stopped) return;
     let cancelled = false;
-    void (async () => {
-      const next = await Promise.all(watch.map(async (w) => ({
-        expr: w.expr,
-        value: await debug.evaluate(w.expr, "watch"),
+    if (!stopped || frameId == null) {
+      setWatchNodes(watchExpressions.map((expr) => ({
+        name: expr, value: "", type: null, variablesReference: 0, parentRef: 0, children: null, expanded: false,
       })));
-      if (!cancelled) setWatch(next);
+      return;
+    }
+    void (async () => {
+      const next = await Promise.all(watchExpressions.map(async (expr) => {
+        const result = await evaluate(expr, "watch");
+        return {
+          name: expr,
+          value: result.value,
+          type: result.type,
+          variablesReference: result.variablesReference,
+          parentRef: 0,
+          children: null,
+          expanded: false,
+        };
+      }));
+      if (!cancelled) setWatchNodes(next);
     })();
     return () => { cancelled = true; };
-    // Intentionally keyed on frame identity, not `watch`, to avoid a loop.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debug, stopped, topFrameId]);
+  }, [evaluate, stopped, frameId, watchExpressions, watchTick]);
 
-  const expandVariable = useCallback((node: VarNode) => {
-    const toggle = (nodes: VarNode[]): VarNode[] => nodes.map((n) => {
-      if (n !== node) return { ...n, children: n.children ? toggle(n.children) : n.children };
-      return { ...n, expanded: !n.expanded };
-    });
-    setVariables((current) => toggle(current));
+  // Keep the console pinned to the latest output.
+  const outputLength = state?.output.length ?? 0;
+  useEffect(() => {
+    const el = consoleRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [outputLength]);
+
+  const makeExpandHandler = useCallback((
+    setNodes: React.Dispatch<React.SetStateAction<VarNode[]>>,
+  ) => (node: VarNode) => {
+    setNodes((current) => updateNode(current, node, (n) => ({ ...n, expanded: !n.expanded })));
     if (!node.expanded && node.children === null && node.variablesReference > 0) {
-      void debug.fetchVariables(node.variablesReference).then((body) => {
-        const children = parseVariables(body);
-        const assign = (nodes: VarNode[]): VarNode[] => nodes.map((n) => {
-          if (n === node) return { ...n, children, expanded: true };
-          return { ...n, children: n.children ? assign(n.children) : n.children };
-        });
-        setVariables((current) => assign(current));
+      void fetchVariables(node.variablesReference).then((body) => {
+        const children = parseVariables(body, node.variablesReference);
+        setNodes((current) => updateNode(current, node, (n) => ({ ...n, children, expanded: true })));
       });
     }
-  }, [debug]);
+  }, [fetchVariables]);
+
+  const expandVariable = makeExpandHandler(setVariables);
+  const expandWatch = makeExpandHandler(setWatchNodes);
+
+  const startEdit = useCallback((node: VarNode) => {
+    setEdit({ node, value: node.value });
+  }, []);
+
+  const submitEdit = useCallback(() => {
+    const node = edit.node;
+    const value = edit.value;
+    setEdit({ node: null, value: "" });
+    if (!node) return;
+    void sessionSetVariable(node.parentRef, node.name, value).then((result) => {
+      if (!result) return;
+      setVariables((current) => updateNode(current, node, (n) => ({
+        ...n,
+        value: result.value,
+        type: result.type ?? n.type,
+        variablesReference: result.variablesReference,
+        children: null,
+        expanded: false,
+      })));
+      // Watch values may depend on the changed variable.
+      setWatchTick((tick) => tick + 1);
+    });
+  }, [sessionSetVariable, edit]);
+
+  const cancelEdit = useCallback(() => setEdit({ node: null, value: "" }), []);
 
   const addWatch = useCallback(() => {
     const expr = watchInput.trim();
     if (!expr) return;
     setWatchInput("");
-    void debug.evaluate(expr, "watch").then((value) => {
-      setWatch((current) => [...current, { expr, value }]);
-    });
+    debug.addWatchExpression(expr);
   }, [debug, watchInput]);
 
-  const [consoleLog, setConsoleLog] = useState<string[]>([]);
   const submitConsole = useCallback(() => {
     const expr = consoleInput.trim();
     if (!expr) return;
     setConsoleInput("");
-    setConsoleLog((current) => [...current, `> ${expr}`]);
-    void debug.evaluate(expr, "repl").then((value) => {
-      setConsoleLog((current) => [...current, value]);
+    debug.logConsole("repl", `> ${expr}\n`);
+    void debug.evaluate(expr, "repl").then((result) => {
+      debug.logConsole("result", `${result.value}\n`);
     });
   }, [debug, consoleInput]);
-  const controlBtn = "taomni-btn h-6 w-6 inline-flex items-center justify-center disabled:opacity-30";
+  const controlBtn = "h-7 w-7 inline-flex items-center justify-center rounded-md transition-colors disabled:opacity-30 disabled:pointer-events-none";
   return (
     <div data-testid="code-workspace-debug-panel" className="h-full min-h-0 flex flex-col text-[11px]">
       <div className="h-8 shrink-0 flex items-center gap-1 border-b border-[var(--taomni-code-border)] px-2">
-        <Bug className="h-3.5 w-3.5" />
+        <Bug className="h-4 w-4" />
         <span className="font-medium">Debug</span>
         {state && (
           <span className="ml-1 text-[10px] text-[var(--taomni-text-muted)]">
             {state.status}{state.stoppedReason ? ` · ${state.stoppedReason}` : ""}
           </span>
         )}
-        <div className="ml-auto flex items-center gap-1">
+        <div className="ml-auto flex items-center gap-0.5 rounded-md border border-[var(--taomni-code-border)] bg-[var(--taomni-code-bg)] p-0.5 shadow-xs">
           {!running && (
-            <button
-              type="button"
-              data-testid="debug-start"
-              className={controlBtn}
-              onClick={() => onStart?.()}
-              disabled={!onStart}
-              title="Start debugging the active file"
-            >
-              <CirclePlay className="h-3.5 w-3.5 text-emerald-500" />
-            </button>
+            <>
+              <button
+                type="button"
+                data-testid="debug-start"
+                className={`${controlBtn} hover:bg-emerald-500/15`}
+                onClick={() => onStart?.()}
+                disabled={!onStart}
+                title="Start debugging the active file"
+              >
+                <CirclePlay className="h-4 w-4 text-emerald-500 dark:text-emerald-400" />
+              </button>
+              {debug.canRestart && (
+                <button
+                  type="button"
+                  data-testid="debug-restart"
+                  className={`${controlBtn} hover:bg-emerald-500/15`}
+                  onClick={() => debug.restart()}
+                  title="Rerun the last debug session"
+                >
+                  <RotateCcw className="h-4 w-4 text-emerald-500 dark:text-emerald-400" />
+                </button>
+              )}
+            </>
           )}
           {running && (
             <>
-              <button type="button" data-testid="debug-continue" className={controlBtn}
-                onClick={() => debug.step("continue")} disabled={!stopped} title="Continue">
-                <CirclePlay className="h-3.5 w-3.5" />
+              <button
+                type="button"
+                data-testid="debug-continue"
+                className={`${controlBtn} hover:bg-emerald-500/15`}
+                onClick={() => debug.step("continue")}
+                disabled={!stopped}
+                title="Continue"
+              >
+                <CirclePlay className="h-4 w-4 text-emerald-500 dark:text-emerald-400" />
               </button>
-              <button type="button" data-testid="debug-pause" className={controlBtn}
-                onClick={() => debug.step("pause")} disabled={stopped} title="Pause">
-                <Pause className="h-3.5 w-3.5" />
+              <button
+                type="button"
+                data-testid="debug-pause"
+                className={`${controlBtn} hover:bg-amber-500/15`}
+                onClick={() => debug.step("pause")}
+                disabled={stopped}
+                title="Pause"
+              >
+                <Pause className="h-4 w-4 text-amber-500 dark:text-amber-400" />
               </button>
-              <button type="button" data-testid="debug-step-over" className={controlBtn}
-                onClick={() => debug.step("stepOver")} disabled={!stopped} title="Step over">
-                <ArrowRightToLine className="h-3.5 w-3.5" />
+              <button
+                type="button"
+                data-testid="debug-step-over"
+                className={`${controlBtn} hover:bg-sky-500/15`}
+                onClick={() => debug.step("stepOver")}
+                disabled={!stopped}
+                title="Step over"
+              >
+                <ArrowRightToLine className="h-4 w-4 text-sky-500 dark:text-sky-400" />
               </button>
-              <button type="button" data-testid="debug-step-in" className={controlBtn}
-                onClick={() => debug.step("stepIn")} disabled={!stopped} title="Step into">
-                <ArrowDownToLine className="h-3.5 w-3.5" />
+              <button
+                type="button"
+                data-testid="debug-step-in"
+                className={`${controlBtn} hover:bg-indigo-500/15`}
+                onClick={() => debug.step("stepIn")}
+                disabled={!stopped}
+                title="Step into"
+              >
+                <ArrowDownToLine className="h-4 w-4 text-indigo-500 dark:text-indigo-400" />
               </button>
-              <button type="button" data-testid="debug-step-out" className={controlBtn}
-                onClick={() => debug.step("stepOut")} disabled={!stopped} title="Step out">
-                <ArrowUpFromLine className="h-3.5 w-3.5" />
+              <button
+                type="button"
+                data-testid="debug-step-out"
+                className={`${controlBtn} hover:bg-violet-500/15`}
+                onClick={() => debug.step("stepOut")}
+                disabled={!stopped}
+                title="Step out"
+              >
+                <ArrowUpFromLine className="h-4 w-4 text-violet-500 dark:text-violet-400" />
               </button>
-              <button type="button" data-testid="debug-hot-reload" className={controlBtn}
-                onClick={() => debug.hotReload()} title="Hot reload changed classes">
-                <FlameKindling className="h-3.5 w-3.5 text-orange-500" />
+              <button
+                type="button"
+                data-testid="debug-hot-reload"
+                className={`${controlBtn} hover:bg-orange-500/15`}
+                onClick={() => debug.hotReload()}
+                title="Hot reload changed classes"
+              >
+                <FlameKindling className="h-4 w-4 text-orange-500 dark:text-orange-400" />
               </button>
-              <button type="button" data-testid="debug-stop" className={controlBtn}
-                onClick={() => debug.terminate()} title="Stop">
-                <Square className="h-3.5 w-3.5 text-red-500" />
+              <button
+                type="button"
+                data-testid="debug-restart"
+                className={`${controlBtn} hover:bg-emerald-500/15`}
+                onClick={() => debug.restart()}
+                title="Restart the debug session"
+              >
+                <RotateCcw className="h-4 w-4 text-emerald-500 dark:text-emerald-400" />
+              </button>
+              <button
+                type="button"
+                data-testid="debug-stop"
+                className={`${controlBtn} hover:bg-rose-500/15`}
+                onClick={() => debug.terminate()}
+                title="Stop"
+              >
+                <Square className="h-4 w-4 text-rose-500 dark:text-rose-400" />
               </button>
             </>
           )}
@@ -238,32 +449,100 @@ export function DebugPanel({ debug, onStart, onOpenFrame }: DebugPanelProps) {
         )}
         {state && (
           <>
+            {state.exceptionInfo && (
+              <div
+                data-testid="debug-exception-info"
+                className="border-b border-[var(--taomni-code-border)] bg-rose-500/10 px-3 py-2"
+              >
+                <div className="font-medium text-rose-600 dark:text-rose-400">{state.exceptionInfo.exceptionId}</div>
+                {state.exceptionInfo.description && (
+                  <div className="text-rose-600/90 dark:text-rose-400/90">{state.exceptionInfo.description}</div>
+                )}
+                {state.exceptionInfo.details && (
+                  <pre className="mt-1 max-h-28 overflow-auto whitespace-pre-wrap font-mono text-[10px] text-[var(--taomni-text-muted)]">
+                    {state.exceptionInfo.details}
+                  </pre>
+                )}
+              </div>
+            )}
+            {state.threads.length > 0 && (
+              <Section title={`Threads (${state.threads.length})`} defaultOpen={false}>
+                {state.threads.map((thread) => (
+                  <button
+                    key={thread.id}
+                    type="button"
+                    data-testid={`debug-thread-${thread.id}`}
+                    className={`w-full flex items-center gap-2 px-3 py-0.5 text-left hover:bg-[var(--taomni-hover-bg)] ${
+                      thread.id === state.selectedThreadId ? "bg-[var(--taomni-hover-bg)]" : ""
+                    }`}
+                    onClick={() => debug.selectThread(thread.id)}
+                    disabled={!stopped}
+                  >
+                    <span className="truncate">{thread.name}</span>
+                    {thread.id === state.stoppedThreadId && (
+                      <Pause className="ml-auto h-3 w-3 shrink-0 text-amber-500" />
+                    )}
+                  </button>
+                ))}
+              </Section>
+            )}
             <Section title="Call Stack">
               {state.frames.length === 0
                 ? <Empty text={stopped ? "No frames" : "Running…"} />
                 : state.frames.map((frame) => (
-                  <button
+                  <div
                     key={frame.id}
-                    type="button"
-                    data-testid={`debug-frame-${frame.id}`}
-                    className="w-full flex items-center gap-2 px-3 py-0.5 text-left hover:bg-[var(--taomni-hover-bg)] disabled:opacity-50"
-                    onClick={() => onOpenFrame(frame)}
-                    disabled={!frame.path}
+                    className={`group flex items-center hover:bg-[var(--taomni-hover-bg)] ${
+                      frame.id === state.selectedFrameId ? "bg-[var(--taomni-hover-bg)]" : ""
+                    }`}
                   >
-                    <span className="truncate">{frame.name}</span>
-                    {frame.path && (
-                      <span className="ml-auto shrink-0 text-[10px] text-[var(--taomni-text-muted)]">
-                        {frame.path.split(/[\\/]/).pop()}:{frame.line}
+                    <button
+                      type="button"
+                      data-testid={`debug-frame-${frame.id}`}
+                      className="min-w-0 flex-1 flex items-center gap-2 px-3 py-0.5 text-left"
+                      onClick={() => {
+                        debug.selectFrame(frame.id);
+                        if (frame.path) onOpenFrame(frame);
+                      }}
+                    >
+                      <span className={`truncate ${frame.path ? "" : "text-[var(--taomni-text-muted)]"}`}>
+                        {frame.name}
                       </span>
+                      {frame.path && (
+                        <span className="ml-auto shrink-0 text-[10px] text-[var(--taomni-text-muted)]">
+                          {frame.path.split(/[\\/]/).pop()}:{frame.line}
+                        </span>
+                      )}
+                    </button>
+                    {canRestartFrame && stopped && (
+                      <button
+                        type="button"
+                        data-testid={`debug-restart-frame-${frame.id}`}
+                        className="shrink-0 px-1 opacity-0 group-hover:opacity-100 hover:text-emerald-500"
+                        onClick={() => debug.restartFrame(frame.id)}
+                        title="Restart frame (re-enter from its start)"
+                      >
+                        <RotateCcw className="h-3 w-3" />
+                      </button>
                     )}
-                  </button>
+                  </div>
                 ))}
             </Section>
             <Section title="Variables">
               {variables.length === 0
                 ? <Empty text={stopped ? "No variables" : "Stopped only"} />
-                : variables.map((node) => (
-                  <VariableRow key={`${node.name}:${node.variablesReference}`} node={node} depth={0} onExpand={expandVariable} />
+                : variables.map((node, i) => (
+                  <VariableRow
+                    key={`${node.name}:${i}`}
+                    node={node}
+                    depth={0}
+                    onExpand={expandVariable}
+                    onStartEdit={canSetVariable && stopped ? startEdit : undefined}
+                    edit={edit}
+                    onEditChange={(value) => setEdit((current) => ({ ...current, value }))}
+                    onEditSubmit={submitEdit}
+                    onEditCancel={cancelEdit}
+                  />
                 ))}
             </Section>
             <Section title="Watch">
@@ -277,18 +556,27 @@ export function DebugPanel({ debug, onStart, onOpenFrame }: DebugPanelProps) {
                   onKeyDown={(e) => { if (e.key === "Enter") addWatch(); }}
                 />
               </div>
-              {watch.map((w, i) => (
-                <div key={`${w.expr}:${i}`} className="flex items-start gap-2 px-3 py-0.5">
-                  <span className="shrink-0 text-[var(--taomni-text)]">{w.expr}</span>
-                  <span className="truncate text-[var(--taomni-text-muted)]">= {w.value}</span>
-                  <button type="button" className="ml-auto shrink-0 text-[var(--taomni-text-muted)]"
-                    onClick={() => setWatch((c) => c.filter((_, j) => j !== i))}>×</button>
-                </div>
+              {watchNodes.map((node, i) => (
+                <VariableRow
+                  key={`${node.name}:${i}`}
+                  node={node}
+                  depth={0}
+                  onExpand={expandWatch}
+                  onRemove={() => debug.removeWatchExpression(i)}
+                />
               ))}
             </Section>
             <Section title="Console">
-              <div className="max-h-40 overflow-auto px-3 font-mono text-[10px] text-[var(--taomni-text-muted)]">
-                {consoleLog.map((line, i) => <div key={i} className="whitespace-pre-wrap">{line}</div>)}
+              <div
+                ref={consoleRef}
+                data-testid="debug-console-output"
+                className="max-h-40 overflow-auto px-3 font-mono text-[10px]"
+              >
+                {state.output.map((line, i) => (
+                  <span key={i} className={`whitespace-pre-wrap ${consoleLineClass(line.category)}`}>
+                    {line.text}
+                  </span>
+                ))}
               </div>
               <div className="flex items-center gap-1 px-3 py-1">
                 <input
@@ -329,8 +617,16 @@ export function DebugPanel({ debug, onStart, onOpenFrame }: DebugPanelProps) {
   );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  const [open, setOpen] = useState(true);
+function Section({
+  title,
+  defaultOpen = true,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
   return (
     <div className="border-b border-[var(--taomni-code-border)]">
       <button

--- a/src/components/editor/workspace/panels/TestsPanel.tsx
+++ b/src/components/editor/workspace/panels/TestsPanel.tsx
@@ -61,11 +61,11 @@ function TestRow({
         <button
           type="button"
           data-testid={`tests-debug-${item.fullName}`}
-          className="shrink-0 opacity-0 group-hover:opacity-100"
+          className="shrink-0 opacity-0 group-hover:opacity-100 hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors"
           onClick={() => onDebug(item)}
           title="Debug test (requires java-debug + java-test bundles)"
         >
-          <Bug className="h-3 w-3" />
+          <Bug className="h-3.5 w-3.5" />
         </button>
       </div>
       {open && hasChildren && item.children.map((child) => (

--- a/src/components/editor/workspace/useCodeDebugSession.ts
+++ b/src/components/editor/workspace/useCodeDebugSession.ts
@@ -12,14 +12,24 @@ import {
   buildSetBreakpointsArgs,
   currentLocation,
   initialDebugState,
+  markResumed,
+  parseBreakpointEvent,
+  parseEvaluate,
+  parseExceptionInfo,
+  parseSetBreakpointsResponse,
   parseStackFrames,
   parseThreads,
+  reconcileBreakpointLines,
   reduceDebugEvent,
   selectExceptionFilters,
+  sortedBreakpoints,
   stepCommandFor,
+  toAdapterSourcePath,
   type DebugBreakpoint,
   type DebugSessionState,
+  type DebugStackFrame,
   type DebugStepAction,
+  type EvaluateResult,
 } from "./dapDebugModel";
 
 /** Breakpoints keyed by absolute file path. */
@@ -29,29 +39,56 @@ export interface CodeDebugSession {
   /** Current session state (null when no debug session is active). */
   state: DebugSessionState | null;
   breakpoints: BreakpointMap;
+  /** Adapter verification per path → line → verified (session-scoped). */
+  breakpointRuntime: Record<string, Record<number, boolean>>;
+  /** Adapter capabilities from `initialize` — gates optional UI (restartFrame, setVariable…). */
+  capabilities: Record<string, unknown>;
   /** Exception-breakpoint filter ids the adapter advertised (D5). */
   availableExceptionFilters: { filter: string; label: string }[];
   enabledExceptionFilters: string[];
-  /** Start a Java debug session with a resolved launch config. */
-  startDebug: (launchConfig: Record<string, unknown>) => Promise<void>;
+  /** Persistent watch expressions (the panel evaluates them per stop). */
+  watchExpressions: string[];
+  /** Start a debug session with a resolved launch config (adapter defaults to Java). */
+  startDebug: (launchConfig: Record<string, unknown>, adapterId?: string) => Promise<void>;
+  /** Re-run the last launch config (IDEA rerun). */
+  restart: () => void;
+  canRestart: boolean;
   toggleBreakpoint: (path: string, line: number) => void;
   setBreakpointOptions: (path: string, line: number, options: Partial<DebugBreakpoint>) => void;
   setExceptionFilters: (ids: string[]) => void;
+  addWatchExpression: (expr: string) => void;
+  removeWatchExpression: (index: number) => void;
   step: (action: DebugStepAction) => void;
+  /** Continue to a line via a transient breakpoint (IDEA Run to Cursor). */
+  runToCursor: (path: string, line: number) => void;
+  /** Show another thread's stack while stopped. */
+  selectThread: (threadId: number) => void;
+  /** Pick the frame that variables / watches / evaluate target. */
+  selectFrame: (frameId: number) => void;
+  /** Re-enter a frame from its start (IDEA Drop Frame; capability-gated). */
+  restartFrame: (frameId: number) => void;
   /** Hot-reload changed classes (java-debug `redefineClasses`); best-effort (D5). */
   hotReload: () => void;
-  evaluate: (expression: string, context?: string) => Promise<string>;
+  evaluate: (expression: string, context?: string) => Promise<EvaluateResult>;
+  /** Change a variable's value (DAP `setVariable`; capability-gated). */
+  setVariable: (variablesReference: number, name: string, value: string) => Promise<EvaluateResult | null>;
+  /** Append a client-side line (REPL echo / result) to the session console. */
+  logConsole: (category: string, text: string) => void;
   /** Fetch variables for a `variablesReference` (D4 lazy tree). */
   fetchVariables: (variablesReference: number) => Promise<unknown>;
   /** Fetch scopes for a stack frame (D4). */
   fetchScopes: (frameId: number) => Promise<unknown>;
   terminate: () => void;
-  /** Source location to highlight as "current" (top frame with a path). */
+  /** Source location to highlight as "current" (selected frame, else top frame). */
   currentLocation: { path: string; line: number } | null;
 }
 
 function breakpointsKey(workspaceInstanceId: string): string {
   return `taomni.codeWorkspace.debugBreakpoints.v1.${workspaceInstanceId}`;
+}
+
+function watchesKey(workspaceInstanceId: string): string {
+  return `taomni.codeWorkspace.debugWatches.v1.${workspaceInstanceId}`;
 }
 
 function readBreakpoints(workspaceInstanceId: string): BreakpointMap {
@@ -63,33 +100,67 @@ function readBreakpoints(workspaceInstanceId: string): BreakpointMap {
       if (!Array.isArray(list)) continue;
       out[path] = list
         .filter((bp): bp is DebugBreakpoint => !!bp && typeof (bp as DebugBreakpoint).line === "number")
-        .map((bp) => ({ line: bp.line, condition: bp.condition, logMessage: bp.logMessage }));
+        .map((bp) => ({
+          line: bp.line,
+          condition: bp.condition,
+          hitCondition: bp.hitCondition,
+          logMessage: bp.logMessage,
+        }));
     }
     return out;
   } catch {
     return {};
   }
 }
+
+function readWatches(workspaceInstanceId: string): string[] {
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(watchesKey(workspaceInstanceId)) ?? "[]");
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
 export function useCodeDebugSession(workspaceInstanceId: string): CodeDebugSession {
   const [state, setState] = useState<DebugSessionState | null>(null);
   const [breakpoints, setBreakpoints] = useState<BreakpointMap>(() => readBreakpoints(workspaceInstanceId));
+  const [breakpointRuntime, setBreakpointRuntime] = useState<Record<string, Record<number, boolean>>>({});
+  const [capabilities, setCapabilities] = useState<Record<string, unknown>>({});
   const [exceptionFilters, setExceptionFiltersState] = useState<string[]>([]);
   const [availableFilters, setAvailableFilters] = useState<{ filter: string; label: string }[]>([]);
+  const [watchExpressions, setWatchExpressions] = useState<string[]>(() => readWatches(workspaceInstanceId));
+  const [canRestart, setCanRestart] = useState(false);
 
   const sessionIdRef = useRef<string | null>(null);
   const capabilitiesRef = useRef<Record<string, unknown>>({});
   const breakpointsRef = useRef(breakpoints);
   const exceptionFiltersRef = useRef(exceptionFilters);
+  const stateRef = useRef<DebugSessionState | null>(null);
   const unlistenRef = useRef<UnlistenFn | null>(null);
   const mountedRef = useRef(true);
+  /** Bumped on every `stopped` event; async work checks it to drop stale results. */
+  const stopEpochRef = useRef(0);
+  /** Adapter breakpoint id → file path, to route `breakpoint` events. */
+  const bpIdIndexRef = useRef(new Map<number, { path: string }>());
+  /** Pending run-to-cursor: its transient breakpoint is removed on the next stop. */
+  const tempRunToCursorRef = useRef<{ path: string } | null>(null);
+  const lastLaunchRef = useRef<{ config: Record<string, unknown>; adapterId: string } | null>(null);
   breakpointsRef.current = breakpoints;
   exceptionFiltersRef.current = exceptionFilters;
+  stateRef.current = state;
 
-  useEffect(() => () => {
-    mountedRef.current = false;
-    unlistenRef.current?.();
-    const id = sessionIdRef.current;
-    if (id) void dapTerminate(id).catch(() => {});
+  useEffect(() => {
+    // Set true on (re)mount: React 18 StrictMode runs mount→cleanup→remount, so
+    // the cleanup below fires once during dev double-invoke. Without resetting to
+    // true here, mountedRef stays false forever and every mounted-guarded setState
+    // (e.g. initialDebugState in startDebug) is silently skipped.
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      unlistenRef.current?.();
+      const id = sessionIdRef.current;
+      if (id) void dapTerminate(id).catch(() => {});
+    };
   }, []);
 
   const persistBreakpoints = useCallback((next: BreakpointMap) => {
@@ -100,29 +171,101 @@ export function useCodeDebugSession(workspaceInstanceId: string): CodeDebugSessi
     }
   }, [workspaceInstanceId]);
 
-  /** Push current breakpoints for a file to the adapter (no-op without a session). */
-  const syncBreakpointsForPath = useCallback(async (path: string) => {
-    const id = sessionIdRef.current;
-    if (!id) return;
-    await dapSendRequest(id, "setBreakpoints", buildSetBreakpointsArgs(path, breakpointsRef.current[path] ?? []))
-      .catch(() => {});
+  const persistWatches = useCallback((next: string[]) => {
+    try {
+      window.localStorage.setItem(watchesKey(workspaceInstanceId), JSON.stringify(next));
+    } catch {
+      // Ignore storage failures.
+    }
+  }, [workspaceInstanceId]);
+
+  const logConsole = useCallback((category: string, text: string) => {
+    setState((prev) => {
+      if (!prev || !text) return prev;
+      return { ...prev, output: [...prev.output, { category, text }].slice(-2000) };
+    });
   }, []);
 
-  /** After a `stopped` event, pull threads + top-of-stack frames for the UI. */
-  const refreshStoppedContext = useCallback(async (threadId: number | null) => {
+  /**
+   * Push current breakpoints for a file to the adapter and record the bindings
+   * it reports: verified flags feed the gutter (grey = not bound), verified
+   * line adjustments are adopted back into the stored set (IDEA/VS Code move a
+   * breakpoint on a blank line to the next executable one). `extraTempLine`
+   * injects the transient run-to-cursor breakpoint without persisting it.
+   */
+  const syncBreakpointsForPath = useCallback(async (path: string, extraTempLine?: number) => {
+    const id = sessionIdRef.current;
+    if (!id) return;
+    const stored = sortedBreakpoints(breakpointsRef.current[path] ?? []);
+    const requested = extraTempLine != null && !stored.some((bp) => bp.line === extraTempLine)
+      ? sortedBreakpoints([...stored, { line: extraTempLine }])
+      : stored;
+    // Breakpoints are keyed by our internal (forward-slash) path, but the adapter
+    // needs the OS-native form (Windows: lowercase drive + backslashes) or it
+    // leaves them unverified.
+    const args = buildSetBreakpointsArgs(path, requested);
+    args.source.path = toAdapterSourcePath(path);
+    const body = await dapSendRequest(id, "setBreakpoints", args).catch(() => null);
+    if (body == null || !mountedRef.current) return;
+    const bindings = parseSetBreakpointsResponse(requested, body);
+    for (const binding of bindings) {
+      if (binding.id != null) bpIdIndexRef.current.set(binding.id, { path });
+    }
+    setBreakpointRuntime((prev) => ({
+      ...prev,
+      [path]: Object.fromEntries(requested.map((bp, i) => [
+        bindings[i]?.line ?? bp.line,
+        bindings[i]?.verified ?? false,
+      ])),
+    }));
+    if (extraTempLine == null) {
+      const reconciled = reconcileBreakpointLines(requested, bindings);
+      if (JSON.stringify(reconciled) !== JSON.stringify(stored)) {
+        setBreakpoints((current) => {
+          const next = { ...current };
+          if (reconciled.length > 0) next[path] = reconciled;
+          else delete next[path];
+          persistBreakpoints(next);
+          return next;
+        });
+      }
+    }
+  }, [persistBreakpoints]);
+
+  /** After a `stopped` event, pull threads + stack + exception details for the UI. */
+  const refreshStoppedContext = useCallback(async (
+    threadId: number | null,
+    reason: string | null,
+    epoch: number,
+  ) => {
     const id = sessionIdRef.current;
     if (!id) return;
     const threadsBody = await dapSendRequest(id, "threads").catch(() => null);
     const threads = parseThreads(threadsBody);
     const tid = threadId ?? threads[0]?.id ?? null;
-    let frames: ReturnType<typeof parseStackFrames> = [];
+    let frames: DebugStackFrame[] = [];
     if (tid != null) {
       const stackBody = await dapSendRequest(id, "stackTrace", { threadId: tid, startFrame: 0, levels: 40 })
         .catch(() => null);
       frames = parseStackFrames(stackBody);
     }
-    if (!mountedRef.current) return;
-    setState((prev) => (prev ? { ...prev, threads, frames } : prev));
+    if (!mountedRef.current || stopEpochRef.current !== epoch) return;
+    setState((prev) => (prev && prev.status === "stopped"
+      ? { ...prev, threads, frames, selectedThreadId: tid, selectedFrameId: frames[0]?.id ?? null }
+      : prev));
+    // IDEA-style exception details when the stop is an exception break.
+    if (
+      tid != null
+      && typeof reason === "string" && reason.toLowerCase().includes("exception")
+      && capabilitiesRef.current.supportsExceptionInfoRequest === true
+    ) {
+      const info = parseExceptionInfo(
+        await dapSendRequest(id, "exceptionInfo", { threadId: tid }).catch(() => null),
+      );
+      if (info && mountedRef.current && stopEpochRef.current === epoch) {
+        setState((prev) => (prev && prev.status === "stopped" ? { ...prev, exceptionInfo: info } : prev));
+      }
+    }
   }, []);
 
   const handleEvent = useCallback((payload: DapEventPayload) => {
@@ -141,18 +284,53 @@ export function useCodeDebugSession(workspaceInstanceId: string): CodeDebugSessi
         await dapSend(id, "configurationDone").catch(() => {});
       })();
     } else if (payload.event === "stopped") {
-      const body = (payload.message as { body?: { threadId?: number } })?.body;
-      void refreshStoppedContext(body?.threadId ?? null);
+      stopEpochRef.current += 1;
+      // Run-to-cursor's transient breakpoint is one-shot: restore the user set.
+      const temp = tempRunToCursorRef.current;
+      tempRunToCursorRef.current = null;
+      if (temp) void syncBreakpointsForPath(temp.path);
+      const body = (payload.message as { body?: { threadId?: number; reason?: string } })?.body;
+      void refreshStoppedContext(body?.threadId ?? null, body?.reason ?? null, stopEpochRef.current);
+    } else if (payload.event === "breakpoint") {
+      const parsed = parseBreakpointEvent(payload.message);
+      const entry = parsed?.id != null ? bpIdIndexRef.current.get(parsed.id) : undefined;
+      if (parsed && parsed.line != null && entry) {
+        const { path } = entry;
+        const { line, verified } = parsed;
+        setBreakpointRuntime((prev) => ({
+          ...prev,
+          [path]: { ...(prev[path] ?? {}), [line]: verified },
+        }));
+      }
+    } else if (payload.event === "terminated" || payload.event === "exited") {
+      // Free the backend session (drops the adapter transport / child); the final
+      // state stays visible in the panel until the next start.
+      const id = sessionIdRef.current;
+      sessionIdRef.current = null;
+      if (id) void dapTerminate(id).catch(() => {});
+      unlistenRef.current?.();
+      unlistenRef.current = null;
+      bpIdIndexRef.current.clear();
+      tempRunToCursorRef.current = null;
+      if (mountedRef.current) setBreakpointRuntime({});
     }
   }, [refreshStoppedContext, syncBreakpointsForPath]);
-  const startDebug = useCallback(async (launchConfig: Record<string, unknown>) => {
+  const startDebug = useCallback(async (
+    launchConfig: Record<string, unknown>,
+    adapterId = "java",
+  ) => {
     // One session at a time: tear down any prior one first.
     const prior = sessionIdRef.current;
+    sessionIdRef.current = null;
     unlistenRef.current?.();
     unlistenRef.current = null;
     if (prior) await dapTerminate(prior).catch(() => {});
+    bpIdIndexRef.current.clear();
+    tempRunToCursorRef.current = null;
+    if (mountedRef.current) setBreakpointRuntime({});
 
-    const result = await dapStartSession("java", launchConfig);
+    lastLaunchRef.current = { config: launchConfig, adapterId };
+    const result = await dapStartSession(adapterId, launchConfig);
     sessionIdRef.current = result.sessionId;
     capabilitiesRef.current = result.capabilities;
     const filters = Array.isArray(result.capabilities.exceptionBreakpointFilters)
@@ -161,6 +339,8 @@ export function useCodeDebugSession(workspaceInstanceId: string): CodeDebugSessi
       : [];
     if (mountedRef.current) {
       setAvailableFilters(filters);
+      setCapabilities(result.capabilities);
+      setCanRestart(true);
       setState(initialDebugState(result.sessionId));
     }
     // Listen before firing launch so the `initialized` event can't be missed.
@@ -169,6 +349,11 @@ export function useCodeDebugSession(workspaceInstanceId: string): CodeDebugSessi
     // Fire launch/attach without awaiting (its response trails configurationDone).
     await dapSend(result.sessionId, result.request, result.arguments).catch(() => {});
   }, [handleEvent]);
+
+  const restart = useCallback(() => {
+    const last = lastLaunchRef.current;
+    if (last) void startDebug(last.config, last.adapterId).catch(() => {});
+  }, [startDebug]);
 
   const toggleBreakpoint = useCallback((path: string, line: number) => {
     setBreakpoints((current) => {
@@ -205,34 +390,162 @@ export function useCodeDebugSession(workspaceInstanceId: string): CodeDebugSessi
     }
   }, []);
 
+  const addWatchExpression = useCallback((expr: string) => {
+    const trimmed = expr.trim();
+    if (!trimmed) return;
+    setWatchExpressions((current) => {
+      if (current.includes(trimmed)) return current;
+      const next = [...current, trimmed];
+      persistWatches(next);
+      return next;
+    });
+  }, [persistWatches]);
+
+  const removeWatchExpression = useCallback((index: number) => {
+    setWatchExpressions((current) => {
+      const next = current.filter((_, i) => i !== index);
+      persistWatches(next);
+      return next;
+    });
+  }, [persistWatches]);
+
   const step = useCallback((action: DebugStepAction) => {
     const id = sessionIdRef.current;
     if (!id) return;
-    const command = stepCommandFor(action);
-    const threadId = state?.stoppedThreadId ?? undefined;
-    // continue/step take a threadId; pause targets a running thread too.
-    void dapSendRequest(id, command, threadId != null ? { threadId } : {}).catch(() => {});
-  }, [state?.stoppedThreadId]);
+    void (async () => {
+      if (action === "pause") {
+        // `pause` requires a threadId; while running we may not have one yet.
+        let tid = stateRef.current?.threads[0]?.id ?? null;
+        if (tid == null) {
+          tid = parseThreads(await dapSendRequest(id, "threads").catch(() => null))[0]?.id ?? null;
+        }
+        if (tid == null) return;
+        await dapSendRequest(id, "pause", { threadId: tid }).catch(() => {});
+        return; // The adapter answers with a `stopped` event.
+      }
+      const epoch = stopEpochRef.current;
+      const tid = stateRef.current?.selectedThreadId ?? stateRef.current?.stoppedThreadId;
+      try {
+        await dapSendRequest(id, stepCommandFor(action), tid != null ? { threadId: tid } : {});
+        // Adapters need not emit `continued` after an explicit resume/step —
+        // flip to running optimistically unless a newer stop already landed.
+        if (mountedRef.current && stopEpochRef.current === epoch) {
+          setState((prev) => (prev && prev.status === "stopped" ? markResumed(prev) : prev));
+        }
+      } catch {
+        // Request failed (e.g. already running): keep the current state.
+      }
+    })();
+  }, []);
+
+  const runToCursor = useCallback((path: string, line: number) => {
+    const id = sessionIdRef.current;
+    const current = stateRef.current;
+    if (!id || !current || current.status !== "stopped") return;
+    void (async () => {
+      const needsTemp = !(breakpointsRef.current[path] ?? []).some((bp) => bp.line === line);
+      if (needsTemp) {
+        tempRunToCursorRef.current = { path };
+        await syncBreakpointsForPath(path, line);
+      }
+      const epoch = stopEpochRef.current;
+      const tid = current.selectedThreadId ?? current.stoppedThreadId;
+      try {
+        await dapSendRequest(id, "continue", tid != null ? { threadId: tid } : {});
+        if (mountedRef.current && stopEpochRef.current === epoch) {
+          setState((prev) => (prev && prev.status === "stopped" ? markResumed(prev) : prev));
+        }
+      } catch {
+        // Continue failed: restore the user's breakpoints right away.
+        if (needsTemp) {
+          tempRunToCursorRef.current = null;
+          await syncBreakpointsForPath(path);
+        }
+      }
+    })();
+  }, [syncBreakpointsForPath]);
+
+  const selectThread = useCallback((threadId: number) => {
+    const id = sessionIdRef.current;
+    if (!id || stateRef.current?.status !== "stopped") return;
+    void (async () => {
+      const epoch = stopEpochRef.current;
+      const stackBody = await dapSendRequest(id, "stackTrace", { threadId, startFrame: 0, levels: 40 })
+        .catch(() => null);
+      const frames = parseStackFrames(stackBody);
+      if (!mountedRef.current || stopEpochRef.current !== epoch) return;
+      setState((prev) => (prev && prev.status === "stopped"
+        ? { ...prev, selectedThreadId: threadId, frames, selectedFrameId: frames[0]?.id ?? null }
+        : prev));
+    })();
+  }, []);
+
+  const selectFrame = useCallback((frameId: number) => {
+    setState((prev) => (prev && prev.status === "stopped" ? { ...prev, selectedFrameId: frameId } : prev));
+  }, []);
+
+  const restartFrame = useCallback((frameId: number) => {
+    const id = sessionIdRef.current;
+    if (!id || capabilitiesRef.current.supportsRestartFrame !== true) return;
+    // The adapter re-stops at the frame entry and emits a `stopped` event.
+    void dapSendRequest(id, "restartFrame", { frameId }).catch(() => {});
+  }, []);
 
   const hotReload = useCallback(() => {
     const id = sessionIdRef.current;
     if (!id) return;
-    // java-debug custom request; adapters without it just error (swallowed).
-    void dapSendRequest(id, "redefineClasses", {}).catch(() => {});
+    // java-debug custom request; adapters without it just error (reported below).
+    void dapSendRequest(id, "redefineClasses", {})
+      .then((body) => {
+        const changed = body && typeof body === "object"
+          ? (body as { changedClasses?: unknown }).changedClasses
+          : null;
+        const count = Array.isArray(changed) ? changed.length : 0;
+        logConsole("console", count > 0
+          ? `Hot reloaded ${count} class${count === 1 ? "" : "es"}\n`
+          : "Hot reload: no changed classes\n");
+      })
+      .catch((error) => {
+        logConsole("stderr", `Hot reload failed: ${error instanceof Error ? error.message : String(error)}\n`);
+      });
+  }, [logConsole]);
+
+  const evaluate = useCallback(async (expression: string, context = "repl"): Promise<EvaluateResult> => {
+    const id = sessionIdRef.current;
+    const current = stateRef.current;
+    if (!id) return { value: "", variablesReference: 0, type: null };
+    const frameId = current?.selectedFrameId ?? current?.frames[0]?.id;
+    try {
+      return parseEvaluate(await dapSendRequest(id, "evaluate", { expression, frameId, context }));
+    } catch (error) {
+      return {
+        value: error instanceof Error ? error.message : String(error),
+        variablesReference: 0,
+        type: null,
+      };
+    }
   }, []);
 
-  const evaluate = useCallback(async (expression: string, context = "repl"): Promise<string> => {
+  const setVariable = useCallback(async (
+    variablesReference: number,
+    name: string,
+    value: string,
+  ): Promise<EvaluateResult | null> => {
     const id = sessionIdRef.current;
-    if (!id) return "";
-    const frameId = state?.frames[0]?.id;
-    const body = await dapSendRequest(id, "evaluate", {
-      expression,
-      frameId,
-      context,
-    }).catch((error) => ({ result: error instanceof Error ? error.message : String(error) }));
-    const record = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
-    return typeof record.result === "string" ? record.result : "";
-  }, [state?.frames]);
+    if (!id) return null;
+    try {
+      const body = await dapSendRequest(id, "setVariable", { variablesReference, name, value });
+      const rec = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+      return {
+        value: typeof rec.value === "string" ? rec.value : "",
+        variablesReference: typeof rec.variablesReference === "number" ? rec.variablesReference : 0,
+        type: typeof rec.type === "string" ? rec.type : null,
+      };
+    } catch (error) {
+      logConsole("stderr", `Set value failed: ${error instanceof Error ? error.message : String(error)}\n`);
+      return null;
+    }
+  }, [logConsole]);
 
   const fetchVariables = useCallback(async (variablesReference: number): Promise<unknown> => {
     const id = sessionIdRef.current;
@@ -251,25 +564,43 @@ export function useCodeDebugSession(workspaceInstanceId: string): CodeDebugSessi
     unlistenRef.current?.();
     unlistenRef.current = null;
     sessionIdRef.current = null;
+    bpIdIndexRef.current.clear();
+    tempRunToCursorRef.current = null;
     if (id) void dapTerminate(id).catch(() => {});
-    if (mountedRef.current) setState(null);
+    if (mountedRef.current) {
+      setState(null);
+      setBreakpointRuntime({});
+    }
   }, []);
 
   return {
     state,
     breakpoints,
+    breakpointRuntime,
+    capabilities,
     availableExceptionFilters: availableFilters,
     enabledExceptionFilters: exceptionFilters,
+    watchExpressions,
     startDebug,
+    restart,
+    canRestart,
     toggleBreakpoint,
     setBreakpointOptions,
     setExceptionFilters,
+    addWatchExpression,
+    removeWatchExpression,
     step,
+    runToCursor,
+    selectThread,
+    selectFrame,
+    restartFrame,
     hotReload,
     evaluate,
+    setVariable,
+    logConsole,
     fetchVariables,
     fetchScopes,
     terminate,
-    currentLocation: state ? currentLocation(state.frames) : null,
+    currentLocation: state ? currentLocation(state.frames, state.selectedFrameId) : null,
   };
 }


### PR DESCRIPTION
…ication fixes, frames, threads, run-to-cursor

Correctness fixes:
- Show debuggee output: default the Java launch console to internalConsole (java-debug streams stdout/stderr as DAP `output` events; the kernel does not implement the runInTerminal reverse request) and render those events in the Debug panel console, merged with REPL echoes, colored by category (stderr red etc.) with autoscroll; print an IDEA-style "Process finished with exit code N" line on exit
- Optimistic resume: adapters are not required to emit `continued` after an explicit continue/step (java-debug does not), so the UI froze on a stale stack + current-line highlight after resuming — mark the session running once the resume request succeeds, guarded by a stop-epoch counter so a racing `stopped` event is never clobbered
- `pause` requires a threadId per the DAP spec but none is known while running — resolve one via a `threads` request first
- Breakpoint verification: parse `setBreakpoints` responses and `breakpoint` events (classes verify as they load); unbound breakpoints render as grey hollow gutter markers, and verified line adjustments (breakpoint on a non-executable line) are adopted back into the stored set with dedup, matching IDEA/VS Code
- Send Windows source paths to the adapter as lowercase-drive + backslashes (JDT's native form) — forward-slash uppercase-drive paths left breakpoints permanently unverified
- Free the backend DAP session on terminated/exited events (it previously leaked in the session map until an explicit stop); the final state stays visible in the panel
- initialize declares supportsConfigurationDoneRequest so java-debug holds the debuggee until breakpoints are configured, and supportsRunInTerminalRequest: false to match the kernel
- Fix the Rust unit test still asserting the old integratedTerminal console default

IDEA-parity features (language-agnostic DAP, capability-gated where optional):
- Auto-reveal the stopped location: breakpoint hits and step landings open the file and jump to the line
- Stack frame selection: clicking a frame retargets variables, watches, evaluate, and the current-line highlight to that frame
- Threads section: inspect any thread's stack while stopped; the stopped thread is marked
- Exception banner: fetch `exceptionInfo` when stopped on an exception (supportsExceptionInfoRequest) and show class, message, and stack trace
- Inline variable editing via `setVariable` (supportsSetVariable): double-click a value, Enter commits, watches re-evaluate
- Hit-count breakpoints (DAP hitCondition) added to the breakpoint edit dialog; conditional breakpoints render amber, logpoints as diamonds
- Run to Cursor in the editor context menu (session-only, enabled while stopped): transient breakpoint + continue, user breakpoints restored on the next stop or on failure
- Restart session (rerun the last launch config, also after termination) and Restart Frame / drop frame (supportsRestartFrame) on stack rows
- Watch expressions persist per workspace (localStorage) and expand into structured children via their variablesReference
- Hot reload now reports its outcome (changed-class count or error) to the console
- Java adapter defaults IDEA-like step filters — skip $JDK classes, synthetic/bridge methods, and static initializers — overridable via the launch config; initialize advertises supportsVariableType so variables carry type tooltips

Also keys DebugPanel effects on the hook's stable callbacks instead of the per-render session object: parent re-renders no longer re-fetch scopes or re-evaluate watches against the adapter.

Validation: vitest 209 files / 1676 tests, tsc -b, cargo test (dap + java adapter, 19 tests) all pass.