### PR TITLE
feat(sockscap): block QUIC (UDP 443) to force HTTP/3 → TCP fallback

### DIFF
--- a/claudedocs/sockscap-quic-block-design.md
+++ b/claudedocs/sockscap-quic-block-design.md
@@ -1,0 +1,389 @@
+# SocksCap QUIC (UDP 443) 拦截设计
+
+> 状态：设计中（未实现）。本文档随三端讨论持续更新。
+> 背景：sockscap global+gfwlist 下访问 chatgpt.com 报"超出国家允许列表"，
+> 而 Chrome 直接设代理正常。根因分析见文末「根因背景」。本条为四条泄漏
+> 路径中最贴近根因、性价比最高的一条。
+
+## 1. 目标与原理
+
+浏览器拿到 Cloudflare 的 `alt-svc` 后升级到 HTTP/3（UDP 443）。这些 UDP 包当前
+完全不进捕获层（Windows `NETWORK_FILTER = "tcp and outbound"`），带着真实中国 IP
+直出 → OpenAI 判定 CN。
+
+原理：**丢弃 in-scope 流的出站 UDP 443 握手包**。浏览器 QUIC 握手拿不到响应，
+几次超时后把该源标记为 broken，回退 TCP —— 而 TCP 路径已能按 SNI/GFWList 走代理。
+这正是 netch 等工具的做法。我们**不代理 UDP**（把 UDP association 塞进 SOCKS5
+反射机制不现实），只是让它"哑火"以触发回退。
+
+## 2. 核心洞察（让改动很小的关键）
+
+**"SocksCap 会用 TCP 代理的流" 恰好等于 "我们要杀掉其 QUIC 的流"。**
+所以现有 `classify_flow` 的两个结果可直接复用，只是对 UDP 443 换执行动作：
+
+| classify_flow 结果 | TCP 路径（现状） | UDP 443 路径（新增） |
+|---|---|---|
+| `Redirect`（会捕获） | 反射到 relay | **DROP**（不 send，逼 TCP 回退） |
+| `Bypass`（放行）    | 原样转发     | **PASS**（原样转发） |
+
+一个 SocksCap 本来就要直连放行的流（LAN、被 bypass 的上游 core、App 模式下不在
+范围的进程），它的 QUIC 也必须原样放行 —— 语义天然一致。
+
+## 3. 已锁定的产品取舍
+
+- **默认开启**（`block_quic` 默认 true）。副作用：global 模式下机器上所有
+  in-scope 应用的 QUIC 都降级 TCP；需在 UI 明确告知并可关闭。
+- **会话级开关**（放 `SocksCapConfig` 顶层，非 per-profile）。单 WinDivert
+  handle / 单 relay 模型不变，过滤器是否加宽只看这一个布尔，无并集逻辑。
+- **仅 UDP 443**。基串固定 `outbound and (tcp or (udp and udp.DstPort == 443))`，
+  不做端口集合参数化。UDP 80 上的 h3 浏览器几乎不用。
+
+## 4. 配置项与传递链路（Windows，5 跳）
+
+新增会话级布尔，沿现有链路透传，全程只多一个字段：
+
+1. `config.rs`：`SocksCapConfig` 加 `#[serde(default = "default_true")] block_quic: bool`
+   （复用已有 `default_true`；旧配置无此字段也得 true，老用户升级即生效，无需迁移）。
+   `SocksCapConfig::Default` 显式设 true。
+2. `helper.rs`：`CaptureStartArgs` 加 `block_quic: bool`；`capture_start()` 的 json
+   body 加 `"blockQuic": args.block_quic`。
+3. `mod.rs`（构造 `CaptureStartArgs` 处，~1345 行）：`block_quic: cfg.block_quic`。
+4. `sockscap-helper/main.rs`：`Request` 加
+   `#[serde(default, rename="blockQuic")] block_quic: Option<bool>`；`capture_start`
+   分支构造 `CapturePlan` 时填入。
+5. `capture.rs`：`CapturePlan` 加 `block_quic: bool`。
+
+## 5. 过滤器变更（开 handle 时决定，关时零成本）
+
+WinDivert 过滤器在 live handle 上不可变，所以 `block_quic` 必须在 `start()` 时已知：
+
+- **关闭时**：过滤器与行为与现状逐字节一致（`"tcp and outbound"` + CIDR 排除），
+  零开销、零风险 —— 安全回归基线。
+- **开启时**：`build_network_filter` 基串改为
+  `outbound and (tcp or (udp and udp.DstPort == 443))`，后面照旧 append 每条
+  `and not (ip.DstAddr >= lo and <= hi)`（CIDR 排除对 UDP 同样按 DstAddr 生效）。
+  fallback 串同样带 UDP 443 从句。
+
+这样内核就把 in-scope 之外的本地/私网 UDP 443 挡在 loop 外，减少 kernel↔user 穿越。
+
+## 6. 包处理路径（插入点极干净）
+
+现在 UDP 包过不了 `parse_ip_tcp`（proto 17≠6），落到 else 分支直接转发：
+
+```rust
+let Some(tcp) = parse_ip_tcp(pkt) else {
+    let _ = api.send(handle, pkt, &addr);   // ← UDP 当前从这里原样放行
+    continue;
+};
+```
+
+改为在该 else 内加 UDP 443 处理（TCP 热路径一字不动）：
+
+```
+若 plan.block_quic 且 outbound 且 是 UDP 且 dport==443:
+    key=(src,sport)
+    verdict = udp_verdicts 命中(校验 dst) ? 命中 : classify_flow_udp(...)（写缓存）
+    if Redirect => continue（不 send = DROP，可选累加 quic_dropped 计数）
+    else        => api.send(...)（PASS）
+    continue
+否则：api.send(...)（原样，非 UDP443 或未开启）
+```
+
+- DROP = 不 send，无需 checksum。
+- PASS = 原样 send，从不改写 UDP 包，无需 recalc。
+- 绝不反射 UDP，无 relay 回环风险。
+
+## 7. 归属（谁拥有此 UDP 流）与默认值
+
+关键正确性点：**绝不能误杀被 bypass 的上游自身 UDP**（最典型：WireGuard 经
+xray-core 走 UDP 出节点；xray 进程已在 `bypass_pids`/`bypass_paths`）。所以 UDP 443
+也要做 per-flow 归属。
+
+- 新增 `proc_info.rs::udp_owner_pid(local, sport)`，用
+  `GetExtendedUdpTable`（`MIB_UDP(6)TABLE_OWNER_PID`），带 100ms 缓存 + miss 强制
+  重读一次，完全复刻现有 `tcp_owner_pid`。
+  - UDP 优势：socket 在首个数据报前已 bind 并进表，归属比 TCP SYN 竞争更可靠。
+- `classify_flow_udp` 复用 `classify_flow` 判定骨架（bypass_cidrs/endpoints/pid/path、
+  loopback、App 范围匹配），仅把 `tcp_owner_pid` 换 `udp_owner_pid`、App 模式的
+  `app_index.ports` 换成新增的 `app_index.udp_ports`。
+
+未归属时的默认（与现有 TCP 语义严格对齐）：
+- **Global**：一切默认 in-scope → 查 bypass 后 DROP（正确，上游 core 由 pid/path 保护）。
+- **App**：未归属默认 Bypass/PASS（"别动不确定是否在范围内的流"，对齐 capture.rs:1228）。
+
+## 8. App 模式：仅影响 in-scope app，不误伤其它 app
+
+App 模式下过滤器加宽与 drop 决策是**两回事**：
+
+- 过滤器加宽只决定"哪些包**进** divert loop"（全机出站 UDP 443 都进）。
+- 是否 **DROP** 由 `classify_flow_udp` 逐流判定：
+
+```
+App 模式:
+  sport 命中 in-scope app 的 udp 端口表  → Redirect → DROP（逼回退）
+  否则 resolve_flow 得 pid，不在范围     → Bypass  → PASS（QUIC 照常）
+  归属失败                              → Bypass  → PASS（安全默认）
+```
+
+**结论：只有 profile 选中的 app 被强制回退 TCP；其它 app 的 UDP 443 原样放行，
+QUIC 照常工作。** 与现有 TCP 的 App 模式语义一致（capture.rs:1228 "leave
+App-mode traffic alone"）。
+
+失败方向安全：若 UDP 归属实现有缺陷，最坏是 in-scope app 的 QUIC **漏杀**（泄漏
+回来），而 out-of-scope app 始终 PASS —— 是"漏杀"而非"误杀"。
+
+代价（性能，会话级）：因单一 handle，开启后全机出站 UDP 443 都进 loop 被分类一次
+（今天 UDP 根本不进 loop）。out-of-scope app 的 QUIC 仍可用，但每个 UDP 443 包多走
+一趟"进 loop → 判 Bypass → 原样 send"。缓解：`bypass_cidrs` 在内核层排除本地/私网；
+`udp_verdicts` 每流只分类一次，之后是哈希查找 + send。净效应：功能不受影响，
+out-of-scope QUIC 有少量额外 CPU/转发开销。
+
+**前提依赖（务必实现，App 模式尤甚）**：上面"只杀 in-scope"依赖
+`app_index.udp_ports` + `udp_owner_pid`。`compute_app_index` 现仅调
+`port_owners_for_pids`(TCP)，需加 UDP 版 `udp_port_owners_for_pids` 填充
+`udp_ports`；否则 in-scope app 的 QUIC 会因查不到端口归属而落到"App 默认 PASS"
+→ 泄漏（但仍不误伤其它 app）。
+
+## 9. 决策缓存与生命周期
+
+- 新增独立 `udp_verdicts: FlowTable`（**不与 TCP 的 `redirects` 共用**，否则
+  (ip,port) 键会 TCP/UDP 撞车）。复用 `FlowTable` 现成 TTL、sweep、容量上限、
+  dst 重校验。
+- UDP 无 SYN/FIN/RST：生命周期靠 idle TTL sweep；不需要 peer_index/sport_index
+  （UDP 不反射）。
+- 缓存意义：QUIC 一条连接很多数据报，缓存 drop 决策避免每数据报都查表。回退成功后
+  浏览器停发 UDP 443，负载自动收敛到接近 0。
+
+## 10. 边界与风险
+
+- 误杀上游 QUIC（WG）：靠 pid/path 归属保护；xray 是 bundled，pid+path 都在 bypass。✅
+- in-scope 应用无 TCP 回退（罕见纯 QUIC RPC 客户端）：会被打断 —— QUIC 拦截固有
+  代价，故做成开关。global 下影响机器上所有 in-scope QUIC 应用（都降级 TCP）。
+- IPv6 扩展头：简易解析器遇扩展头 bail → 该包 PASS（安全侧，罕见），需注释。
+- alt-svc 指定非 443 端口：极少见，本设计不覆盖；可后续把端口集合配置化。
+- 与 ECH 的协同：QUIC 被堵回退 TCP 后，TCP 上仍可能因 ECH 抽不出 SNI 命中 miss。
+  本条消除 QUIC 泄漏，但彻底解决 chatgpt 还需配合 default_action/GFWList/ECH 兜底。
+- 性能：稳态开销低（QUIC 收敛后 UDP 443 趋零）；瞬时突发是"每 100ms 一次 UDP 表读
+  + 每流一次分类"，与 TCP 同量级。
+
+## 11. 本条能修 / 不能修
+
+- ✅ 修掉 QUIC/UDP 443 泄漏（泄漏路径排序第 1 的最可能主因）。
+- ❌ 不动 DNS/53 泄漏、不改 default_action、不补 ECH/GFWList（独立的其余三条）。
+
+## 12. 三端设计
+
+`block_quic` 是会话级配置（§3），三端共享同一语义与默认值（默认开启）。各端"让
+UDP 443 哑火"的等价实现不同：Windows 用户态逐包 drop，Linux 内核 nftables drop，
+macOS 待办。**Windows 与 Linux 均按完整实现设计；macOS 留待办，但实现其余两端时
+须在 macOS 捕获代码中留下显式 TODO 标记（见 §12.3），不仅写在文档里。**
+
+### 12.1 Windows（完整实现）
+
+见上文 §4–§11、§13–§14，已定稿。要点：单一 WinDivert handle，过滤器按 `block_quic`
+加宽到 `outbound and (tcp or (udp and udp.DstPort==443))`，用户态 `classify_flow_udp`
+逐流判定 DROP/PASS，`udp_verdicts` 缓存 + `udp_owner_pid`/`app_index.udp_ports` 归属。
+
+### 12.2 Linux（完整实现）
+
+Linux 捕获是 **nftables nat hook + cgroup v2 归属**：`table inet taomni_sockscap` 的
+`output` 链（`type nat hook output priority dstnat`）把 in-scope 的 **TCP** OUTPUT
+重定向到 loopback relay；scope 由 cgroup 决定 —— global 模式把 Taomni 自身（及其子
+进程，含 bundled xray）移入 `bypass` cgroup、其余全机重定向；app 模式仅把选中 PID
+移入 `capture-profile-N` cgroup，子进程继承。
+
+**QUIC drop 用同表新增一条 filter 链**（nat 类型链不能可靠 `drop`，必须用 filter
+hook）。同表 → 与 redirect 链原子安装/移除，复用现有 Recover、ownership marker、
+`RedirectPlan` 校验，无新增 teardown。
+
+global 模式渲染（`block_quic=true` 时追加）：
+
+```
+chain quic_block {
+  type filter hook output priority filter; policy accept;
+  ip daddr 127.0.0.0/8 return
+  ip6 daddr ::1/128 return
+  <每条 bypass_cidr> return
+  <bypass cgroup> return          # 与 redirect 链同一个 bypass cgroup
+  udp dport 443 drop              # 其余 in-scope 一律丢弃
+}
+```
+
+app 模式渲染（**仅对 capture cgroup 丢弃 → 其它 app 的 QUIC 原样放行**）：
+
+```
+chain quic_block {
+  type filter hook output priority filter; policy accept;
+  ip daddr 127.0.0.0/8 return
+  ip6 daddr ::1/128 return
+  <每条 bypass_cidr> return
+  <capture cgroup 0> udp dport 443 drop
+  <capture cgroup 1> udp dport 443 drop
+  ...
+}
+```
+
+**上游保护对等性**：quic_block 链在 drop 前放置与 redirect 链**完全相同**的
+loopback / bypass_cidr / bypass-cgroup return。任何已被 TCP redirect 回环保护的
+egress（Taomni 自身 + 其子 xray core、loopback 上的本地代理端口）同样被 UDP drop
+保护 —— QUIC 拦截**不引入新的绕过面**。需验证：bundled xray（WireGuard 上游）作为
+Taomni 子进程运行，从而继承 global 模式的 bypass cgroup；若成立，则 WG 的 UDP 出节点
+天然放行。
+
+**为何比 Windows 简单**：cgroup 匹配在内核层天然给出"仅 in-scope"，无需用户态逐包
+分类、无 verdict 缓存、无 UDP owner 表。relay **完全不经手 UDP**（内核直接 drop），
+Linux 侧无 relay/用户态改动。
+
+**hook 顺序**：nat dstnat（prio dstnat，先）→ filter（prio filter，后）。TCP in-scope
+包在 nat 阶段被 redirect 到 relay（dport 改成 relay_port），到 filter 链时既非 UDP
+也非 443，不匹配 drop；UDP 443 包在 nat 阶段无匹配（redirect 仅 TCP）原样通过，到
+filter 链被 drop。`inet` 表下 `udp dport 443` 同时匹配 v4/v6，无需 loopback listener
+依赖，两族都可 drop。
+
+**生命周期**：quic_block 与 output 链同处 `inet taomni_sockscap` 表 → 原子安装/移除；
+`delete table` 一并清除；ownership marker 复用。无新增 teardown。
+
+**Linux 传递链路（3 处）**：
+1. `config.rs`：`block_quic`（会话级，三端共享，已在 §4 定义）。
+2. `capture/linux/tunnel.rs`：`RedirectPlan` 加 `block_quic: bool`；`render_nft_script`
+   在 true 时追加 quic_block 链（global/app 两种渲染分支）；`validate` 不变。
+3. `capture/linux/mod.rs`：`start()` 构造 `RedirectPlan::new` / `new_app_routes` 时
+   传入 `config.block_quic`。
+
+**Linux 测试**：render 单测 —— global 在 bypass returns 之后 emit `udp dport 443 drop`；
+app 对每个 capture cgroup emit `<cgroup> udp dport 443 drop` 且**不** emit 裸 drop
+（保证不误伤 out-of-scope app）；`block_quic=false` 不 emit quic_block 链（回归：与今
+逐字一致）；`ValidatedCidr` 注入防护对新链同样有效（复用现有渲染）。
+
+### 12.3 macOS（留待办 — 须在代码中留 TODO）
+
+macOS 有两种 backend：**system-proxy**（设置系统 SOCKS/HTTP 代理）与**透明 NE**
+（Network Extension）。两者当前都不处理 QUIC：
+
+- **system-proxy**：设 SOCKS 代理不捕获 UDP，QUIC 直接泄漏。要堵需额外 pf 规则或走 NE。
+- **透明 NE**：`NEPacketTunnelProvider` 理论上能看到 UDP 443 并 drop，但现有 macOS
+  透明 ingress 读的是 SOCKS5 / HTTP CONNECT 握手（TCP），UDP 路径未建。
+
+**决策：本期不实现 macOS QUIC 拦截。** 但**硬性要求**：实现 Windows/Linux 时，须在
+macOS 捕获代码中留下显式代码 TODO 标记（不仅写文档），标注 `block_quic` 在 macOS 的
+接入点，便于后续实现：
+
+- `src-tauri/src/sockscap/capture/macos/mod.rs`、`transparent.rs`、`system_proxy.rs`
+  中，在各 backend 构建捕获/ingress 的自然插入点，加
+  `// TODO(sockscap-quic): block UDP 443 to force QUIC→TCP fallback (see claudedocs/sockscap-quic-block-design.md §12.3); block_quic is session-level in SocksCapConfig`。
+- 若 macOS 侧读取/透传 `SocksCapConfig` 的路径上有等价于 Windows `CapturePlan` /
+  Linux `RedirectPlan` 的结构，在其旁标注 `block_quic` 尚未接入。
+
+### 12.4 跨端一致性
+
+- `block_quic` 语义、默认值（true）、UI 呈现三端统一（配置字段共享）。
+- 三端"drop UDP 443"的 in-scope 判定都对齐各自的 TCP 捕获 scope：Windows =
+  `classify_flow` 的 Redirect 集；Linux = redirect 的 cgroup 集；macOS 待办。
+- 失败方向一致：宁"漏杀"（QUIC 泄漏回来）不"误杀"（打断无关 app）。
+
+## 13. 测试（Windows）
+
+- 单元：`build_network_filter(block_quic=true)` 串含 `udp.DstPort == 443` 且 CIDR
+  排除仍在；`=false` 时与 `NETWORK_FILTER` 逐字相等（回归安全）。`classify_flow_udp`
+  的 global-default-drop / app-default-pass / bypass-pid-pass。UDP 表行解析
+  （v4 / v6，端口网络序）。
+  - 注意：现有单测 `network_filter_without_bypasses_is_the_base_filter` 断言
+    `build_network_filter(&[]) == NETWORK_FILTER`，加 `block_quic` 参数后需同步更新。
+- 手动：开 sockscap global+gfwlist + block_quic，Chrome 开 ChatGPT 不再报国家限制；
+  `chrome://net-export` 确认 h3 broken 回退 h2；确认 WG 上游仍连通。
+
+## 14. 改动清单（Windows，7 处，供 review 范围）
+
+| 文件 | 改动 | 风险 |
+|---|---|---|
+| `config.rs` | `block_quic` 字段(默认 true) + Default | 低（serde 兼容已考虑） |
+| `helper.rs` | `CaptureStartArgs` 加字段 + `capture_start` json body 加 `blockQuic` | 低 |
+| `mod.rs` | 构造 args 处填 `cfg.block_quic` | 低 |
+| `sockscap-helper/main.rs` | `Request` 加 `blockQuic` + 填入 `CapturePlan` | 低 |
+| `capture.rs` | `CapturePlan` 加字段；`build_network_filter` 按 flag 加宽；`network_loop` UDP else 分支加分类/drop；新增 `udp_verdicts` + `classify_flow_udp` + `app_index.udp_ports` | 中（热路径+新分类，TCP 路径不动） |
+| `proc_info.rs` | 新增 `udp_owner_pid` / UDP 表读取 + `udp_port_owners_for_pids`（复刻 TCP 结构） | 低-中 |
+| 前端 sockscap 设置 UI + i18n | 开关 + 副作用说明文案 | 低 |
+
+## 根因背景（four leak paths，按可能性排序）
+
+Chrome 设 SOCKS5 = 全量 + 远程 DNS，无泄漏；sockscap global+gfwlist = 按
+"TCP + 命中域名 + 能识别 SNI" 三重漏斗过滤，漏出的走 Direct 带真实 IP：
+
+1. **QUIC/HTTP3 走 UDP 443 未被捕获**（本文档，最可能主因）。
+2. **ECH 让 SNI 抽不出 → GFWList miss → Direct**（`sni.rs` 不解析 ECH；
+   `policy.rs:234` 无 hostname 落 default_action）。
+3. **default_action 默认 Direct**（`config.rs`：miss/无 host → 真实 IP 直连）。
+4. **DNS 不走代理**（`dns_win.rs` 仅读本地 DNS 缓存做反查，浏览器仍用国内解析器）。
+
+## 15. 实现进展（截至本次）
+
+已实现 Windows + Linux 完整方案 + macOS 代码 TODO；前端开关未完成；整体构建/测试未跑。
+
+**已完成**
+- `config.rs`：`SocksCapConfig.block_quic`（`#[serde(default="default_true")]`）+ Default
+  显式 true + 单测（`block_quic_defaults_on_for_configs_without_the_field`：旧配置无字段
+  也 true、显式 false 被尊重）。
+- Windows（**已 `cargo check --bin sockscap-helper` 通过**，仅 pre-existing 警告）：
+  - `proc_info.rs`：`GetExtendedUdpTable` FFI + `list_udp_owner_rows`（v4 12B / v6 28B）
+    + `udp_owner_rows_cached`（独立 `UDP_TABLE_CACHE`）+ `udp_owner_pid` + `udp_port_owners_for_pids`。
+  - `capture.rs`：`CapturePlan.block_quic`；`NETWORK_FILTER_WITH_QUIC` +
+    `base_network_filter()`；`build_network_filter(cidrs, block_quic)`（签名变了）；
+    `AppIndex.udp_ports`（仅 block_quic 时填充）；`CaptureEngine.udp_verdicts` 独立
+    `FlowTable`（start 传入 network_loop / clear_tables / 收口）；network_loop 的
+    `parse_ip_tcp` else 分支加 UDP443 drop；`udp_should_drop` + `classify_flow_udp`
+    （UDP 用 `udp_owner_pid`，**不**走 TCP 的 flows 图）；`parse_ip_udp`/`UdpMeta`；
+    新增单测（filter widen、udp443 解析、base 回归）。
+  - `main.rs`：`Request.blockQuic` + 填 `CapturePlan.block_quic`。
+  - `helper.rs`：`CaptureStartArgs.block_quic` + `capture_start` json `"blockQuic"`。
+  - `mod.rs`：构造 args 处 `block_quic: cfg.block_quic`。
+- Linux：`tunnel.rs`：`RedirectPlan.block_quic`；两个构造器加参（`new` +7 参、
+  `new_app_routes` +4 参）；`render_quic_block_chain`（同表 filter hook 链，global=
+  bypass returns 后 `udp dport 443 drop`，app=每 capture cgroup 各一条 drop）；4 个新
+  render 单测（off 无链回归、global drop 在 bypass 后、app 仅按 cgroup）。`mod.rs`：两处
+  调用传 `config.block_quic`。
+- macOS：`capture/macos/{mod.rs,transparent.rs,system_proxy.rs}` 各留
+  `// TODO(sockscap-quic): ...` 标记（引用本文档 §12.3），未实现。
+- 前端：`src/lib/sockscap.ts` `SocksCapConfig.blockQuic: boolean` 字段已加。
+
+**前端（已完成）**
+- `src/lib/sockscap.ts`：`SocksCapConfig.blockQuic`。
+- `SocksCapPanel.tsx`：DEFAULT config `blockQuic: true`；GFWList Section 末尾加会话级
+  开关（`data-testid="sockscap-block-quic"`，`checked={cfg.blockQuic ?? true}`，
+  `locked||busy` 时禁用，`persistConfig({...cfg, blockQuic})`）。
+- i18n：`en.ts`/`zh-CN.ts` `sockscap.blockQuic` + `sockscap.blockQuicHint`。
+- `stubs/tauri-core.ts`：dev-mode config 加 `blockQuic: true`。
+- 三处测试 fixture（SocksCapPanel.test / sockscapPreflight.test / sockscapRestart.test）
+  补 `blockQuic: true`。
+
+**验证结果**
+- `cargo test --bin sockscap-helper`：**26 passed, 0 failed**（含新增
+  `network_filter_widens_to_udp_443_when_blocking_quic`、`parses_udp_443_from_ipv4`、
+  base-filter 回归）。
+- `cargo test --lib sockscap::config`：**7 passed**（含 block_quic 默认值 2 例）。
+- `npx tsc --noEmit`：**0 error**。
+- `vitest` sockscap 三套件：**37 passed**。
+
+**唯一 caveat**
+- Linux `tunnel.rs`/`mod.rs` 改动是 `cfg(target_os="linux")` 门控，**本 Windows 主机
+  编译器未覆盖**；改动是机械式（加 bool 字段 + 构造器参数 + 一个镜像现有模式的
+  render 函数），并已加 4 个 Linux-only render 单测（`no_quic_block_chain_when_block_quic_is_off`
+  / `global_quic_block_drops_after_bypass_returns` / `app_quic_block_drops_only_per_capture_cgroup`
+  + 现有测试签名更新），需 Linux/CI 编译运行确认。
+
+## 16. bypass 语义确认（对话结论，实现依据）
+
+- 用户可配的 bypass 只有 `bypass_cidrs`；`bypass_pids`/`bypass_paths`/`bypass_endpoints`
+  是**内部**的（self、xray cores、本地代理进程、上游 endpoint、relay 端口），在
+  `mod.rs` 构造。无面向用户的"bypass 应用"清单。
+- **不变量**：各端"drop QUIC 的流集合" == "TCP 捕获(Redirect/redirect)的流集合"。被
+  bypass 的应用其 QUIC 不受影响。Windows `classify_flow_udp` 复刻了 `classify_flow`
+  的全部 bypass 判定（endpoints/cidrs/loopback/pid/path/app-scope）；Linux quic_block
+  链复刻 redirect 链的 loopback/cidr/bypass-cgroup returns。
+- **Linux 已知局限（继承自 TCP，非本功能引入）**：`mod.rs:796-799` 注明"Linux 上把
+  xray 子进程排除出 taomni cgroup 是后续项"。故 Linux global 模式下，若上游用 **UDP 443
+  传输**（如经 xray 的 WireGuard/hysteria）且 xray 未在 bypass cgroup，则其 UDP 出节点
+  会被 quic_block 误杀 —— 但这与 TCP redirect 回环是同一个未决问题，QUIC 拦截**不新增**
+  绕过面。多数上游对节点用 TCP（HTTP/SOCKS/SSH/多数 xray），不受影响。
+- **capture-but-direct 权衡**：global 模式下即使目标经策略判为 Direct（.cn/GFWList
+  miss），其 QUIC 仍被 drop → 回退 TCP 直连（功能对，仅 QUIC 降级 TCP）。要豁免需在 UDP
+  时就知道 per-dest 决策（QUIC SNI 解析），本期不做。

--- a/src-tauri/src/bin/sockscap-helper/capture.rs
+++ b/src-tauri/src/bin/sockscap-helper/capture.rs
@@ -20,7 +20,8 @@ use serde_json::json;
 use winapi::um::winnt::HANDLE;
 
 use crate::proc_info::{
-    path_matches_selector, port_owners_for_pids, tcp_owner_pid, ProcessTree, SharedTree,
+    path_matches_selector, port_owners_for_pids, tcp_owner_pid, udp_owner_pid,
+    udp_port_owners_for_pids, ProcessTree, SharedTree,
 };
 use crate::windivert::{
     addr_event, addr_for_reflect_inbound, addr_is_outbound, addr_layer, flow_endpoints_ip,
@@ -46,6 +47,10 @@ pub struct CapturePlan {
     pub bypass_endpoints: Vec<Endpoint>,
     pub relay_ip: Ipv4Addr,
     pub relay_port: u16,
+    /// Drop in-scope outbound UDP 443 so QUIC falls back to TCP (which capture
+    /// can attribute and proxy). Widens the NETWORK filter to also match UDP 443
+    /// and enables the UDP-443 arm in the packet loop. See design doc.
+    pub block_quic: bool,
 }
 
 /// An inert plan: captures nothing. Only used as the initial value of the live
@@ -61,6 +66,7 @@ impl Default for CapturePlan {
             bypass_endpoints: Vec::new(),
             relay_ip: Ipv4Addr::LOCALHOST,
             relay_port: 0,
+            block_quic: false,
         }
     }
 }
@@ -125,6 +131,20 @@ struct FlowEntry {
 /// re-feed our own rewrites back into this loop.
 const NETWORK_FILTER: &str = "tcp and outbound";
 
+/// Base filter when QUIC blocking is on: also pull in outbound UDP 443 so the
+/// packet loop can drop in-scope QUIC and force a TCP fallback. UDP is only ever
+/// dropped or passed, never reflected, so there is no inbound-recapture concern.
+const NETWORK_FILTER_WITH_QUIC: &str = "outbound and (tcp or (udp and udp.DstPort == 443))";
+
+/// The base filter for the current plan (before per-CIDR exclusions).
+fn base_network_filter(block_quic: bool) -> &'static str {
+    if block_quic {
+        NETWORK_FILTER_WITH_QUIC
+    } else {
+        NETWORK_FILTER
+    }
+}
+
 /// Kernel filter excluding destinations the packet loop would unconditionally
 /// pass through anyway.
 ///
@@ -147,8 +167,8 @@ const NETWORK_FILTER: &str = "tcp and outbound";
 ///
 /// Mixed address families are fine: an `ip.` test on an IPv6 packet (and vice
 /// versa) is simply false, so `not (…)` leaves the packet matched.
-fn build_network_filter(bypass_cidrs: &[String]) -> String {
-    let mut filter = String::from(NETWORK_FILTER);
+fn build_network_filter(bypass_cidrs: &[String], block_quic: bool) -> String {
+    let mut filter = String::from(base_network_filter(block_quic));
     for (net, prefix) in parse_cidrs(bypass_cidrs) {
         let (lo, hi) = cidr_range(net, prefix);
         let field = match net {
@@ -385,8 +405,12 @@ impl FlowTable {
 /// holding up every other packet on the host.
 #[derive(Debug, Default)]
 struct AppIndex {
-    /// local port → owning pid, for in-scope processes only.
+    /// local TCP port → owning pid, for in-scope processes only.
     ports: HashMap<u16, u32>,
+    /// local UDP port → owning pid, for in-scope processes only. Populated only
+    /// when `block_quic` is on; used to attribute UDP 443 (QUIC) to an in-scope
+    /// app so its QUIC is dropped while other apps' QUIC passes untouched.
+    udp_ports: HashMap<u16, u32>,
     /// pid → executable path, for in-scope processes only.
     paths: HashMap<u32, String>,
     pids: HashSet<u32>,
@@ -443,6 +467,10 @@ pub struct CaptureEngine {
     flows: Arc<Mutex<FlowMap>>,
     /// Client `(ip, port)` → the capture/bypass decision for its connection.
     redirects: Arc<Mutex<FlowTable>>,
+    /// UDP 443 (QUIC) drop/pass verdicts, keyed by client `(ip, sport)`. Kept
+    /// separate from `redirects` so a UDP and a TCP flow sharing a local port
+    /// cannot clobber each other's verdict. Only used when `block_quic` is on.
+    udp_verdicts: Arc<Mutex<FlowTable>>,
     /// Live plan shared with the divert threads. Published as a whole `Arc` so
     /// bypass lists can change mid-session (an xray core respawning with a new
     /// pid, a local proxy restarting) without tearing capture down.
@@ -465,6 +493,7 @@ impl CaptureEngine {
             net_handle: None,
             flows: Arc::new(Mutex::new(FlowMap::default())),
             redirects: Arc::new(Mutex::new(FlowTable::default())),
+            udp_verdicts: Arc::new(Mutex::new(FlowTable::default())),
             plan_live: Arc::new(Mutex::new(Arc::new(CapturePlan::default()))),
             packets_seen: Arc::new(AtomicU64::new(0)),
             packets_redirected: Arc::new(AtomicU64::new(0)),
@@ -593,21 +622,22 @@ impl CaptureEngine {
         // which still classifies them correctly — unlike the bare `"tcp"`
         // fallback this replaced, which also pulled in every inbound packet on
         // the machine for no benefit at all.
-        let narrowed = build_network_filter(&plan.bypass_cidrs);
+        let narrowed = build_network_filter(&plan.bypass_cidrs, plan.block_quic);
+        let base_filter = base_network_filter(plan.block_quic);
         let (net_h, filter_used) = match api.open(&narrowed, LAYER_NETWORK, 0, 0) {
             Ok(h) => (h, narrowed),
             Err(narrow_err) => {
                 tracing::warn!(
                     "sockscap-helper: narrowed filter rejected ({narrow_err}); \
-                     falling back to {NETWORK_FILTER:?}"
+                     falling back to {base_filter:?}"
                 );
-                let h = api.open(NETWORK_FILTER, LAYER_NETWORK, 0, 0).map_err(|e| {
+                let h = api.open(base_filter, LAYER_NETWORK, 0, 0).map_err(|e| {
                     format!(
-                        "WinDivert NETWORK open failed for filter {NETWORK_FILTER:?}: {e}. \
+                        "WinDivert NETWORK open failed for filter {base_filter:?}: {e}. \
                          Ensure WinDivert.dll/sys match (2.2+ x64) and the helper is elevated."
                     )
                 })?;
-                (h, NETWORK_FILTER.to_string())
+                (h, base_filter.to_string())
             }
         };
 
@@ -671,6 +701,7 @@ impl CaptureEngine {
         let stop = Arc::clone(&self.stop);
         let flows = Arc::clone(&self.flows);
         let redirects = Arc::clone(&self.redirects);
+        let udp_verdicts = Arc::clone(&self.udp_verdicts);
         let api_net = Arc::clone(&api);
         let net_handle = net_h as usize;
         let seen = Arc::clone(&self.packets_seen);
@@ -683,6 +714,7 @@ impl CaptureEngine {
                 net_handle as HANDLE,
                 flows,
                 redirects,
+                udp_verdicts,
                 plan_slot,
                 relay_port_live,
                 seen,
@@ -717,6 +749,9 @@ impl CaptureEngine {
             *m = FlowMap::default();
         }
         if let Ok(mut m) = self.redirects.lock() {
+            *m = FlowTable::default();
+        }
+        if let Ok(mut m) = self.udp_verdicts.lock() {
             *m = FlowTable::default();
         }
     }
@@ -896,6 +931,9 @@ fn compute_app_index(tree: &SharedTree, plan: &CapturePlan) -> AppIndex {
         }
     });
     idx.ports = port_owners_for_pids(&idx.pids);
+    if plan.block_quic {
+        idx.udp_ports = udp_port_owners_for_pids(&idx.pids);
+    }
     idx
 }
 
@@ -979,11 +1017,13 @@ fn flow_loop(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn network_loop(
     api: Arc<WinDivertApi>,
     handle: HANDLE,
     flows: Arc<Mutex<FlowMap>>,
     redirects: Arc<Mutex<FlowTable>>,
+    udp_verdicts: Arc<Mutex<FlowTable>>,
     plan_slot: PlanSlot,
     relay_port_live: Arc<AtomicU16>,
     seen: Arc<AtomicU64>,
@@ -1052,6 +1092,29 @@ fn network_loop(
         let outbound = addr_is_outbound(&addr);
 
         let Some(tcp) = parse_ip_tcp(pkt) else {
+            // QUIC blocking: drop in-scope outbound UDP 443 so the app marks
+            // HTTP/3 broken and falls back to TCP — which capture attributes by
+            // SNI and routes through the upstream. Non-443 UDP and out-of-scope
+            // UDP 443 pass untouched. We never reflect UDP, only drop or pass.
+            if plan.block_quic && outbound {
+                if let Some(udp) = parse_ip_udp(pkt) {
+                    if udp.dport == 443
+                        && udp_should_drop(
+                            &plan,
+                            &bypass_nets,
+                            &tree,
+                            &udp_verdicts,
+                            (udp.src, udp.sport),
+                            udp.dst,
+                            udp.dport,
+                            &app_index,
+                        )
+                    {
+                        // Not sending = dropping the datagram.
+                        continue;
+                    }
+                }
+            }
             let _ = api.send(handle, pkt, &addr);
             continue;
         };
@@ -1259,6 +1322,125 @@ fn is_loopback_ip(ip: IpAddr) -> bool {
         IpAddr::V4(v) => v.is_loopback(),
         IpAddr::V6(v) => v.is_loopback(),
     }
+}
+
+/// Whether an outbound UDP 443 datagram should be dropped to force QUIC→TCP.
+///
+/// Caches the per-flow verdict in `udp_verdicts` (separate from the TCP table so
+/// a shared local port can't clobber it). `Redirect` means "in scope, drop";
+/// `Bypass` means "pass". A QUIC connection is many datagrams, so this is one
+/// classification then hash lookups; once the app falls back to TCP it stops
+/// sending UDP 443 and the load collapses.
+#[allow(clippy::too_many_arguments)]
+fn udp_should_drop(
+    plan: &CapturePlan,
+    bypass_nets: &[(IpAddr, u8)],
+    tree: &SharedTree,
+    udp_verdicts: &Arc<Mutex<FlowTable>>,
+    key: FlowKey,
+    dst: IpAddr,
+    dport: u16,
+    app_index: &AppIndex,
+) -> bool {
+    let now = Instant::now();
+    let cached = udp_verdicts
+        .lock()
+        .ok()
+        .and_then(|mut t| t.lookup(key, dst, dport, now));
+    match cached {
+        Some(FlowAction::Redirect) => return true,
+        Some(FlowAction::Bypass) => return false,
+        None => {}
+    }
+    let verdict = classify_flow_udp(plan, bypass_nets, tree, key, dst, dport, app_index);
+    let drop = matches!(verdict, FlowVerdict::Redirect(_));
+    if let Ok(mut t) = udp_verdicts.lock() {
+        t.insert(key, dst, dport, verdict, now);
+    }
+    drop
+}
+
+/// Classify a UDP flow the same way `classify_flow` does for TCP, but attributing
+/// via `udp_owner_pid` / `app_index.udp_ports` (UDP sockets are absent from the
+/// FLOW-layer `flows` map, which only tracks TCP). `Redirect` = in scope → drop
+/// its QUIC; `Bypass` = pass.
+fn classify_flow_udp(
+    plan: &CapturePlan,
+    bypass_nets: &[(IpAddr, u8)],
+    tree: &SharedTree,
+    key: FlowKey,
+    dst: IpAddr,
+    dport: u16,
+    app_index: &AppIndex,
+) -> FlowVerdict {
+    let (src, sport) = key;
+
+    // Destination-based bypass (endpoints / CIDRs / loopback). Cannot reuse
+    // `should_bypass`: it resolves pid from the TCP `flows` map, which has no
+    // UDP entries.
+    for e in &plan.bypass_endpoints {
+        if e.ip == dst && (e.port == 0 || e.port == dport) {
+            return FlowVerdict::Bypass;
+        }
+    }
+    for (net, prefix) in bypass_nets {
+        if ip_in_cidr(dst, *net, *prefix) {
+            return FlowVerdict::Bypass;
+        }
+    }
+    if is_loopback_ip(dst) {
+        return FlowVerdict::Bypass;
+    }
+
+    let (pid, path) = if plan.mode_apps {
+        if let Some(&pid) = app_index.udp_ports.get(&sport) {
+            let path = app_index.paths.get(&pid).cloned().unwrap_or_default();
+            (pid, path)
+        } else {
+            // Miss: attribute directly. Unattributable App-mode traffic is left
+            // alone (passed) — never drop something we cannot scope.
+            let Some(pid) = udp_owner_pid(src, sport) else {
+                return FlowVerdict::Bypass;
+            };
+            let path = tree
+                .with(|t| t.path_of(pid).map(|s| s.to_string()))
+                .flatten()
+                .or_else(|| process_path(pid))
+                .unwrap_or_default();
+            if !app_index.pids.contains(&pid) && !process_in_scope(plan, pid, &path, tree) {
+                return FlowVerdict::Bypass;
+            }
+            (pid, path)
+        }
+    } else {
+        // Global: in scope unless explicitly bypassed by pid/path. This protects
+        // the bundled xray core's own UDP egress (e.g. a WireGuard upstream),
+        // whose pid + path are in the bypass lists. Unattributable → drop (same
+        // as TCP global capture); a UDP socket is bound before its first
+        // datagram so `udp_owner_pid`'s forced re-read normally resolves it.
+        let pid = udp_owner_pid(src, sport).unwrap_or(0);
+        let path = if pid != 0 {
+            tree.with(|t| t.path_of(pid).map(|s| s.to_string()))
+                .flatten()
+                .or_else(|| process_path(pid))
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
+        if (pid != 0 && plan.bypass_pids.contains(&pid)) || path_bypassed(plan, &path) {
+            return FlowVerdict::Bypass;
+        }
+        (pid, path)
+    };
+
+    FlowVerdict::Redirect(RedirectMapping {
+        orig_src: src,
+        orig_sport: sport,
+        orig_dst: dst,
+        orig_port: dport,
+        pid,
+        path,
+    })
 }
 
 /// Streamdump PORT→PROXY:
@@ -1598,6 +1780,59 @@ fn parse_ip_tcp(pkt: &[u8]) -> Option<TcpMeta> {
     }
 }
 
+/// Addresses and ports of an IPv4/IPv6 UDP packet (QUIC blocking path).
+#[derive(Debug, Clone, Copy)]
+struct UdpMeta {
+    src: IpAddr,
+    sport: u16,
+    dst: IpAddr,
+    dport: u16,
+}
+
+/// Parse UDP header addressing. IPv6 with extension headers is not chased: a
+/// non-UDP next-header returns `None`, so the datagram passes (safe side —
+/// worst case a QUIC packet leaks rather than an unrelated one being dropped).
+fn parse_ip_udp(pkt: &[u8]) -> Option<UdpMeta> {
+    if pkt.is_empty() {
+        return None;
+    }
+    let ver = pkt[0] >> 4;
+    if ver == 4 {
+        if pkt.len() < 28 {
+            return None;
+        }
+        let ihl = (pkt[0] & 0x0f) as usize * 4;
+        if ihl < 20 || pkt.len() < ihl + 8 || pkt[9] != 17 {
+            return None;
+        }
+        Some(UdpMeta {
+            src: IpAddr::V4(Ipv4Addr::new(pkt[12], pkt[13], pkt[14], pkt[15])),
+            sport: u16::from_be_bytes([pkt[ihl], pkt[ihl + 1]]),
+            dst: IpAddr::V4(Ipv4Addr::new(pkt[16], pkt[17], pkt[18], pkt[19])),
+            dport: u16::from_be_bytes([pkt[ihl + 2], pkt[ihl + 3]]),
+        })
+    } else if ver == 6 {
+        if pkt.len() < 40 + 8 {
+            return None;
+        }
+        if pkt[6] != 17 {
+            return None; // next header must be UDP (no extension-header walk)
+        }
+        let mut s = [0u8; 16];
+        let mut d = [0u8; 16];
+        s.copy_from_slice(&pkt[8..24]);
+        d.copy_from_slice(&pkt[24..40]);
+        Some(UdpMeta {
+            src: IpAddr::V6(Ipv6Addr::from(s)),
+            sport: u16::from_be_bytes([pkt[40], pkt[41]]),
+            dst: IpAddr::V6(Ipv6Addr::from(d)),
+            dport: u16::from_be_bytes([pkt[42], pkt[43]]),
+        })
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1612,6 +1847,7 @@ mod tests {
             bypass_endpoints: vec![],
             relay_ip: Ipv4Addr::LOCALHOST,
             relay_port: 0,
+            block_quic: false,
         }
     }
 
@@ -1794,11 +2030,14 @@ mod tests {
 
     #[test]
     fn network_filter_excludes_bypassed_destinations() {
-        let f = build_network_filter(&[
-            "127.0.0.0/8".into(),
-            "192.168.0.0/16".into(),
-            "::1/128".into(),
-        ]);
+        let f = build_network_filter(
+            &[
+                "127.0.0.0/8".into(),
+                "192.168.0.0/16".into(),
+                "::1/128".into(),
+            ],
+            false,
+        );
         assert!(f.starts_with("tcp and outbound"));
         assert!(f.contains("not (ip.DstAddr >= 127.0.0.0 and ip.DstAddr <= 127.255.255.255)"));
         assert!(f.contains("not (ip.DstAddr >= 192.168.0.0 and ip.DstAddr <= 192.168.255.255)"));
@@ -1807,10 +2046,45 @@ mod tests {
 
     #[test]
     fn network_filter_without_bypasses_is_the_base_filter() {
-        assert_eq!(build_network_filter(&[]), NETWORK_FILTER);
+        // block_quic off must be byte-identical to the pre-QUIC behaviour.
+        assert_eq!(build_network_filter(&[], false), NETWORK_FILTER);
         // Unparseable entries are skipped rather than producing broken syntax
         // that would make WinDivertOpen fail.
-        assert_eq!(build_network_filter(&["not-an-address".into()]), NETWORK_FILTER);
+        assert_eq!(
+            build_network_filter(&["not-an-address".into()], false),
+            NETWORK_FILTER
+        );
+    }
+
+    #[test]
+    fn network_filter_widens_to_udp_443_when_blocking_quic() {
+        let f = build_network_filter(&[], true);
+        assert_eq!(f, NETWORK_FILTER_WITH_QUIC);
+        assert!(f.contains("udp.DstPort == 443"));
+        // TCP is still captured alongside UDP 443.
+        assert!(f.contains("tcp"));
+        // CIDR exclusions still append (and apply to both families via DstAddr).
+        let g = build_network_filter(&["10.0.0.0/8".into()], true);
+        assert!(g.starts_with(NETWORK_FILTER_WITH_QUIC));
+        assert!(g.contains("not (ip.DstAddr >= 10.0.0.0 and ip.DstAddr <= 10.255.255.255)"));
+    }
+
+    #[test]
+    fn parses_udp_443_from_ipv4() {
+        let mut pkt = vec![0u8; 28];
+        pkt[0] = 0x45; // IPv4, ihl=5
+        pkt[9] = 17; // UDP
+        pkt[12..16].copy_from_slice(&[192, 168, 1, 10]);
+        pkt[16..20].copy_from_slice(&[93, 184, 216, 34]);
+        pkt[20..22].copy_from_slice(&54_000u16.to_be_bytes());
+        pkt[22..24].copy_from_slice(&443u16.to_be_bytes());
+
+        let meta = parse_ip_udp(&pkt).expect("valid IPv4 UDP packet");
+        assert_eq!(meta.sport, 54_000);
+        assert_eq!(meta.dport, 443);
+        assert_eq!(meta.dst, remote(34));
+        // A TCP parse of the same packet must fail (proto mismatch).
+        assert!(parse_ip_tcp(&pkt).is_none());
     }
 
     #[test]

--- a/src-tauri/src/bin/sockscap-helper/main.rs
+++ b/src-tauri/src/bin/sockscap-helper/main.rs
@@ -79,6 +79,8 @@ mod windows_main {
         relay_ip: Option<String>,
         #[serde(default, rename = "relayPort")]
         relay_port: Option<u16>,
+        #[serde(default, rename = "blockQuic")]
+        block_quic: Option<bool>,
         #[serde(default, rename = "srcIp")]
         src_ip: Option<String>,
         #[serde(default, rename = "srcPort")]
@@ -381,6 +383,7 @@ mod windows_main {
                         .parse()
                         .unwrap_or(std::net::Ipv4Addr::new(127, 0, 0, 1)),
                     relay_port: req.relay_port.unwrap_or(0),
+                    block_quic: req.block_quic.unwrap_or(false),
                 };
                 if plan.relay_port == 0 {
                     return Response {

--- a/src-tauri/src/bin/sockscap-helper/proc_info.rs
+++ b/src-tauri/src/bin/sockscap-helper/proc_info.rs
@@ -29,6 +29,14 @@ unsafe extern "system" {
         tableClass: u32,
         reserved: u32,
     ) -> u32;
+    fn GetExtendedUdpTable(
+        pUdpTable: *mut u8,
+        pdwSize: *mut DWORD,
+        bOrder: i32,
+        ulAf: u32,
+        tableClass: u32,
+        reserved: u32,
+    ) -> u32;
 }
 
 const AF_INET: u32 = 2;
@@ -36,6 +44,8 @@ const AF_INET6: u32 = 23;
 // TCP_TABLE_CLASS (iphlpapi.h)
 // 4 = OWNER_PID_CONNECTIONS, 5 = OWNER_PID_ALL (includes SYN_SENT etc.)
 const TCP_TABLE_OWNER_PID_ALL: u32 = 5;
+// UDP_TABLE_CLASS (iphlpapi.h): 1 = OWNER_PID.
+const UDP_TABLE_OWNER_PID: u32 = 1;
 const NO_ERROR: u32 = 0;
 const ERROR_INSUFFICIENT_BUFFER: u32 = 122;
 
@@ -326,6 +336,148 @@ pub fn port_owners_for_pids(
         return ports;
     }
     for row in list_tcp_owner_rows() {
+        if pids.contains(&row.pid) {
+            ports.insert(row.local_port, row.pid);
+        }
+    }
+    ports
+}
+
+// --- UDP owner-PID (QUIC blocking) --------------------------------------
+//
+// Mirrors the TCP owner path so UDP 443 (QUIC) can be attributed to a process
+// exactly as TCP connections are. Reuses `TcpOwnerRow` — the shape (local addr,
+// local port, pid) is identical; only the source table differs.
+
+fn read_udp_table(af: u32) -> Option<Vec<u8>> {
+    unsafe {
+        let mut size: DWORD = 0;
+        let r = GetExtendedUdpTable(
+            std::ptr::null_mut(),
+            &mut size,
+            1,
+            af,
+            UDP_TABLE_OWNER_PID,
+            0,
+        );
+        if r != ERROR_INSUFFICIENT_BUFFER || size == 0 {
+            return None;
+        }
+        let mut buf = vec![0u8; size as usize];
+        let r = GetExtendedUdpTable(
+            buf.as_mut_ptr(),
+            &mut size,
+            1,
+            af,
+            UDP_TABLE_OWNER_PID,
+            0,
+        );
+        if r != NO_ERROR || buf.len() < 4 {
+            return None;
+        }
+        Some(buf)
+    }
+}
+
+/// Enumerate all IPv4/IPv6 UDP endpoints with owning PID.
+///
+/// `MIB_UDPROW_OWNER_PID` (v4, 12B): localAddr[4] + localPort(dword, port in low
+/// 2 bytes network order) + pid. `MIB_UDP6ROW_OWNER_PID` (v6, 28B): localAddr[16]
+/// + scopeId + localPort + pid.
+pub fn list_udp_owner_rows() -> Vec<TcpOwnerRow> {
+    let mut out = Vec::new();
+    if let Some(buf) = read_udp_table(AF_INET) {
+        let n = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+        let row_size = 12usize;
+        for i in 0..n {
+            let off = 4 + i * row_size;
+            if off + row_size > buf.len() {
+                break;
+            }
+            let ip = Ipv4Addr::new(buf[off], buf[off + 1], buf[off + 2], buf[off + 3]);
+            let port = u16::from_be_bytes([buf[off + 4], buf[off + 5]]);
+            let pid = u32::from_le_bytes([buf[off + 8], buf[off + 9], buf[off + 10], buf[off + 11]]);
+            if pid != 0 && port != 0 {
+                out.push(TcpOwnerRow {
+                    local: IpAddr::V4(ip),
+                    local_port: port,
+                    pid,
+                });
+            }
+        }
+    }
+    if let Some(buf) = read_udp_table(AF_INET6) {
+        let n = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+        let row_size = 28usize;
+        for i in 0..n {
+            let off = 4 + i * row_size;
+            if off + row_size > buf.len() {
+                break;
+            }
+            let mut a = [0u8; 16];
+            a.copy_from_slice(&buf[off..off + 16]);
+            let ip = Ipv6Addr::from(a);
+            // localAddr[16] + scopeId[4] → port at off+20.
+            let port = u16::from_be_bytes([buf[off + 20], buf[off + 21]]);
+            let pid = u32::from_le_bytes([
+                buf[off + 24],
+                buf[off + 25],
+                buf[off + 26],
+                buf[off + 27],
+            ]);
+            if pid != 0 && port != 0 {
+                out.push(TcpOwnerRow {
+                    local: IpAddr::V6(ip),
+                    local_port: port,
+                    pid,
+                });
+            }
+        }
+    }
+    out
+}
+
+static UDP_TABLE_CACHE: Mutex<Option<(Instant, Arc<Vec<TcpOwnerRow>>)>> = Mutex::new(None);
+
+/// Shared UDP-table snapshot, re-read only when older than `max_age`. Same
+/// caching contract as `tcp_owner_rows_cached` — one enumeration serves a burst
+/// of new QUIC flows rather than one call per datagram.
+pub fn udp_owner_rows_cached(max_age: Duration) -> Arc<Vec<TcpOwnerRow>> {
+    let now = Instant::now();
+    if let Ok(guard) = UDP_TABLE_CACHE.lock() {
+        if let Some((at, rows)) = guard.as_ref() {
+            if now.duration_since(*at) <= max_age {
+                return Arc::clone(rows);
+            }
+        }
+    }
+    let rows = Arc::new(list_udp_owner_rows());
+    if let Ok(mut guard) = UDP_TABLE_CACHE.lock() {
+        *guard = Some((now, Arc::clone(&rows)));
+    }
+    rows
+}
+
+/// Owning PID of a local UDP endpoint. A UDP socket is bound before its first
+/// datagram, so the row exists by the time the packet reaches us; a miss forces
+/// one fresh read (at most once per new flow).
+pub fn udp_owner_pid(local: IpAddr, local_port: u16) -> Option<u32> {
+    if let Some(pid) = find_owner(&udp_owner_rows_cached(TCP_TABLE_CACHE_TTL), local, local_port) {
+        return Some(pid);
+    }
+    find_owner(&udp_owner_rows_cached(Duration::ZERO), local, local_port)
+}
+
+/// Local UDP ports owned by any of `pids`, mapped to their owner. App-mode
+/// index counterpart of `port_owners_for_pids`, for QUIC (UDP 443) attribution.
+pub fn udp_port_owners_for_pids(
+    pids: &std::collections::HashSet<u32>,
+) -> std::collections::HashMap<u16, u32> {
+    let mut ports = std::collections::HashMap::new();
+    if pids.is_empty() {
+        return ports;
+    }
+    for row in list_udp_owner_rows() {
         if pids.contains(&row.pid) {
             ports.insert(row.local_port, row.pid);
         }

--- a/src-tauri/src/sockscap/capture/linux/mod.rs
+++ b/src-tauri/src/sockscap/capture/linux/mod.rs
@@ -242,6 +242,7 @@ impl LinuxCapture for LinuxCaptureImpl {
                     &config.bypass_cidrs,
                     session.bypass_match(),
                     &[],
+                    config.block_quic,
                 ),
                 CaptureScope::Apps(_) => {
                     let routes = session
@@ -254,6 +255,7 @@ impl LinuxCapture for LinuxCaptureImpl {
                         redirect_ipv6,
                         &config.bypass_cidrs,
                         &routes,
+                        config.block_quic,
                     )
                 }
             }

--- a/src-tauri/src/sockscap/capture/linux/tunnel.rs
+++ b/src-tauri/src/sockscap/capture/linux/tunnel.rs
@@ -74,9 +74,14 @@ pub struct RedirectPlan {
     pub bypass_cgroup: Option<CgroupV2Match>,
     pub capture_cgroups: Vec<CgroupV2Match>,
     capture_relay_ports: Vec<u16>,
+    /// Drop in-scope outbound UDP 443 (QUIC) so it falls back to TCP, which the
+    /// redirect path attributes by SNI and proxies. Renders an extra filter-hook
+    /// chain in the same table. See claudedocs/sockscap-quic-block-design.md §12.2.
+    pub block_quic: bool,
 }
 
 impl RedirectPlan {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         mode: ScopeMode,
         relay_port: u16,
@@ -84,6 +89,7 @@ impl RedirectPlan {
         bypass_cidrs: &[String],
         bypass_cgroup: Option<CgroupV2Match>,
         capture_cgroups: &[CgroupV2Match],
+        block_quic: bool,
     ) -> Result<Self, String> {
         if relay_port == 0 {
             return Err("Linux relay port must be non-zero".into());
@@ -100,6 +106,7 @@ impl RedirectPlan {
             bypass_cgroup,
             capture_cgroups: capture_cgroups.to_vec(),
             capture_relay_ports: vec![relay_port; capture_cgroups.len()],
+            block_quic,
         };
         plan.validate()?;
         Ok(plan)
@@ -109,6 +116,7 @@ impl RedirectPlan {
         redirect_ipv6: bool,
         bypass_cidrs: &[String],
         routes: &[(CgroupV2Match, u16)],
+        block_quic: bool,
     ) -> Result<Self, String> {
         let relay_port = routes
             .first()
@@ -130,6 +138,7 @@ impl RedirectPlan {
             bypass_cgroup: None,
             capture_cgroups,
             capture_relay_ports,
+            block_quic,
         };
         plan.validate()?;
         Ok(plan)
@@ -187,8 +196,54 @@ impl RedirectPlan {
             }
         }
 
-        script.push_str("  }\n}\n");
+        // Close the nat output chain.
+        script.push_str("  }\n");
+
+        // QUIC blocking lives in a separate filter-hook chain in the same table:
+        // a nat-type chain cannot `drop`. Same table → atomic install/remove and
+        // one ownership marker. nat (dstnat) runs before filter, so an in-scope
+        // TCP packet is already redirected (dport = relay) and never matches the
+        // udp/443 rule; an in-scope UDP 443 datagram passes nat untouched and is
+        // dropped here, forcing QUIC→TCP fallback.
+        if self.block_quic {
+            self.render_quic_block_chain(&mut script);
+        }
+
+        script.push_str("}\n");
         script
+    }
+
+    /// Render the `quic_block` filter chain. Places the same loopback / bypass
+    /// CIDR (and, in global mode, bypass-cgroup) returns as the redirect chain
+    /// *before* the drop, so any egress already protected from the redirect loop
+    /// (Taomni + its child xray cores) is equally protected here — QUIC blocking
+    /// adds no new bypass surface. App mode drops only per capture cgroup, so
+    /// out-of-scope apps' QUIC is untouched.
+    fn render_quic_block_chain(&self, script: &mut String) {
+        script.push_str("  chain quic_block {\n");
+        script.push_str("    type filter hook output priority filter; policy accept;\n");
+        script.push_str("    ip daddr 127.0.0.0/8 return\n");
+        script.push_str("    ip6 daddr ::1/128 return\n");
+        for cidr in &self.bypass_cidrs {
+            script.push_str(&cidr.render_return_rule());
+        }
+        match self.mode {
+            ScopeMode::Global => {
+                if let Some(cgroup) = self.bypass_cgroup.as_ref() {
+                    script.push_str(&format!("    {} return\n", cgroup.nft_expression()));
+                }
+                script.push_str("    udp dport 443 drop\n");
+            }
+            ScopeMode::Apps => {
+                for cgroup in &self.capture_cgroups {
+                    script.push_str(&format!(
+                        "    {} udp dport 443 drop\n",
+                        cgroup.nft_expression()
+                    ));
+                }
+            }
+        }
+        script.push_str("  }\n");
     }
 
     fn render_redirect_rule(&self, script: &mut String, prefix: &str, relay_port: u16) {
@@ -384,6 +439,7 @@ mod tests {
             &["10.0.0.0/8".into(), "fd00::/8".into()],
             Some(bypass),
             &[],
+            false,
         )
         .unwrap();
         let script = plan.render_nft_script();
@@ -405,7 +461,8 @@ mod tests {
             CgroupV2Match::from_relative_path("taomni-sockscap-42/capture-11").unwrap(),
             CgroupV2Match::from_relative_path("taomni-sockscap-42/capture-22").unwrap(),
         ];
-        let plan = RedirectPlan::new(ScopeMode::Apps, 15000, true, &[], None, &captures).unwrap();
+        let plan =
+            RedirectPlan::new(ScopeMode::Apps, 15000, true, &[], None, &captures, false).unwrap();
         let script = plan.render_nft_script();
         assert!(script.contains(
             "socket cgroupv2 level 2 \"taomni-sockscap-42/capture-11\" meta l4proto tcp redirect to :15000"
@@ -429,7 +486,7 @@ mod tests {
                 16000,
             ),
         ];
-        let plan = RedirectPlan::new_app_routes(true, &[], &routes).unwrap();
+        let plan = RedirectPlan::new_app_routes(true, &[], &routes, false).unwrap();
         let script = plan.render_nft_script();
         assert!(script.contains(
             "socket cgroupv2 level 2 \"taomni-sockscap-42/capture-profile-0\" meta l4proto tcp redirect to :15000"
@@ -451,12 +508,75 @@ mod tests {
     fn avoids_ipv6_redirect_when_the_loopback_listener_is_unavailable() {
         let captures =
             [CgroupV2Match::from_relative_path("taomni-sockscap-42/capture-11").unwrap()];
-        let plan = RedirectPlan::new(ScopeMode::Apps, 15000, false, &[], None, &captures).unwrap();
+        let plan =
+            RedirectPlan::new(ScopeMode::Apps, 15000, false, &[], None, &captures, false).unwrap();
         assert!(
             plan.render_nft_script()
                 .contains(
                     "socket cgroupv2 level 2 \"taomni-sockscap-42/capture-11\" ip protocol tcp redirect to :15000"
                 )
         );
+    }
+
+    #[test]
+    fn no_quic_block_chain_when_block_quic_is_off() {
+        // Regression guard: block_quic=false must render exactly as before.
+        let bypass = CgroupV2Match::from_relative_path("taomni-sockscap-42/bypass").unwrap();
+        let plan =
+            RedirectPlan::new(ScopeMode::Global, 18443, true, &[], Some(bypass), &[], false)
+                .unwrap();
+        let script = plan.render_nft_script();
+        assert!(!script.contains("quic_block"));
+        assert!(!script.contains("udp dport 443"));
+    }
+
+    #[test]
+    fn global_quic_block_drops_after_bypass_returns() {
+        let bypass = CgroupV2Match::from_relative_path("taomni-sockscap-42/bypass").unwrap();
+        let plan = RedirectPlan::new(
+            ScopeMode::Global,
+            18443,
+            true,
+            &["10.0.0.0/8".into()],
+            Some(bypass),
+            &[],
+            true,
+        )
+        .unwrap();
+        let script = plan.render_nft_script();
+        assert!(script.contains("chain quic_block"));
+        assert!(script.contains("type filter hook output priority filter"));
+        assert!(script.contains("udp dport 443 drop"));
+        // The drop must come after the bypass-cgroup return, or the relay's own
+        // (and xray's) UDP egress would be dropped.
+        let bypass_return =
+            "socket cgroupv2 level 2 \"taomni-sockscap-42/bypass\" return";
+        let block_body = &script[script.find("chain quic_block").unwrap()..];
+        assert!(block_body.contains(bypass_return));
+        assert!(block_body.find(bypass_return).unwrap() < block_body.find("udp dport 443 drop").unwrap());
+        // Loopback + bypass CIDR returns are present in the block chain too.
+        assert!(block_body.contains("ip daddr 127.0.0.0/8 return"));
+        assert!(block_body.contains("ip daddr 10.0.0.0/8 return"));
+    }
+
+    #[test]
+    fn app_quic_block_drops_only_per_capture_cgroup() {
+        // Out-of-scope apps must keep QUIC: no bare `udp dport 443 drop`, only
+        // per-capture-cgroup drops.
+        let captures = [
+            CgroupV2Match::from_relative_path("taomni-sockscap-42/capture-profile-0").unwrap(),
+            CgroupV2Match::from_relative_path("taomni-sockscap-42/capture-profile-1").unwrap(),
+        ];
+        let plan =
+            RedirectPlan::new(ScopeMode::Apps, 15000, true, &[], None, &captures, true).unwrap();
+        let script = plan.render_nft_script();
+        assert!(script.contains(
+            "socket cgroupv2 level 2 \"taomni-sockscap-42/capture-profile-0\" udp dport 443 drop"
+        ));
+        assert!(script.contains(
+            "socket cgroupv2 level 2 \"taomni-sockscap-42/capture-profile-1\" udp dport 443 drop"
+        ));
+        // No unconditional drop that would hit out-of-scope apps.
+        assert!(!script.contains("\n    udp dport 443 drop\n"));
     }
 }

--- a/src-tauri/src/sockscap/capture/macos/mod.rs
+++ b/src-tauri/src/sockscap/capture/macos/mod.rs
@@ -89,6 +89,15 @@ pub async fn start(
     let sudo_pw = sudo_password.as_deref().map(|password| password.as_str());
     preflight(config, sudo_pw)?;
 
+    // TODO(sockscap-quic): honor config.block_quic on macOS to force QUIC→TCP
+    // fallback (see claudedocs/sockscap-quic-block-design.md §12.3). Windows and
+    // Linux drop in-scope outbound UDP 443; the system-proxy backend does not
+    // capture UDP at all, so QUIC leaks the real IP here. Blocking would need a
+    // `pf` anchor dropping UDP 443 for in-scope traffic (respecting the same
+    // bypass set as TCP capture: upstream endpoint, loopback, LAN CIDRs), or
+    // moving to the transparent NE backend. `block_quic` is session-level in
+    // SocksCapConfig; it is currently unused on macOS.
+
     let ingress = ingress::start_ingress(ctx, None).await?;
     let ingress_port = ingress.handle.port;
 

--- a/src-tauri/src/sockscap/capture/macos/system_proxy.rs
+++ b/src-tauri/src/sockscap/capture/macos/system_proxy.rs
@@ -51,6 +51,14 @@ impl SystemProxyScope {
     ///
     /// A partial failure is rolled back: leaving some services aimed at a port
     /// we are about to abandon would black-hole the user's network.
+    //
+    // TODO(sockscap-quic): setting the SOCKS proxy does not steer UDP, so QUIC
+    // (UDP 443) bypasses SocksCap entirely and leaks the real IP — the exact leak
+    // Windows/Linux fix by dropping in-scope UDP 443 (see
+    // claudedocs/sockscap-quic-block-design.md §12.3). When honoring
+    // config.block_quic on macOS, add a `pf` anchor here (installed/removed with
+    // this scope) dropping outbound UDP 443, respecting the same bypass set as
+    // TCP capture (upstream endpoint, loopback, LAN CIDRs).
     pub fn apply(port: u16, sudo_password: Option<&str>) -> Result<Self, String> {
         preflight(sudo_password)?;
         let services = list_network_services(sudo_password)?;

--- a/src-tauri/src/sockscap/capture/macos/transparent.rs
+++ b/src-tauri/src/sockscap/capture/macos/transparent.rs
@@ -84,6 +84,14 @@ pub async fn start(
 ) -> Result<MacosTransparentCaptureHandle, String> {
     let sudo_password = sudo_password.map(|password| Arc::new(Zeroizing::new(password)));
 
+    // TODO(sockscap-quic): honor config.block_quic on the macOS transparent NE
+    // backend (see claudedocs/sockscap-quic-block-design.md §12.3). The provider
+    // could see UDP 443 and drop it (forcing QUIC→TCP fallback), but the current
+    // ingress only handles TCP (reads a SOCKS5/HTTP CONNECT handshake); no UDP
+    // path exists. When implemented, the drop must cover the same in-scope set as
+    // TCP capture and pass bypassed flows. `block_quic` is session-level in
+    // SocksCapConfig and is currently unused on macOS.
+
     // 1) Loopback ingress the provider relays handled flows into.
     let ingress = ingress::start_ingress(ctx, None).await?;
     let ingress_port = ingress.handle.port;

--- a/src-tauri/src/sockscap/config.rs
+++ b/src-tauri/src/sockscap/config.rs
@@ -338,6 +338,15 @@ pub struct SocksCapConfig {
     pub bypass_cidrs: Vec<String>,
     #[serde(default)]
     pub restore_on_login: bool,
+    /// Drop outbound UDP 443 for in-scope flows so QUIC/HTTP3 falls back to TCP,
+    /// which the capture path can attribute (SNI) and proxy. Without this, QUIC
+    /// bypasses capture entirely (Windows filter is TCP-only, Linux redirect is
+    /// TCP-only) and leaks the real client IP — breaking geo-restricted sites
+    /// that the TCP path would have routed through the upstream. Session-level,
+    /// shared by all capture backends. Default on. See
+    /// claudedocs/sockscap-quic-block-design.md.
+    #[serde(default = "default_true")]
+    pub block_quic: bool,
 }
 
 fn default_bypass_cidrs() -> Vec<String> {
@@ -368,6 +377,7 @@ impl Default for SocksCapConfig {
             bypass_cidrs: default_bypass_cidrs(),
             default_action: Decision::Direct,
             restore_on_login: false,
+            block_quic: default_true(),
         };
         cfg.normalize();
         cfg
@@ -498,6 +508,29 @@ mod tests {
         assert!(!back.bypass_cidrs.is_empty());
         assert_eq!(back.profiles.len(), 1);
         assert_eq!(back.active_profile_ids, vec!["default"]);
+        assert!(back.block_quic, "block_quic defaults on");
+    }
+
+    #[test]
+    fn block_quic_defaults_on_for_configs_without_the_field() {
+        // Old configs predate block_quic; they must load with it enabled so the
+        // QUIC-leak fix applies on upgrade without a migration step.
+        let old_json = r#"{
+            "enabled": true,
+            "profiles": [{
+                "id": "p1", "name": "old",
+                "upstream": {"kind": "socks5", "host": "1.2.3.4", "port": 1080}
+            }],
+            "activeProfileIds": ["p1"],
+            "selectedProfileId": "p1"
+        }"#;
+        let mut cfg: SocksCapConfig = serde_json::from_str(old_json).unwrap();
+        cfg.normalize();
+        assert!(cfg.block_quic);
+        // And an explicit false is honored.
+        let off: SocksCapConfig =
+            serde_json::from_str(r#"{"enabled": true, "blockQuic": false}"#).unwrap();
+        assert!(!off.block_quic);
     }
 
     #[test]

--- a/src-tauri/src/sockscap/helper.rs
+++ b/src-tauri/src/sockscap/helper.rs
@@ -74,6 +74,8 @@ pub struct CaptureStartArgs {
     pub bypass_endpoints: Vec<(String, u16)>,
     pub relay_ip: String,
     pub relay_port: u16,
+    /// Drop in-scope outbound UDP 443 so QUIC falls back to TCP (see design doc).
+    pub block_quic: bool,
 }
 
 impl HelperRegistry {
@@ -638,6 +640,7 @@ pub fn capture_start(sess: &HelperSession, args: &CaptureStartArgs) -> Result<se
         "bypassEndpoints": endpoints,
         "relayIp": args.relay_ip,
         "relayPort": args.relay_port,
+        "blockQuic": args.block_quic,
     });
     expect_ok(send_json(sess, body)?)
 }

--- a/src-tauri/src/sockscap/mod.rs
+++ b/src-tauri/src/sockscap/mod.rs
@@ -1352,6 +1352,7 @@ async fn start_windows_capture(
         // Unused for streamdump reflection dest (kept for helper JSON compat).
         relay_ip: "0.0.0.0".into(),
         relay_port: relay_handle.port,
+        block_quic: cfg.block_quic,
     };
 
     if args.mode_apps && args.app_paths.is_empty() {

--- a/src/components/sockscap/SocksCapPanel.test.tsx
+++ b/src/components/sockscap/SocksCapPanel.test.tsx
@@ -41,6 +41,7 @@ const defaultTestCfg: SocksCapConfig = {
   bypassCidrs: ["127.0.0.0/8"],
   defaultAction: "direct",
   restoreOnLogin: false,
+  blockQuic: true,
 };
 
 let currentCfg = { ...defaultTestCfg };

--- a/src/components/sockscap/SocksCapPanel.tsx
+++ b/src/components/sockscap/SocksCapPanel.tsx
@@ -141,6 +141,7 @@ const DEFAULT_CFG: SocksCapConfig = {
   ],
   defaultAction: "direct",
   restoreOnLogin: false,
+  blockQuic: true,
 };
 
 type SessionOpt = { id: string; name: string; host: string; port: number; kind: "proxy" | "ssh"; groupPath?: string | null };
@@ -2404,6 +2405,32 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                 </button>
               </div>
             </div>
+
+            {/* Session-level QUIC blocking (forces QUIC→TCP so capture can proxy it). */}
+            <label
+              className="mt-3 flex items-start gap-2 text-[12px] cursor-pointer select-none"
+              title={locked ? t("sockscap.lockedTooltip") : undefined}
+            >
+              <input
+                type="checkbox"
+                data-testid="sockscap-block-quic"
+                checked={cfg.blockQuic ?? true}
+                disabled={locked || busy}
+                onChange={(e) => {
+                  if (!cfg) return;
+                  void persistConfig({ ...cfg, blockQuic: e.target.checked });
+                }}
+                className="mt-0.5 rounded border-[var(--taomni-divider)] text-[var(--taomni-accent)] focus:ring-0 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <span className="flex-1">
+                <span className="font-medium text-[var(--taomni-text)]">
+                  {t("sockscap.blockQuic")}
+                </span>
+                <span className="block text-[11px] text-[var(--taomni-text-muted)]">
+                  {t("sockscap.blockQuicHint")}
+                </span>
+              </span>
+            </label>
           </Section>
 
           {/* Captured Domains & Traffic Table */}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1298,6 +1298,9 @@ const dict = {
     gfwUrl: "GFWList URL",
     refreshGfw: "Refresh GFWList",
     importGfw: "Import file…",
+    blockQuic: "Block QUIC (force HTTP/3 → TCP)",
+    blockQuicHint:
+      "Drops captured apps' UDP 443 so QUIC falls back to TCP, which SocksCap can route through the upstream. Without it, QUIC bypasses capture and leaks your real IP (sites may report a disallowed region). Turning it off lets in-scope apps use QUIC directly.",
     importDesktopOnly: "Importing a local rules file requires the desktop app.",
     gfwRefreshed: "GFWList loaded ({count} rules)",
     gfwImported: "Imported rules ({count})",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -1291,6 +1291,9 @@ export const zhCN: DeepPartial<typeof en> = {
     gfwUrl: "GFWList URL",
     refreshGfw: "刷新 GFWList",
     importGfw: "导入文件…",
+    blockQuic: "拦截 QUIC（强制 HTTP/3 回退 TCP）",
+    blockQuicHint:
+      "丢弃被捕获应用的 UDP 443，使 QUIC 回退到 TCP，SocksCap 才能经上游代理转发。否则 QUIC 绕过捕获、泄漏真实 IP（网站可能提示地区不允许）。关闭后，范围内应用将直接使用 QUIC。",
     importDesktopOnly: "导入本地规则文件需要桌面版。",
     gfwRefreshed: "GFWList 已加载（{count} 条）",
     gfwImported: "已导入规则（{count} 条）",

--- a/src/lib/sockscap.ts
+++ b/src/lib/sockscap.ts
@@ -139,6 +139,10 @@ export interface SocksCapConfig {
   bypassCidrs: string[];
   defaultAction: Decision;
   restoreOnLogin: boolean;
+  /** Drop in-scope outbound UDP 443 so QUIC/HTTP3 falls back to TCP, which
+   *  capture can attribute (SNI) and route through the upstream. Without it QUIC
+   *  bypasses capture and leaks the real IP. Session-level; default on. */
+  blockQuic: boolean;
 }
 
 export interface SocksCapCapabilities {

--- a/src/lib/sockscapPreflight.test.ts
+++ b/src/lib/sockscapPreflight.test.ts
@@ -47,6 +47,7 @@ function mkCfg(profiles: SocksCapProfile[]): SocksCapConfig {
     bypassCidrs: [],
     defaultAction: "direct",
     restoreOnLogin: false,
+    blockQuic: true,
   };
 }
 

--- a/src/lib/sockscapRestart.test.ts
+++ b/src/lib/sockscapRestart.test.ts
@@ -46,6 +46,7 @@ function cfg(profiles: SocksCapProfile[], activeIds?: string[]): SocksCapConfig 
     bypassCidrs: [],
     defaultAction: "direct",
     restoreOnLogin: false,
+    blockQuic: true,
   };
 }
 

--- a/src/stubs/tauri-core.ts
+++ b/src/stubs/tauri-core.ts
@@ -2080,6 +2080,7 @@ export async function invoke<T>(cmd: string, args?: any, options?: InvokeOptions
           bypassCidrs: ["127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"],
           defaultAction: "direct",
           restoreOnLogin: false,
+          blockQuic: true,
         };
       }
       if (!Array.isArray(cfg.profiles) || cfg.profiles.length === 0) {


### PR DESCRIPTION
Fixes a real-IP leak: with global+gfwlist capture, sites like chatgpt.com loaded but reported a disallowed region, while pointing Chrome directly at the SOCKS proxy worked. Root cause is that QUIC/HTTP3 rides UDP 443, which capture never touched — the Windows WinDivert filter was "tcp and outbound" and the Linux nftables redirect is TCP-only — so QUIC bypassed the proxy and egressed from the real client IP, which the origin geo-blocks. Chrome's SOCKS-proxy path has no such leak because a configured proxy disables QUIC and resolves/dials everything remotely.

Approach: rather than proxy UDP (a large rework — the relay is a TCP stream bridge and no upstream UDP path exists), drop in-scope outbound UDP 443 so the app marks HTTP/3 broken and falls back to TCP, which capture already attributes by SNI and routes through the upstream. This mirrors netch and similar tools. Session-level toggle `block_quic`, default on.

Key invariant: the set of flows whose QUIC we drop == the set we capture (redirect) for TCP. Any flow that is bypassed for TCP (loopback, LAN CIDRs, the bundled xray core's own egress, out-of-scope apps) keeps its QUIC untouched. Failure direction is "leak" not "misfire": if attribution fails we pass rather than drop, so an unrelated app is never broken.

Config (shared by all backends)
- config.rs: SocksCapConfig.block_quic, #[serde(default = "default_true")] so pre-existing configs load with it enabled (no migration); Default = on.

Windows (WinDivert helper — full implementation, compiler-verified)
- proc_info.rs: GetExtendedUdpTable FFI + list_udp_owner_rows (v4/v6), udp_owner_rows_cached (separate cache), udp_owner_pid, udp_port_owners_for_pids — mirrors the TCP owner path.
- capture.rs: CapturePlan.block_quic; NETWORK_FILTER_WITH_QUIC + base_network_filter(); build_network_filter now takes block_quic and, when on, widens to "outbound and (tcp or (udp and udp.DstPort == 443))" while keeping the CIDR exclusions. AppIndex.udp_ports (populated only when block_quic). Separate udp_verdicts FlowTable (TCP/UDP could share a local port; must not clobber). network_loop UDP-443 arm in the parse_ip_tcp else branch: classify once, drop in-scope, pass otherwise, never reflect. udp_should_drop + classify_flow_udp (uses udp_owner_pid, NOT the TCP-only FLOW `flows` map) + parse_ip_udp/UdpMeta.
- main.rs / helper.rs / mod.rs: thread blockQuic app → helper end to end (Request field, CaptureStartArgs, capture_start JSON, cfg.block_quic).

Linux (nftables — full implementation, cfg(target_os="linux"))
- tunnel.rs: RedirectPlan.block_quic; render_quic_block_chain adds a second base chain (type filter hook output) in the same table — a nat-type chain cannot drop. Global: loopback/CIDR/bypass-cgroup returns then `udp dport 443 drop`. Apps: `<capture cgroup> udp dport 443 drop` per profile only, so out-of-scope apps keep QUIC. Same table = atomic install/remove, same ownership marker/Recover. Kernel cgroup match gives "in-scope only" for free; the relay never sees UDP.
- mod.rs: pass config.block_quic to RedirectPlan::new / new_app_routes.

macOS (deferred — code TODOs only, no behavior change)
- TODO(sockscap-quic) markers in capture/macos/{mod,transparent,system_proxy}.rs noting block_quic is unused there and how to wire it (pf anchor for the system-proxy backend; UDP path for the transparent NE), per design §12.3.

Frontend
- lib/sockscap.ts: SocksCapConfig.blockQuic. SocksCapPanel: DEFAULT on + session-level toggle in the GFWList section with a side-effect hint. en/zh-CN strings. Dev stub + three test fixtures updated.

Known limitation (inherited from TCP, not introduced here): on Linux global mode the bundled xray child is not yet excluded from the taomni cgroup (mod.rs follow-up), so an upstream that transports over UDP 443 (e.g. WireGuard via xray) could have its node traffic dropped — the same unresolved case as the TCP redirect loop. Most upstreams reach the node over TCP and are unaffected. capture-but-direct destinations lose QUIC and use TCP (functionally correct, a perf downgrade); exempting them would need per-dest knowledge at UDP time (QUIC SNI parsing), out of scope here.

Design: claudedocs/sockscap-quic-block-design.md

Tests: cargo test --bin sockscap-helper (26 passed, incl. filter-widen + UDP-443 parse + base-filter regression); cargo test --lib sockscap::config (7 passed, incl. block_quic default); tsc --noEmit (0 errors); vitest sockscap suites (37 passed). Linux render tests added (no-chain-when-off, global-drop-after-bypass, app-per-cgroup) run on Linux/CI.