### PR TITLE
feat(sockscap): lock config while running, copyable test results, no-…

### DIFF
--- a/src/components/sockscap/SocksCapPanel.test.tsx
+++ b/src/components/sockscap/SocksCapPanel.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SocksCapPanel } from "./SocksCapPanel";
 import {
   sockscapStart,
+  sockscapStatus,
   sockscapParseShareLink,
   sockscapImportSubscription,
   type SocksCapConfig,
@@ -124,6 +125,14 @@ describe("SocksCapPanel Multi-Profile UI", () => {
       message: "active",
       ruleCount: 0,
       captureBackend: "test",
+    });
+    // Default to idle so the panel is unlocked; the lock test overrides this.
+    vi.mocked(sockscapStatus).mockReset();
+    vi.mocked(sockscapStatus).mockResolvedValue({
+      phase: "idle",
+      message: "idle",
+      ruleCount: 0,
+      captureBackend: "none",
     });
   });
 
@@ -308,6 +317,52 @@ describe("SocksCapPanel Multi-Profile UI", () => {
     expect(b.upstream.params?.flow).toBe("xtls-rprx-vision");
     // Imported profiles are not auto-activated.
     expect(currentCfg.activeProfileIds).not.toContain(a.id);
+  });
+
+  it("locks scope/upstream/profile edits while running but keeps Add profile", async () => {
+    // Report the engine as Active so the panel enters the locked state.
+    vi.mocked(sockscapStatus).mockResolvedValue({
+      phase: "active",
+      message: "active",
+      ruleCount: 0,
+      captureBackend: "test",
+    });
+    render(<SocksCapPanel />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("sockscap-locked-banner")).toBeInTheDocument(),
+    );
+    // Restart-requiring controls are disabled…
+    expect(screen.getByTestId("sockscap-upstream-kind")).toBeDisabled();
+    expect(screen.getByTestId("sockscap-mode-global")).toBeDisabled();
+    expect(screen.getByTestId("sockscap-upstream-source")).toBeDisabled();
+    expect(screen.getByTestId("sockscap-profile-checkbox-default")).toBeDisabled();
+    // …but adding a new profile is still allowed.
+    expect(screen.getByTestId("sockscap-add-profile")).not.toBeDisabled();
+  });
+
+  it("shows a copyable detail modal after testing the upstream", async () => {
+    const writeMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText: writeMock } });
+    render(<SocksCapPanel />);
+
+    // Shadowsocks routes the test through the mocked core-upstream tester.
+    const kindSelect = await screen.findByTestId("sockscap-upstream-kind");
+    fireEvent.change(kindSelect, { target: { value: "shadowsocks" } });
+
+    fireEvent.click(await screen.findByTestId("sockscap-test-upstream"));
+
+    const body = await screen.findByTestId("sockscap-test-detail-body");
+    expect(body).toHaveTextContent("ok");
+
+    fireEvent.click(screen.getByTestId("sockscap-test-detail-copy"));
+    await waitFor(() => expect(writeMock).toHaveBeenCalledWith("ok"));
+  });
+
+  it("shows the no-proxy help block when no local proxy is detected", async () => {
+    render(<SocksCapPanel />);
+    // Default upstream is socks5 with no detected proxies and no session.
+    expect(await screen.findByTestId("sockscap-noproxy-help")).toBeInTheDocument();
   });
 
   it("prompts for sudo when Linux nftables reports missing CAP_NET_ADMIN", async () => {

--- a/src/components/sockscap/SocksCapPanel.tsx
+++ b/src/components/sockscap/SocksCapPanel.tsx
@@ -7,8 +7,10 @@ import {
   ChevronDown,
   ChevronRight,
   Copy,
+  HelpCircle,
   Layers,
   Loader2,
+  Lock,
   PanelLeftClose,
   PanelLeftOpen,
   Play,
@@ -76,6 +78,7 @@ import {
 } from "../../lib/ipc";
 import { useT } from "../../lib/i18n";
 import { isTauriRuntime } from "../../lib/runtime";
+import { writeText } from "../../lib/clipboard";
 import { open } from "@tauri-apps/plugin-dialog";
 
 interface Props {
@@ -227,6 +230,13 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
   const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
   const [testHost, setTestHost] = useState("www.google.com");
   const [testResult, setTestResult] = useState<TargetTestResult | null>(null);
+  // Dedicated flag for in-flight tests so the test buttons lock (with a spinner)
+  // independently of the global `busy` and the background status poll.
+  const [testing, setTesting] = useState(false);
+  // Full text of the last test, shown in a copyable modal (the status bar only
+  // gets a short summary — long upstream diagnostics get truncated there).
+  const [testDetail, setTestDetail] = useState<{ title: string; body: string } | null>(null);
+  const [testCopied, setTestCopied] = useState(false);
   const [newRule, setNewRule] = useState<UserRule>({
     pattern: "",
     action: "direct",
@@ -303,6 +313,33 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
     },
     [onStatusMessage],
   );
+
+  // Status bar / inline message is single-line and truncated, so collapse a
+  // multi-line test result to its first non-empty line for the summary. The
+  // full text goes to the copyable modal via openTestDetail.
+  const summarize = (text: string): string => {
+    const first = text
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => l.length > 0);
+    return first || text.trim();
+  };
+
+  const openTestDetail = (title: string, body: string) => {
+    setTestCopied(false);
+    setTestDetail({ title, body });
+  };
+
+  const copyTestDetail = async () => {
+    if (!testDetail) return;
+    try {
+      await writeText(testDetail.body);
+      setTestCopied(true);
+      report(t("common.copied"));
+    } catch (e) {
+      report(String(e), false);
+    }
+  };
 
   // Re-run local-proxy detection and refresh the picker's "detected" group.
   // Errors are reported but non-fatal (detection is best-effort). Declared here
@@ -404,6 +441,14 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
     status?.phase === "active" ||
     status?.phase === "degraded" ||
     status?.phase === "preparing";
+
+  // While capture is running the backend only hot-reloads the rule surface
+  // (ruleMode / userRules / defaultAction / bypassCidrs / GFWList). Scope, app
+  // list, upstream, and the active-profile set are snapshotted at Start and
+  // ignored until the next Stop+Start (see lib/sockscapRestart + orchestrator
+  // hot_reload_policy). So lock every "needs restart" control while running and
+  // tell the user to stop first. Adding a NEW profile stays allowed.
+  const locked = running;
 
   const selectedProf = useMemo(() => {
     if (!cfg) return DEFAULT_PROFILE;
@@ -839,22 +884,30 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
   };
 
   const onTestTarget = async () => {
-    setBusy(true);
+    setTesting(true);
     try {
       if (cfg) await sockscapSetConfig(cfg);
       const res = await sockscapTestTarget(testHost.trim(), 443);
       setTestResult(res);
-      report(
-        t("sockscap.testTargetResult", {
-          host: res.host,
-          decision: res.decision,
-          reason: res.reason,
-        }),
-      );
+      const summary = t("sockscap.testTargetResult", {
+        host: res.host,
+        decision: res.decision,
+        reason: res.reason,
+      });
+      report(summary);
+      const body = [
+        `${t("sockscap.host")}: ${res.host}:${res.port}`,
+        `${t("sockscap.testDecision")}: ${res.decision}`,
+        `${t("sockscap.testMatchedRule")}: ${res.matchedRule || "-"}`,
+        `${t("common.message")}: ${res.reason}`,
+      ].join("\n");
+      openTestDetail(t("sockscap.testTargetDetailTitle", { host: res.host }), body);
     } catch (e) {
-      report(String(e), false);
+      const err = String(e);
+      report(err, false);
+      openTestDetail(t("sockscap.testTargetDetailTitle", { host: testHost.trim() }), err);
     } finally {
-      setBusy(false);
+      setTesting(false);
     }
   };
 
@@ -898,34 +951,40 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
 
   const onTestUpstream = async () => {
     if (!cfg) return;
-    setBusy(true);
+    setTesting(true);
+    const title = t("sockscap.testUpstreamDetailTitle", {
+      kind: selectedProf.upstream.kind,
+    });
     try {
       const u = selectedProf.upstream;
+      let text: string;
       // Core-backed kinds spawn a throwaway xray sidecar (secrets from vault).
       if (upstreamRequiresCore(u.kind)) {
-        const text = await sockscapTestCoreUpstream({
+        text = await sockscapTestCoreUpstream({
           upstream: u,
           testHost: "www.google.com",
           testPort: 443,
         });
-        report(text);
-        return;
+      } else {
+        text = await sockscapTestUpstream({
+          kind: u.kind,
+          host: u.host || "127.0.0.1",
+          port: u.port || 1080,
+          username: u.username,
+          password: password || u.passwordRef || undefined,
+          sessionId: u.sessionId || undefined,
+          testHost: "www.google.com",
+          testPort: 443,
+        });
       }
-      const text = await sockscapTestUpstream({
-        kind: u.kind,
-        host: u.host || "127.0.0.1",
-        port: u.port || 1080,
-        username: u.username,
-        password: password || u.passwordRef || undefined,
-        sessionId: u.sessionId || undefined,
-        testHost: "www.google.com",
-        testPort: 443,
-      });
-      report(text);
+      report(summarize(text));
+      openTestDetail(title, text);
     } catch (e) {
-      report(String(e), false);
+      const err = String(e);
+      report(summarize(err), false);
+      openTestDetail(title, err);
     } finally {
-      setBusy(false);
+      setTesting(false);
     }
   };
 
@@ -1249,7 +1308,14 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
     );
 
     return (
-      <>
+      // A disabled <fieldset> natively disables every descendant control;
+      // `display:contents` keeps the parent grid layout intact. Lets us lock the
+      // whole protocol-params block while running without touching each field.
+      <fieldset
+        disabled={locked}
+        className="contents"
+        title={locked ? t("sockscap.lockedTooltip") : undefined}
+      >
         {kind === "shadowsocks" && (
           <Field label={t("sockscap.ssMethod")}>
             <select
@@ -1273,7 +1339,7 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
         {transportFields}
         {tlsFields}
         {wgFields}
-      </>
+      </fieldset>
     );
   };
 
@@ -1490,6 +1556,19 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
         </div>
       </div>
 
+      {/* Running → scope/upstream/profile-structure locked (backend snapshots
+          them at Start). Rules stay editable (hot-reloaded); new profiles can
+          still be added. */}
+      {locked && (
+        <div
+          data-testid="sockscap-locked-banner"
+          className="px-4 py-2 bg-sky-500/10 border-b border-sky-500/30 text-[11px] flex items-center gap-1.5 text-sky-700 dark:text-sky-400"
+        >
+          <Lock className="w-3.5 h-3.5 shrink-0" />
+          {t("sockscap.lockedHint")}
+        </div>
+      )}
+
       {/* Scope/upstream edited while running — needs Stop+Start to apply */}
       {needsRestart && running && (
         <div
@@ -1607,8 +1686,10 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
               <button
                 type="button"
                 data-testid="sockscap-sub-import-toggle"
-                className="w-full text-[11px] px-2 py-1 rounded border border-[var(--taomni-divider)] text-[var(--taomni-text-muted)] hover:text-[var(--taomni-text)] hover:bg-[var(--taomni-hover)] transition-colors"
+                className="w-full text-[11px] px-2 py-1 rounded border border-[var(--taomni-divider)] text-[var(--taomni-text-muted)] hover:text-[var(--taomni-text)] hover:bg-[var(--taomni-hover)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 onClick={() => setShowSubImport((v) => !v)}
+                disabled={locked}
+                title={locked ? t("sockscap.lockedTooltip") : undefined}
               >
                 {t("sockscap.subImportToggle")}
               </button>
@@ -1624,9 +1705,9 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                   <button
                     type="button"
                     data-testid="sockscap-sub-import"
-                    className="w-full text-[11px] px-2 py-1 rounded border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)]"
+                    className="w-full text-[11px] px-2 py-1 rounded border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
                     onClick={() => void onImportSubscription()}
-                    disabled={busy || !subInput.trim()}
+                    disabled={busy || locked || !subInput.trim()}
                   >
                     {t("sockscap.subImportBtn")}
                   </button>
@@ -1655,12 +1736,19 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                           type="checkbox"
                           data-testid={`sockscap-profile-checkbox-${p.id}`}
                           checked={isActive}
+                          disabled={locked}
                           onChange={(e) => {
                             e.stopPropagation();
                             void toggleProfileActive(p.id);
                           }}
-                          className="rounded border-[var(--taomni-divider)] text-[var(--taomni-accent)] focus:ring-0 cursor-pointer"
-                          title={isActive ? t("sockscap.activeTooltipActive") : t("sockscap.activeTooltipInactive")}
+                          className="rounded border-[var(--taomni-divider)] text-[var(--taomni-accent)] focus:ring-0 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                          title={
+                            locked
+                              ? t("sockscap.lockedTooltip")
+                              : isActive
+                                ? t("sockscap.activeTooltipActive")
+                                : t("sockscap.activeTooltipInactive")
+                          }
                         />
                         <span className="text-[13px]">{p.icon || "🛡️"}</span>
                         <span className="font-semibold truncate">{p.name}</span>
@@ -1668,9 +1756,10 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                       <div className="flex items-center gap-1 shrink-0" onClick={(e) => e.stopPropagation()}>
                         <button
                           type="button"
-                          className="p-1 text-[var(--taomni-text-muted)] hover:text-[var(--taomni-text)] rounded"
-                          title={t("sockscap.duplicateProfileTooltip")}
+                          className="p-1 text-[var(--taomni-text-muted)] hover:text-[var(--taomni-text)] rounded disabled:opacity-40 disabled:cursor-not-allowed"
+                          title={locked ? t("sockscap.lockedTooltip") : t("sockscap.duplicateProfileTooltip")}
                           onClick={() => void duplicateProfile(p)}
+                          disabled={locked}
                         >
                           <Copy className="w-3 h-3" />
                         </button>
@@ -1678,9 +1767,10 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                           <button
                             type="button"
                             data-testid={`sockscap-delete-profile-${p.id}`}
-                            className="p-1 text-[var(--taomni-text-muted)] hover:text-red-500 rounded"
-                            title={t("sockscap.deleteProfileTooltip")}
+                            className="p-1 text-[var(--taomni-text-muted)] hover:text-red-500 rounded disabled:opacity-40 disabled:cursor-not-allowed"
+                            title={locked ? t("sockscap.lockedTooltip") : t("sockscap.deleteProfileTooltip")}
                             onClick={() => void deleteProfile(p.id)}
+                            disabled={locked}
                           >
                             <Trash2 className="w-3 h-3" />
                           </button>
@@ -1721,8 +1811,10 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               <Field label={t("sockscap.profileNameLabel")}>
                 <input
-                  className="w-full text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)]"
+                  className="w-full text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
                   value={selectedProf.name}
+                  disabled={locked}
+                  title={locked ? t("sockscap.lockedTooltip") : undefined}
                   onChange={(e) => void patchSelectedProfile({ name: e.target.value })}
                 />
               </Field>
@@ -1732,7 +1824,9 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                     <button
                       key={ic}
                       type="button"
-                      className={`px-2 py-1 rounded text-[13px] border ${
+                      disabled={locked}
+                      title={locked ? t("sockscap.lockedTooltip") : undefined}
+                      className={`px-2 py-1 rounded text-[13px] border disabled:opacity-50 disabled:cursor-not-allowed ${
                         selectedProf.icon === ic
                           ? "border-[var(--taomni-accent)] bg-[var(--taomni-accent)]/20"
                           : "border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)]"
@@ -1755,7 +1849,9 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                   key={m}
                   type="button"
                   data-testid={`sockscap-mode-${m}`}
-                  className={`px-3 py-1.5 rounded text-[12px] border ${
+                  disabled={locked}
+                  title={locked ? t("sockscap.lockedTooltip") : undefined}
+                  className={`px-3 py-1.5 rounded text-[12px] border disabled:opacity-50 disabled:cursor-not-allowed ${
                     selectedProf.mode === m
                       ? "border-[var(--taomni-accent)] bg-[var(--taomni-accent)]/15 text-[var(--taomni-accent)] font-medium"
                       : "border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)]"
@@ -1771,13 +1867,15 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                 <div className="flex gap-2">
                   <button
                     type="button"
-                    className="inline-flex items-center gap-1 px-2 py-1 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)]"
+                    className="inline-flex items-center gap-1 px-2 py-1 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
                     onClick={() => void loadProcesses()}
+                    disabled={locked}
+                    title={locked ? t("sockscap.lockedTooltip") : undefined}
                   >
                     <Plus className="w-3 h-3" />
                     {t("sockscap.pickProcess")}
                   </button>
-                  <ManualAppAdd onAdd={(path) => void addAppPath(path)} />
+                  <ManualAppAdd onAdd={(path) => void addAppPath(path)} disabled={locked} />
                 </div>
                 {selectedProf.apps.length === 0 ? (
                   <div className="text-[11px] text-[var(--taomni-text-muted)]">{t("sockscap.appsEmpty")}</div>
@@ -1793,7 +1891,9 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                         </span>
                         <button
                           type="button"
-                          className="p-1 hover:text-red-500"
+                          className="p-1 hover:text-red-500 disabled:opacity-40 disabled:cursor-not-allowed"
+                          disabled={locked}
+                          title={locked ? t("sockscap.lockedTooltip") : undefined}
                           onClick={() =>
                             void patchSelectedProfile({
                               apps: selectedProf.apps.filter((x) => x.path !== a.path),
@@ -1823,12 +1923,38 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
 
           {/* Upstream */}
           <Section title={t("sockscap.section.upstream")}>
+            {/* No local proxy detected → guide the user to run one correctly
+                (proxy/SOCKS inbound only; NOT system-proxy/global, NOT TUN),
+                then rescan or import a share link. Only for native socks5/http
+                upstreams with no saved session picked. */}
+            {detectedProxies.length === 0 &&
+              (selectedProf.upstream.kind === "socks5" ||
+                selectedProf.upstream.kind === "http") &&
+              !selectedProf.upstream.sessionId && (
+                <div
+                  data-testid="sockscap-noproxy-help"
+                  className="mb-3 px-3 py-2 rounded text-[11px] border border-sky-500/40 bg-sky-500/10 text-sky-800 dark:text-sky-300"
+                >
+                  <div className="flex items-center gap-1.5 font-semibold mb-1">
+                    <HelpCircle className="w-3.5 h-3.5 shrink-0" />
+                    {t("sockscap.noProxyHelpTitle")}
+                  </div>
+                  <ol className="list-decimal pl-4 space-y-0.5 text-[var(--taomni-text-muted)]">
+                    <li>{t("sockscap.noProxyHelpStep1")}</li>
+                    <li>{t("sockscap.noProxyHelpStep2")}</li>
+                    <li>{t("sockscap.noProxyHelpStep3")}</li>
+                    <li>{t("sockscap.noProxyHelpStep4")}</li>
+                  </ol>
+                </div>
+              )}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               <Field label={t("sockscap.upstreamKind")}>
                 <select
                   data-testid="sockscap-upstream-kind"
-                  className="w-full text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)]"
+                  className="w-full text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
                   value={selectedProf.upstream.kind}
+                  disabled={locked}
+                  title={locked ? t("sockscap.lockedTooltip") : undefined}
                   onChange={(e) =>
                     void patchSelectedProfile({
                       upstream: {
@@ -1854,17 +1980,19 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                   <div className="flex gap-1.5">
                     <input
                       data-testid="sockscap-sharelink-input"
-                      className="flex-1 text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)]"
+                      className="flex-1 text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
                       placeholder="ss:// vmess:// vless:// trojan://"
                       value={shareLink}
+                      disabled={locked}
+                      title={locked ? t("sockscap.lockedTooltip") : undefined}
                       onChange={(e) => setShareLink(e.target.value)}
                     />
                     <button
                       type="button"
                       data-testid="sockscap-sharelink-import"
-                      className="px-2 py-1.5 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] shrink-0"
+                      className="px-2 py-1.5 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
                       onClick={() => void onImportShareLink()}
-                      disabled={busy || !shareLink.trim()}
+                      disabled={busy || locked || !shareLink.trim()}
                     >
                       {t("sockscap.shareLinkImportBtn")}
                     </button>
@@ -1881,6 +2009,8 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                     onSelect={onSelectUpstreamSource}
                     onRescan={rescanLocalProxies}
                     busy={busy}
+                    disabled={locked}
+                    lockedTooltip={locked ? t("sockscap.lockedTooltip") : undefined}
                     t={t}
                   />
                 </Field>
@@ -1888,8 +2018,10 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
 
               <Field label={t("sockscap.host")}>
                 <input
-                  className="w-full text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)]"
+                  className="w-full text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
                   value={selectedProf.upstream.host}
+                  disabled={locked}
+                  title={locked ? t("sockscap.lockedTooltip") : undefined}
                   onChange={(e) =>
                     void patchSelectedProfile({
                       upstream: { ...selectedProf.upstream, host: e.target.value },
@@ -1900,8 +2032,10 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
               <Field label={t("sockscap.port")}>
                 <input
                   type="number"
-                  className="w-full text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)]"
+                  className="w-full text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
                   value={selectedProf.upstream.port}
+                  disabled={locked}
+                  title={locked ? t("sockscap.lockedTooltip") : undefined}
                   onChange={(e) =>
                     void patchSelectedProfile({
                       upstream: {
@@ -1914,8 +2048,10 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
               </Field>
               <Field label={t("sockscap.username")}>
                 <input
-                  className="w-full text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)]"
+                  className="w-full text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
                   value={selectedProf.upstream.username || ""}
+                  disabled={locked}
+                  title={locked ? t("sockscap.lockedTooltip") : undefined}
                   onChange={(e) =>
                     void patchSelectedProfile({
                       upstream: { ...selectedProf.upstream, username: e.target.value },
@@ -1927,28 +2063,31 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                 <div className="flex gap-1.5">
                   <input
                     type="password"
-                    className="flex-1 text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)]"
+                    className="flex-1 text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
                     placeholder={
                       selectedProf.upstream.passwordRef
                         ? t("sockscap.passwordStored")
                         : t("sockscap.passwordPh")
                     }
                     value={password}
+                    disabled={locked}
+                    title={locked ? t("sockscap.lockedTooltip") : undefined}
                     onChange={(e) => setPassword(e.target.value)}
                   />
                   <button
                     type="button"
-                    className="px-2 py-1.5 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] shrink-0"
+                    className="px-2 py-1.5 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
                     onClick={() => void storePassword()}
-                    disabled={storingPass || !password}
+                    disabled={storingPass || locked || !password}
                   >
                     {t("sockscap.passwordStore")}
                   </button>
                   {selectedProf.upstream.passwordRef && (
                     <button
                       type="button"
-                      className="px-2 py-1.5 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] text-red-500 shrink-0"
+                      className="px-2 py-1.5 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] text-red-500 shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
                       onClick={() => void clearPassword()}
+                      disabled={locked}
                     >
                       {t("common.clear")}
                     </button>
@@ -1961,11 +2100,13 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
             <div className="mt-3 flex gap-2">
               <button
                 type="button"
-                className="px-3 py-1.5 rounded text-[12px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)]"
+                data-testid="sockscap-test-upstream"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-[12px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] disabled:opacity-60 disabled:cursor-not-allowed"
                 onClick={() => void onTestUpstream()}
-                disabled={busy}
+                disabled={busy || testing}
               >
-                {t("sockscap.testUpstream")}
+                {testing && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+                {testing ? t("sockscap.testing") : t("sockscap.testUpstream")}
               </button>
             </div>
           </Section>
@@ -2076,11 +2217,12 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
               <button
                 type="button"
                 data-testid="sockscap-test-target"
-                className="px-3 py-1.5 rounded text-[12px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)]"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-[12px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] disabled:opacity-60 disabled:cursor-not-allowed"
                 onClick={() => void onTestTarget()}
-                disabled={busy}
+                disabled={busy || testing}
               >
-                {t("sockscap.testTarget")}
+                {testing && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+                {testing ? t("sockscap.testing") : t("sockscap.testTarget")}
               </button>
             </div>
             {testResult && (
@@ -2364,6 +2506,59 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
           busy={rootPromptBusy}
         />
       )}
+
+      {/* Full test result — status bar only shows a summary; this shows the
+          complete text and lets the user copy it. */}
+      {testDetail && (
+        <div
+          className="absolute inset-0 bg-black/40 flex items-center justify-center z-20"
+          data-testid="sockscap-test-detail"
+        >
+          <div className="w-[min(620px,92vw)] max-h-[75vh] flex flex-col rounded-lg bg-[var(--taomni-panel)] border border-[var(--taomni-divider)] shadow-xl">
+            <div className="flex items-center justify-between px-3 py-2 border-b border-[var(--taomni-divider)]">
+              <div className="text-[13px] font-semibold truncate">{testDetail.title}</div>
+              <button
+                type="button"
+                className="p-1 rounded hover:bg-[var(--taomni-hover)]"
+                onClick={() => setTestDetail(null)}
+                aria-label={t("common.close")}
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+            <div className="flex-1 overflow-auto p-3">
+              <pre
+                data-testid="sockscap-test-detail-body"
+                className="whitespace-pre-wrap break-words text-[11px] font-mono text-[var(--taomni-text)] leading-relaxed"
+              >
+                {testDetail.body}
+              </pre>
+            </div>
+            <div className="flex items-center justify-end gap-2 px-3 py-2 border-t border-[var(--taomni-divider)]">
+              <button
+                type="button"
+                data-testid="sockscap-test-detail-copy"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-[12px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)]"
+                onClick={() => void copyTestDetail()}
+              >
+                {testCopied ? (
+                  <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500" />
+                ) : (
+                  <Copy className="w-3.5 h-3.5" />
+                )}
+                {testCopied ? t("common.copied") : t("common.copy")}
+              </button>
+              <button
+                type="button"
+                className="px-3 py-1.5 rounded text-[12px] bg-[var(--taomni-accent)] text-white hover:opacity-90"
+                onClick={() => setTestDetail(null)}
+              >
+                {t("common.close")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -2386,20 +2581,30 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   );
 }
 
-function ManualAppAdd({ onAdd }: { onAdd: (path: string) => void }) {
+function ManualAppAdd({
+  onAdd,
+  disabled,
+}: {
+  onAdd: (path: string) => void;
+  disabled?: boolean;
+}) {
   const t = useT();
   const [path, setPath] = useState("");
   return (
     <div className="flex gap-1 flex-1 min-w-[200px]">
       <input
-        className="flex-1 text-[11px] px-2 py-1 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)]"
+        className="flex-1 text-[11px] px-2 py-1 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
         placeholder={t("sockscap.appPathPh")}
         value={path}
+        disabled={disabled}
+        title={disabled ? t("sockscap.lockedTooltip") : undefined}
         onChange={(e) => setPath(e.target.value)}
       />
       <button
         type="button"
-        className="px-2 py-1 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)]"
+        className="px-2 py-1 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
+        disabled={disabled}
+        title={disabled ? t("sockscap.lockedTooltip") : undefined}
         onClick={() => {
           if (path.trim()) {
             onAdd(path.trim());

--- a/src/components/sockscap/UpstreamSourcePicker.tsx
+++ b/src/components/sockscap/UpstreamSourcePicker.tsx
@@ -34,6 +34,10 @@ export interface UpstreamSourcePickerProps {
   /** Re-run detection; the picker shows a spinner while awaited. */
   onRescan: () => Promise<void>;
   busy?: boolean;
+  /** Lock the trigger (e.g. capture running — upstream can't change live). */
+  disabled?: boolean;
+  /** Tooltip shown on the disabled trigger explaining why. */
+  lockedTooltip?: string;
   t: (key: string, vars?: Record<string, string>) => string;
   testId?: string;
 }
@@ -263,6 +267,8 @@ export function UpstreamSourcePicker({
   onSelect,
   onRescan,
   busy = false,
+  disabled = false,
+  lockedTooltip,
   t,
   testId = "sockscap-upstream-source",
 }: UpstreamSourcePickerProps) {
@@ -444,7 +450,9 @@ export function UpstreamSourcePicker({
         aria-haspopup="tree"
         aria-expanded={open}
         data-testid={testId}
-        className="w-full text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)] text-left inline-flex items-center gap-1"
+        disabled={disabled}
+        title={disabled ? lockedTooltip : undefined}
+        className="w-full text-[12px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)] text-left inline-flex items-center gap-1 disabled:opacity-60 disabled:cursor-not-allowed"
         onClick={() => setOpen((v) => !v)}
       >
         <span className="min-w-0 flex-1 truncate">{selectedLabel}</span>

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -46,6 +46,8 @@ const dict = {
     backToTop: "Back to top",
     error: "Error",
     message: "Message",
+    copy: "Copy",
+    copied: "Copied to clipboard",
   },
   git: {
     workspaceChanges: {
@@ -1169,6 +1171,23 @@ const dict = {
     restartNeeded:
       "Scope or upstream changes won't apply until capture restarts.",
     restartNow: "Restart capture",
+    lockedHint:
+      "Running — scope, upstream, and profile structure are locked. Only rules hot-reload. Stop capture to edit them (adding a new profile is still allowed).",
+    lockedTooltip: "Locked while running — stop capture to edit.",
+    testing: "Testing…",
+    testTargetDetailTitle: "Test target · {host}",
+    testUpstreamDetailTitle: "Test upstream · {kind}",
+    testDecision: "Decision",
+    testMatchedRule: "Matched rule",
+    noProxyHelpTitle: "No local proxy detected — how to get online",
+    noProxyHelpStep1:
+      "Start your proxy client (Clash / Mihomo / v2rayN / sing-box …) and connect to a node.",
+    noProxyHelpStep2:
+      "Enable only its proxy / SOCKS inbound. Turn OFF System Proxy (global) and TUN / virtual-adapter mode — those collide with SocksCap's capture.",
+    noProxyHelpStep3:
+      "Come back and click \"Rescan for local proxies\", then pick the detected proxy as the upstream.",
+    noProxyHelpStep4:
+      "Or switch the upstream type to Shadowsocks / VMess / VLESS / Trojan and use \"Import share link\" — SocksCap runs the node for you via the bundled core.",
     captureNotReady: "OS capture not active yet",
     captureNotReadyHint:
       "Rules engine and upstream dialers work now. WinDivert / platform capture is still being integrated.",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -45,6 +45,8 @@ export const zhCN: DeepPartial<typeof en> = {
     backToTop: "回到顶部",
     error: "错误",
     message: "消息",
+    copy: "复制",
+    copied: "已复制到剪贴板",
   },
   git: {
     workspaceChanges: {
@@ -1166,6 +1168,23 @@ export const zhCN: DeepPartial<typeof en> = {
     recovered: "已请求恢复网络",
     restartNeeded: "作用域或上游的修改需重启捕获后才会生效。",
     restartNow: "重启捕获",
+    lockedHint:
+      "运行中 — 作用域、上游与方案结构已锁定，仅规则可热更新。需先停止捕获再修改（仍可新增方案）。",
+    lockedTooltip: "运行中已锁定 — 请先停止捕获再修改。",
+    testing: "测试中…",
+    testTargetDetailTitle: "测试目标 · {host}",
+    testUpstreamDetailTitle: "测试上游 · {kind}",
+    testDecision: "判定",
+    testMatchedRule: "命中规则",
+    noProxyHelpTitle: "未检测到本地代理 — 如何先联网",
+    noProxyHelpStep1:
+      "先启动你的代理客户端(Clash / Mihomo / v2rayN / sing-box 等)并连接节点。",
+    noProxyHelpStep2:
+      "只开启它的 代理 / SOCKS 入站；关闭 系统代理(全局) 和 TUN / 虚拟网卡 模式 — 这两者会与 SocksCap 的捕获冲突。",
+    noProxyHelpStep3:
+      "回到这里点击「重新扫描本地代理」，然后选中检测到的代理作为上游。",
+    noProxyHelpStep4:
+      "或将上游类型改为 Shadowsocks / VMess / VLESS / Trojan 并使用「导入分享链接」— SocksCap 会用内置内核替你运行该节点。",
     captureNotReady: "系统捕获尚未就绪",
     captureNotReadyHint:
       "规则引擎与上游拨号已可用。WinDivert / 平台捕获仍在接入中。",


### PR DESCRIPTION
…proxy help

Address three UX gaps in the SocksCap panel.

1. Lock restart-requiring config while capture is running The backend only hot-reloads the rule surface (ruleMode / userRules / defaultAction / bypassCidrs / GFWList) via hot_reload_policy; scope, app list, upstream, and the active-profile set are snapshotted at Start and silently ignored until the next Stop+Start. Previously those fields stayed editable and only a "needs restart" banner appeared after the fact.

   Now `locked = running` disables every restart-requiring control with a tooltip explaining why, and a blue banner states the rule at the top:
   - scope mode buttons, app pick/manual-add/remove
   - upstream kind, host/port/username/password + store/clear, share-link import, the UpstreamSourcePicker trigger, and all core protocol params (wrapped in a disabled <fieldset class="contents"> so one flag locks the whole block without breaking the grid layout)
   - profile rename/icon/duplicate/delete/active-toggle and subscription import Adding a NEW profile stays allowed; rule controls stay editable since they hot-reload. The old restart banner is kept only as a fallback.

2. Test result: status-bar summary + copyable detail modal Test buttons now use a dedicated `testing` state (decoupled from the global `busy` and the 1.5s status poll) so they grey out with a spinner and a "Testing..." label while a test is in flight. The status bar keeps a one-line summary (first non-empty line), while a new modal shows the full result in a scrollable <pre> with a Copy button (reuses lib/clipboard writeText). Both the upstream test and the target-match test open it, including on error.

3. No-proxy help block When no local proxy is detected and the upstream is a native socks5/http with no saved session, show an info block guiding the user to: start their proxy client, enable ONLY its proxy/SOCKS inbound (turn OFF system-proxy and TUN/virtual-adapter mode, which collide with SocksCap capture), rescan, or switch to a core kind and import a share link.

UpstreamSourcePicker gains `disabled` / `lockedTooltip` props to lock its trigger. i18n: adds sockscap lockedHint / lockedTooltip / testing / test*DetailTitle / testDecision / testMatchedRule / noProxyHelpStep1-4 and common.copy / common.copied to both en and zh-CN.

Tests: 3 new SocksCapPanel cases (runtime lock keeps Add enabled, copyable test modal, no-proxy help). tsc -b clean; 38 sockscap tests pass.