### PR TITLE
fix(dap): surface silent launch failures that left Java debug stuck a…

### DIFF
--- a/src-tauri/src/dap.rs
+++ b/src-tauri/src/dap.rs
@@ -118,6 +118,35 @@ pub fn classify_message(message: &Value) -> InboundMessage {
     }
 }
 
+/// Extract the most useful error text from a failed DAP response. The spec's
+/// `ErrorResponse` carries a structured `body.error` message with a `format`
+/// template and `{key}` placeholders resolved from `variables`; the flat
+/// top-level `message` is often just a terse summary (java-debug puts the real
+/// reason — "Failed to launch debuggee VM. Reason: …" — in `body.error`).
+pub fn extract_error_message(message: &Value) -> String {
+    if let Some(error) = message.pointer("/body/error") {
+        if let Some(format) = error.get("format").and_then(Value::as_str) {
+            let mut text = format.to_string();
+            if let Some(variables) = error.get("variables").and_then(Value::as_object) {
+                for (key, value) in variables {
+                    if let Some(value) = value.as_str() {
+                        text = text.replace(&format!("{{{key}}}"), value);
+                    }
+                }
+            }
+            if !text.trim().is_empty() {
+                return text;
+            }
+        }
+    }
+    message
+        .get("message")
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or("debug adapter request failed")
+        .to_string()
+}
+
 /// How the kernel reaches a debug adapter. `Stdio` spawns a process and speaks DAP
 /// over its stdin/stdout; `Tcp` connects to an already-listening adapter (java-debug
 /// hands back a port via jdtls, so the Java adapter, D2, will use `Tcp`).
@@ -362,11 +391,7 @@ async fn run_reader(
                         let payload = if ok {
                             Ok(message.get("body").cloned().unwrap_or(Value::Null))
                         } else {
-                            Err(message
-                                .get("message")
-                                .and_then(Value::as_str)
-                                .unwrap_or("debug adapter request failed")
-                                .to_string())
+                            Err(extract_error_message(&message))
                         };
                         let _ = tx.send(payload);
                     }
@@ -618,6 +643,31 @@ mod tests {
     fn empty_registry_returns_none() {
         let registry = DebugAdapterRegistry::new();
         assert!(registry.get("java").is_none());
+    }
+
+    #[test]
+    fn extracts_structured_error_details_with_variable_substitution() {
+        // ErrorResponse body.error wins over the terse top-level message.
+        let response = json!({
+            "type": "response", "success": false, "message": "launch failed",
+            "body": { "error": {
+                "format": "Failed to launch debuggee VM. Reason: {reason}",
+                "variables": { "reason": "mainClass not found" },
+            }},
+        });
+        assert_eq!(
+            extract_error_message(&response),
+            "Failed to launch debuggee VM. Reason: mainClass not found",
+        );
+        // Falls back to the flat message, then to a generic string.
+        assert_eq!(
+            extract_error_message(&json!({ "success": false, "message": "boom" })),
+            "boom",
+        );
+        assert_eq!(
+            extract_error_message(&json!({ "success": false })),
+            "debug adapter request failed",
+        );
     }
 
     #[test]

--- a/src-tauri/src/java_debug_adapter.rs
+++ b/src-tauri/src/java_debug_adapter.rs
@@ -57,9 +57,10 @@ fn session_scope(cfg: &Value) -> Result<SessionScope, String> {
 struct MainClassCandidate {
     main_class: String,
     project_name: String,
+    file_path: Option<String>,
 }
 
-/// Parse `vscode.java.resolveMainClass` output (`[{ mainClass, projectName }]`).
+/// Parse `vscode.java.resolveMainClass` output (`[{ mainClass, projectName, filePath }]`).
 fn parse_main_classes(value: &Value) -> Vec<MainClassCandidate> {
     value
         .as_array()
@@ -78,11 +79,39 @@ fn parse_main_classes(value: &Value) -> Vec<MainClassCandidate> {
                             .and_then(Value::as_str)
                             .unwrap_or("")
                             .to_string(),
+                        file_path: item
+                            .get("filePath")
+                            .and_then(Value::as_str)
+                            .filter(|s| !s.is_empty())
+                            .map(str::to_string),
                     })
                 })
                 .collect()
         })
         .unwrap_or_default()
+}
+
+/// Normalize a path for comparison: forward slashes + lowercase (Windows
+/// paths from jdtls and from the frontend differ in slash direction and
+/// drive-letter case).
+fn comparable_path(path: &str) -> String {
+    path.replace('\\', "/").to_lowercase()
+}
+
+/// Pick the main class to launch: the candidate declared in the active file
+/// ("debug the file I'm looking at", like IDEA's run gutter), else the first.
+/// jdtls returns the whole workspace's mains in arbitrary order, so taking the
+/// first blindly can launch a different class than the one on screen.
+fn pick_main_class(
+    candidates: Vec<MainClassCandidate>,
+    target_file: &str,
+) -> Option<MainClassCandidate> {
+    let target = comparable_path(target_file);
+    candidates
+        .iter()
+        .find(|c| c.file_path.as_deref().is_some_and(|p| comparable_path(p) == target))
+        .cloned()
+        .or_else(|| candidates.into_iter().next())
 }
 
 /// Parse `vscode.java.resolveClasspath` output — a `[[modulepaths],[classpaths]]`
@@ -192,9 +221,7 @@ impl DebugAdapter for JavaDebugAdapter {
             }
             _ => {
                 let resolved = run("vscode.java.resolveMainClass", vec![]).await?;
-                let candidate = parse_main_classes(&resolved)
-                    .into_iter()
-                    .next()
+                let candidate = pick_main_class(parse_main_classes(&resolved), &scope.file_path)
                     .ok_or("No runnable main class found in this Java project")?;
                 (candidate.main_class, candidate.project_name)
             }
@@ -267,7 +294,31 @@ mod tests {
         assert_eq!(mains.len(), 1);
         assert_eq!(mains[0].main_class, "com.example.App");
         assert_eq!(mains[0].project_name, "demo");
+        assert_eq!(mains[0].file_path.as_deref(), Some("/x/App.java"));
         assert!(parse_main_classes(&Value::Null).is_empty());
+    }
+
+    #[test]
+    fn picks_the_main_class_declared_in_the_active_file() {
+        let candidates = vec![
+            MainClassCandidate {
+                main_class: "com.example.Other".into(),
+                project_name: "demo".into(),
+                file_path: Some("D:\\repo\\src\\Other.java".into()),
+            },
+            MainClassCandidate {
+                main_class: "com.example.App".into(),
+                project_name: "demo".into(),
+                file_path: Some("D:\\repo\\src\\App.java".into()),
+            },
+        ];
+        // Slash direction + drive-letter case differences must not break matching.
+        let picked = pick_main_class(candidates.clone(), "d:/repo/src/App.java").unwrap();
+        assert_eq!(picked.main_class, "com.example.App");
+        // No file match: fall back to the first candidate.
+        let fallback = pick_main_class(candidates, "/elsewhere/Main.java").unwrap();
+        assert_eq!(fallback.main_class, "com.example.Other");
+        assert!(pick_main_class(vec![], "/x.java").is_none());
     }
 
     #[test]

--- a/src/components/editor/workspace/useCodeDebugSession.ts
+++ b/src/components/editor/workspace/useCodeDebugSession.ts
@@ -9,6 +9,7 @@ import {
   type DapEventPayload,
 } from "../../../lib/editor/dap";
 import {
+  appendConsoleLine,
   buildSetBreakpointsArgs,
   currentLocation,
   initialDebugState,
@@ -145,6 +146,8 @@ export function useCodeDebugSession(workspaceInstanceId: string): CodeDebugSessi
   /** Pending run-to-cursor: its transient breakpoint is removed on the next stop. */
   const tempRunToCursorRef = useRef<{ path: string } | null>(null);
   const lastLaunchRef = useRef<{ config: Record<string, unknown>; adapterId: string } | null>(null);
+  /** Whether the adapter has emitted `initialized` for the current session. */
+  const initializedRef = useRef(false);
   breakpointsRef.current = breakpoints;
   exceptionFiltersRef.current = exceptionFilters;
   stateRef.current = state;
@@ -272,6 +275,7 @@ export function useCodeDebugSession(workspaceInstanceId: string): CodeDebugSessi
     if (payload.sessionId !== sessionIdRef.current) return;
     setState((prev) => (prev ? reduceDebugEvent(prev, payload.event, payload.message) : prev));
     if (payload.event === "initialized") {
+      initializedRef.current = true;
       // Configure breakpoints before the debuggee runs, then release it.
       void (async () => {
         const id = sessionIdRef.current;
@@ -346,9 +350,39 @@ export function useCodeDebugSession(workspaceInstanceId: string): CodeDebugSessi
     // Listen before firing launch so the `initialized` event can't be missed.
     unlistenRef.current = await listenDapEvents(result.sessionId, handleEvent);
     setState((prev) => (prev ? { ...prev, status: "running" } : prev));
-    // Fire launch/attach without awaiting (its response trails configurationDone).
-    await dapSend(result.sessionId, result.request, result.arguments).catch(() => {});
-  }, [handleEvent]);
+    initializedRef.current = false;
+    // Fire launch/attach as a correlated request but do NOT await it here: the
+    // response only arrives after configurationDone (awaiting would deadlock
+    // the initialized → setBreakpoints → configurationDone sequence). The
+    // correlation exists to surface failures — when the launch fails the
+    // adapter never emits `initialized`, so without this the error response is
+    // silently dropped and the UI sits at "running" forever.
+    const launchedSession = result.sessionId;
+    void dapSendRequest(launchedSession, result.request, result.arguments).catch((error) => {
+      if (sessionIdRef.current !== launchedSession) return; // already torn down
+      const message = error instanceof Error ? error.message : String(error);
+      sessionIdRef.current = null;
+      unlistenRef.current?.();
+      unlistenRef.current = null;
+      void dapTerminate(launchedSession).catch(() => {});
+      if (mountedRef.current) {
+        setBreakpointRuntime({});
+        setState((prev) => (prev && prev.sessionId === launchedSession
+          ? appendConsoleLine({ ...prev, status: "terminated" }, "stderr", `Launch failed: ${message}\n`)
+          : prev));
+      }
+    });
+    // Watchdog: if the adapter never becomes ready, say so instead of showing
+    // an eternally-running empty session.
+    window.setTimeout(() => {
+      if (sessionIdRef.current !== launchedSession || initializedRef.current) return;
+      logConsole(
+        "console",
+        "Still waiting for the debug adapter to become ready (no 'initialized' event after 15s). "
+          + "The project may have build errors, or the launch is stalled.\n",
+      );
+    }, 15_000);
+  }, [handleEvent, logConsole]);
 
   const restart = useCallback(() => {
     const last = lastLaunchRef.current;


### PR DESCRIPTION
…t Running

Root cause of "start debug → forever Running…, empty console, breakpoint never hit": java-debug only emits the `initialized` event from LaunchWithDebuggingDelegate.postLaunch, i.e. AFTER the debuggee VM started. When the launch fails (build errors, wrong main class, VM start failure), no `initialized` ever arrives and the failure is reported ONLY in the launch request's error response — which the client fired via the fire-and-forget `dap_send`, so the error response had no pending oneshot and was dropped on the floor. Result: no configurationDone, VM never runs, UI shows "running" with nothing in it, no error anywhere.

Fixes:
- Send launch/attach as a correlated request (still not awaited — its response legitimately trails configurationDone, awaiting would deadlock the initialized → setBreakpoints → configurationDone sequence). On a rejected launch: print "Launch failed: <reason>" to the debug console, mark the session terminated, and free the backend session
- Extract the real error text from DAP ErrorResponse bodies in the kernel: prefer body.error.format with {variable} substitution over the terse top-level message (java-debug puts "Failed to launch debuggee VM. Reason: …" there), with fallbacks
- Pick the main class declared in the ACTIVE file: resolveMainClass returns every main in the jdtls workspace in arbitrary order and the adapter blindly took the first, so debugging file A could actually launch (or fail to launch) class B. Candidates are now matched by filePath (slash/drive-case tolerant) with first-candidate fallback, matching IDEA's run-current-file behavior
- Add a 15s watchdog after firing launch: if no `initialized` has arrived and the session is still alive, log a console hint (build errors / stalled launch) instead of an eternally-running empty session

Validation: cargo test (21 dap/adapter tests incl. new error-extraction and main-class-picking cases), vitest editor suite 56 files / 325 tests, tsc -b.