### PR TITLE
fix(sockscap): release WinDivert/helper file locks before in-place up…

### DIFF
--- a/src-tauri/nsis/hooks.nsh
+++ b/src-tauri/nsis/hooks.nsh
@@ -7,24 +7,39 @@
 ; still held when the installer writes files, the install fails with a "cannot
 ; overwrite file" error.
 ;
-; The installer runs elevated, so unlike the app itself it can actually stop
-; both. Everything here is best-effort: a missing process or an already-stopped
-; service is the normal case and must not fail the install.
+; IMPORTANT: this hook is only a BACKSTOP, not the primary release path. Taomni
+; ships as a per-user (currentUser) install, so the installer runs UNELEVATED.
+; Against the UAC-elevated helper and the WinDivert kernel service, this hook's
+; taskkill/sc-stop get Access Denied and do nothing. The real teardown happens
+; app-side, before the updater launches this installer: the app asks its own
+; elevated helper (over the control channel it owns) to close the driver handles
+; and exit — see `sockscap_prepare_for_update` in src/sockscap/mod.rs.
+;
+; What this hook still buys us:
+;   - per-machine installs (should they ever ship), where the installer IS
+;     elevated and these commands succeed;
+;   - xray.exe, which runs at the app's own integrity level and so can be killed
+;     from an unelevated installer;
+;   - a crashed/orphaned helper the app-side path never got to stop.
+; Everything here is best-effort: a missing process, an already-stopped service,
+; or an Access-Denied is the normal case and must not fail the install.
 
 !macro StopSocksCapRuntime
   DetailPrint "Stopping SocksCap helper and WinDivert driver (if running)..."
 
-  ; The elevated helper. It exits on its own when Taomni quits cleanly; this
-  ; covers a crashed or orphaned one.
+  ; The elevated helper. Normally already stopped app-side before we get here;
+  ; this only lands for a crashed/orphaned one, and only if we are elevated.
   nsExec::Exec 'taskkill.exe /F /IM sockscap-helper.exe'
   Pop $0
 
-  ; Bundled xray-core sidecars, for the same reason.
+  ; Bundled xray-core sidecars. These run at our own integrity level, so this
+  ; succeeds even on an unelevated per-user install.
   nsExec::Exec 'taskkill.exe /F /IM xray.exe'
   Pop $0
 
-  ; Unload the driver so WinDivert64.sys is releasable. The service name differs
-  ; across WinDivert versions; try each, ignoring "not installed".
+  ; Unload the driver so WinDivert64.sys is releasable (elevated installs only).
+  ; The service name differs across WinDivert versions; try each, ignoring
+  ; "not installed" / "access denied".
   nsExec::Exec 'sc.exe stop WinDivert'
   Pop $0
   nsExec::Exec 'sc.exe stop WinDivert1.4'

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -586,6 +586,7 @@ pub fn run() {
             sockscap::sockscap_status,
             sockscap::sockscap_start,
             sockscap::sockscap_stop,
+            sockscap::sockscap_prepare_for_update,
             sockscap::sockscap_recover,
             sockscap::sockscap_stats_snapshot,
             sockscap::sockscap_get_domain_records,

--- a/src-tauri/src/sockscap/mod.rs
+++ b/src-tauri/src/sockscap/mod.rs
@@ -1481,6 +1481,116 @@ pub async fn sockscap_stop(
     Ok(orch.status())
 }
 
+/// Release every privileged file the auto-updater is about to overwrite, so an
+/// in-place upgrade does not fail with "Error opening file for writing".
+///
+/// The lock the installer trips over is a kernel one: while SocksCap captures,
+/// WinDivert is loaded and Windows keeps `WinDivert64.sys` locked until the last
+/// handle to it closes and the driver unloads. `sockscap-helper.exe` and
+/// `WinDivert.dll` are locked too, as the running helper's own image.
+///
+/// The NSIS installer *cannot* release these on a per-user (`currentUser`)
+/// install: it runs unelevated, so its `taskkill /F` against the UAC-elevated
+/// helper and its `sc stop WinDivert` both get Access Denied. The app can,
+/// though — not by elevating itself, but by asking the helper (over the control
+/// channel it already owns) to close its WinDivert handles and exit. Closing the
+/// handles unloads the driver (freeing the `.sys`); exiting frees the exe/DLL.
+///
+/// Best-effort throughout: SocksCap not running, or the helper already gone, is
+/// the normal case and must not block the update. Windows-only work; a no-op
+/// elsewhere (returns immediately) since no other platform locks files this way.
+#[tauri::command]
+pub async fn sockscap_prepare_for_update(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    // 1) Stop capture: closes WinDivert NETWORK/FLOW handles → driver unloads →
+    //    `WinDivert64.sys` becomes writable. Also stops relay + xray sidecars.
+    //    A teardown error here is not fatal to the update — the helper shutdown
+    //    below and the installer's own preinstall hook are the further backstops.
+    if let Err(e) = full_teardown(&app, &state, true).await {
+        tracing::warn!("sockscap: prepare-for-update teardown incomplete: {e}");
+    }
+
+    // 2) Ask the elevated helper to exit, freeing `sockscap-helper.exe` and
+    //    `WinDivert.dll`. Reuses the same shutdown path as the Stop button.
+    if let Err(e) = helper::sockscap_helper_stop(state.clone()).await {
+        tracing::warn!("sockscap: prepare-for-update helper stop failed: {e}");
+    }
+
+    // 3) The driver unload is asynchronous, so poll until the files the installer
+    //    overwrites are actually releasable (or a short deadline passes).
+    #[cfg(windows)]
+    wait_for_privileged_files_unlocked(&app).await;
+
+    Ok(())
+}
+
+/// Poll the bundled privileged files until each is openable for writing (i.e.
+/// no longer locked by a live driver/helper), or a short deadline elapses.
+///
+/// Only the install-directory copies matter: those are what the updater
+/// overwrites. When runtime staging is active the loaded driver's `.sys` lives
+/// under app-data instead, so the install-directory copy is never locked and
+/// this returns on the first probe.
+#[cfg(windows)]
+async fn wait_for_privileged_files_unlocked(app: &AppHandle) {
+    use std::time::{Duration, Instant};
+
+    let mut files: Vec<PathBuf> = Vec::new();
+    if let Some(dir) = paths::resolve_windivert_dir(app) {
+        files.push(dir.join("WinDivert64.sys"));
+        files.push(dir.join("WinDivert.dll"));
+    }
+    if let Ok(helper_exe) = paths::resolve_helper_exe(app) {
+        files.push(helper_exe);
+    }
+    if let Some(xray_exe) = paths::resolve_xray_exe(app) {
+        files.push(xray_exe);
+    }
+    files.retain(|p| p.is_file());
+    if files.is_empty() {
+        return;
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(6);
+    loop {
+        let still_locked: Vec<&PathBuf> = files.iter().filter(|p| is_file_locked(p)).collect();
+        if still_locked.is_empty() {
+            tracing::info!("sockscap: privileged files released; safe to upgrade");
+            return;
+        }
+        if Instant::now() >= deadline {
+            tracing::warn!(
+                "sockscap: {} privileged file(s) still locked after wait; \
+                 the installer may prompt to retry/ignore: {:?}",
+                still_locked.len(),
+                still_locked
+            );
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+}
+
+/// True when `path` cannot be opened for writing because something holds it with
+/// a sharing violation (a loaded driver or running image). An unrelated failure
+/// (access denied, not found) is treated as "not our lock" so we never wait on
+/// something stopping the helper would not fix.
+#[cfg(windows)]
+fn is_file_locked(path: &std::path::Path) -> bool {
+    const ERROR_SHARING_VIOLATION: i32 = 32;
+    const ERROR_LOCK_VIOLATION: i32 = 33;
+    // Open for write without truncation: probes the lock without altering bytes.
+    match std::fs::OpenOptions::new().write(true).open(path) {
+        Ok(_) => false,
+        Err(e) => matches!(
+            e.raw_os_error(),
+            Some(ERROR_SHARING_VIOLATION) | Some(ERROR_LOCK_VIOLATION)
+        ),
+    }
+}
+
 #[tauri::command]
 pub async fn sockscap_recover(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
     // Even if stopping the active session was incomplete, recovery gets one

--- a/src/lib/updateService.ts
+++ b/src/lib/updateService.ts
@@ -113,9 +113,35 @@ export async function checkForUpdate(target?: string): Promise<AvailableUpdate |
 }
 
 /**
- * Download + install the update for `target`, then leave the app running until
- * the caller decides to relaunch (confirmation gate #2). Reuses the Update from
- * a prior checkForUpdate(target) when available.
+ * Release SocksCap's privileged files before the installer overwrites them.
+ *
+ * On Windows, while SocksCap captures, the WinDivert kernel driver keeps
+ * `WinDivert64.sys` locked and the elevated helper keeps its own exe + DLL
+ * locked. A per-user installer runs unelevated and cannot stop either, so the
+ * upgrade would fail with "Error opening file for writing". The app asks its
+ * elevated helper to close the driver handles and exit first. Best-effort: a
+ * failure here must not block the install (the installer's preinstall hook is a
+ * further backstop), and it is a Windows-only concern.
+ */
+async function prepareSocksCapForUpgrade(): Promise<void> {
+  if (!isTauriRuntime() || getAppPlatform() !== "windows") return;
+  try {
+    await invoke("sockscap_prepare_for_update");
+  } catch (e) {
+    // Non-fatal: proceed with the install regardless.
+    console.warn("sockscap prepare-for-update failed; continuing with install", e);
+  }
+}
+
+/**
+ * Download the update for `target`, release SocksCap's locked files (Windows),
+ * then install — leaving the app running until the caller decides to relaunch
+ * (confirmation gate #2). Reuses the Update from a prior checkForUpdate(target)
+ * when available.
+ *
+ * Download and install are run as separate steps (not `downloadAndInstall`) so
+ * SocksCap can be torn down in between: capture must keep working during the
+ * download, but the driver/helper must be gone before the installer writes.
  */
 export async function downloadAndInstall(
   target: string | undefined,
@@ -135,7 +161,7 @@ export async function downloadAndInstall(
 
   let total: number | null = null;
   let downloaded = 0;
-  await update.downloadAndInstall((event) => {
+  await update.download((event) => {
     switch (event.event) {
       case "Started":
         total = event.data.contentLength ?? null;
@@ -155,6 +181,13 @@ export async function downloadAndInstall(
         break;
     }
   });
+
+  // Download done → progress pinned at 100% (UI reads this as "installing").
+  // Stop SocksCap so the installer can overwrite the locked driver/helper.
+  onProgress({ downloaded, total, percent: 100 });
+  await prepareSocksCapForUpgrade();
+
+  await update.install();
 }
 
 /** Restart into the freshly installed version (confirmation gate #2). */


### PR DESCRIPTION
…date

While SocksCap capture is running, a Windows in-place upgrade fails with "Error opening file for writing ...\resources\sockscap\windows\WinDivert64.sys".

Root cause
----------
The lock is a kernel one. On capture start, WinDivertOpen loads WinDivert64.sys as a kernel driver; Windows keeps the .sys locked until the last handle closes and the driver unloads. The elevated sockscap-helper.exe and WinDivert.dll are also locked as the running helper's own image.

Taomni ships as a per-user (currentUser) NSIS install, so the updater's installer runs UNELEVATED. Against the UAC-elevated helper and the WinDivert kernel service, the preinstall hook's `taskkill /F` and `sc stop WinDivert` get Access Denied and do nothing — so the driver stays loaded, the .sys stays locked, and the overwrite fails.

Fix (app-side teardown before the installer runs)
-------------------------------------------------
The installer can't stop the elevated pieces, but the app can — not by elevating itself, but by asking the helper (over the local control channel it already owns) to close its WinDivert handles and exit. Closing the handles unloads the driver (frees the .sys); exiting frees the exe/DLL. No new UAC prompt: elevation was already paid when capture started; teardown is just local-socket IPC to the live helper.

- New Tauri command `sockscap_prepare_for_update` (src/sockscap/mod.rs): 1) full_teardown() — closes NETWORK/FLOW handles (driver unloads), stops relay + xray sidecars; 2) sockscap_helper_stop() — asks the elevated helper to exit, freeing sockscap-helper.exe and WinDivert.dll; 3) Windows-only wait_for_privileged_files_unlocked() — polls the bundled privileged files (150ms, 6s cap) via is_file_locked(), which write-opens each and treats only ERROR_SHARING_VIOLATION/ERROR_LOCK_VIOLATION as a real lock, so we never wait on unrelated failures. The driver unload is async, so this replaces the installer hook's blind Sleep with an actual readiness check. No-op on non-Windows. Best-effort throughout: SocksCap not running, or the helper already gone, is the normal case and must not block the update.

- Register the command in lib.rs.

- Frontend (src/lib/updateService.ts): split downloadAndInstall into update.download() -> prepareSocksCapForUpgrade() (Windows only) -> update.install(). Capture keeps working during the download; the driver/helper are torn down only just before the installer writes. Progress is pinned at 100% across prepare+install, so the dialog's "installing" state (status==="downloading" && percent===100) is unchanged — no store/dialog edits needed. prepare is best-effort and never aborts the install.

- nsis/hooks.nsh: correct the "installer runs elevated" comment (false for per-user installs). Document that the hook is now only a BACKSTOP — for per-machine installs (elevated), for xray.exe (runs at the app's own integrity level, killable unelevated), and for a crashed/orphaned helper. The primary release path is the app-side sockscap_prepare_for_update.

Notes
-----
- No new UAC prompt: prepare only sends IPC to the already-elevated helper.
- If SocksCap/WinDivert isn't running, prepare is a fast no-op (no session to stop, files already writable, no UAC ever involved).
- Forward-only: this makes future upgrades clean. It cannot retroactively fix a running pre-existing build (<=0.3.37) that lacks this code; that upgrade still needs the manual workaround (Ignore the file / stop capture / fully quit first). From a build carrying this fix onward, the lock error no longer occurs.

Verification: tsc -b clean; updateStore.test.ts 15/15; cargo check --bin taomni exit 0 with no warnings from the new code.