### PR TITLE
fix(appearance): keep dialogs usable at larger UI fonts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import { attachSftpSync } from "./lib/sftpSync";
 import { sweepExpiredHandoffs } from "./components/filebrowser/SftpDetachedWindow";
 import { dispatchNativeFileDrop, isOsFileDrag } from "./lib/osFileDrop";
 import { isTauriRuntime, getAppPlatform } from "./lib/runtime";
-import { useAppStore } from "./stores/appStore";
+import { subscribeUiAppearanceStorage, useAppStore } from "./stores/appStore";
 import { AppDialogProvider } from "./lib/appDialogs";
 import { VaultGateProvider } from "./lib/vaultGate";
 import { StartupVaultUnlockGate } from "./components/vault/StartupVaultUnlockGate";
@@ -39,6 +39,8 @@ function App() {
     root.style.setProperty("--taomni-ui-font-family", uiFontFamily);
     root.style.setProperty("--taomni-ui-font-size", `${uiFontSize}px`);
   }, [uiFontFamily, uiFontSize]);
+
+  useEffect(() => subscribeUiAppearanceStorage(), []);
 
   useEffect(() => {
     applyCodeViewProfile(loadCodeViewProfile(), DEFAULT_TERMINAL_PROFILE, {

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -43,7 +43,7 @@ export function AboutDialog({ onClose }: AboutDialogProps) {
         aria-label={t("about.title")}
         aria-modal="true"
         data-testid="about-dialog"
-        className="w-[380px] rounded shadow-lg p-5"
+        className="w-[380px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] overflow-y-auto rounded shadow-lg p-5"
         style={{ background: "var(--taomni-bg)", border: "1px solid var(--taomni-card-border)" }}
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/components/UpdateDialog.tsx
+++ b/src/components/UpdateDialog.tsx
@@ -132,7 +132,7 @@ export function UpdateDialog() {
         aria-label={title}
         aria-modal={nonModal ? undefined : "true"}
         data-testid="update-dialog"
-        className={`w-[440px] rounded shadow-lg p-5${nonModal ? " pointer-events-auto" : ""}`}
+        className={`w-[440px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] overflow-y-auto rounded shadow-lg p-5${nonModal ? " pointer-events-auto" : ""}`}
         style={{
           background: "var(--taomni-bg)",
           border: "1px solid var(--taomni-card-border)",

--- a/src/components/database/HBaseShellTab.tsx
+++ b/src/components/database/HBaseShellTab.tsx
@@ -312,7 +312,7 @@ function CommandsMenu({
     <>
       <div className="fixed inset-0 z-40" onClick={onClose} />
       <div
-        className="absolute left-2 top-9 z-50 w-[360px] max-h-[420px] overflow-auto taomni-scroll-y rounded shadow-lg py-1 text-[12px]"
+        className="absolute left-2 top-9 z-50 w-[360px] max-w-[calc(100vw-24px)] max-h-[min(420px,calc(100vh-48px))] overflow-auto taomni-scroll-y rounded shadow-lg py-1 text-[12px]"
         style={{ background: "var(--taomni-panel-bg)", border: "1px solid var(--taomni-divider)", color: "var(--taomni-text)" }}
       >
         {CATEGORY_ORDER.map((cat) => {
@@ -353,7 +353,7 @@ function HistoryDropdown({ history, onPick, onClose }: { history: string[]; onPi
   return (
     <>
       <div className="fixed inset-0 z-40" onClick={onClose} />
-      <div className="absolute right-2 top-9 z-50 w-[420px] max-h-[300px] overflow-auto rounded shadow-lg taomni-scroll-y flex flex-col" style={{ background: "var(--taomni-panel-bg)", border: "1px solid var(--taomni-divider)" }}>
+      <div className="absolute right-2 top-9 z-50 w-[420px] max-w-[calc(100vw-24px)] max-h-[min(300px,calc(100vh-48px))] overflow-auto rounded shadow-lg taomni-scroll-y flex flex-col" style={{ background: "var(--taomni-panel-bg)", border: "1px solid var(--taomni-divider)" }}>
         {history.length === 0 ? (
           <div className="px-3 py-2 text-[11px] text-[var(--taomni-text-muted)]">No command history yet.</div>
         ) : (
@@ -377,7 +377,7 @@ function HelpDialog({ transport, onClose }: { transport: HBaseTransport; onClose
         aria-label={t("hbaseObjects.helpTitle")}
         aria-modal="true"
         data-testid="hbase-help-dialog"
-        className="w-[640px] max-h-[80vh] overflow-auto taomni-scroll-y rounded shadow-lg p-4"
+        className="w-[640px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] overflow-auto taomni-scroll-y rounded shadow-lg p-4"
         style={{ background: "var(--taomni-bg)", border: "1px solid var(--taomni-card-border)" }}
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/components/database/RedisNewKeyDialog.tsx
+++ b/src/components/database/RedisNewKeyDialog.tsx
@@ -57,16 +57,16 @@ export function RedisNewKeyDialog({ sessionId, onClose, onCreated }: RedisNewKey
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: "rgba(20,30,45,0.4)" }}>
       <div
-        className="w-[440px] rounded-[6px] shadow-2xl border overflow-hidden"
+        className="w-[440px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] flex flex-col rounded-[6px] shadow-2xl border overflow-hidden"
         style={{ background: "var(--taomni-panel-bg)", borderColor: "var(--taomni-chrome-border)", color: "var(--taomni-text)" }}
       >
-        <div className="h-7 flex items-center px-2 text-[12px] font-semibold" style={{ background: "linear-gradient(to bottom,#5895c8,#2b5d8b)", color: "#fff" }}>
+        <div className="h-7 flex shrink-0 items-center px-2 text-[12px] font-semibold" style={{ background: "linear-gradient(to bottom,#5895c8,#2b5d8b)", color: "#fff" }}>
           New Redis key
           <button type="button" className="ml-auto hover:bg-red-500 rounded p-0.5" onClick={onClose}>
             <X className="w-3.5 h-3.5" />
           </button>
         </div>
-        <div className="p-3 grid grid-cols-4 gap-2 items-center text-[12px]">
+        <div className="min-h-0 overflow-y-auto p-3 grid grid-cols-4 gap-2 items-center text-[12px]">
           <label className="text-right">Key</label>
           <input className="taomni-input col-span-3" value={key} onChange={(e) => setKey(e.target.value)} aria-label="Key name" autoFocus />
 
@@ -100,7 +100,7 @@ export function RedisNewKeyDialog({ sessionId, onClose, onCreated }: RedisNewKey
 
           {error && <div className="col-span-4 text-[11px]" style={{ color: "#d9534f" }}>{error}</div>}
         </div>
-        <div className="flex items-center justify-end gap-2 px-3 py-2" style={{ borderTop: "1px solid var(--taomni-divider)", background: "var(--taomni-quick-bg)" }}>
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 px-3 py-2" style={{ borderTop: "1px solid var(--taomni-divider)", background: "var(--taomni-quick-bg)" }}>
           <button type="button" className="taomni-btn" onClick={onClose}>Cancel</button>
           <button type="button" className="taomni-btn" data-primary="true" disabled={saving} onClick={() => void submit()}>
             {saving ? "Creating…" : "Create"}

--- a/src/components/filebrowser/ChmodDialog.tsx
+++ b/src/components/filebrowser/ChmodDialog.tsx
@@ -121,7 +121,7 @@ export function ChmodDialog({ entries, onCancel, onApply }: ChmodDialogProps) {
       <div
         role="dialog"
         aria-label={t("fileBrowser.chmodHeading")}
-        className="w-[420px] rounded shadow-lg p-4"
+        className="w-[420px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] overflow-y-auto rounded shadow-lg p-4"
         style={{ background: "var(--taomni-bg)", border: "1px solid var(--taomni-card-border)" }}
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/components/lanchat/GroupCreateDialog.tsx
+++ b/src/components/lanchat/GroupCreateDialog.tsx
@@ -45,7 +45,7 @@ export function GroupCreateDialog({ onClose }: { onClose: () => void }) {
   return (
     <div className="fixed inset-0 z-[120] grid place-items-center" style={{ background: "rgba(0,0,0,.35)" }} onClick={onClose}>
       <div
-        className="flex max-h-[80vh] w-[360px] flex-col overflow-hidden rounded-xl"
+        className="flex max-h-[calc(100vh-24px)] w-[360px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-xl"
         style={{ background: "var(--taomni-panel-bg)", border: "1px solid var(--taomni-chrome-border)", boxShadow: "var(--taomni-shadow-lg)" }}
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/components/lanchat/LanChatGate.tsx
+++ b/src/components/lanchat/LanChatGate.tsx
@@ -98,7 +98,7 @@ function EnablePrompt({
     >
       <div
         data-testid="lanchat-enable-prompt"
-        className="w-[400px] overflow-hidden rounded-xl"
+        className="w-[400px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] overflow-x-hidden overflow-y-auto rounded-xl"
         style={{
           background: "var(--taomni-panel-bg)",
           border: "1px solid var(--taomni-chrome-border)",

--- a/src/components/lanchat/PrivacySettings.tsx
+++ b/src/components/lanchat/PrivacySettings.tsx
@@ -71,7 +71,7 @@ export function PrivacySettings({ onClose }: { onClose: () => void }) {
       onClick={onClose}
     >
       <div
-        className="w-[400px] overflow-hidden rounded-xl"
+        className="w-[400px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] overflow-x-hidden overflow-y-auto rounded-xl"
         style={{ background: "var(--taomni-panel-bg)", border: "1px solid var(--taomni-chrome-border)", boxShadow: "var(--taomni-shadow-lg)" }}
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/components/lanchat/ProfileEditor.tsx
+++ b/src/components/lanchat/ProfileEditor.tsx
@@ -61,7 +61,7 @@ export function ProfileEditor({ onClose }: { onClose: () => void }) {
       onClick={onClose}
     >
       <div
-        className="w-[360px] overflow-hidden rounded-xl"
+        className="w-[360px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] overflow-x-hidden overflow-y-auto rounded-xl"
         style={{ background: "var(--taomni-panel-bg)", border: "1px solid var(--taomni-chrome-border)", boxShadow: "var(--taomni-shadow-lg)" }}
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/components/lanchat/TransferPanel.tsx
+++ b/src/components/lanchat/TransferPanel.tsx
@@ -364,7 +364,7 @@ export function TransferTrayButton({
           <div className="fixed inset-0 z-[150]" onClick={() => setOpen(false)} />
           <div
             data-testid="lanchat-transfer-tray-popover"
-            className={`absolute right-0 z-[151] ${popoverPosition} w-[330px] rounded-lg p-2 text-[12px]`}
+            className={`absolute right-0 z-[151] ${popoverPosition} w-[330px] max-w-[calc(100vw-24px)] rounded-lg p-2 text-[12px]`}
             style={{
               background: "var(--taomni-card-bg)",
               border: "1px solid var(--taomni-card-border)",

--- a/src/components/session/AuthPrompt.tsx
+++ b/src/components/session/AuthPrompt.tsx
@@ -36,10 +36,10 @@ export function AuthPrompt({ host, username, onSubmit, onCancel }: AuthPromptPro
       <form
         data-testid="auth-prompt"
         onSubmit={handleSubmit}
-        className="w-[400px] rounded-md shadow-2xl border overflow-hidden"
+        className="w-[400px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] flex flex-col rounded-md shadow-2xl border overflow-hidden"
         style={{ background: "var(--taomni-panel-bg)", borderColor: "var(--taomni-chrome-border)", color: "var(--taomni-text)" }}
       >
-        <div className="h-8 flex items-center px-3"
+        <div className="h-8 flex shrink-0 items-center px-3"
              style={{ background: "linear-gradient(to bottom, #5895c8, #2b5d8b)", color: "white" }}>
           <KeyRound className="w-3.5 h-3.5 mr-1.5" />
           <span className="text-[12px] font-semibold">{t("authPrompt.titleRequired")}</span>
@@ -49,7 +49,7 @@ export function AuthPrompt({ host, username, onSubmit, onCancel }: AuthPromptPro
           </button>
         </div>
 
-        <div className="p-4">
+        <div className="min-h-0 overflow-y-auto p-4">
           <div className="text-[12px] mb-3 text-[var(--taomni-text-muted)]">
             {t("authPrompt.subtitle", { user: username, host })}
           </div>
@@ -84,7 +84,7 @@ export function AuthPrompt({ host, username, onSubmit, onCancel }: AuthPromptPro
           </label>
         </div>
 
-        <div className="h-12 flex items-center justify-end px-3 gap-2 border-t"
+        <div className="min-h-12 flex shrink-0 flex-wrap items-center justify-end gap-2 border-t px-3 py-2"
              style={{ background: "var(--taomni-quick-bg)", borderColor: "var(--taomni-divider)" }}>
           <button data-testid="auth-cancel" type="button" onClick={onCancel}
                   className="taomni-btn">

--- a/src/components/session/ExternalVaultUnlockDialog.tsx
+++ b/src/components/session/ExternalVaultUnlockDialog.tsx
@@ -87,7 +87,7 @@ export function ExternalVaultUnlockDialog({
         aria-label={t("externalVault.ariaLabel", { tool: toolName })}
         aria-modal="true"
         data-testid="external-vault-unlock-dialog"
-        className="w-[460px] rounded shadow-lg p-4"
+        className="w-[460px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] overflow-y-auto rounded shadow-lg p-4"
         style={{
           background: "var(--taomni-bg)",
           border: "1px solid var(--taomni-card-border)",

--- a/src/components/session/MfaPrompt.tsx
+++ b/src/components/session/MfaPrompt.tsx
@@ -42,7 +42,7 @@ export function MfaPrompt({ host, username, request, onSubmit, onCancel }: MfaPr
       <form
         data-testid="mfa-prompt"
         onSubmit={handleSubmit}
-        className="w-[420px] rounded-md shadow-2xl border overflow-hidden"
+        className="w-[420px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] flex flex-col rounded-md shadow-2xl border overflow-hidden"
         style={{
           background: "var(--taomni-panel-bg)",
           borderColor: "var(--taomni-chrome-border)",
@@ -50,7 +50,7 @@ export function MfaPrompt({ host, username, request, onSubmit, onCancel }: MfaPr
         }}
       >
         <div
-          className="h-8 flex items-center px-3"
+          className="h-8 flex shrink-0 items-center px-3"
           style={{ background: "linear-gradient(to bottom, #5895c8, #2b5d8b)", color: "white" }}
         >
           <ShieldCheck className="w-3.5 h-3.5 mr-1.5" />
@@ -69,7 +69,7 @@ export function MfaPrompt({ host, username, request, onSubmit, onCancel }: MfaPr
           </button>
         </div>
 
-        <div className="p-4">
+        <div className="min-h-0 overflow-y-auto p-4">
           <div className="text-[12px] mb-2 text-[var(--taomni-text-muted)]">
             {t("mfaPrompt.subtitle", { user: username, host })}
           </div>
@@ -103,7 +103,7 @@ export function MfaPrompt({ host, username, request, onSubmit, onCancel }: MfaPr
         </div>
 
         <div
-          className="h-12 flex items-center justify-end px-3 gap-2 border-t"
+          className="min-h-12 flex shrink-0 flex-wrap items-center justify-end gap-2 border-t px-3 py-2"
           style={{ background: "var(--taomni-quick-bg)", borderColor: "var(--taomni-divider)" }}
         >
           <button data-testid="mfa-cancel" type="button" onClick={onCancel} className="taomni-btn">

--- a/src/components/session/SessionEditor.test.tsx
+++ b/src/components/session/SessionEditor.test.tsx
@@ -148,6 +148,25 @@ describe("SessionEditor SSH settings tabs", { timeout: 15_000 }, () => {
     cleanup();
   });
 
+  it("keeps primary actions reachable when UI text grows", () => {
+    renderEditor();
+
+    const editor = screen.getByTestId("session-editor");
+    expect(editor).toHaveClass("max-w-[calc(100vw-24px)]", "max-h-[calc(100vh-24px)]");
+
+    const protocolPicker = screen.getByTestId("session-proto-ssh").parentElement?.parentElement;
+    expect(protocolPicker).toHaveClass("overflow-y-auto");
+
+    const save = screen.getByTestId("session-save");
+    const primaryActions = save.parentElement;
+    expect(primaryActions).toHaveClass("shrink-0");
+
+    const footer = primaryActions?.parentElement;
+    expect(footer).toHaveClass("flex-wrap");
+    expect(footer?.firstElementChild).toHaveClass("min-w-0", "flex-wrap");
+    expect(screen.getByTitle(/Will be saved to/)).toHaveClass("min-w-0", "truncate");
+  });
+
   it("switches between all SSH settings sections", async () => {
     const user = userEvent.setup();
     renderEditor();

--- a/src/components/session/SessionEditor.tsx
+++ b/src/components/session/SessionEditor.tsx
@@ -4056,7 +4056,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
       <div
         ref={containerRef}
         data-testid="session-editor"
-        className="w-[1020px] max-w-[96%] max-h-[92vh] flex flex-col rounded-[6px] shadow-2xl border overflow-hidden"
+        className="w-[1020px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] flex flex-col rounded-[6px] shadow-2xl border overflow-hidden"
         style={{ background: "var(--taomni-panel-bg)", borderColor: "var(--taomni-chrome-border)", color: "var(--taomni-text)" }}
       >
         {/* Modal title bar */}
@@ -4094,7 +4094,7 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
 
         {/* Protocol picker */}
         <div
-          className="px-3 pt-3 pb-2 border-b shrink-0"
+          className="max-h-[min(210px,32vh)] overflow-y-auto overscroll-contain px-3 pt-3 pb-2 border-b shrink-0 taomni-scroll-y"
           style={{ borderColor: "var(--taomni-divider)" }}
         >
           <div className="flex flex-wrap gap-1">
@@ -4671,115 +4671,120 @@ export function SessionEditor({ session, defaultGroupPath = null, initialProto, 
 
         {/* Footer */}
         <div
-          className="h-12 flex items-center px-3 gap-2 border-t shrink-0"
+          className="min-h-12 flex flex-wrap items-center gap-2 px-3 py-2 border-t shrink-0"
           style={{ background: "var(--taomni-quick-bg)", borderColor: "var(--taomni-divider)" }}
         >
-          {isSSH && needsHost && (
-            <button
-              className="taomni-btn flex items-center gap-1.5"
-              onClick={handleTestConnection}
-              disabled={testing}
-              type="button"
-              aria-label={testing ? t("sessionEditor2.testing") : t("sessionEditor2.testConnection")}
-            >
-              <FlaskConical className="w-3.5 h-3.5" />
-              {testing ? t("sessionEditor2.testing") : t("sessionEditor2.testConnection")}{shortcuts.test}
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+            {isSSH && needsHost && (
+              <button
+                className="taomni-btn shrink-0 flex items-center gap-1.5"
+                onClick={handleTestConnection}
+                disabled={testing}
+                type="button"
+                aria-label={testing ? t("sessionEditor2.testing") : t("sessionEditor2.testConnection")}
+              >
+                <FlaskConical className="w-3.5 h-3.5" />
+                {testing ? t("sessionEditor2.testing") : t("sessionEditor2.testConnection")}{shortcuts.test}
+              </button>
+            )}
+            {isDb && (
+              <button
+                className="taomni-btn shrink-0 flex items-center gap-1.5"
+                data-testid="db-test-connection"
+                onClick={() => void handleTestDbConnection()}
+                disabled={testing}
+                type="button"
+                aria-label={testing ? t("sessionEditor2.testing") : t("sessionEditor2.testConnection")}
+              >
+                <FlaskConical className="w-3.5 h-3.5" />
+                {testing ? t("sessionEditor2.testing") : t("sessionEditor2.testConnection")}{shortcuts.test}
+              </button>
+            )}
+            {isHBase && (
+              <button
+                className="taomni-btn shrink-0 flex items-center gap-1.5"
+                data-testid="hbase-test-connection"
+                onClick={() => void handleTestHBaseConnection()}
+                disabled={testing}
+                type="button"
+                aria-label={testing ? t("sessionEditor2.testing") : t("sessionEditor2.testConnection")}
+              >
+                <FlaskConical className="w-3.5 h-3.5" />
+                {testing ? t("sessionEditor2.testing") : t("sessionEditor2.testConnection")}{shortcuts.test}
+              </button>
+            )}
+            {isProxy && (
+              <button
+                className="taomni-btn shrink-0 flex items-center gap-1.5"
+                data-testid="proxy-test-connection"
+                onClick={() => void handleTestProxyConnection()}
+                disabled={testing}
+                type="button"
+                aria-label={testing ? t("sessionEditor2.proxyTestTesting") : t("sessionEditor2.proxyTestBtn")}
+              >
+                <FlaskConical className="w-3.5 h-3.5" />
+                {testing ? t("sessionEditor2.proxyTestTesting") : t("sessionEditor2.proxyTestBtn")}{shortcuts.test}
+              </button>
+            )}
+            <button className="taomni-btn shrink-0 flex items-center gap-1.5" type="button" onClick={() => void handleSaveTemplate()}>
+              <Save className="w-3.5 h-3.5" /> {t("sessionEditor2.saveTemplate")}
             </button>
-          )}
-          {isDb && (
-            <button
-              className="taomni-btn flex items-center gap-1.5"
-              data-testid="db-test-connection"
-              onClick={() => void handleTestDbConnection()}
-              disabled={testing}
-              type="button"
-              aria-label={testing ? t("sessionEditor2.testing") : t("sessionEditor2.testConnection")}
-            >
-              <FlaskConical className="w-3.5 h-3.5" />
-              {testing ? t("sessionEditor2.testing") : t("sessionEditor2.testConnection")}{shortcuts.test}
+            <button className="taomni-btn shrink-0 flex items-center gap-1.5" type="button" onClick={handleReset}>
+              <RotateCcw className="w-3.5 h-3.5" /> {t("sessionEditor2.reset")}
             </button>
-          )}
-          {isHBase && (
-            <button
-              className="taomni-btn flex items-center gap-1.5"
-              data-testid="hbase-test-connection"
-              onClick={() => void handleTestHBaseConnection()}
-              disabled={testing}
-              type="button"
-              aria-label={testing ? t("sessionEditor2.testing") : t("sessionEditor2.testConnection")}
-            >
-              <FlaskConical className="w-3.5 h-3.5" />
-              {testing ? t("sessionEditor2.testing") : t("sessionEditor2.testConnection")}{shortcuts.test}
-            </button>
-          )}
-          {isProxy && (
-            <button
-              className="taomni-btn flex items-center gap-1.5"
-              data-testid="proxy-test-connection"
-              onClick={() => void handleTestProxyConnection()}
-              disabled={testing}
-              type="button"
-              aria-label={testing ? t("sessionEditor2.proxyTestTesting") : t("sessionEditor2.proxyTestBtn")}
-            >
-              <FlaskConical className="w-3.5 h-3.5" />
-              {testing ? t("sessionEditor2.proxyTestTesting") : t("sessionEditor2.proxyTestBtn")}{shortcuts.test}
-            </button>
-          )}
-          <button className="taomni-btn flex items-center gap-1.5" type="button" onClick={() => void handleSaveTemplate()}>
-            <Save className="w-3.5 h-3.5" /> {t("sessionEditor2.saveTemplate")}
-          </button>
-          <button className="taomni-btn flex items-center gap-1.5" type="button" onClick={handleReset}>
-            <RotateCcw className="w-3.5 h-3.5" /> {t("sessionEditor2.reset")}
-          </button>
-          
-          {(testResult || saveError) && (
+
+            {(testResult || saveError) && (
+              <span
+                className="text-[11px] min-w-0 max-w-[280px] truncate"
+                title={saveError ?? testResult?.msg}
+                style={{ color: testResult?.ok && !saveError ? "#2f8a3e" : "#b22222" }}
+                data-testid="session-test-result-summary"
+              >
+                {saveError ?? testResult?.msg}
+              </span>
+            )}
+
             <span
-              className="text-[11px] min-w-0 max-w-[280px] truncate"
-              title={saveError ?? testResult?.msg}
-              style={{ color: testResult?.ok && !saveError ? "#2f8a3e" : "#b22222" }}
-              data-testid="session-test-result-summary"
+              className="min-w-0 basis-40 flex-1 truncate text-[11px] text-[var(--taomni-text-muted)]"
+              title={`${t("sessionEditor2.willBeSavedTo")} ${groupPath ? folderOptionLabel(groupPath) : SESSION_ROOT_LABEL} / ${name || host || "..."}`}
             >
-              {saveError ?? testResult?.msg}
+              {t("sessionEditor2.willBeSavedTo")}{" "}
+              <span className="taomni-mono">
+                {groupPath ? folderOptionLabel(groupPath) : SESSION_ROOT_LABEL} / {name || host || "..."}
+              </span>
             </span>
-          )}
+          </div>
 
-          <span className="ml-2 text-[11px] text-[var(--taomni-text-muted)]">
-            {t("sessionEditor2.willBeSavedTo")}{" "}
-            <span className="taomni-mono">
-              {groupPath ? folderOptionLabel(groupPath) : SESSION_ROOT_LABEL} / {name || host || "..."}
-            </span>
-          </span>
-
-          <div className="flex-1" />
-
-          {isEdit && (
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            {isEdit && (
+              <button
+                className="taomni-btn"
+                onClick={handleDelete}
+                type="button"
+                style={{ color: "#b22222" }}
+              >
+                {t("sessionEditor2.delete")}
+              </button>
+            )}
             <button
               className="taomni-btn"
-              onClick={handleDelete}
+              onClick={onClose}
               type="button"
-              style={{ color: "#b22222" }}
+              aria-label={t("sessionEditor2.cancel")}
             >
-              {t("sessionEditor2.delete")}
+              {t("sessionEditor2.cancel")}{shortcuts.cancel}
             </button>
-          )}
-          <button
-            className="taomni-btn"
-            onClick={onClose}
-            type="button"
-            aria-label={t("sessionEditor2.cancel")}
-          >
-            {t("sessionEditor2.cancel")}{shortcuts.cancel}
-          </button>
-          <button
-            className="taomni-btn"
-            data-testid="session-save"
-            data-primary="true"
-            onClick={handleSave}
-            type="button"
-            aria-label={t("sessionEditor2.ok")}
-          >
-            {t("sessionEditor2.ok")}{shortcuts.save}
-          </button>
+            <button
+              className="taomni-btn"
+              data-testid="session-save"
+              data-primary="true"
+              onClick={handleSave}
+              type="button"
+              aria-label={t("sessionEditor2.ok")}
+            >
+              {t("sessionEditor2.ok")}{shortcuts.save}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/sidebar/FolderNameDialog.tsx
+++ b/src/components/sidebar/FolderNameDialog.tsx
@@ -68,7 +68,7 @@ export function FolderNameDialog({
         aria-label={resolvedTitle}
         aria-modal="true"
         data-testid="folder-name-dialog"
-        className="w-[420px] rounded shadow-lg p-4"
+        className="w-[420px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] overflow-y-auto rounded shadow-lg p-4"
         style={{ background: "var(--taomni-bg)", border: "1px solid var(--taomni-card-border)" }}
         onClick={(event) => event.stopPropagation()}
       >

--- a/src/components/sockscap/SocksCapRootPrompt.tsx
+++ b/src/components/sockscap/SocksCapRootPrompt.tsx
@@ -41,7 +41,7 @@ export function SocksCapRootPrompt({
       <form
         data-testid="sockscap-root-prompt-dialog"
         onSubmit={handleSubmit}
-        className="w-[420px] rounded-md shadow-2xl border overflow-hidden"
+        className="w-[420px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] flex flex-col rounded-md shadow-2xl border overflow-hidden"
         style={{
           background: "var(--taomni-panel-bg)",
           borderColor: "var(--taomni-chrome-border)",
@@ -49,7 +49,7 @@ export function SocksCapRootPrompt({
         }}
       >
         <div
-          className="h-8 flex items-center px-3"
+          className="h-8 flex shrink-0 items-center px-3"
           style={{
             background: "linear-gradient(to bottom, #5895c8, #2b5d8b)",
             color: "white",
@@ -71,7 +71,7 @@ export function SocksCapRootPrompt({
           </button>
         </div>
 
-        <div className="p-4">
+        <div className="min-h-0 overflow-y-auto p-4">
           <div className="text-[12px] mb-3 text-[var(--taomni-text-muted)]">
             {subtitle ?? t("sockscap.rootPromptSubtitle")}
           </div>
@@ -103,7 +103,7 @@ export function SocksCapRootPrompt({
         </div>
 
         <div
-          className="h-12 flex items-center justify-end px-3 gap-2 border-t"
+          className="min-h-12 flex shrink-0 flex-wrap items-center justify-end gap-2 border-t px-3 py-2"
           style={{
             background: "var(--taomni-quick-bg)",
             borderColor: "var(--taomni-divider)",

--- a/src/components/terminal/ZmodemConflictDialog.tsx
+++ b/src/components/terminal/ZmodemConflictDialog.tsx
@@ -39,7 +39,7 @@ export function ZmodemConflictDialog({ fileName, hasMore, mode, onResolve }: Zmo
         aria-label={title}
         aria-modal="true"
         data-testid="zmodem-conflict"
-        className="w-[400px] rounded shadow-lg p-4"
+        className="w-[400px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] overflow-y-auto rounded shadow-lg p-4"
         style={{ background: "var(--taomni-bg)", border: "1px solid var(--taomni-card-border)" }}
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/components/vault/VaultEntriesDialog.tsx
+++ b/src/components/vault/VaultEntriesDialog.tsx
@@ -62,7 +62,7 @@ export function VaultEntriesDialog({ onClose }: VaultEntriesDialogProps) {
     >
       <div
         ref={containerRef}
-        className="w-[640px] h-[500px] max-w-[96%] max-h-[92vh] flex flex-col rounded-[6px] shadow-2xl border overflow-hidden"
+        className="w-[640px] h-[500px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] flex flex-col rounded-[6px] shadow-2xl border overflow-hidden"
         style={{
           background: "var(--taomni-panel-bg)",
           borderColor: "var(--taomni-chrome-border)",

--- a/src/components/vault/VaultSetupDialog.tsx
+++ b/src/components/vault/VaultSetupDialog.tsx
@@ -60,7 +60,7 @@ export function VaultSetupDialog({ onCancel, onSubmit }: VaultSetupDialogProps) 
         aria-label={t("vault.setupTitleSet")}
         aria-modal="true"
         data-testid="vault-setup-dialog"
-        className="w-[440px] rounded shadow-lg p-4"
+        className="w-[440px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] overflow-y-auto rounded shadow-lg p-4"
         style={{ background: "var(--taomni-bg)", border: "1px solid var(--taomni-card-border)" }}
         onClick={(event) => event.stopPropagation()}
       >

--- a/src/components/vault/VaultUnlockDialog.tsx
+++ b/src/components/vault/VaultUnlockDialog.tsx
@@ -124,7 +124,7 @@ export function VaultUnlockDialog({
         aria-modal="true"
         tabIndex={-1}
         data-testid="vault-unlock-dialog"
-        className="w-[420px] rounded shadow-lg p-4"
+        className="w-[420px] max-w-[calc(100vw-24px)] max-h-[calc(100vh-24px)] overflow-y-auto rounded shadow-lg p-4"
         style={{ background: "var(--taomni-bg)", border: "1px solid var(--taomni-card-border)" }}
         onClick={(event) => event.stopPropagation()}
       >

--- a/src/index.css
+++ b/src/index.css
@@ -511,7 +511,9 @@ body.notes-detached-document,
  *   password fields — that can hide ::-ms-reveal.
  */
 .taomni-input {
-  height: 22px;
+  height: auto;
+  min-height: max(22px, calc(1em + 6px));
+  line-height: 1.25;
   font-size: var(--taomni-ui-font-size);
   border: 1px solid var(--taomni-input-border);
   background: var(--taomni-input-bg);
@@ -977,7 +979,9 @@ select.taomni-input:not(.appearance-none):not([multiple]) {
     align-items: center;
     justify-content: center;
     white-space: nowrap;
-    height: 26px;
+    height: auto;
+    min-height: max(26px, calc(1em + 8px));
+    line-height: 1.25;
     padding: 0 14px;
     font-size: var(--taomni-ui-font-size);
     background: linear-gradient(to bottom, var(--taomni-button-from), var(--taomni-button-to));

--- a/src/stores/appStore.test.ts
+++ b/src/stores/appStore.test.ts
@@ -3,6 +3,7 @@ import {
   VAULT_UNLOCK_MODE_KEY,
   computeNewTerminalTitle,
   recentWorkspaceIdFromParts,
+  subscribeUiAppearanceStorage,
   updateDuplicateAutoTitle,
   useAppStore,
   type CodeWorkspaceContext,
@@ -528,6 +529,34 @@ describe("appStore.uiAppearance", () => {
     useAppStore.getState().setUiFontSize(3);
     expect(useAppStore.getState().uiFontSize).toBe(10);
     expect(window.localStorage.getItem("taomni.uiFontSize")).toBe("10");
+  });
+
+  it("synchronizes UI appearance changes from another window", () => {
+    const unsubscribe = subscribeUiAppearanceStorage();
+    try {
+      window.localStorage.setItem("taomni.uiFontFamily", '"Segoe UI", sans-serif');
+      window.dispatchEvent(new StorageEvent("storage", {
+        key: "taomni.uiFontFamily",
+        newValue: '"Segoe UI", sans-serif',
+      }));
+      expect(useAppStore.getState().uiFontFamily).toBe('"Segoe UI", sans-serif');
+
+      window.localStorage.setItem("taomni.uiFontSize", "17");
+      window.dispatchEvent(new StorageEvent("storage", {
+        key: "taomni.uiFontSize",
+        newValue: "17",
+      }));
+      expect(useAppStore.getState().uiFontSize).toBe(17);
+
+      window.localStorage.removeItem("taomni.uiFontSize");
+      window.dispatchEvent(new StorageEvent("storage", {
+        key: "taomni.uiFontSize",
+        newValue: null,
+      }));
+      expect(useAppStore.getState().uiFontSize).toBe(12);
+    } finally {
+      unsubscribe();
+    }
   });
 
   it("allows setting and persisting the welcome recent session limit", () => {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1548,3 +1548,29 @@ export const useAppStore = create<AppState>((set) => ({
       return { sqlEcho: enabled };
     }),
 }));
+
+export function syncUiAppearanceFromStorage(event: Pick<StorageEvent, "key" | "newValue">): void {
+  if (event.key === null || event.key === UI_FONT_FAMILY_KEY) {
+    const uiFontFamily = event.key === UI_FONT_FAMILY_KEY && event.newValue
+      ? event.newValue
+      : readUiFontFamily();
+    useAppStore.setState({ uiFontFamily });
+  }
+
+  if (event.key === null || event.key === UI_FONT_SIZE_KEY) {
+    const parsed = event.key === UI_FONT_SIZE_KEY && event.newValue !== null
+      ? Number.parseInt(event.newValue, 10)
+      : readUiFontSize();
+    const uiFontSize = Number.isFinite(parsed)
+      ? clampUiFontSize(parsed)
+      : readUiFontSize();
+    useAppStore.setState({ uiFontSize });
+  }
+}
+
+export function subscribeUiAppearanceStorage(): () => void {
+  if (typeof window === "undefined") return () => undefined;
+  const handleStorage = (event: StorageEvent) => syncUiAppearanceFromStorage(event);
+  window.addEventListener("storage", handleStorage);
+  return () => window.removeEventListener("storage", handleStorage);
+}


### PR DESCRIPTION
Resolve #458 by making shared input and button heights responsive to the configured UI font size while preserving the existing root font scaling behavior.

Constrain Session Editor to the viewport, make the protocol chooser scroll independently, and allow the footer actions to wrap so Delete, Cancel, and OK remain reachable at larger appearance settings.

Apply the same viewport and overflow safeguards to authentication, vault, database, file browser, LAN chat, update, about, and other modal surfaces.

Synchronize UI font family and size changes across detached windows through storage events, including reset handling and size clamping.

Add regression coverage for Session Editor layout constraints and cross-window appearance synchronization.