### PR TITLE
feat(editor): add "Syntax" action to teach language grammar for a sel…

### DIFF
--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -298,6 +298,59 @@ function isJavaBuildFile(languagePath: string): boolean {
     || name === "settings.gradle.kts";
 }
 
+const LANGUAGE_DISPLAY_NAMES: Record<string, string> = {
+  js: "JavaScript",
+  jsx: "JavaScript (JSX)",
+  mjs: "JavaScript",
+  cjs: "JavaScript",
+  ts: "TypeScript",
+  tsx: "TypeScript (TSX)",
+  json: "JSON",
+  jsonc: "JSON",
+  py: "Python",
+  pyi: "Python",
+  rs: "Rust",
+  java: "Java",
+  kt: "Kotlin",
+  kts: "Kotlin",
+  go: "Go",
+  css: "CSS",
+  scss: "SCSS",
+  less: "Less",
+  html: "HTML",
+  htm: "HTML",
+  vue: "Vue",
+  svelte: "Svelte",
+  md: "Markdown",
+  markdown: "Markdown",
+  xml: "XML",
+  svg: "SVG",
+  yaml: "YAML",
+  yml: "YAML",
+  c: "C",
+  h: "C/C++",
+  cc: "C++",
+  cpp: "C++",
+  cxx: "C++",
+  hpp: "C++",
+  hxx: "C++",
+  php: "PHP",
+  sql: "SQL",
+  sh: "Shell",
+  bash: "Shell",
+  rb: "Ruby",
+  swift: "Swift",
+  cs: "C#",
+  toml: "TOML",
+};
+
+/** Best-effort human-readable language name for a path, used to focus AI syntax prompts. */
+function languageDisplayNameForPath(languagePath: string): string | null {
+  const name = languagePath.toLowerCase();
+  const ext = name.includes(".") ? name.slice(name.lastIndexOf(".") + 1) : name;
+  return LANGUAGE_DISPLAY_NAMES[ext] ?? null;
+}
+
 // Keep document synchronization ahead of the comparatively expensive derived
 // LSP features.  In particular, rust-analyzer semantic tokens can be large
 // enough that applying them while somebody is still typing is noticeable.
@@ -2026,6 +2079,28 @@ export function CodeWorkspaceTab({
       ].join("\n"));
       setEditorAiSelection(null);
       setStatusMessage("Staged explain request in AI chat");
+      return;
+    }
+    if (action === "syntax") {
+      // Teaching-focused: explain the language syntax/grammar rather than what the code does.
+      const language = languageDisplayNameForPath(file.languagePath);
+      await attachToComposer([
+        `请把下面这段代码当作教学示例，讲解其中用到的语言语法与写法，帮助我打好语言基础。请覆盖：`,
+        `1. 逐一说明用到的语法结构、关键字和语言特性（例如声明方式、控制流、类型、作用域、异步、装饰器/宏、泛型等），解释它们的含义和规则；`,
+        `2. 为什么这里会这样写，这种写法解决了什么问题、有什么好处或注意事项（可读性、性能、安全、惯用法等）；`,
+        `3. 还有哪些等价的其它写法，并对比各自的优缺点；`,
+        `4. 在这个场景下哪种写法更合适，给出你的推荐和理由。`,
+        `请用通俗易懂的方式讲解，必要时配简短示例。`,
+        "",
+        ...(language ? [`语言: ${language}`] : []),
+        `文件: ${pathLabel}`,
+        "",
+        "```",
+        text,
+        "```",
+      ].join("\n"));
+      setEditorAiSelection(null);
+      setStatusMessage("Staged syntax explanation request in AI chat");
       return;
     }
     if (action === "fix") {

--- a/src/components/editor/workspace/EditorSelectionAiToolbar.test.tsx
+++ b/src/components/editor/workspace/EditorSelectionAiToolbar.test.tsx
@@ -18,10 +18,12 @@ describe("EditorSelectionAiToolbar", () => {
       />,
     );
     fireEvent.click(screen.getByText("Explain"));
+    fireEvent.click(screen.getByText("Syntax"));
     fireEvent.click(screen.getByText("Fix"));
     fireEvent.click(screen.getByText("Ask AI"));
     fireEvent.click(screen.getByTitle("Dismiss AI toolbar"));
     expect(onAction).toHaveBeenCalledWith("explain", "const value = 1;");
+    expect(onAction).toHaveBeenCalledWith("syntax", "const value = 1;");
     expect(onAction).toHaveBeenCalledWith("fix", "const value = 1;");
     expect(onAction).toHaveBeenCalledWith("rewrite", "const value = 1;");
     expect(onDismiss).toHaveBeenCalledTimes(1);

--- a/src/components/editor/workspace/EditorSelectionAiToolbar.tsx
+++ b/src/components/editor/workspace/EditorSelectionAiToolbar.tsx
@@ -1,6 +1,6 @@
-import { BookOpen, Sparkles, WandSparkles, X } from "lucide-react";
+import { BookOpen, GraduationCap, Sparkles, WandSparkles, X } from "lucide-react";
 
-export type EditorAiAction = "explain" | "fix" | "rewrite";
+export type EditorAiAction = "explain" | "syntax" | "fix" | "rewrite";
 
 interface EditorSelectionAiToolbarProps {
   visible: boolean;
@@ -25,7 +25,7 @@ export function EditorSelectionAiToolbar({
   const PADDING = 8;
   const placeAbove = rect.top > TOOLBAR_HEIGHT + PADDING;
   const top = placeAbove ? rect.top - TOOLBAR_HEIGHT - PADDING : rect.bottom + PADDING;
-  const left = Math.max(8, Math.min(rect.left, window.innerWidth - 320));
+  const left = Math.max(8, Math.min(rect.left, window.innerWidth - 420));
 
   return (
     <div
@@ -43,6 +43,16 @@ export function EditorSelectionAiToolbar({
       >
         <BookOpen className="h-3.5 w-3.5" />
         Explain
+      </button>
+      <button
+        type="button"
+        className="h-7 inline-flex items-center gap-1 rounded px-2 text-[11px] text-[var(--taomni-code-text)] hover:bg-[var(--taomni-code-active-line-bg)] disabled:opacity-40"
+        disabled={busy}
+        title="Explain the language syntax used in the selection"
+        onClick={() => onAction("syntax", selectionText)}
+      >
+        <GraduationCap className="h-3.5 w-3.5" />
+        Syntax
       </button>
       <button
         type="button"


### PR DESCRIPTION
…ection

Add a fourth button to the editor's floating AI selection toolbar that explains the language syntax of the selected code, rather than what the code does. It targets learning: helping the user understand the grammar, why the code is written this way, what equivalent alternatives exist, and which is most suitable in context.

Behavior:
- The new "Syntax" button (graduation-cap icon) sits between "Explain" and "Fix". Clicking it is read-only like "Explain" (no rewrite dialog); it stages a structured prompt into the AI chat composer via attachToComposer.
- The staged prompt asks the model to (1) walk through each syntax construct, keyword, and language feature with its rules, (2) explain why the code is written this way and the tradeoffs (readability, performance, safety, idioms), (3) show equivalent alternative styles with pros/cons, and (4) recommend the best fit here with reasoning. The selection, file label, and detected language name are included as context.

Details:
- EditorSelectionAiToolbar.tsx: extend EditorAiAction with "syntax", render the button, and widen the off-screen clamp (320 -> 420px) so the extra button stays within the viewport.
- CodeWorkspaceTab.tsx: add a languageDisplayNameForPath() helper (extension -> human-readable language name, mirroring diffLanguage.ts coverage plus a few extras) and a "syntax" branch in handleEditorAiAction that builds the teaching prompt and names the language when known.

This distinguishes the new action from the existing "Explain" (what the code does and its issues) by focusing on grammar and idiom education instead.

Tests:
- EditorSelectionAiToolbar.test.tsx: assert the "Syntax" button renders and routes onAction("syntax", ...).
- Verified: EditorSelectionAiToolbar tests pass, CodeWorkspaceTab suite (37) passes, and `tsc -b` is clean.