### PR TITLE
fix(workspace): make Code Workspace build/run robust and configurable…

### DIFF
--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1,10 +1,13 @@
+use crate::state::AppState;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::UNIX_EPOCH;
+use tauri::State;
 
 const DEFAULT_MAX_TEXT_BYTES: u64 = 5 * 1024 * 1024;
 const DEFAULT_RECURSIVE_MAX_DEPTH: usize = 25;
@@ -63,6 +66,16 @@ pub struct WorkspaceGitRoot {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct WorkspaceTaskExecution {
+    pub executable: String,
+    pub args: Vec<String>,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct WorkspaceTask {
     pub id: String,
     pub label: String,
@@ -71,6 +84,8 @@ pub struct WorkspaceTask {
     pub source: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub module_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution: Option<WorkspaceTaskExecution>,
 }
 
 /// A runnable Java `public static void main` entry point discovered from source.
@@ -90,6 +105,176 @@ pub struct JavaRunTarget {
     pub build_system: String,
     /// Workspace-relative build/module directory (`.` for the root project).
     pub module_path: String,
+    pub execution: WorkspaceTaskExecution,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceToolConfig {
+    #[serde(default, alias = "mvn", alias = "mavenExecutable")]
+    pub maven: Option<String>,
+    #[serde(default, alias = "gradleExecutable")]
+    pub gradle: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostPlatform {
+    Windows,
+    Unix,
+}
+
+impl HostPlatform {
+    fn current() -> Self {
+        if cfg!(windows) {
+            Self::Windows
+        } else {
+            Self::Unix
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BuildTool {
+    Maven,
+    Gradle,
+}
+
+impl BuildTool {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Maven => "Maven",
+            Self::Gradle => "Gradle",
+        }
+    }
+
+    fn path_command(self) -> &'static str {
+        match self {
+            Self::Maven => "mvn",
+            Self::Gradle => "gradle",
+        }
+    }
+
+    fn configured<'a>(self, config: Option<&'a WorkspaceToolConfig>) -> Option<&'a str> {
+        match self {
+            Self::Maven => config.and_then(|config| config.maven.as_deref()),
+            Self::Gradle => config.and_then(|config| config.gradle.as_deref()),
+        }
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    }
+
+    fn wrapper_names(self, platform: HostPlatform) -> &'static [&'static str] {
+        match (self, platform) {
+            (Self::Maven, HostPlatform::Windows) => &["mvnw.cmd", "mvnw.bat", "mvnw"],
+            (Self::Maven, HostPlatform::Unix) => &["mvnw"],
+            (Self::Gradle, HostPlatform::Windows) => &["gradlew.bat", "gradlew.cmd", "gradlew"],
+            (Self::Gradle, HostPlatform::Unix) => &["gradlew"],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ToolSource {
+    Wrapper,
+    Configured,
+    Path,
+}
+
+impl ToolSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Wrapper => "wrapper",
+            Self::Configured => "configured",
+            Self::Path => "path",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ToolResolution {
+    tool: BuildTool,
+    executable: PathBuf,
+    source: ToolSource,
+    available: bool,
+    diagnostic: Option<String>,
+}
+
+impl ToolResolution {
+    fn task_runner(&self, platform: HostPlatform) -> String {
+        if self.source == ToolSource::Path {
+            self.tool.path_command().to_string()
+        } else {
+            wrapper_command_for(&self.executable, platform)
+        }
+    }
+
+    fn execution(&self, args: &[&str]) -> WorkspaceTaskExecution {
+        self.execution_owned(args.iter().map(|arg| (*arg).to_string()).collect())
+    }
+
+    fn execution_owned(&self, args: Vec<String>) -> WorkspaceTaskExecution {
+        WorkspaceTaskExecution {
+            executable: path_to_string(&self.executable),
+            args,
+            source: self.source.as_str().to_string(),
+            error: self.diagnostic.clone(),
+        }
+    }
+
+    fn require_available(&self) -> Result<(), String> {
+        if self.available {
+            Ok(())
+        } else {
+            Err(self.diagnostic.clone().unwrap_or_else(|| {
+                format!("{} executable could not be resolved", self.tool.name())
+            }))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ToolLaunchPlan {
+    program: String,
+    args: Vec<String>,
+}
+
+fn is_windows_batch(path: &Path) -> bool {
+    path.extension()
+        .and_then(OsStr::to_str)
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("cmd") || extension.eq_ignore_ascii_case("bat")
+        })
+}
+
+fn plan_tool_launch(executable: &Path, args: &[String], platform: HostPlatform) -> ToolLaunchPlan {
+    if platform == HostPlatform::Windows && is_windows_batch(executable) {
+        let mut command_line = format!("\"{}\"", path_to_string(executable).replace('"', "\"\""));
+        for arg in args {
+            command_line.push(' ');
+            command_line.push_str(&quote_windows_cmd_arg(arg));
+        }
+        ToolLaunchPlan {
+            program: "cmd.exe".to_string(),
+            args: vec!["/D".into(), "/S".into(), "/C".into(), command_line],
+        }
+    } else {
+        ToolLaunchPlan {
+            program: path_to_string(executable),
+            args: args.to_vec(),
+        }
+    }
+}
+
+fn quote_windows_cmd_arg(value: &str) -> String {
+    if value.is_empty()
+        || value
+            .chars()
+            .any(|character| character.is_whitespace() || "&|<>()^\"".contains(character))
+    {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
 }
 
 fn push_task(
@@ -107,7 +292,22 @@ fn push_task(
         cwd: path_to_string(cwd),
         source: source.to_string(),
         module_path: None,
+        execution: None,
     });
+}
+
+fn push_tool_task(
+    tasks: &mut Vec<WorkspaceTask>,
+    source: &str,
+    label: &str,
+    resolution: &ToolResolution,
+    cwd: &Path,
+) {
+    let runner = resolution.task_runner(HostPlatform::current());
+    push_task(tasks, source, label, format!("{runner} {label}"), cwd);
+    if let Some(task) = tasks.last_mut() {
+        task.execution = Some(resolution.execution(&[label]));
+    }
 }
 
 fn parse_named_targets(contents: &str) -> Vec<String> {
@@ -353,29 +553,182 @@ pub struct WorkspaceTaskGroup {
     pub tasks: Vec<WorkspaceTask>,
 }
 
-/// Wrapper-aware Gradle invocation for `root` (`./gradlew`, `.\gradlew.bat`,
-/// or `gradle`). PowerShell does not search the current directory, hence the
-/// explicit `.\` on Windows.
-fn gradle_runner(root: &Path) -> &'static str {
-    if cfg!(windows) && root.join("gradlew.bat").is_file() {
-        r".\gradlew.bat"
-    } else if root.join("gradlew").is_file() {
-        "./gradlew"
+fn wrapper_command_for(path: &Path, platform: HostPlatform) -> String {
+    let quoted = shell_quote_for(&path_to_string(path), platform);
+    if platform == HostPlatform::Windows {
+        format!("& {quoted}")
     } else {
-        "gradle"
+        quoted
     }
 }
 
-/// Wrapper-aware Maven invocation for `root` (`.\mvnw.cmd`, `./mvnw`, or
-/// `mvn`). PowerShell does not search the current directory.
-fn maven_runner(root: &Path) -> &'static str {
-    if cfg!(windows) && root.join("mvnw.cmd").is_file() {
-        r".\mvnw.cmd"
-    } else if root.join("mvnw").is_file() {
-        "./mvnw"
+fn shell_quote_for(value: &str, platform: HostPlatform) -> String {
+    if platform == HostPlatform::Windows {
+        format!("'{}'", value.replace('\'', "''"))
     } else {
-        "mvn"
+        format!("'{}'", value.replace('\'', "'\"'\"'"))
     }
+}
+
+fn find_on_path(command: &str, path: Option<&OsStr>, platform: HostPlatform) -> Option<PathBuf> {
+    let path = path?;
+    let names: Vec<String> = if platform == HostPlatform::Windows {
+        if Path::new(command).extension().is_some() {
+            vec![command.to_string()]
+        } else {
+            vec![
+                format!("{command}.exe"),
+                format!("{command}.cmd"),
+                format!("{command}.bat"),
+                command.to_string(),
+            ]
+        }
+    } else {
+        vec![command.to_string()]
+    };
+    std::env::split_paths(path)
+        .flat_map(|directory| names.iter().map(move |name| directory.join(name)))
+        .find(|candidate| candidate.is_file())
+        .and_then(|candidate| fs::canonicalize(&candidate).ok().or(Some(candidate)))
+}
+
+fn resolve_configured_executable(
+    configured: &str,
+    workspace_root: &Path,
+    path: Option<&OsStr>,
+    platform: HostPlatform,
+) -> Option<PathBuf> {
+    let configured_path = Path::new(configured);
+    if configured_path.is_absolute()
+        || configured_path.components().count() > 1
+        || configured.contains(['/', '\\'])
+    {
+        let candidate = if configured_path.is_absolute() {
+            configured_path.to_path_buf()
+        } else {
+            workspace_root.join(configured_path)
+        };
+        return candidate
+            .is_file()
+            .then(|| fs::canonicalize(&candidate).unwrap_or(candidate));
+    }
+    find_on_path(configured, path, platform)
+}
+
+fn resolve_build_tool_with_path(
+    build_dir: &Path,
+    workspace_root: &Path,
+    tool: BuildTool,
+    config: Option<&WorkspaceToolConfig>,
+    platform: HostPlatform,
+    path: Option<&OsStr>,
+) -> ToolResolution {
+    let mut current = Some(build_dir);
+    while let Some(directory) = current {
+        for name in tool.wrapper_names(platform) {
+            let candidate = directory.join(name);
+            if candidate.is_file() {
+                let executable = fs::canonicalize(&candidate).unwrap_or(candidate);
+                return ToolResolution {
+                    tool,
+                    executable,
+                    source: ToolSource::Wrapper,
+                    available: true,
+                    diagnostic: None,
+                };
+            }
+        }
+        if directory == workspace_root {
+            break;
+        }
+        current = directory
+            .parent()
+            .filter(|parent| parent.starts_with(workspace_root));
+    }
+
+    if let Some(configured) = tool.configured(config) {
+        if let Some(executable) =
+            resolve_configured_executable(configured, workspace_root, path, platform)
+        {
+            return ToolResolution {
+                tool,
+                executable,
+                source: ToolSource::Configured,
+                available: true,
+                diagnostic: None,
+            };
+        }
+        return ToolResolution {
+            tool,
+            executable: PathBuf::from(configured),
+            source: ToolSource::Configured,
+            available: false,
+            diagnostic: Some(format!(
+                "Configured {} executable was not found: {configured}. Add a project wrapper, correct the configured path, or put `{}` on PATH.",
+                tool.name(),
+                tool.path_command()
+            )),
+        };
+    }
+
+    if let Some(executable) = find_on_path(tool.path_command(), path, platform) {
+        return ToolResolution {
+            tool,
+            executable,
+            source: ToolSource::Path,
+            available: true,
+            diagnostic: None,
+        };
+    }
+
+    ToolResolution {
+        tool,
+        executable: PathBuf::from(tool.path_command()),
+        source: ToolSource::Path,
+        available: false,
+        diagnostic: Some(format!(
+            "{} executable was not found. Add a project wrapper ({}), configure an executable override, or put `{}` on PATH.",
+            tool.name(),
+            tool.wrapper_names(platform).join(" or "),
+            tool.path_command()
+        )),
+    }
+}
+
+fn resolve_build_tool(
+    build_dir: &Path,
+    workspace_root: &Path,
+    tool: BuildTool,
+    config: Option<&WorkspaceToolConfig>,
+) -> ToolResolution {
+    resolve_build_tool_with_path(
+        build_dir,
+        workspace_root,
+        tool,
+        config,
+        HostPlatform::current(),
+        std::env::var_os("PATH").as_deref(),
+    )
+}
+
+/// Like [`resolve_build_tool`] but searches an explicit `PATH` for the global
+/// (last-tier) fallback — used when spawning a build tool directly so the lookup
+/// matches the SDK-enhanced environment the process will actually run with.
+fn resolve_build_tool_on_path(
+    build_dir: &Path,
+    workspace_root: &Path,
+    tool: BuildTool,
+    config: Option<&WorkspaceToolConfig>,
+    path: Option<&OsStr>,
+) -> ToolResolution {
+    resolve_build_tool_with_path(
+        build_dir,
+        workspace_root,
+        tool,
+        config,
+        HostPlatform::current(),
+        path,
+    )
 }
 
 /// Maven's default lifecycle phases most people run, in lifecycle order.
@@ -468,8 +821,11 @@ fn gradle_task_selector(invocation_root: &Path, build_dir: &Path, task: &str) ->
 /// Build the grouped task tree: detected tasks bucketed by source (first-seen
 /// order preserved), with Maven/Gradle enriched to their full lifecycle / common
 /// tasks. Pure and offline — no build tool is spawned.
-fn build_workspace_task_tree(root: &Path) -> Result<Vec<WorkspaceTaskGroup>, String> {
-    let detected = detect_workspace_tasks(root)?;
+fn build_workspace_task_tree(
+    root: &Path,
+    tool_config: Option<&WorkspaceToolConfig>,
+) -> Result<Vec<WorkspaceTaskGroup>, String> {
+    let detected = detect_workspace_tasks(root, tool_config)?;
     let mut groups: Vec<WorkspaceTaskGroup> = Vec::new();
     let mut index: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
     let push = |groups: &mut Vec<WorkspaceTaskGroup>,
@@ -497,7 +853,9 @@ fn build_workspace_task_tree(root: &Path) -> Result<Vec<WorkspaceTaskGroup>, Str
     for (build_system, build_dir, module_path) in discover_java_build_directories(root)? {
         match build_system {
             JavaBuildSystem::Maven => {
-                let runner = find_wrapper(&build_dir, root, build_system);
+                let resolution =
+                    resolve_build_tool(&build_dir, root, BuildTool::Maven, tool_config);
+                let runner = resolution.task_runner(HostPlatform::current());
                 for phase in MAVEN_LIFECYCLE_PHASES {
                     push(
                         &mut groups,
@@ -509,6 +867,7 @@ fn build_workspace_task_tree(root: &Path) -> Result<Vec<WorkspaceTaskGroup>, Str
                             cwd: path_to_string(&build_dir),
                             source: "Maven".into(),
                             module_path: Some(module_path.clone()),
+                            execution: Some(resolution.execution(&[phase])),
                         },
                     );
                 }
@@ -522,12 +881,15 @@ fn build_workspace_task_tree(root: &Path) -> Result<Vec<WorkspaceTaskGroup>, Str
                         cwd: path_to_string(&build_dir),
                         source: "Maven".into(),
                         module_path: Some(module_path),
+                        execution: Some(resolution.execution(&["clean", "compile"])),
                     },
                 );
             }
             JavaBuildSystem::Gradle => {
                 let invocation_root = gradle_invocation_root(root, &build_dir);
-                let runner = find_wrapper(&invocation_root, root, build_system);
+                let resolution =
+                    resolve_build_tool(&invocation_root, root, BuildTool::Gradle, tool_config);
+                let runner = resolution.task_runner(HostPlatform::current());
                 for task in GRADLE_COMMON_TASKS {
                     let selector = gradle_task_selector(&invocation_root, &build_dir, task);
                     push(
@@ -540,6 +902,7 @@ fn build_workspace_task_tree(root: &Path) -> Result<Vec<WorkspaceTaskGroup>, Str
                             cwd: path_to_string(&invocation_root),
                             source: "Gradle".into(),
                             module_path: Some(module_path.clone()),
+                            execution: Some(resolution.execution(&[&selector])),
                         },
                     );
                 }
@@ -559,6 +922,7 @@ fn build_workspace_task_tree(root: &Path) -> Result<Vec<WorkspaceTaskGroup>, Str
                         cwd: path_to_string(&invocation_root),
                         source: "Gradle".into(),
                         module_path: Some(module_path),
+                        execution: Some(resolution.execution(&[&clean, &classes])),
                     },
                 );
             }
@@ -572,7 +936,10 @@ fn build_workspace_task_tree(root: &Path) -> Result<Vec<WorkspaceTaskGroup>, Str
     Ok(groups)
 }
 
-fn detect_workspace_tasks(root: &Path) -> Result<Vec<WorkspaceTask>, String> {
+fn detect_workspace_tasks(
+    root: &Path,
+    tool_config: Option<&WorkspaceToolConfig>,
+) -> Result<Vec<WorkspaceTask>, String> {
     let mut tasks = Vec::new();
 
     let package_json = root.join("package.json");
@@ -643,28 +1010,16 @@ fn detect_workspace_tasks(root: &Path) -> Result<Vec<WorkspaceTask>, String> {
     }
 
     if root.join("build.gradle").is_file() || root.join("build.gradle.kts").is_file() {
-        let runner = gradle_runner(root);
+        let resolution = resolve_build_tool(root, root, BuildTool::Gradle, tool_config);
         for target in ["build", "test"] {
-            push_task(
-                &mut tasks,
-                "Gradle",
-                target,
-                format!("{runner} {target}"),
-                root,
-            );
+            push_tool_task(&mut tasks, "Gradle", target, &resolution, root);
         }
     }
 
     if root.join("pom.xml").is_file() {
-        let runner = maven_runner(root);
+        let resolution = resolve_build_tool(root, root, BuildTool::Maven, tool_config);
         for target in ["package", "test"] {
-            push_task(
-                &mut tasks,
-                "Maven",
-                target,
-                format!("{runner} {target}"),
-                root,
-            );
+            push_tool_task(&mut tasks, "Maven", target, &resolution, root);
         }
     }
 
@@ -881,45 +1236,6 @@ fn shell_quote(value: &str) -> String {
     }
 }
 
-fn wrapper_command(path: &Path) -> String {
-    let quoted = shell_quote(&path_to_string(path));
-    if cfg!(windows) {
-        format!("& {quoted}")
-    } else {
-        quoted
-    }
-}
-
-fn find_wrapper(build_dir: &Path, workspace_root: &Path, tool: JavaBuildSystem) -> String {
-    let names: &[&str] = match tool {
-        JavaBuildSystem::Maven if cfg!(windows) => &["mvnw.cmd"],
-        JavaBuildSystem::Maven => &["mvnw"],
-        JavaBuildSystem::Gradle if cfg!(windows) => &["gradlew.bat"],
-        JavaBuildSystem::Gradle => &["gradlew"],
-        JavaBuildSystem::SourceFile => &[],
-    };
-    let mut current = Some(build_dir);
-    while let Some(dir) = current {
-        for name in names {
-            let candidate = dir.join(name);
-            if candidate.is_file() {
-                return wrapper_command(&candidate);
-            }
-        }
-        if dir == workspace_root {
-            break;
-        }
-        current = dir
-            .parent()
-            .filter(|parent| parent.starts_with(workspace_root));
-    }
-    match tool {
-        JavaBuildSystem::Maven => "mvn".into(),
-        JavaBuildSystem::Gradle => "gradle".into(),
-        JavaBuildSystem::SourceFile => "java".into(),
-    }
-}
-
 fn nearest_java_build(workspace_root: &Path, source_file: &Path) -> (JavaBuildSystem, PathBuf) {
     let mut current = source_file.parent();
     while let Some(dir) = current {
@@ -979,6 +1295,7 @@ fn gradle_run_init_script() -> Result<PathBuf, String> {
 fn java_run_target_for_path(
     workspace_root: &Path,
     source_file: &Path,
+    tool_config: Option<&WorkspaceToolConfig>,
 ) -> Result<JavaRunTarget, String> {
     let metadata = fs::metadata(source_file)
         .map_err(|error| format!("stat {}: {error}", source_file.display()))?;
@@ -1008,9 +1325,19 @@ fn java_run_target_for_path(
         .unwrap_or_else(|| class_name.to_string());
     let relative_file = relative_path(workspace_root, source_file)?;
     let (build_system, build_dir) = nearest_java_build(workspace_root, source_file);
-    let (command, cwd, module_path, build_system_name) = match build_system {
+    let (command, cwd, module_path, build_system_name, execution) = match build_system {
         JavaBuildSystem::Maven => {
-            let runner = find_wrapper(&build_dir, workspace_root, build_system);
+            let resolution =
+                resolve_build_tool(&build_dir, workspace_root, BuildTool::Maven, tool_config);
+            let runner = resolution.task_runner(HostPlatform::current());
+            let args = vec![
+                "-q".into(),
+                "-DskipTests".into(),
+                format!("-Dexec.mainClass={main_class}"),
+                "-Dexec.cleanupDaemonThreads=false".into(),
+                "compile".into(),
+                "org.codehaus.mojo:exec-maven-plugin:3.5.0:java".into(),
+            ];
             let command = format!(
                 "{runner} -q -DskipTests -Dexec.mainClass={} -Dexec.cleanupDaemonThreads=false compile org.codehaus.mojo:exec-maven-plugin:3.5.0:java",
                 shell_quote(&main_class),
@@ -1020,11 +1347,18 @@ fn java_run_target_for_path(
                 path_to_string(&build_dir),
                 relative_path(workspace_root, &build_dir).unwrap_or_else(|_| ".".into()),
                 "maven",
+                resolution.execution_owned(args),
             )
         }
         JavaBuildSystem::Gradle => {
             let invocation_root = gradle_invocation_root(workspace_root, &build_dir);
-            let runner = find_wrapper(&invocation_root, workspace_root, build_system);
+            let resolution = resolve_build_tool(
+                &invocation_root,
+                workspace_root,
+                BuildTool::Gradle,
+                tool_config,
+            );
+            let runner = resolution.task_runner(HostPlatform::current());
             let init_script = gradle_run_init_script()?;
             let module_relative = build_dir
                 .strip_prefix(&invocation_root)
@@ -1043,6 +1377,13 @@ fn java_run_target_for_path(
                     format!(":{project}:taomniRun")
                 })
                 .unwrap_or_else(|| "taomniRun".into());
+            let args = vec![
+                "--console=plain".into(),
+                "-I".into(),
+                path_to_string(&init_script),
+                format!("-PtaomniMainClass={main_class}"),
+                task.clone(),
+            ];
             let command = format!(
                 "{runner} --console=plain -I {} -PtaomniMainClass={} {}",
                 shell_quote(&path_to_string(&init_script)),
@@ -1054,14 +1395,24 @@ fn java_run_target_for_path(
                 path_to_string(&invocation_root),
                 relative_path(workspace_root, &build_dir).unwrap_or_else(|_| ".".into()),
                 "gradle",
+                resolution.execution_owned(args),
             )
         }
-        JavaBuildSystem::SourceFile => (
-            format!("java {}", shell_quote(&path_to_string(source_file))),
-            path_to_string(workspace_root),
-            ".".into(),
-            "source-file",
-        ),
+        JavaBuildSystem::SourceFile => {
+            let file_path = path_to_string(source_file);
+            (
+                format!("java {}", shell_quote(&file_path)),
+                path_to_string(workspace_root),
+                ".".into(),
+                "source-file",
+                WorkspaceTaskExecution {
+                    executable: "java".into(),
+                    args: vec![file_path],
+                    source: "path".into(),
+                    error: None,
+                },
+            )
+        }
     };
     let module_path = if module_path.is_empty() {
         ".".into()
@@ -1077,10 +1428,14 @@ fn java_run_target_for_path(
         cwd,
         build_system: build_system_name.into(),
         module_path,
+        execution,
     })
 }
 
-fn detect_java_run_targets(root: &Path) -> Result<Vec<JavaRunTarget>, String> {
+fn detect_java_run_targets(
+    root: &Path,
+    tool_config: Option<&WorkspaceToolConfig>,
+) -> Result<Vec<JavaRunTarget>, String> {
     let mut files = Vec::new();
     collect_workspace_files(
         root,
@@ -1101,7 +1456,7 @@ fn detect_java_run_targets(root: &Path) -> Result<Vec<JavaRunTarget>, String> {
             continue;
         }
         let source_file = root.join(&entry.path);
-        match java_run_target_for_path(root, &source_file) {
+        match java_run_target_for_path(root, &source_file, tool_config) {
             Ok(target) => targets.push(target),
             Err(error) if error.starts_with("No `static void main") => {}
             Err(error) if error.starts_with("Java source is too large") => {}
@@ -1118,36 +1473,46 @@ fn detect_java_run_targets(root: &Path) -> Result<Vec<JavaRunTarget>, String> {
 }
 
 #[tauri::command]
-pub fn workspace_detect_tasks(repo_root: String) -> Result<Vec<WorkspaceTask>, String> {
+pub fn workspace_detect_tasks(
+    repo_root: String,
+    tool_config: Option<WorkspaceToolConfig>,
+) -> Result<Vec<WorkspaceTask>, String> {
     let root = canonical_repo_root(&repo_root)?;
-    detect_workspace_tasks(&root)
+    detect_workspace_tasks(&root, tool_config.as_ref())
 }
 
 #[tauri::command]
-pub fn workspace_java_run_targets(repo_root: String) -> Result<Vec<JavaRunTarget>, String> {
+pub fn workspace_java_run_targets(
+    repo_root: String,
+    tool_config: Option<WorkspaceToolConfig>,
+) -> Result<Vec<JavaRunTarget>, String> {
     let root = canonical_repo_root(&repo_root)?;
-    detect_java_run_targets(&root)
+    detect_java_run_targets(&root, tool_config.as_ref())
 }
 
 #[tauri::command]
 pub fn workspace_java_run_target(
     repo_root: String,
     file_path: String,
+    tool_config: Option<WorkspaceToolConfig>,
 ) -> Result<JavaRunTarget, String> {
     let root = canonical_repo_root(&repo_root)?;
     let source_file = resolve_existing_path(&root, &file_path)?;
     if source_file.extension().and_then(|value| value.to_str()) != Some("java") {
         return Err("Run Java File requires a .java source file".into());
     }
-    java_run_target_for_path(&root, &source_file)
+    java_run_target_for_path(&root, &source_file, tool_config.as_ref())
 }
 
 /// Grouped task tree for the Build panel (M7 F-2). Maven/Gradle carry their full
 /// lifecycle / common tasks; other ecosystems group their detected tasks by source.
 #[tauri::command]
-pub fn workspace_task_tree(repo_root: String) -> Result<Vec<WorkspaceTaskGroup>, String> {
+pub fn workspace_task_tree(
+    repo_root: String,
+    tool_config: Option<WorkspaceToolConfig>,
+) -> Result<Vec<WorkspaceTaskGroup>, String> {
     let root = canonical_repo_root(&repo_root)?;
-    build_workspace_task_tree(&root)
+    build_workspace_task_tree(&root, tool_config.as_ref())
 }
 
 /// Suppress the transient console window when spawning `.cmd`/`.bat` wrappers
@@ -1171,7 +1536,11 @@ const DEPENDENCY_TREE_TIMEOUT: std::time::Duration = std::time::Duration::from_s
 /// Requires the tool (or its wrapper) to be available; returns a clear error if
 /// the project is neither Maven nor Gradle, or the command fails / times out.
 #[tauri::command]
-pub async fn workspace_dependency_tree(repo_root: String) -> Result<Vec<DependencyNode>, String> {
+pub async fn workspace_dependency_tree(
+    repo_root: String,
+    tool_config: Option<WorkspaceToolConfig>,
+    state: State<'_, AppState>,
+) -> Result<Vec<DependencyNode>, String> {
     let root = canonical_repo_root(&repo_root)?;
     let is_maven = root.join("pom.xml").is_file();
     let is_gradle = root.join("build.gradle").is_file() || root.join("build.gradle.kts").is_file();
@@ -1182,15 +1551,38 @@ pub async fn workspace_dependency_tree(repo_root: String) -> Result<Vec<Dependen
         );
     }
 
-    // Maven is preferred when both exist (rare); its tree carries scopes.
-    let (program, args): (String, Vec<String>) = if is_maven {
+    // Resolve the workspace SDK environment so a directly-spawned build tool sees
+    // the same JAVA_HOME/PATH the integrated terminal injects. Best-effort — fall
+    // back to the inherited environment if resolution fails.
+    let sdk_environment = state.sdk.resolve_environment(&root, &root).await.ok();
+    let process_path = std::env::var_os("PATH");
+    let sdk_path: Option<OsString> = sdk_environment
+        .as_ref()
+        .and_then(|env| env.prepend_path(process_path.as_deref()));
+    let lookup_path = sdk_path.as_deref().or(process_path.as_deref());
+
+    // Maven is preferred when both exist (rare); its tree carries scopes. The
+    // global (PATH) fallback tier searches the SDK-enhanced PATH.
+    let (resolution, args): (ToolResolution, Vec<String>) = if is_maven {
         (
-            maven_runner(&root).to_string(),
+            resolve_build_tool_on_path(
+                &root,
+                &root,
+                BuildTool::Maven,
+                tool_config.as_ref(),
+                lookup_path,
+            ),
             vec!["-B".into(), "-q".into(), "dependency:tree".into()],
         )
     } else {
         (
-            gradle_runner(&root).to_string(),
+            resolve_build_tool_on_path(
+                &root,
+                &root,
+                BuildTool::Gradle,
+                tool_config.as_ref(),
+                lookup_path,
+            ),
             vec![
                 "-q".into(),
                 "dependencies".into(),
@@ -1199,16 +1591,37 @@ pub async fn workspace_dependency_tree(repo_root: String) -> Result<Vec<Dependen
             ],
         )
     };
+    // Surface a clear diagnostic instead of spawning a runner we know is missing.
+    resolution.require_available()?;
 
-    let mut command = tokio::process::Command::new(&program);
-    command.args(&args).current_dir(&root).kill_on_drop(true);
+    // On Windows a `.cmd`/`.bat` wrapper cannot be launched directly by
+    // CreateProcess and needs `cmd.exe /D /S /C`. `plan_tool_launch` returns the
+    // correct program/args pair for the resolved executable.
+    let plan = plan_tool_launch(&resolution.executable, &args, HostPlatform::current());
+    let display = path_to_string(&resolution.executable);
+
+    let mut command = tokio::process::Command::new(&plan.program);
+    command
+        .args(&plan.args)
+        .current_dir(&root)
+        .kill_on_drop(true);
+    // Inject the SDK environment (JAVA_HOME etc. + prepended PATH) so the build
+    // tool resolves the workspace's configured JDK, matching the terminal.
+    if let Some(environment) = sdk_environment.as_ref() {
+        for (key, value) in &environment.environment {
+            command.env(key, value);
+        }
+        if let Some(path) = sdk_path.as_ref() {
+            command.env("PATH", path);
+        }
+    }
     no_console_window(&mut command);
 
     let output = tokio::time::timeout(DEPENDENCY_TREE_TIMEOUT, command.output())
         .await
         .map_err(|_| "Dependency resolution timed out".to_string())?
         .map_err(|error| {
-            format!("Failed to run `{program}` (is it installed / on PATH?): {error}")
+            format!("Failed to run `{display}` (is it installed / on PATH?): {error}")
         })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -1222,7 +1635,7 @@ pub async fn workspace_dependency_tree(repo_root: String) -> Result<Vec<Dependen
         };
         let snippet: String = detail.chars().take(600).collect();
         return Err(format!(
-            "`{program}` exited with {}: {snippet}",
+            "`{display}` exited with {}: {snippet}",
             output.status
         ));
     }
@@ -2364,7 +2777,7 @@ mod tests {
         )
         .unwrap();
 
-        let tasks = detect_workspace_tasks(dir.path()).unwrap();
+        let tasks = detect_workspace_tasks(dir.path(), None).unwrap();
         assert!(tasks.iter().any(|task| {
             task.source == "package.json" && task.label == "dev" && task.command == "pnpm run dev"
         }));
@@ -2390,7 +2803,7 @@ mod tests {
         .unwrap();
         fs::write(dir.path().join("uv.lock"), "version = 1").unwrap();
 
-        let tasks = detect_workspace_tasks(dir.path()).unwrap();
+        let tasks = detect_workspace_tasks(dir.path(), None).unwrap();
         for command in [
             "go test ./...",
             "gradle build",
@@ -2483,7 +2896,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         fs::write(dir.path().join("pom.xml"), "<project />").unwrap();
         fs::write(dir.path().join("build.gradle"), "plugins {}").unwrap();
 
-        let groups = build_workspace_task_tree(dir.path()).unwrap();
+        let groups = build_workspace_task_tree(dir.path(), None).unwrap();
         let find = |source: &str| groups.iter().find(|group| group.source == source);
 
         // Maven carries the full lifecycle (not just the Run-tab package/test subset).
@@ -2541,6 +2954,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         let target = workspace_java_run_target(
             dir.path().to_string_lossy().into_owned(),
             "src/com/example/App.java".into(),
+            None,
         )
         .unwrap();
         assert_eq!(target.main_class, "com.example.App");
@@ -2567,6 +2981,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         let error = workspace_java_run_target(
             dir.path().to_string_lossy().into_owned(),
             "Example.java".into(),
+            None,
         )
         .unwrap_err();
         assert!(error.contains("No `static void main"));
@@ -2585,11 +3000,15 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         )
         .unwrap();
 
-        let target = java_run_target_for_path(dir.path(), &source_dir.join("Main.java")).unwrap();
+        let target =
+            java_run_target_for_path(dir.path(), &source_dir.join("Main.java"), None).unwrap();
         assert_eq!(target.build_system, "maven");
         assert_eq!(target.main_class, "demo.Main");
         assert_eq!(target.cwd, path_to_string(dir.path()));
         assert!(target.command.contains("mvnw"));
+        assert_eq!(target.execution.source, "wrapper");
+        assert!(target.execution.executable.contains("mvnw"));
+        assert!(target.execution.error.is_none());
         assert!(target.command.contains("-Dexec.mainClass='demo.Main'"));
         assert!(target.command.contains("exec-maven-plugin:3.5.0:java"));
     }
@@ -2609,7 +3028,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         )
         .unwrap();
 
-        let target = java_run_target_for_path(dir.path(), &source).unwrap();
+        let target = java_run_target_for_path(dir.path(), &source, None).unwrap();
         assert_eq!(target.build_system, "gradle");
         assert_eq!(target.module_path, "app");
         assert_eq!(target.cwd, path_to_string(dir.path()));
@@ -2617,7 +3036,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         assert!(target.command.contains("-PtaomniMainClass='demo.App'"));
         assert!(target.command.contains("java-run.init.gradle"));
 
-        let groups = build_workspace_task_tree(dir.path()).unwrap();
+        let groups = build_workspace_task_tree(dir.path(), None).unwrap();
         let gradle = groups
             .iter()
             .find(|group| group.source == "Gradle")
@@ -2648,8 +3067,173 @@ runtimeClasspath - Runtime classpath of source set 'main'.
             )
             .unwrap();
         }
-        let targets = detect_java_run_targets(dir.path()).unwrap();
+        let targets = detect_java_run_targets(dir.path(), None).unwrap();
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0].main_class, "demo.App");
+    }
+
+    // ---- Cross-platform tool resolution (M11 build/run robustness) ----
+    //
+    // These tests inject `HostPlatform` and `PATH` explicitly so the Windows
+    // `.cmd`/`.bat` resolution and launch planning are exercised on non-Windows
+    // CI too (the production entry points use `HostPlatform::current()`).
+
+    #[test]
+    fn resolves_windows_batch_wrapper_before_configured_or_path() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("pom.xml"), "<project />").unwrap();
+        fs::write(dir.path().join("mvnw.cmd"), "@echo off").unwrap();
+        let config = WorkspaceToolConfig {
+            maven: Some("C:/tools/mvn.cmd".into()),
+            gradle: None,
+        };
+        let resolution = resolve_build_tool_with_path(
+            dir.path(),
+            dir.path(),
+            BuildTool::Maven,
+            Some(&config),
+            HostPlatform::Windows,
+            None,
+        );
+        assert_eq!(resolution.source, ToolSource::Wrapper);
+        assert!(resolution.available);
+        assert!(resolution.executable.ends_with("mvnw.cmd"));
+        // PowerShell call operator + absolute path (never the fragile bare `.\mvnw.cmd`).
+        let runner = resolution.task_runner(HostPlatform::Windows);
+        assert!(runner.starts_with("& '"));
+        assert!(runner.contains("mvnw.cmd"));
+    }
+
+    #[test]
+    fn walks_up_to_find_wrapper_in_monorepo() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("mvnw"), "#!/bin/sh").unwrap();
+        let module = dir.path().join("services/api");
+        fs::create_dir_all(&module).unwrap();
+        let resolution = resolve_build_tool_with_path(
+            &module,
+            dir.path(),
+            BuildTool::Maven,
+            None,
+            HostPlatform::Unix,
+            None,
+        );
+        assert_eq!(resolution.source, ToolSource::Wrapper);
+        assert!(resolution.executable.ends_with("mvnw"));
+    }
+
+    #[test]
+    fn falls_back_to_configured_executable_then_reports_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("pom.xml"), "<project />").unwrap();
+        let mvn = dir.path().join("custom-mvn");
+        fs::write(&mvn, "#!/bin/sh").unwrap();
+
+        // A configured path with a directory separator resolves relative to the
+        // workspace root; a bare name (no separator) is a PATH lookup instead.
+        let config = WorkspaceToolConfig {
+            maven: Some("./custom-mvn".into()),
+            gradle: None,
+        };
+        let resolution = resolve_build_tool_with_path(
+            dir.path(),
+            dir.path(),
+            BuildTool::Maven,
+            Some(&config),
+            HostPlatform::Unix,
+            None,
+        );
+        assert_eq!(resolution.source, ToolSource::Configured);
+        assert!(resolution.available);
+        assert_eq!(resolution.executable, fs::canonicalize(&mvn).unwrap_or(mvn));
+
+        // A configured executable that does not exist yields a clear diagnostic
+        // rather than a shell "not recognized" error at run time.
+        let missing = WorkspaceToolConfig {
+            maven: Some("nope-not-here".into()),
+            gradle: None,
+        };
+        let resolution = resolve_build_tool_with_path(
+            dir.path(),
+            dir.path(),
+            BuildTool::Maven,
+            Some(&missing),
+            HostPlatform::Unix,
+            None,
+        );
+        assert_eq!(resolution.source, ToolSource::Configured);
+        assert!(!resolution.available);
+        assert!(resolution.require_available().is_err());
+        assert!(
+            resolution
+                .diagnostic
+                .as_deref()
+                .unwrap()
+                .contains("nope-not-here")
+        );
+    }
+
+    #[test]
+    fn reports_missing_tool_when_no_wrapper_config_or_path() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("build.gradle"), "plugins {}").unwrap();
+        let resolution = resolve_build_tool_with_path(
+            dir.path(),
+            dir.path(),
+            BuildTool::Gradle,
+            None,
+            HostPlatform::Unix,
+            None,
+        );
+        assert_eq!(resolution.source, ToolSource::Path);
+        assert!(!resolution.available);
+        let error = resolution.require_available().unwrap_err();
+        assert!(error.contains("Gradle"));
+        assert!(error.contains("gradlew"));
+    }
+
+    #[test]
+    fn plans_windows_batch_launch_via_cmd_exe() {
+        let plan = plan_tool_launch(
+            Path::new(r"C:\proj\mvnw.cmd"),
+            &["-B".into(), "dependency:tree".into()],
+            HostPlatform::Windows,
+        );
+        assert_eq!(plan.program, "cmd.exe");
+        assert_eq!(plan.args[0], "/D");
+        assert_eq!(plan.args[1], "/S");
+        assert_eq!(plan.args[2], "/C");
+        // The whole command line is one argument, wrapper quoted, args appended.
+        assert!(plan.args[3].contains(r"C:\proj\mvnw.cmd"));
+        assert!(plan.args[3].contains("dependency:tree"));
+    }
+
+    #[test]
+    fn plans_direct_launch_for_plain_executable() {
+        let plan = plan_tool_launch(
+            Path::new("/usr/bin/gradle"),
+            &["dependencies".into()],
+            HostPlatform::Unix,
+        );
+        assert_eq!(plan.program, "/usr/bin/gradle");
+        assert_eq!(plan.args, vec!["dependencies".to_string()]);
+    }
+
+    #[test]
+    fn build_task_tree_surfaces_missing_tool_diagnostic() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("pom.xml"), "<project />").unwrap();
+        // No wrapper, no config; PATH lookup disabled → execution carries the error.
+        let resolution = resolve_build_tool_with_path(
+            dir.path(),
+            dir.path(),
+            BuildTool::Maven,
+            None,
+            HostPlatform::Unix,
+            None,
+        );
+        let execution = resolution.execution(&["package"]);
+        assert_eq!(execution.args, vec!["package".to_string()]);
+        assert!(execution.error.is_some());
     }
 }

--- a/src/components/editor/CodeWorkspaceTab.test.tsx
+++ b/src/components/editor/CodeWorkspaceTab.test.tsx
@@ -2261,6 +2261,7 @@ describe("CodeWorkspaceTab", () => {
     await waitFor(() => expect(workspaceMocks.workspaceJavaRunTarget).toHaveBeenCalledWith(
       "/repo/app",
       "src/main/java/com/acme/App.java",
+      undefined,
     ));
     expect(screen.getByRole("tab", { name: /Terminal/, selected: true })).toBeInTheDocument();
     expect(await screen.findByTestId("mock-workspace-terminal")).toHaveAttribute(

--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -53,6 +53,7 @@ import {
   workspaceWriteFile,
   workspaceWriteLooseFile,
   type WorkspaceGitRoot,
+  type WorkspaceToolConfig,
 } from "../../lib/editor/workspace";
 import {
   gitBlameLines,
@@ -200,6 +201,7 @@ import { type RecentFileEntry } from "./workspace/RecentFilesPopup";
 import { EditorGroup } from "./workspace/EditorGroup";
 import { WorkspacePopupsHost } from "./workspace/WorkspacePopupsHost";
 import { WorkspaceSdkStatus } from "./workspace/WorkspaceSdkStatus";
+import { WorkspaceBuildRunToolsDialog } from "./workspace/WorkspaceBuildRunToolsDialog";
 import { FileTreePane } from "./workspace/FileTreePane";
 import { ProjectTree } from "./workspace/ProjectTree";
 import { MarkdownPreview } from "./workspace/MarkdownPreview";
@@ -321,7 +323,11 @@ import {
   type OpenFileState,
   type TreeSelection,
   type TreeViewMode,
+  type WorkspaceBuildRunTools,
   type WorkspaceTreeCommandPayload,
+  readWorkspaceBuildRunTools,
+  writeWorkspaceBuildRunTools,
+  workspaceToolExecutables,
   CODE_WORKSPACE_DEFAULT_TREE_FONT_SIZE,
   CODE_WORKSPACE_MAX_FONT_SIZE,
   CODE_WORKSPACE_MAX_TREE_FONT_SIZE,
@@ -858,6 +864,23 @@ export function CodeWorkspaceTab({
   const runPanelRef = useRef<RunPanelHandle | null>(null);
   const runActiveJavaFileRef = useRef<() => void>(() => {});
   const buildActiveProjectRef = useRef<(rebuild?: boolean) => void>(() => {});
+
+  // Per-workspace Maven/Gradle executable overrides (project wrapper still wins;
+  // this is the "configured" tier between wrapper and PATH). Persisted per
+  // workspace instance and threaded into every task/dependency detector.
+  const [buildRunTools, setBuildRunTools] = useState<WorkspaceBuildRunTools>(
+    () => readWorkspaceBuildRunTools(workspaceInstanceId),
+  );
+  const [buildRunToolsOpen, setBuildRunToolsOpen] = useState(false);
+  useEffect(() => {
+    setBuildRunTools(readWorkspaceBuildRunTools(workspaceInstanceId));
+  }, [workspaceInstanceId]);
+  const toolConfig = useMemo<WorkspaceToolConfig | undefined>(() => {
+    const executables = workspaceToolExecutables(buildRunTools);
+    return Object.keys(executables).length > 0 ? executables : undefined;
+  }, [buildRunTools]);
+  const toolConfigRef = useRef(toolConfig);
+  toolConfigRef.current = toolConfig;
 
   /** Run a workspace task in the integrated terminal (shared by Run + Build panels). */
   const runWorkspaceTask = useCallback(
@@ -4980,7 +5003,7 @@ export function CodeWorkspaceTab({
         if (file.dirty) {
           await saveOpenBufferText(file.key, file.text);
         }
-        const target = await workspaceJavaRunTarget(root.path, file.ref.path);
+        const target = await workspaceJavaRunTarget(root.path, file.ref.path, toolConfigRef.current);
         launchWorkspaceTask({
           id: target.id,
           label: target.label,
@@ -4989,6 +5012,7 @@ export function CodeWorkspaceTab({
           source: `Java · ${target.buildSystem === "source-file" ? "JDK" : target.buildSystem}`,
           rootId: root.id,
           rootName: root.name,
+          execution: target.execution,
         });
         setStatusMessage(`Running ${target.mainClass}`);
       } catch (error) {
@@ -5021,7 +5045,7 @@ export function CodeWorkspaceTab({
       if (!root) return;
       setProjectBuildBusy(true);
       try {
-        const groups = await workspaceTaskTree(root.path);
+        const groups = await workspaceTaskTree(root.path, toolConfigRef.current);
         const preferred = rebuild
           ? [["Maven", "rebuild"], ["Gradle", "rebuild"]]
           : [
@@ -5094,7 +5118,7 @@ export function CodeWorkspaceTab({
     const root = findRoot(activeFile.ref.rootId);
     if (!root) return;
     let cancelled = false;
-    void workspaceTaskTree(root.path)
+    void workspaceTaskTree(root.path, toolConfigRef.current)
       .then((groups) => {
         if (cancelled) return;
         const mavenTask = groups
@@ -6098,6 +6122,8 @@ export function CodeWorkspaceTab({
                 roots={roots}
                 active={bottomDockOpen && bottomDockTab === "run"}
                 onRun={runWorkspaceTask}
+                toolConfig={toolConfig}
+                onConfigureTools={() => setBuildRunToolsOpen(true)}
               />
             ),
           },
@@ -6111,6 +6137,7 @@ export function CodeWorkspaceTab({
                 roots={roots}
                 active={bottomDockOpen && bottomDockTab === "build"}
                 onRunTask={(task) => runWorkspaceTask(task)}
+                toolConfig={toolConfig}
                 onLoadModules={(rootPath) =>
                   // A synthetic .java path selects the root's jdtls session
                   // (session keys on project scope, not on the file existing).
@@ -6247,6 +6274,17 @@ export function CodeWorkspaceTab({
             setAiRewriteState(null);
             setStatusMessage("Applied AI proposal to the selection");
           }}
+        />
+      )}
+      {buildRunToolsOpen && (
+        <WorkspaceBuildRunToolsDialog
+          config={buildRunTools}
+          onSave={(next) => {
+            setBuildRunTools(writeWorkspaceBuildRunTools(workspaceInstanceId, next));
+            setBuildRunToolsOpen(false);
+            setStatusMessage("Saved build and run tool settings");
+          }}
+          onClose={() => setBuildRunToolsOpen(false)}
         />
       )}
     </div>

--- a/src/components/editor/workspace/WorkspaceBuildRunToolsDialog.tsx
+++ b/src/components/editor/workspace/WorkspaceBuildRunToolsDialog.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import type { WorkspaceBuildRunTools } from "./codeWorkspaceModel";
+
+interface WorkspaceBuildRunToolsDialogProps {
+  config: WorkspaceBuildRunTools;
+  onSave: (config: WorkspaceBuildRunTools) => void;
+  onClose: () => void;
+}
+
+const TOOLS = [
+  { id: "maven", label: "Maven", placeholder: "mvn, mvn.cmd, or an absolute path" },
+  { id: "gradle", label: "Gradle", placeholder: "gradle, gradle.bat, or an absolute path" },
+] as const;
+
+export function WorkspaceBuildRunToolsDialog({
+  config,
+  onSave,
+  onClose,
+}: WorkspaceBuildRunToolsDialogProps) {
+  const [values, setValues] = useState<Record<string, string>>(() => Object.fromEntries(
+    TOOLS.map(({ id }) => [id, config.tools[id]?.executable ?? ""]),
+  ));
+
+  return (
+    <div
+      className="fixed inset-0 z-[900] flex items-center justify-center bg-black/40 p-4"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Build and run tools"
+        className="w-[520px] max-w-[calc(100vw-32px)] rounded-md border border-[var(--taomni-code-border)] bg-[var(--taomni-code-bg)] shadow-xl"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="flex h-10 items-center border-b border-[var(--taomni-code-border)] px-3">
+          <span className="font-medium">Build and Run Tools</span>
+          <button type="button" aria-label="Close build and run tools" className="ml-auto" onClick={onClose}>
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="space-y-3 p-3 text-xs">
+          <p className="text-[var(--taomni-code-muted)]">
+            Resolution order is project wrapper, configured executable, then workspace SDK/PATH.
+            Leave a field empty for automatic discovery.
+          </p>
+          {TOOLS.map((tool) => (
+            <label key={tool.id} className="grid grid-cols-[80px_1fr] items-center gap-2">
+              <span>{tool.label}</span>
+              <input
+                aria-label={`${tool.label} executable`}
+                value={values[tool.id]}
+                placeholder={tool.placeholder}
+                onChange={(event) => setValues((current) => ({ ...current, [tool.id]: event.target.value }))}
+                className="h-7 rounded border border-[var(--taomni-code-border)] bg-[var(--taomni-code-gutter-bg)] px-2"
+              />
+            </label>
+          ))}
+        </div>
+        <div className="flex justify-end gap-2 border-t border-[var(--taomni-code-border)] p-3">
+          <button type="button" className="taomni-btn h-7 px-3" onClick={onClose}>Cancel</button>
+          <button
+            type="button"
+            className="taomni-btn h-7 px-3"
+            onClick={() => {
+              const tools = { ...config.tools };
+              for (const { id } of TOOLS) {
+                const executable = values[id].trim();
+                if (executable) tools[id] = { executable };
+                else delete tools[id];
+              }
+              onSave({ tools });
+            }}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/workspace/codeWorkspaceModel.buildRunTools.test.ts
+++ b/src/components/editor/workspace/codeWorkspaceModel.buildRunTools.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  normalizeWorkspaceBuildRunTools,
+  readWorkspaceBuildRunTools,
+  workspaceToolExecutables,
+  writeWorkspaceBuildRunTools,
+} from "./codeWorkspaceModel";
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("workspace build/run tool persistence", () => {
+  it("defaults to automatic tool discovery", () => {
+    expect(readWorkspaceBuildRunTools("workspace-a")).toEqual({ tools: {} });
+  });
+
+  it("isolates executable overrides by workspace", () => {
+    writeWorkspaceBuildRunTools("workspace-a", {
+      tools: { maven: { executable: " C:\\Tools\\mvn.cmd " } },
+    });
+    expect(readWorkspaceBuildRunTools("workspace-a")).toEqual({
+      tools: { maven: { executable: "C:\\Tools\\mvn.cmd" } },
+    });
+    expect(readWorkspaceBuildRunTools("workspace-b")).toEqual({ tools: {} });
+  });
+
+  it("keeps generic tool ids and drops malformed entries", () => {
+    expect(normalizeWorkspaceBuildRunTools({
+      tools: {
+        gradle: { executable: "gradle" },
+        cargo: { executable: "/opt/rust/bin/cargo" },
+        broken: { executable: 42 },
+      },
+    })).toEqual({
+      tools: {
+        gradle: { executable: "gradle" },
+        cargo: { executable: "/opt/rust/bin/cargo" },
+      },
+    });
+  });
+
+  it("recovers from corrupt JSON and flattens backend overrides", () => {
+    window.localStorage.setItem(
+      "taomni.codeWorkspace.buildRunTools.v1.workspace-a",
+      "{broken",
+    );
+    expect(readWorkspaceBuildRunTools("workspace-a")).toEqual({ tools: {} });
+    expect(workspaceToolExecutables({
+      tools: {
+        maven: { executable: "mvn-custom" },
+        gradle: { executable: "gradle-custom" },
+      },
+    })).toEqual({ maven: "mvn-custom", gradle: "gradle-custom" });
+  });
+});

--- a/src/components/editor/workspace/codeWorkspaceModel.ts
+++ b/src/components/editor/workspace/codeWorkspaceModel.ts
@@ -22,6 +22,18 @@ export interface LspCustomCommandConfig {
   args: string;
 }
 
+export interface WorkspaceBuildRunTool {
+  executable: string;
+}
+
+export interface WorkspaceBuildRunTools {
+  tools: Record<string, WorkspaceBuildRunTool>;
+}
+
+export const DEFAULT_WORKSPACE_BUILD_RUN_TOOLS: WorkspaceBuildRunTools = {
+  tools: {},
+};
+
 export interface DirectoryState {
   entries: WorkspaceEntry[];
   loaded: boolean;
@@ -72,6 +84,7 @@ export const DEFAULT_LSP_JAVA_VMARGS = "-Xms1024m -Xmx1024m";
 export const LSP_JAVA_SETTINGS_KEY = "taomni.codeWorkspace.lspJavaSettings.v1";
 /** jdtls extension bundle paths (java-debug / java-test) for debug + test (M8). */
 export const LSP_JAVA_BUNDLES_KEY = "taomni.codeWorkspace.lspJavaBundles.v1";
+export const WORKSPACE_BUILD_RUN_TOOLS_KEY_PREFIX = "taomni.codeWorkspace.buildRunTools.v1";
 export const CUSTOM_LSP_COMMAND_ID = "__custom__";
 export const TREE_FONT_SIZE_KEY = "taomni.codeWorkspace.treeFontSize.v1";
 export const TREE_VIEW_MODE_KEY = "taomni.codeWorkspace.treeViewMode.v1";
@@ -780,6 +793,55 @@ export function subscribeLspServerPrefs(listener: () => void): () => void {
     window.removeEventListener(LSP_PREFS_CHANGED_EVENT, onCustom);
     window.removeEventListener("storage", onStorage);
   };
+}
+
+export function normalizeWorkspaceBuildRunTools(raw: unknown): WorkspaceBuildRunTools {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { tools: {} };
+  }
+  const rawTools = (raw as { tools?: unknown }).tools;
+  if (!rawTools || typeof rawTools !== "object" || Array.isArray(rawTools)) {
+    return { tools: {} };
+  }
+  const tools: Record<string, WorkspaceBuildRunTool> = {};
+  for (const [toolId, value] of Object.entries(rawTools)) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+    const executable = (value as { executable?: unknown }).executable;
+    if (typeof executable === "string" && executable.trim()) {
+      tools[toolId] = { executable: executable.trim() };
+    }
+  }
+  return { tools };
+}
+
+function workspaceBuildRunToolsKey(workspaceInstanceId: string): string {
+  return `${WORKSPACE_BUILD_RUN_TOOLS_KEY_PREFIX}.${workspaceInstanceId}`;
+}
+
+export function readWorkspaceBuildRunTools(workspaceInstanceId: string): WorkspaceBuildRunTools {
+  try {
+    const stored = window.localStorage.getItem(workspaceBuildRunToolsKey(workspaceInstanceId));
+    return stored ? normalizeWorkspaceBuildRunTools(JSON.parse(stored)) : { tools: {} };
+  } catch {
+    return { tools: {} };
+  }
+}
+
+export function writeWorkspaceBuildRunTools(
+  workspaceInstanceId: string,
+  config: WorkspaceBuildRunTools,
+): WorkspaceBuildRunTools {
+  const normalized = normalizeWorkspaceBuildRunTools(config);
+  try {
+    window.localStorage.setItem(workspaceBuildRunToolsKey(workspaceInstanceId), JSON.stringify(normalized));
+  } catch {
+    // Ignore storage failures.
+  }
+  return normalized;
+}
+
+export function workspaceToolExecutables(config: WorkspaceBuildRunTools): Record<string, string> {
+  return Object.fromEntries(Object.entries(config.tools).map(([id, tool]) => [id, tool.executable]));
 }
 
 export function readLspCommandPrefs(): Record<string, string> {

--- a/src/components/editor/workspace/panels/BuildPanel.test.tsx
+++ b/src/components/editor/workspace/panels/BuildPanel.test.tsx
@@ -108,7 +108,7 @@ describe("BuildPanel", () => {
     expect(workspaceMocks.workspaceDependencyTree).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByTestId("build-panel-deps-load-app"));
-    await waitFor(() => expect(workspaceMocks.workspaceDependencyTree).toHaveBeenCalledWith("/repo/app"));
+    await waitFor(() => expect(workspaceMocks.workspaceDependencyTree).toHaveBeenCalledWith("/repo/app", undefined));
     await screen.findByText("spring-core");
     // Arbitration conflict surfaces a badge.
     expect(screen.getByText("conflict")).toBeInTheDocument();

--- a/src/components/editor/workspace/panels/BuildPanel.tsx
+++ b/src/components/editor/workspace/panels/BuildPanel.tsx
@@ -5,6 +5,7 @@ import {
   workspaceTaskTree,
   type DependencyNode,
   type WorkspaceTaskGroup,
+  type WorkspaceToolConfig,
 } from "../../../../lib/editor/workspace";
 import type { JavaModule } from "../../../../lib/editor/lsp";
 import type { CodeWorkspaceRootInfo } from "../../../../types";
@@ -63,13 +64,15 @@ interface BuildPanelProps {
   onRunTask: (task: WorkspaceTaskItem) => void;
   /** Resolve Java modules for a root via jdtls (M7 F-4); omitted → no Modules section. */
   onLoadModules?: (rootPath: string) => Promise<JavaModule[]>;
+  /** Per-workspace Maven/Gradle executable overrides (wrapper still wins). */
+  toolConfig?: WorkspaceToolConfig;
 }
 
 /**
  * Build panel (M7 F): the task tree (F-2) grouped root -> source -> task.
  * Dependency tree (F-1) and module view (F-4) attach as further sections.
  */
-export function BuildPanel({ roots, active, onRunTask, onLoadModules }: BuildPanelProps) {
+export function BuildPanel({ roots, active, onRunTask, onLoadModules, toolConfig }: BuildPanelProps) {
   const [trees, setTrees] = useState<RootTaskTree[]>([]);
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
@@ -105,7 +108,7 @@ export function BuildPanel({ roots, active, onRunTask, onLoadModules }: BuildPan
     setDepsLoading((current) => ({ ...current, [rootId]: true }));
     setDepsError((current) => ({ ...current, [rootId]: null }));
     try {
-      const tree = await workspaceDependencyTree(rootPath);
+      const tree = await workspaceDependencyTree(rootPath, toolConfig);
       setDeps((current) => ({ ...current, [rootId]: tree }));
     } catch (reason) {
       setDepsError((current) => ({
@@ -115,7 +118,7 @@ export function BuildPanel({ roots, active, onRunTask, onLoadModules }: BuildPan
     } finally {
       setDepsLoading((current) => ({ ...current, [rootId]: false }));
     }
-  }, []);
+  }, [toolConfig]);
 
   const refresh = useCallback(async () => {
     if (roots.length === 0) {
@@ -130,7 +133,7 @@ export function BuildPanel({ roots, active, onRunTask, onLoadModules }: BuildPan
         rootId: root.id,
         rootName: root.name,
         rootPath: root.path,
-        groups: await workspaceTaskTree(root.path),
+        groups: await workspaceTaskTree(root.path, toolConfig),
       })));
       setTrees(next);
       setLoaded(true);
@@ -140,10 +143,18 @@ export function BuildPanel({ roots, active, onRunTask, onLoadModules }: BuildPan
     } finally {
       setLoading(false);
     }
-  }, [roots]);
+  }, [roots, toolConfig]);
   useEffect(() => {
     if (active && !loaded && !loading) void refresh();
   }, [active, loaded, loading, refresh]);
+
+  // Re-detect tasks (and clear resolved dependency trees) when the tool config
+  // changes so the Build panel reflects the new wrapper/executable resolution.
+  useEffect(() => {
+    if (active && loaded) void refresh();
+    setDeps({});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toolConfig]);
 
   const toggle = useCallback((key: string) => {
     setCollapsed((current) => ({ ...current, [key]: !current[key] }));

--- a/src/components/editor/workspace/panels/RunPanel.tsx
+++ b/src/components/editor/workspace/panels/RunPanel.tsx
@@ -6,11 +6,12 @@ import {
   useMemo,
   useState,
 } from "react";
-import { Loader2, Play, Plus, RefreshCw } from "lucide-react";
+import { AlertTriangle, Loader2, Play, Plus, RefreshCw, Settings2 } from "lucide-react";
 import {
   workspaceDetectTasks,
   workspaceJavaRunTargets,
   type WorkspaceTask,
+  type WorkspaceToolConfig,
 } from "../../../../lib/editor/workspace";
 import type { CodeWorkspaceRootInfo } from "../../../../types";
 
@@ -39,6 +40,10 @@ interface RunPanelProps {
   roots: CodeWorkspaceRootInfo[];
   active: boolean;
   onRun: (task: WorkspaceTaskItem, onExit: (exitCode: number) => void) => void;
+  /** Per-workspace Maven/Gradle executable overrides (wrapper still wins). */
+  toolConfig?: WorkspaceToolConfig;
+  /** Open the Build/Run tools settings dialog. */
+  onConfigureTools?: () => void;
 }
 
 function customTasksKey(workspaceInstanceId: string): string {
@@ -61,6 +66,8 @@ export const RunPanel = forwardRef<RunPanelHandle, RunPanelProps>(function RunPa
   roots,
   active,
   onRun,
+  toolConfig,
+  onConfigureTools,
 }, ref) {
   const [detectedTasks, setDetectedTasks] = useState<WorkspaceTaskItem[]>([]);
   const [customTasks, setCustomTasks] = useState<WorkspaceTaskItem[]>(
@@ -84,8 +91,8 @@ export const RunPanel = forwardRef<RunPanelHandle, RunPanelProps>(function RunPa
     try {
       const groups = await Promise.all(roots.map(async (root) => {
         const [tasks, javaTargets] = await Promise.all([
-          workspaceDetectTasks(root.path),
-          workspaceJavaRunTargets(root.path),
+          workspaceDetectTasks(root.path, toolConfig),
+          workspaceJavaRunTargets(root.path, toolConfig),
         ]);
         const detected = tasks.map((task): WorkspaceTaskItem => ({
           ...task,
@@ -100,6 +107,7 @@ export const RunPanel = forwardRef<RunPanelHandle, RunPanelProps>(function RunPa
           source: `Java · ${target.buildSystem === "source-file" ? "JDK" : target.buildSystem}`,
           rootId: root.id,
           rootName: root.name,
+          execution: target.execution,
         }));
         return [...java, ...detected];
       }));
@@ -111,11 +119,18 @@ export const RunPanel = forwardRef<RunPanelHandle, RunPanelProps>(function RunPa
     } finally {
       setLoading(false);
     }
-  }, [roots]);
+  }, [roots, toolConfig]);
 
   useEffect(() => {
     if (active && !loaded && !loading) void refresh();
   }, [active, loaded, loading, refresh]);
+
+  // Re-detect when the tool config changes so wrapper/executable resolution and
+  // any "tool not found" diagnostics reflect the new settings immediately.
+  useEffect(() => {
+    if (active && loaded) void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toolConfig]);
 
   useEffect(() => {
     window.localStorage.setItem(customTasksKey(workspaceInstanceId), JSON.stringify(customTasks));
@@ -207,6 +222,17 @@ export const RunPanel = forwardRef<RunPanelHandle, RunPanelProps>(function RunPa
         <button type="button" aria-label="Add custom task" onClick={addCustomTask} className="h-6 w-6 rounded">
           <Plus className="h-3.5 w-3.5" />
         </button>
+        {onConfigureTools && (
+          <button
+            type="button"
+            aria-label="Configure build and run tools"
+            title="Configure build and run tools (Maven / Gradle)"
+            onClick={onConfigureTools}
+            className="h-6 w-6 rounded"
+          >
+            <Settings2 className="h-3.5 w-3.5" />
+          </button>
+        )}
         <button type="button" aria-label="Refresh tasks" onClick={() => void refresh()} className="h-6 w-6 rounded">
           {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
         </button>
@@ -221,15 +247,19 @@ export const RunPanel = forwardRef<RunPanelHandle, RunPanelProps>(function RunPa
             return (
               <div key={root.id} className="mb-2">
                 <div className="mb-1 font-semibold">{root.name}</div>
-                {rootTasks.map((task) => (
+                {rootTasks.map((task) => {
+                  const toolError = task.execution?.error;
+                  return (
                   <div key={task.id} className="group flex items-center gap-1 rounded hover:bg-[var(--taomni-code-active-line-bg)]">
                     <button
                       type="button"
                       className="flex min-w-0 flex-1 items-center gap-1 px-1 py-1 text-left"
-                      title={`${task.command} — ${task.cwd}`}
+                      title={toolError ? toolError : `${task.command} — ${task.cwd}`}
                       onClick={() => runTask(task)}
                     >
-                      <Play className="h-3 w-3 shrink-0 text-emerald-500" />
+                      {toolError
+                        ? <AlertTriangle className="h-3 w-3 shrink-0 text-amber-500" />
+                        : <Play className="h-3 w-3 shrink-0 text-emerald-500" />}
                       <span className="truncate">{task.label}</span>
                       <span className="ml-auto shrink-0 text-[10px] text-[var(--taomni-code-muted)]">{task.source}</span>
                     </button>
@@ -244,7 +274,8 @@ export const RunPanel = forwardRef<RunPanelHandle, RunPanelProps>(function RunPa
                       </button>
                     )}
                   </div>
-                ))}
+                  );
+                })}
               </div>
             );
           })}

--- a/src/components/editor/workspace/panels/TerminalDockPanel.tsx
+++ b/src/components/editor/workspace/panels/TerminalDockPanel.tsx
@@ -10,6 +10,7 @@ import {
 import { Plus, TerminalSquare, X } from "lucide-react";
 import { TerminalPanel } from "../../../terminal/TerminalPanel";
 import { getTerminal } from "../../../../lib/terminal/terminalRegistry";
+import { buildInteractiveCommandInput, renderTerminalTask } from "../../../../lib/terminal/commandInput";
 import { getAppPlatform } from "../../../../lib/runtime";
 import type { CodeWorkspaceRootInfo } from "../../../../types";
 
@@ -131,10 +132,16 @@ export const TerminalDockPanel = forwardRef<TerminalDockHandle, TerminalDockPane
         if (!instance?.pendingCommand) return;
         const terminal = getTerminal(id);
         if (terminal) {
-          const command = getAppPlatform() === "windows"
-            ? `& { ${instance.pendingCommand} }; $taomniStatus=$LASTEXITCODE; [Console]::Write([char]27+']633;TaomniTaskExit='+$taomniStatus+[char]7)\n`
-            : `${instance.pendingCommand}; __taomni_status=$?; printf '\\033]633;TaomniTaskExit=%s\\a' "$__taomni_status"\n`;
-          terminal.writeInput(command);
+          if (terminal.runTask) {
+            terminal.runTask(instance.pendingCommand);
+          } else {
+            // Backward-compatible path for lightweight registrants and tests.
+            const task = renderTerminalTask(
+              instance.pendingCommand,
+              terminal.localEnvironment ?? { platform: getAppPlatform() },
+            );
+            terminal.writeInput(buildInteractiveCommandInput(task.input));
+          }
           setInstances((current) => current.map((item) => item.id === id
             ? { ...item, pendingCommand: null }
             : item));

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -69,6 +69,7 @@ import {
 import { Bot, ExternalLink, FolderOpen, Maximize2, Minimize2, X } from "lucide-react";
 import {
   createOsc7BlankingSuppressor,
+  createTaskStartOutputSuppressor,
   type InputEchoSuppressor,
 } from "../../lib/terminalOutputFilter";
 import { makeHostKey, useCommandHistory } from "../../lib/history";
@@ -108,6 +109,7 @@ import { extractTerminalCommand } from "../../lib/terminalCommand";
 import { normalizeLocalStartCwd } from "../../lib/terminalCwd";
 import { inferTerminalProgram } from "../../lib/terminalActivity";
 import { buildSshCwdIntegration } from "../../lib/terminalShellIntegration";
+import { buildInteractiveCommandInput, renderTerminalTask } from "../../lib/terminal/commandInput";
 import { registerTerminal, consumeTerminalDetachPending } from "../../lib/terminal/terminalRegistry";
 import {
   ZmodemSession,
@@ -3398,6 +3400,34 @@ export function TerminalPanel({
           }
         }
         writeTerminal(registeredSessionId, encodeBase64(data)).catch(console.error);
+      },
+      runTask: (command: string) => {
+        if (readOnlyRef.current) return;
+        const task = renderTerminalTask(command, {
+          platform: getAppPlatform(),
+          shellId: resolvedLocalShellId ?? localShell?.id ?? null,
+          shellName: localShell?.name ?? null,
+        });
+        const suppressor = createTaskStartOutputSuppressor(
+          task.startMarker,
+          task.displayCommand,
+        );
+        injectedInputEchoSuppressorRef.current = suppressor;
+        const program = inferTerminalProgram(task.displayCommand);
+        setTerminalRuntime(tabId, {
+          state: "running",
+          program: program ?? undefined,
+          activitySource: "input-heuristic",
+        });
+        writeTerminal(
+          registeredSessionId,
+          encodeBase64(buildInteractiveCommandInput(task.input)),
+        ).catch((err) => {
+          if (injectedInputEchoSuppressorRef.current === suppressor) {
+            injectedInputEchoSuppressorRef.current = null;
+          }
+          console.error(err);
+        });
       },
       // Display-only echo (xterm.write): mirror Claude Code's captured-run
       // activity into this terminal as a read-only trace. Intentionally NOT

--- a/src/lib/editor/workspace.ts
+++ b/src/lib/editor/workspace.ts
@@ -39,6 +39,18 @@ export interface WorkspaceGitRoot {
   isSubmodule?: boolean;
 }
 
+/**
+ * Structured execution for a Maven/Gradle task: the resolved absolute executable,
+ * its arguments, how it was resolved (wrapper/configured/path), and a diagnostic
+ * when the tool could not be resolved. Present only for build-tool tasks.
+ */
+export interface WorkspaceTaskExecution {
+  executable: string;
+  args: string[];
+  source: "wrapper" | "configured" | "path";
+  error?: string;
+}
+
 export interface WorkspaceTask {
   id: string;
   label: string;
@@ -47,6 +59,7 @@ export interface WorkspaceTask {
   source: string;
   /** Workspace-relative Maven/Gradle module directory when applicable. */
   modulePath?: string;
+  execution?: WorkspaceTaskExecution;
 }
 
 /** A Java `static void main` entry point with a ready-to-run terminal command. */
@@ -59,6 +72,16 @@ export interface JavaRunTarget {
   cwd: string;
   buildSystem: "maven" | "gradle" | "source-file";
   modulePath: string;
+  execution: WorkspaceTaskExecution;
+}
+
+/**
+ * Optional per-workspace build-tool executable overrides passed to the task
+ * detectors. Empty/omitted entries fall back to project wrapper then PATH.
+ */
+export interface WorkspaceToolConfig {
+  maven?: string;
+  gradle?: string;
 }
 
 export function workspaceListDir(
@@ -100,21 +123,32 @@ export function workspaceDetectGitRoots(
   return invoke<WorkspaceGitRoot[]>("workspace_detect_git_roots", { roots });
 }
 
-export function workspaceDetectTasks(repoRoot: string): Promise<WorkspaceTask[]> {
-  return invoke<WorkspaceTask[]>("workspace_detect_tasks", { repoRoot });
+export function workspaceDetectTasks(
+  repoRoot: string,
+  toolConfig?: WorkspaceToolConfig,
+): Promise<WorkspaceTask[]> {
+  return invoke<WorkspaceTask[]>("workspace_detect_tasks", { repoRoot, toolConfig: toolConfig ?? null });
 }
 
 /** Discover runnable Java main classes without requiring the java-debug bundle. */
-export function workspaceJavaRunTargets(repoRoot: string): Promise<JavaRunTarget[]> {
-  return invoke<JavaRunTarget[]>("workspace_java_run_targets", { repoRoot });
+export function workspaceJavaRunTargets(
+  repoRoot: string,
+  toolConfig?: WorkspaceToolConfig,
+): Promise<JavaRunTarget[]> {
+  return invoke<JavaRunTarget[]>("workspace_java_run_targets", { repoRoot, toolConfig: toolConfig ?? null });
 }
 
 /** Resolve the Java main class declared in one workspace-relative source file. */
 export function workspaceJavaRunTarget(
   repoRoot: string,
   filePath: string,
+  toolConfig?: WorkspaceToolConfig,
 ): Promise<JavaRunTarget> {
-  return invoke<JavaRunTarget>("workspace_java_run_target", { repoRoot, filePath });
+  return invoke<JavaRunTarget>("workspace_java_run_target", {
+    repoRoot,
+    filePath,
+    toolConfig: toolConfig ?? null,
+  });
 }
 
 /** A source-grouped bucket of tasks for the Build panel task tree (M7 F-2). */
@@ -128,8 +162,11 @@ export interface WorkspaceTaskGroup {
  * other ecosystems group their detected tasks by source. Pure/offline (no build
  * tool is spawned).
  */
-export function workspaceTaskTree(repoRoot: string): Promise<WorkspaceTaskGroup[]> {
-  return invoke<WorkspaceTaskGroup[]>("workspace_task_tree", { repoRoot });
+export function workspaceTaskTree(
+  repoRoot: string,
+  toolConfig?: WorkspaceToolConfig,
+): Promise<WorkspaceTaskGroup[]> {
+  return invoke<WorkspaceTaskGroup[]>("workspace_task_tree", { repoRoot, toolConfig: toolConfig ?? null });
 }
 
 /** A resolved dependency-tree node (Maven / Gradle) for the Build panel (M7 F-1). */
@@ -148,8 +185,11 @@ export interface DependencyNode {
  * (`mvn dependency:tree` / `gradle dependencies`). Slow on a cold cache; requires
  * the tool (or wrapper) present. Rejects for non-Maven/Gradle projects.
  */
-export function workspaceDependencyTree(repoRoot: string): Promise<DependencyNode[]> {
-  return invoke<DependencyNode[]>("workspace_dependency_tree", { repoRoot });
+export function workspaceDependencyTree(
+  repoRoot: string,
+  toolConfig?: WorkspaceToolConfig,
+): Promise<DependencyNode[]> {
+  return invoke<DependencyNode[]>("workspace_dependency_tree", { repoRoot, toolConfig: toolConfig ?? null });
 }
 
 export function workspaceReadFile(

--- a/src/lib/terminal/commandInput.test.ts
+++ b/src/lib/terminal/commandInput.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildInteractiveCommandInput } from "./commandInput";
+import { buildInteractiveCommandInput, renderTerminalTask, terminalTaskShell } from "./commandInput";
 
 describe("buildInteractiveCommandInput", () => {
   it("submits a single command with carriage return", () => {
@@ -21,5 +21,46 @@ describe("buildInteractiveCommandInput", () => {
 
   it("preserves intentional blank lines inside the command", () => {
     expect(buildInteractiveCommandInput("cat <<'EOF'\n\nEOF")).toBe("cat <<'EOF'\r\rEOF\r");
+  });
+});
+
+describe("terminal task rendering", () => {
+  it("uses the registered shell instead of the host platform", () => {
+    expect(terminalTaskShell({ platform: "windows", shellId: "git-bash" })).toBe("posix");
+    expect(terminalTaskShell({ platform: "linux", shellId: "powershell" })).toBe("powershell");
+    expect(terminalTaskShell({ platform: "windows", shellId: "command-prompt" })).toBe("cmd");
+  });
+
+  it("renders and escapes a PowerShell task", () => {
+    const task = renderTerminalTask("Write-Output 'it''s fine'", {
+      platform: "windows",
+      shellId: "powershell",
+    });
+    expect(task.shell).toBe("powershell");
+    expect(task.input).toContain("[scriptblock]::Create('Write-Output ''it''''s fine''')");
+    expect(task.input).toContain("TaomniTaskExit=");
+    expect(buildInteractiveCommandInput(task.input).endsWith("\r")).toBe(true);
+  });
+
+  it("renders POSIX and Git Bash tasks with single-quote escaping", () => {
+    const task = renderTerminalTask("printf '%s\\n' \"it's\"", {
+      platform: "windows",
+      shellId: "git-bash",
+    });
+    expect(task.shell).toBe("posix");
+    expect(task.input).toContain(`eval 'printf '"'"'%s\\n'"'"' "it'"'"'s"'`);
+    expect(task.input).toContain("__taomni_status=$?");
+  });
+
+  it("renders cmd with deferred status capture and protects outer metacharacters", () => {
+    const task = renderTerminalTask("echo one && echo 100%", {
+      platform: "windows",
+      shellId: "command-prompt",
+    });
+    expect(task.shell).toBe("cmd");
+    expect(task.input).toContain("echo one ^&^& echo 100%%");
+    expect(task.input).toContain('call set "taomniStatus=%%errorlevel%%"');
+    expect(task.input.split("\n")).toHaveLength(2);
+    expect(buildInteractiveCommandInput(task.input)).not.toContain("\n");
   });
 });

--- a/src/lib/terminal/commandInput.ts
+++ b/src/lib/terminal/commandInput.ts
@@ -1,3 +1,95 @@
+export type TerminalTaskShell = "powershell" | "posix" | "cmd";
+
+export interface TerminalTaskEnvironment {
+  platform?: string | null;
+  shellId?: string | null;
+  shellName?: string | null;
+}
+
+export interface RenderedTerminalTask {
+  input: string;
+  displayCommand: string;
+  startMarker: string;
+  shell: TerminalTaskShell;
+}
+
+const TASK_START_BEL = "\x1b]633;TaomniTaskStart\x07";
+const TASK_START_ST = "\x1b]633;TaomniTaskStart\x1b\\";
+
+/** Resolve task syntax from the shell that the backend actually launched. */
+export function terminalTaskShell(environment?: TerminalTaskEnvironment | null): TerminalTaskShell {
+  const id = environment?.shellId?.trim().toLowerCase() ?? "";
+  const name = environment?.shellName?.trim().toLowerCase() ?? "";
+  const identity = `${id} ${name}`;
+
+  if (/powershell|pwsh/.test(identity)) return "powershell";
+  if (id === "command-prompt" || /(^|[\\/\s])cmd(?:\.exe)?($|\s)/.test(identity)) return "cmd";
+  // A concrete non-default shell id is authoritative. Bash, Git Bash, zsh,
+  // WSL, and other workspace shells use POSIX task syntax even on Windows.
+  if (id && id !== "default") return "posix";
+  return environment?.platform?.toLowerCase() === "windows" ? "powershell" : "posix";
+}
+
+/** Render a task wrapper that reports status without replacing the live shell. */
+export function renderTerminalTask(
+  command: string,
+  environment?: TerminalTaskEnvironment | null,
+): RenderedTerminalTask {
+  const source = command.replace(/\r\n|\r/g, "\n").trim();
+  const displayCommand = source.replace(/\s*\n\s*/g, " ");
+  const shell = terminalTaskShell(environment);
+
+  if (shell === "powershell") {
+    const script = source.replace(/'/g, "''");
+    return {
+      shell,
+      displayCommand,
+      startMarker: TASK_START_BEL,
+      input: `[Console]::Write([char]27+']633;TaomniTaskStart'+[char]7); & ([scriptblock]::Create('${script}')); $taomniSucceeded=$?; $taomniStatus=if ($taomniSucceeded) { 0 } elseif ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) { $LASTEXITCODE } else { 1 }; [Console]::Write([char]27+']633;TaomniTaskExit='+$taomniStatus+[char]7)`,
+    };
+  }
+
+  if (shell === "cmd") {
+    const escaped = escapeCmdCall(source);
+    return {
+      shell,
+      displayCommand,
+      startMarker: TASK_START_ST,
+      input: `for /F "delims=" %A in ('echo prompt $E^| cmd') do @set "taomniEsc=%A"\n<nul set /p "=%taomniEsc%]633;TaomniTaskStart%taomniEsc%\\" & call ${escaped} & call set "taomniStatus=%%errorlevel%%" & call <nul set /p "=%%taomniEsc%%]633;TaomniTaskExit=%%taomniStatus%%%%taomniEsc%%\\"`,
+    };
+  }
+
+  const script = source.replace(/'/g, `'"'"'`);
+  return {
+    shell,
+    displayCommand,
+    startMarker: TASK_START_BEL,
+    input: `printf '\\033]633;TaomniTaskStart\\a'; eval '${script}'; __taomni_status=$?; printf '\\033]633;TaomniTaskExit=%s\\a' "$__taomni_status"`,
+  };
+}
+
+function escapeCmdCall(command: string): string {
+  // CALL reparses its argument. Protect metacharacters from the outer parse,
+  // then let the CALL parse restore their original command meaning.
+  let out = "";
+  let quoted = false;
+  for (const char of command) {
+    if (char === '"') {
+      quoted = !quoted;
+      out += char;
+    } else if (char === "%") {
+      out += "%%";
+    } else if (char === "^") {
+      out += "^^^^";
+    } else if (!quoted && /[&|<>()]/.test(char)) {
+      out += `^${char}`;
+    } else {
+      out += char;
+    }
+  }
+  return out;
+}
+
 /**
  * Build stdin for an interactive terminal command.
  *

--- a/src/lib/terminal/terminalRegistry.ts
+++ b/src/lib/terminal/terminalRegistry.ts
@@ -42,6 +42,12 @@ export interface TerminalRegistryEntry {
   /** Write text to the terminal's stdin (newlines flow as-is). */
   writeInput: (data: string) => void;
   /**
+   * Run a command as an integrated task using the registered local shell's
+   * syntax. The implementation reports completion through OSC 633 while
+   * leaving the interactive shell alive. Optional for legacy/test registrants.
+   */
+  runTask?: (command: string) => void;
+  /**
    * Write display-only text directly to the terminal screen (xterm `write`),
    * WITHOUT sending it to the backend pty/ssh stdin. Used to mirror Claude
    * Code's captured-run activity (`run_captured`, the independent-channel B

--- a/src/lib/terminalOutputFilter.test.ts
+++ b/src/lib/terminalOutputFilter.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createInputEchoSuppressor, createOsc7BlankingSuppressor } from "./terminalOutputFilter";
+import {
+  createInputEchoSuppressor,
+  createOsc7BlankingSuppressor,
+  createTaskStartOutputSuppressor,
+} from "./terminalOutputFilter";
 
 const enc = new TextEncoder();
 const dec = new TextDecoder();
@@ -115,6 +119,44 @@ describe("OSC 7 blanking suppressor", () => {
     const suppressor = createOsc7BlankingSuppressor(50, 100);
     expect(text(suppressor.filter(bytes("echoed command no osc7"), 120))).toBe(clearLine);
     expect(text(suppressor.filter(bytes("later real output"), 200))).toBe("later real output");
+    expect(suppressor.done).toBe(true);
+  });
+});
+
+describe("task start output suppressor", () => {
+  const clearLine = "\r\x1b[2K";
+  const marker = "\x1b]633;TaomniTaskStart\x07";
+
+  it("hides the echoed wrapper, shows the display command, keeps task output", () => {
+    const suppressor = createTaskStartOutputSuppressor(marker, "pnpm test", 5000, 100);
+    // The shell echoes the whole instrumented wrapper, then the marker fires,
+    // then real task output flows.
+    const echoed = "& ([scriptblock]::Create('pnpm test')); [Console]::Write(...)";
+    const output = text(
+      suppressor.filter(bytes(`${echoed}\r\n${marker}PASS  1 test\r\n`), 120),
+    );
+    expect(output).toBe(`${clearLine}pnpm test\r\nPASS  1 test\r\n`);
+    expect(output).not.toContain("scriptblock");
+    expect(suppressor.done).toBe(true);
+  });
+
+  it("finds the marker even when split across chunks with noisy ANSI echo", () => {
+    const suppressor = createTaskStartOutputSuppressor(marker, "mvn compile", 5000, 100);
+    // Noisy PSReadLine colouring precedes the marker, which itself is split.
+    const first = text(
+      suppressor.filter(bytes(`\x1b[93m& { mvn compile }\x1b[0m\r\n\x1b]633;Taomni`), 110),
+    );
+    const second = text(suppressor.filter(bytes(`TaskStart\x07[INFO] BUILD\r\n`), 120));
+    expect(first).toBe(""); // nothing shown until the marker completes
+    expect(second).toBe(`${clearLine}mvn compile\r\n[INFO] BUILD\r\n`);
+    expect(suppressor.done).toBe(true);
+  });
+
+  it("fails open when the marker never arrives before the window expires", () => {
+    const suppressor = createTaskStartOutputSuppressor(marker, "go build", 50, 100);
+    expect(text(suppressor.filter(bytes("partial wrapper echo"), 120))).toBe("");
+    // On timeout the held bytes are released rather than lost.
+    expect(text(suppressor.filter(bytes(" more"), 200))).toBe("partial wrapper echo more");
     expect(suppressor.done).toBe(true);
   });
 });

--- a/src/lib/terminalOutputFilter.ts
+++ b/src/lib/terminalOutputFilter.ts
@@ -273,6 +273,94 @@ export function createOsc7BlankingSuppressor(
   return new Osc7BlankingSuppressor(ttlMs, now);
 }
 
+/**
+ * Hide an injected task wrapper until its real OSC start marker arrives.
+ * Shell line editors may colorize, wrap, or split the echo, so matching the
+ * echoed source is unreliable. The marker is emitted immediately before the
+ * real command; everything after it is genuine task output and passes through.
+ */
+class TaskStartOutputSuppressor implements InputEchoSuppressor {
+  private readonly marker: Uint8Array;
+  private readonly display: Uint8Array;
+  private readonly expiresAt: number;
+  private readonly held: number[] = [];
+  private finished = false;
+
+  constructor(marker: string, displayCommand: string, ttlMs: number, now: number) {
+    const encoder = new TextEncoder();
+    this.marker = encoder.encode(marker);
+    this.display = encoder.encode(displayCommand);
+    this.expiresAt = now + ttlMs;
+  }
+
+  get done(): boolean {
+    return this.finished;
+  }
+
+  filter(data: Uint8Array, now = Date.now()): Uint8Array {
+    if (this.finished || this.marker.length === 0) return data;
+    for (const byte of data) this.held.push(byte);
+
+    const markerAt = indexOfBytes(this.held, this.marker);
+    if (markerAt >= 0) {
+      const after = new Uint8Array(this.held.slice(markerAt + this.marker.length));
+      this.held.length = 0;
+      this.finished = true;
+      return concatManyBytes(
+        new Uint8Array(CLEAR_CURRENT_LINE),
+        this.display,
+        new Uint8Array([0x0d, 0x0a]),
+        after,
+      );
+    }
+
+    // Never hold an unbounded stream. On timeout or excessive preamble, fail
+    // open so no real terminal output can be lost.
+    if (now > this.expiresAt || this.held.length > 64 * 1024) {
+      const released = new Uint8Array(this.held);
+      this.held.length = 0;
+      this.finished = true;
+      return released;
+    }
+    return new Uint8Array();
+  }
+}
+
+export function createTaskStartOutputSuppressor(
+  marker: string,
+  displayCommand: string,
+  ttlMs = 5000,
+  now = Date.now(),
+): InputEchoSuppressor {
+  return new TaskStartOutputSuppressor(marker, displayCommand, ttlMs, now);
+}
+
+function indexOfBytes(haystack: number[], needle: Uint8Array): number {
+  const last = haystack.length - needle.length;
+  for (let start = 0; start <= last; start += 1) {
+    let matches = true;
+    for (let offset = 0; offset < needle.length; offset += 1) {
+      if (haystack[start + offset] !== needle[offset]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) return start;
+  }
+  return -1;
+}
+
+function concatManyBytes(...parts: Uint8Array[]): Uint8Array {
+  const length = parts.reduce((total, part) => total + part.length, 0);
+  const out = new Uint8Array(length);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
 function isPrefix(value: number[], prefix: Uint8Array): boolean {
   if (value.length > prefix.length) return false;
   for (let i = 0; i < value.length; i += 1) {


### PR DESCRIPTION
… across shells

The integrated Run/Build flow worked on Linux but broke on Windows: it could not find mvnw.cmd, and it echoed the internal exit-status wrapper into the terminal (the visible `& { mvnw.cmd compile }; $taomniStatus=$LASTEXITCODE; ...` line). Root causes were an OS-hardcoded, PowerShell-only command injected as keyboard input; two divergent Maven/Gradle resolvers that disagreed and only matched .cmd/.bat on Windows; and a dependency-tree spawn that fed .cmd/.bat straight to CreateProcess (which cannot execute batch files).

This unifies tool resolution, makes task execution shell-aware without leaking the wrapper, and adds a small per-workspace tool configuration. Java Maven/Gradle is fully covered; other languages keep their existing behavior and the model is extensible.

Backend (src-tauri/src/workspace.rs)
- Add a single tool resolver with a wrapper -> configured executable -> PATH precedence, replacing maven_runner/gradle_runner/find_wrapper. Wrappers are returned as absolute paths, resolved by walking up from the module dir to the workspace root (monorepo-aware), and .cmd/.bat/.exe plus POSIX wrappers are all recognized on Windows.
- When no tool can be resolved, tasks carry a clear diagnostic instead of letting the shell print "not recognized" at run time.
- Fix workspace_dependency_tree on Windows: launch .cmd/.bat via `cmd.exe /D /S /C` (mirrors the lsp.rs pattern) with the absolute wrapper path, and inject the workspace SDK environment (JAVA_HOME + prepended PATH) so a directly-spawned build tool resolves the same JDK the integrated terminal uses; the PATH fallback tier now searches the SDK-enhanced PATH.
- WorkspaceTask/JavaRunTarget now carry structured `execution` metadata (executable, args, source, error). Add optional serde WorkspaceToolConfig and thread it through workspace_detect_tasks / workspace_java_run_target(s) / workspace_task_tree / workspace_dependency_tree.
- HostPlatform is injected into the pure resolver/launch-planner so Windows cmd.exe planning and .cmd/.bat resolution are unit-tested on every host. Adds 7 tests covering precedence, monorepo walk-up, configured fallback + missing diagnostic, PATH-tier missing diagnostic, and Windows/Unix launch planning.

Integrated terminal (shell-aware execution, no echo)
- Add renderTerminalTask (src/lib/terminal/commandInput.ts): pick PowerShell / POSIX-Git Bash / cmd syntax from the terminal's resolved shell id rather than the host OS, submit with a carriage return, and emit an OSC 633 start marker before the command plus the exit-code marker after it.
- Add TaskStartOutputSuppressor (src/lib/terminalOutputFilter.ts): hide the echoed wrapper until the real start marker arrives, then paint a concise display command and pass all genuine task output through. It fails open on timeout or >64 KiB of preamble so real output is never lost.
- TerminalPanel exposes runTask on the registry (installs the suppressor, sets runtime state, retains the interactive shell + OSC 633 exit callback); TerminalDockPanel prefers runTask and falls back to a shell-aware writeInput for lightweight registrants/tests.

Per-workspace build/run tool configuration
- codeWorkspaceModel.ts: versioned, per-workspace-instance store (taomni.codeWorkspace.buildRunTools.v1.<id>) with a generic { tools } map, normalization, and corrupt-JSON recovery, modeled on the jdtls settings helpers.
- WorkspaceBuildRunToolsDialog surfaces Maven/Gradle executable overrides (empty = auto). RunPanel gains a Configure button and shows an amber warning on tasks whose tool could not be resolved; RunPanel/BuildPanel re-detect when the config changes; CodeWorkspaceTab owns the state and threads it through every detector and the Java run/test/build flows.

Tests
- 7 new Rust resolver tests; new buildRunTools persistence test; task-rendering tests for PowerShell/POSIX/cmd escaping and CR submission; TaskStartOutputSuppressor tests for wrapper-hiding, split/noisy markers, and fail-open on timeout.
- Update BuildPanel/CodeWorkspaceTab tests for the added toolConfig argument.
- Full frontend suite (1721) passes; pnpm build (tsc + vite) clean; workspace Rust tests pass except two pre-existing Windows tempfile \\?\-prefix failures that fail identically on HEAD and pass on Linux CI.