### PR TITLE
fix(sdk): strip Windows verbatim path prefixes from injected environment

### DIFF
--- a/src-tauri/src/sdk/mod.rs
+++ b/src-tauri/src/sdk/mod.rs
@@ -218,9 +218,10 @@ impl SdkManager {
         }
 
         let analysis_root = root.clone();
-        let analysis = tokio::task::spawn_blocking(move || detect::analyze_workspace(&analysis_root))
-            .await
-            .map_err(|error| format!("SDK workspace analysis task failed: {error}"))??;
+        let analysis =
+            tokio::task::spawn_blocking(move || detect::analyze_workspace(&analysis_root))
+                .await
+                .map_err(|error| format!("SDK workspace analysis task failed: {error}"))??;
         let registry = self.snapshot().await;
         let resolution = resolve::resolve_workspace(analysis, &registry).await;
         self.resolution_cache.lock().await.insert(
@@ -594,7 +595,7 @@ fn load_registry(path: &Path) -> Result<SdkRegistry, String> {
 fn read_registry(path: &Path) -> Result<SdkRegistry, String> {
     let text = std::fs::read_to_string(path)
         .map_err(|error| format!("read {}: {error}", path.display()))?;
-    let registry: SdkRegistry = serde_json::from_str(&text)
+    let mut registry: SdkRegistry = serde_json::from_str(&text)
         .map_err(|error| format!("parse {}: {error}", path.display()))?;
     if registry.schema_version != SDK_REGISTRY_SCHEMA_VERSION {
         return Err(format!(
@@ -602,7 +603,47 @@ fn read_registry(path: &Path) -> Result<SdkRegistry, String> {
             registry.schema_version
         ));
     }
+    // Heal registries written before verbatim-prefix stripping: a stored
+    // `\\?\C:\...` location becomes `JAVA_HOME` / a PATH entry that cmd.exe and
+    // batch launchers (mvn.cmd, gradlew.bat) cannot resolve. Strip on load so
+    // every downstream consumer — terminals, jdtls, the frontend — sees a plain
+    // path, and the next save persists the cleaned form.
+    normalize_registry_paths(&mut registry);
     Ok(registry)
+}
+
+/// Strip Windows verbatim/extended-length prefixes (`\\?\`, `\\?\UNC\`) from
+/// every stored path in the registry. A no-op for already-clean paths and on
+/// non-Windows hosts, so it is safe to run unconditionally on load.
+fn normalize_registry_paths(registry: &mut SdkRegistry) {
+    for installation in &mut registry.installations {
+        installation.location = strip_verbatim_prefix(&installation.location);
+        for executable in installation.executables.values_mut() {
+            *executable = strip_verbatim_prefix(executable);
+        }
+    }
+    for binding in &mut registry.bindings {
+        binding.scope_path = strip_verbatim_prefix(&binding.scope_path);
+    }
+}
+
+/// Remove a Windows verbatim path prefix so the result works with cmd.exe,
+/// batch scripts (`%JAVA_HOME%\bin\java.exe`), and PATH lookup — none of which
+/// accept `\\?\`. Mirrors `workspace.rs::path_to_string`. Returns the input
+/// unchanged when no such prefix is present (all Unix paths, clean Windows
+/// paths), converting a `\\?\UNC\server\share` path back to `\\server\share`.
+pub(crate) fn strip_verbatim_prefix(value: &str) -> String {
+    if let Some(rest) = value.strip_prefix(r"\\?\UNC\") {
+        return format!(r"\\{rest}");
+    }
+    if let Some(rest) = value.strip_prefix("//?/UNC/") {
+        return format!(r"\\{rest}");
+    }
+    value
+        .strip_prefix(r"\\?\")
+        .or_else(|| value.strip_prefix("//?/"))
+        .unwrap_or(value)
+        .to_string()
 }
 
 fn persist_registry(path: &Path, registry: &SdkRegistry) -> Result<(), String> {
@@ -685,7 +726,9 @@ fn normalize_scope_path(path: &str) -> Result<String, String> {
     }
     let expanded = PathBuf::from(shellexpand::tilde(trimmed).to_string());
     let normalized = std::fs::canonicalize(&expanded).unwrap_or(expanded);
-    Ok(normalized.to_string_lossy().into_owned())
+    // `canonicalize` yields a `\\?\` verbatim path on Windows; strip it so
+    // stored bindings and the resolution cache key match plain caller paths.
+    Ok(strip_verbatim_prefix(&normalized.to_string_lossy()))
 }
 
 fn paths_equal(left: &str, right: &str) -> bool {
@@ -843,6 +886,73 @@ mod tests {
         assert!(registry.installations.is_empty());
         assert!(registry.defaults.is_empty());
         assert!(registry.bindings.is_empty());
+    }
+
+    #[test]
+    fn strip_verbatim_prefix_cleans_windows_extended_paths() {
+        assert_eq!(
+            strip_verbatim_prefix(r"\\?\C:\Program Files\Java\jdk-21"),
+            r"C:\Program Files\Java\jdk-21"
+        );
+        assert_eq!(strip_verbatim_prefix(r"//?/C:/Tools/jdk"), "C:/Tools/jdk");
+        // UNC verbatim paths fold back to the `\\server\share` form.
+        assert_eq!(
+            strip_verbatim_prefix(r"\\?\UNC\server\share\jdk"),
+            r"\\server\share\jdk"
+        );
+        // Already-clean paths (and all Unix paths) pass through untouched.
+        assert_eq!(
+            strip_verbatim_prefix(r"C:\Program Files\Java\jdk-21"),
+            r"C:\Program Files\Java\jdk-21"
+        );
+        assert_eq!(
+            strip_verbatim_prefix("/usr/lib/jvm/jdk-21"),
+            "/usr/lib/jvm/jdk-21"
+        );
+    }
+
+    #[test]
+    fn normalize_registry_paths_heals_verbatim_locations_on_load() {
+        let mut registry = SdkRegistry {
+            installations: vec![SdkInstallation {
+                id: "jdk-21".into(),
+                kind: SdkKind::Java,
+                name: "java21".into(),
+                location: r"\\?\C:\Program Files\Java\jdk-21".into(),
+                executables: BTreeMap::from([(
+                    "java".to_string(),
+                    r"\\?\C:\Program Files\Java\jdk-21\bin\java.exe".to_string(),
+                )]),
+                version: Some("21.0.4".into()),
+                vendor: None,
+                architecture: None,
+                origin: SdkOrigin::Manual,
+                status: SdkStatus::Ready,
+                last_error: None,
+                last_probed_at: None,
+            }],
+            bindings: vec![WorkspaceSdkBinding {
+                scope_path: r"\\?\D:\code\ads\ique".into(),
+                kind: SdkKind::Java,
+                role: SdkRole::Project,
+                mode: SdkBindingMode::Manual,
+                sdk_id: Some("jdk-21".into()),
+                updated_at: "now".into(),
+            }],
+            ..SdkRegistry::default()
+        };
+
+        normalize_registry_paths(&mut registry);
+
+        assert_eq!(
+            registry.installations[0].location,
+            r"C:\Program Files\Java\jdk-21"
+        );
+        assert_eq!(
+            registry.installations[0].executables.get("java").unwrap(),
+            r"C:\Program Files\Java\jdk-21\bin\java.exe"
+        );
+        assert_eq!(registry.bindings[0].scope_path, r"D:\code\ads\ique");
     }
 
     #[tokio::test]

--- a/src-tauri/src/sdk/probe.rs
+++ b/src-tauri/src/sdk/probe.rs
@@ -488,7 +488,10 @@ fn canonical_or_original(path: &Path) -> PathBuf {
 }
 
 fn path_string(path: &Path) -> String {
-    path.to_string_lossy().into_owned()
+    // `canonical_or_original` returns a `\\?\` verbatim path on Windows; strip
+    // it so persisted locations/executables stay usable by cmd.exe, batch
+    // launchers, and PATH lookup rather than resolving to "path not found".
+    super::strip_verbatim_prefix(&path.to_string_lossy())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/sdk/runtime.rs
+++ b/src-tauri/src/sdk/runtime.rs
@@ -126,23 +126,26 @@ pub fn build_workspace_environment(
     let (tooling_java, tooling_java_error) = select_tooling_java(registry, &requested_scope);
 
     let mut environment = BTreeMap::new();
-    let project_java_home = project_java.as_ref().map(|sdk| sdk.location.clone());
-    let launcher_java_home = launcher_java.as_ref().map(|sdk| sdk.location.clone());
+    // All home paths are normalized (verbatim prefix stripped) before they
+    // become environment values so a legacy `\\?\C:\...` registry entry can't
+    // poison JAVA_HOME/VIRTUAL_ENV for shells and batch launchers.
+    let project_java_home = project_java.as_ref().map(sdk_home);
+    let launcher_java_home = launcher_java.as_ref().map(sdk_home);
     if let Some(java_home) = launcher_java_home.as_ref().or(project_java_home.as_ref()) {
         environment.insert("JAVA_HOME".to_string(), java_home.clone());
     }
 
-    let python_home = python.as_ref().map(|sdk| sdk.location.clone());
+    let python_home = python.as_ref().map(sdk_home);
     if let Some(sdk) = python.as_ref()
         && is_python_environment(&sdk.location)
     {
-        environment.insert("VIRTUAL_ENV".to_string(), sdk.location.clone());
+        environment.insert("VIRTUAL_ENV".to_string(), sdk_home(sdk));
     }
-    let kotlin_home = kotlin.as_ref().map(|sdk| sdk.location.clone());
+    let kotlin_home = kotlin.as_ref().map(sdk_home);
     if let Some(home) = kotlin_home.as_ref() {
         environment.insert("KOTLIN_HOME".to_string(), home.clone());
     }
-    let scala_home = scala.as_ref().map(|sdk| sdk.location.clone());
+    let scala_home = scala.as_ref().map(sdk_home);
     if let Some(home) = scala_home.as_ref() {
         environment.insert("SCALA_HOME".to_string(), home.clone());
     }
@@ -156,7 +159,7 @@ pub fn build_workspace_environment(
     ];
     let path_entries = executable_directories(selected.into_iter().flatten());
     let java_runtimes = java_runtime_configurations(registry, project_java.as_ref());
-    let tooling_java_home = tooling_java.as_ref().map(|sdk| sdk.location.clone());
+    let tooling_java_home = tooling_java.as_ref().map(sdk_home);
     let workspace_root = path_string(&workspace_root);
     let scope_path = path_string(&requested_scope);
     let project_scope_path = path_string(&project_scope);
@@ -413,7 +416,8 @@ fn java_runtime_configurations(
             } else {
                 format!("JavaSE-{major}")
             },
-            path: sdk.location.clone(),
+            // jdtls writes this into runtime configs; keep it a plain path.
+            path: sdk_home(&sdk),
             default: project_java
                 .is_some_and(|project| paths_equal(&project.location, &sdk.location)),
         });
@@ -510,7 +514,16 @@ fn path_key(path: &Path) -> String {
 }
 
 fn path_string(path: &Path) -> String {
-    path.to_string_lossy().into_owned()
+    // Strip Windows `\\?\` verbatim prefixes (from `canonicalize`) so emitted
+    // scope paths and PATH entries work with cmd.exe / batch launchers.
+    super::strip_verbatim_prefix(&path.to_string_lossy())
+}
+
+/// An SDK's install location as a plain string for use as an environment value
+/// (`JAVA_HOME`, `VIRTUAL_ENV`, …). Strips any verbatim prefix so batch
+/// launchers resolving `%JAVA_HOME%\bin\java.exe` don't hit "path not found".
+fn sdk_home(installation: &SdkInstallation) -> String {
+    super::strip_verbatim_prefix(&installation.location)
 }
 
 fn fingerprint(parts: &[&str]) -> String {
@@ -656,6 +669,71 @@ mod tests {
                 .tooling_java_error
                 .as_deref()
                 .is_some_and(|error| error.contains("requires JDK 21+"))
+        );
+    }
+
+    #[test]
+    fn strips_verbatim_prefix_from_java_home_and_path_entries() {
+        // A registry entry saved with a Windows `\\?\` verbatim prefix must not
+        // reach JAVA_HOME / PATH: cmd.exe and batch launchers (mvn.cmd) resolve
+        // `%JAVA_HOME%\bin\java.exe` and fail with "path not found" on `\\?\`.
+        let root = if cfg!(windows) { r"C:\repo" } else { "/repo" };
+        let mut project = installation(
+            "jdk-21",
+            SdkKind::Java,
+            "21.0.4",
+            r"\\?\C:\Program Files\Java\jdk-21",
+        );
+        project.executables = BTreeMap::from([(
+            "java".to_string(),
+            r"\\?\C:\Program Files\Java\jdk-21\bin\java.exe".to_string(),
+        )]);
+        let registry = SdkRegistry {
+            installations: vec![project.clone()],
+            ..SdkRegistry::default()
+        };
+        let resolution = resolution(
+            root,
+            root,
+            vec![resolved(root, SdkKind::Java, SdkRole::Project, project)],
+        );
+
+        let environment = build_workspace_environment(&resolution, &registry, Path::new(root));
+
+        // Core of the bug: JAVA_HOME must be a plain path (pure string strip,
+        // identical on every host).
+        assert_eq!(
+            environment.environment.get("JAVA_HOME").map(String::as_str),
+            Some(r"C:\Program Files\Java\jdk-21")
+        );
+        assert_eq!(
+            environment.project_java_home.as_deref(),
+            Some(r"C:\Program Files\Java\jdk-21")
+        );
+        // Invariant that holds on every host: nothing emitted keeps a verbatim
+        // prefix (env values, PATH entries, runtime paths).
+        assert!(
+            environment
+                .environment
+                .values()
+                .chain(environment.path_entries.iter())
+                .chain(
+                    environment
+                        .java_runtimes
+                        .iter()
+                        .map(|runtime| &runtime.path)
+                )
+                .all(|value| !value.contains(r"\\?\") && !value.contains("//?/")),
+            "no emitted path may keep a verbatim prefix: env={:?} path={:?}",
+            environment.environment,
+            environment.path_entries,
+        );
+        // The executable-derived PATH entry maps to `<home>\bin` on Windows,
+        // where `\\?\...\bin\java.exe`'s parent resolves natively.
+        #[cfg(windows)]
+        assert_eq!(
+            environment.path_entries.first().map(String::as_str),
+            Some(r"C:\Program Files\Java\jdk-21\bin")
         );
     }
 


### PR DESCRIPTION
The Code Workspace Run/Build terminal injects the resolved workspace SDK environment (JAVA_HOME + prepended PATH). SDK locations are canonicalized with std::fs::canonicalize, which on Windows yields extended-length paths (\\?\C:\...). That prefix was persisted in sdk.json and re-emitted verbatim, so a JDK-bound workspace launched the shell with JAVA_HOME=\\?\C:\...\jdk-21.

mvn.cmd/gradlew.bat run "%JAVA_HOME%\bin\java.exe" via cmd.exe, which cannot resolve \\?\ verbatim paths, producing "The system cannot find the path specified." A hand-opened shell has a clean JAVA_HOME, so it worked there.

Add a shared strip_verbatim_prefix helper (mirrors workspace.rs::path_to_string) and apply it at three layers so every consumer sees plain paths:
- mod.rs: heal the registry on load (normalize_registry_paths) so existing dirty sdk.json files are fixed in-memory without re-registering JDKs, and strip in normalize_scope_path so bindings/cache keys stay clean.
- probe.rs: strip in path_string so newly probed/saved locations and executables never carry the prefix.
- runtime.rs: route every emitted home (JAVA_HOME, VIRTUAL_ENV, KOTLIN_HOME, SCALA_HOME, tooling JDK, java_runtimes) and scope/PATH string through the stripper, making build_workspace_environment self-sufficiently clean.

Add tests: prefix stripping (incl. UNC), registry load-heal, and a verbatim JAVA_HOME -> clean end-to-end check.