### PR TITLE
feat: add cross-process module locks

### DIFF
--- a/src-tauri/src/lanchat/commands.rs
+++ b/src-tauri/src/lanchat/commands.rs
@@ -614,8 +614,8 @@ pub async fn lanchat_get_service_state(
 
 /// Start the background service on demand (manual enable from the chat UI).
 /// Idempotent and one-way: once started it runs until the app exits. The work
-/// is spawned so the command returns immediately rather than blocking on the
-/// discovery loop; the `lanchat://service` event reports when it is live.
+/// The service's long-running loops are spawned internally; lock or bind
+/// failures are returned to the caller and also published via the service event.
 #[tauri::command]
 pub async fn lanchat_start_service(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
     if state
@@ -625,11 +625,7 @@ pub async fn lanchat_start_service(app: AppHandle, state: State<'_, AppState>) -
     {
         return Ok(());
     }
-    ensure_ready(&state).await?;
-    tauri::async_runtime::spawn(async move {
-        crate::lanchat::start_service(app).await;
-    });
-    Ok(())
+    crate::lanchat::start_service(app).await
 }
 
 /// Set the "start LanChat on app launch" policy. Does not start/stop the

--- a/src-tauri/src/lanchat/mod.rs
+++ b/src-tauri/src/lanchat/mod.rs
@@ -39,6 +39,7 @@ use tokio::sync::Mutex as AsyncMutex;
 use tokio::sync::RwLock;
 use zeroize::Zeroizing;
 
+use crate::module_lock::ModuleLock;
 use protocol::PeerRecord;
 
 const MSG_KEY_VAULT_ID: &str = "lanchat.message-key-v1";
@@ -98,6 +99,9 @@ pub struct LanChatState {
     /// cleared while the app runs (there is no runtime "stop"). Guards against
     /// double-start when both boot-autostart and a manual enable race.
     pub running: AtomicBool,
+    /// Cross-process ownership of the stable LanChat node identity, discovery
+    /// advertisements, listeners, and SQLite-backed message service.
+    _service_lock: StdMutex<Option<ModuleLock>>,
     /// Peers discovered via mDNS, keyed by node id.
     pub peers: RwLock<HashMap<String, PeerRecord>>,
     /// Live control-channel connections, keyed by remote node id.
@@ -137,6 +141,7 @@ impl LanChatState {
             init_lock: AsyncMutex::new(()),
             node_id: RwLock::new(node_id),
             running: AtomicBool::new(false),
+            _service_lock: StdMutex::new(None),
             peers: RwLock::new(HashMap::new()),
             connections: RwLock::new(HashMap::new()),
             daemon: StdMutex::new(None),
@@ -253,29 +258,58 @@ impl LanChatState {
 /// Launch the LanChat background service (idempotent, one-way).
 ///
 /// Reserves the TCP control port, starts the transport accept loop over that
-/// listener, then runs mDNS discovery. Discovery + transport run concurrently
+/// listener, then starts mDNS discovery. Discovery + transport run concurrently
 /// for the lifetime of the app — there is no runtime "stop"; the only way to
 /// go dark is to not start (see the `start_on_launch` policy) or quit the app.
 ///
 /// Safe to call more than once: the first call latches `running` and proceeds;
 /// later calls return immediately. This lets boot-autostart and a manual
 /// `lanchat_start_service` from the UI race without double-binding the port.
-pub async fn start_service(app: AppHandle) {
+pub async fn start_service(app: AppHandle) -> Result<(), String> {
     use std::sync::atomic::Ordering;
     use tauri::{Emitter, Manager};
 
     let app_state = app.state::<crate::state::AppState>();
     let lanchat = app_state.lanchat.clone();
     let vault = app_state.vault.clone();
-    if let Err(e) = lanchat.ensure_unlocked(&vault).await {
-        log::warn!("lanchat: service start skipped; vault is not ready ({e})");
-        let _ = app.emit(events::SERVICE, serde_json::json!({ "running": false }));
-        return;
-    }
+    let app_data_dir = lanchat
+        .db_path
+        .parent()
+        .ok_or_else(|| "resolve LanChat app data directory".to_string())?;
 
     // One-way latch: if already started, do nothing.
     if lanchat.running.swap(true, Ordering::SeqCst) {
-        return;
+        return Ok(());
+    }
+
+    let process_lock = match ModuleLock::try_acquire(
+        app_data_dir,
+        "lanchat",
+        "service",
+        "LanChat service",
+    ) {
+        Ok(lock) => lock,
+        Err(error) => {
+            lanchat.running.store(false, Ordering::SeqCst);
+            let _ = app.emit(
+                events::SERVICE,
+                serde_json::json!({ "running": false, "error": error.clone() }),
+            );
+            return Err(error);
+        }
+    };
+
+    // Initialize the stable identity only while this process owns the service.
+    // This avoids two fresh instances racing to generate different node keys.
+    if let Err(e) = lanchat.ensure_unlocked(&vault).await {
+        log::warn!("lanchat: service start skipped; vault is not ready ({e})");
+        let error = format!("LanChat vault is not ready: {e}");
+        lanchat.running.store(false, Ordering::SeqCst);
+        let _ = app.emit(
+            events::SERVICE,
+            serde_json::json!({ "running": false, "error": error.clone() }),
+        );
+        return Err(error);
     }
 
     // Reserve an ephemeral control port now so the mDNS TXT can advertise it;
@@ -285,6 +319,10 @@ pub async fn start_service(app: AppHandle) {
             let port = listener.local_addr().map(|a| a.port()).unwrap_or(0);
             lanchat.control_port.store(port, Ordering::SeqCst);
             *lanchat.control_listener.lock().await = Some(listener);
+            *lanchat
+                ._service_lock
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(process_lock);
             log::info!("lanchat: reserved control port {}", port);
 
             // Announce the service is now live to every window.
@@ -343,13 +381,21 @@ pub async fn start_service(app: AppHandle) {
             });
 
             // mDNS discovery (runs for the app lifetime).
-            discovery::run(app, lanchat, port).await;
+            tokio::spawn(async move {
+                discovery::run(app, lanchat, port).await;
+            });
+            Ok(())
         }
         Err(e) => {
-            log::error!("lanchat: failed to reserve control port: {e}");
+            let error = format!("LanChat failed to reserve control port: {e}");
+            log::error!("lanchat: {error}");
             // Roll back the latch so a later manual enable can retry.
             lanchat.running.store(false, Ordering::SeqCst);
-            let _ = app.emit(events::SERVICE, serde_json::json!({ "running": false }));
+            let _ = app.emit(
+                events::SERVICE,
+                serde_json::json!({ "running": false, "error": error.clone() }),
+            );
+            Err(error)
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ pub mod llm;
 mod mail;
 mod migrate;
 pub mod models;
+mod module_lock;
 mod nettools;
 mod notes;
 mod objectstorage;
@@ -224,7 +225,9 @@ pub fn run() {
                     .get_start_on_launch()
                     .unwrap_or(false);
                 if start_on_launch {
-                    lanchat::start_service(app_for_lanchat).await;
+                    if let Err(error) = lanchat::start_service(app_for_lanchat).await {
+                        log::warn!("lanchat: autostart skipped: {error}");
+                    }
                 } else {
                     log::info!("lanchat: start_on_launch disabled; service idle until enabled");
                 }

--- a/src-tauri/src/module_lock.rs
+++ b/src-tauri/src/module_lock.rs
@@ -1,0 +1,153 @@
+//! Cross-process ownership locks for runtime modules that cannot safely run in
+//! two Taomni processes at once.
+//!
+//! Lock files are stable and never deleted: ownership is the OS lock held on
+//! the open file handle, not the file's existence. Dropping [`ModuleLock`]
+//! releases ownership automatically, including when the process exits.
+
+use std::fs::{File, OpenOptions, TryLockError};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Manager};
+
+const LOCK_DIR: &str = "module-locks";
+
+#[derive(Debug)]
+pub struct ModuleLock {
+    file: File,
+    #[cfg_attr(not(test), allow(dead_code))]
+    path: PathBuf,
+}
+
+impl ModuleLock {
+    pub fn try_acquire_for_app(
+        app: &AppHandle,
+        scope: &str,
+        resource: &str,
+        label: &str,
+    ) -> Result<Self, String> {
+        let app_data = app
+            .path()
+            .app_data_dir()
+            .map_err(|error| format!("resolve app data directory for {label}: {error}"))?;
+        Self::try_acquire(&app_data, scope, resource, label)
+    }
+
+    pub fn try_acquire(
+        app_data_dir: &Path,
+        scope: &str,
+        resource: &str,
+        label: &str,
+    ) -> Result<Self, String> {
+        let lock_dir = app_data_dir.join(LOCK_DIR);
+        std::fs::create_dir_all(&lock_dir)
+            .map_err(|error| format!("create module lock directory: {error}"))?;
+        let path = lock_path(&lock_dir, scope, resource);
+        let mut file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)
+            .map_err(|error| format!("open {label} lock: {error}"))?;
+
+        match file.try_lock() {
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => {
+                let owner = read_owner(&mut file);
+                let owner = if owner.is_empty() {
+                    "another Taomni process".to_string()
+                } else {
+                    owner
+                };
+                return Err(format!("{label} is already active in {owner}"));
+            }
+            Err(TryLockError::Error(error)) => {
+                return Err(format!("acquire {label} lock: {error}"));
+            }
+        }
+
+        if let Err(error) = write_owner(&mut file, label) {
+            let _ = file.unlock();
+            return Err(format!("write {label} lock owner: {error}"));
+        }
+        Ok(Self { file, path })
+    }
+
+    #[cfg(test)]
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ModuleLock {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
+
+fn lock_path(lock_dir: &Path, scope: &str, resource: &str) -> PathBuf {
+    let digest = Sha256::digest(format!("{scope}\0{resource}").as_bytes());
+    let readable_scope: String = scope
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .take(32)
+        .collect();
+    lock_dir.join(format!(
+        "{readable_scope}-{}.lock",
+        &hex::encode(digest)[..24]
+    ))
+}
+
+fn read_owner(file: &mut File) -> String {
+    let _ = file.seek(SeekFrom::Start(0));
+    let mut owner = String::new();
+    if file.read_to_string(&mut owner).is_err() {
+        return String::new();
+    }
+    owner.lines().next().unwrap_or_default().trim().to_string()
+}
+
+fn write_owner(file: &mut File, label: &str) -> std::io::Result<()> {
+    let safe_label = label.replace(['\r', '\n'], " ");
+    file.set_len(0)?;
+    file.seek(SeekFrom::Start(0))?;
+    writeln!(file, "Taomni pid {} ({safe_label})", std::process::id())?;
+    file.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_resource_is_exclusive_until_guard_drops() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = ModuleLock::try_acquire(dir.path(), "sockscap", "global", "SocksCap")
+            .expect("first lock");
+        let error = ModuleLock::try_acquire(dir.path(), "sockscap", "global", "SocksCap")
+            .expect_err("second lock must be rejected");
+        assert!(error.contains("already active"));
+
+        let path = first.path().to_path_buf();
+        drop(first);
+        let reacquired =
+            ModuleLock::try_acquire(dir.path(), "sockscap", "global", "SocksCap").unwrap();
+        assert_eq!(reacquired.path(), path);
+    }
+
+    #[test]
+    fn different_resources_do_not_contend() {
+        let dir = tempfile::tempdir().unwrap();
+        let _first = ModuleLock::try_acquire(dir.path(), "tunnel", "one", "Tunnel one").unwrap();
+        let _second = ModuleLock::try_acquire(dir.path(), "tunnel", "two", "Tunnel two").unwrap();
+    }
+}

--- a/src-tauri/src/servers/mod.rs
+++ b/src-tauri/src/servers/mod.rs
@@ -33,6 +33,7 @@ use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+use crate::module_lock::ModuleLock;
 use crate::state::AppState;
 use engine::{set_status, ServerCtx};
 
@@ -206,6 +207,7 @@ pub struct ActiveServer {
     pub task: JoinHandle<()>,
     pub auto_stop_task: Option<JoinHandle<()>>,
     pub status: ServerStatus,
+    _process_lock: ModuleLock,
 }
 
 #[derive(Default)]
@@ -305,6 +307,14 @@ pub async fn start_local_server(
 
     let config: ServerConfig = serde_json::from_value(config)
         .map_err(|e| format!("invalid config for {}: {}", server_type, e))?;
+    // There is one persisted configuration per server type. Keep that type
+    // exclusive across Taomni processes; different server types may coexist.
+    let process_lock = ModuleLock::try_acquire_for_app(
+        &app,
+        "local-server",
+        st.as_str(),
+        &format!("{} server", st.as_str()),
+    )?;
 
     // Publish Starting.
     let starting = ServerStatus {
@@ -367,6 +377,7 @@ pub async fn start_local_server(
                 task: started.task,
                 auto_stop_task,
                 status: running_status.clone(),
+                _process_lock: process_lock,
             },
         );
     }

--- a/src-tauri/src/sockscap/mod.rs
+++ b/src-tauri/src/sockscap/mod.rs
@@ -42,6 +42,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager, State};
 use tokio::sync::RwLock;
 
+use crate::module_lock::ModuleLock;
 use crate::state::AppState;
 
 /* ---------------------------- runtime handle ---------------------------- */
@@ -54,6 +55,9 @@ pub struct SocksCapRuntime {
     /// terminate. Handed to the next helper launch, which runs under UAC and
     /// can finish the job. See [`boot_repair`].
     pub pending_reap: std::sync::Mutex<Vec<u32>>,
+    /// Cross-process ownership of the OS capture stack. SocksCap changes
+    /// machine-wide proxy/divert state, so only one Taomni process may own it.
+    activation_lock: std::sync::Mutex<Option<ModuleLock>>,
     /// xray-core sidecar pool for core-backed upstreams. Initialized during
     /// `setup()` once the `AppHandle` (resource dir / app data dir) is available
     /// via [`init_xray_manager`]; `None` until then.
@@ -66,6 +70,7 @@ impl SocksCapRuntime {
             orch: Arc::new(RwLock::new(Orchestrator::new())),
             helper: Arc::new(helper::HelperRegistry::new()),
             pending_reap: std::sync::Mutex::new(Vec::new()),
+            activation_lock: std::sync::Mutex::new(None),
             xray: std::sync::OnceLock::new(),
         }
     }
@@ -73,6 +78,27 @@ impl SocksCapRuntime {
     /// The xray manager, if it has been initialized.
     pub fn xray(&self) -> Option<&Arc<core::XrayManager>> {
         self.xray.get()
+    }
+
+    fn has_activation_lock(&self) -> bool {
+        self.activation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_some()
+    }
+
+    fn install_activation_lock(&self, lock: ModuleLock) {
+        *self
+            .activation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(lock);
+    }
+
+    fn release_activation_lock(&self) {
+        self.activation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
     }
 }
 
@@ -383,9 +409,10 @@ pub async fn sockscap_start(
     let cfg = SocksCapConfig::load(&cfg_path);
     cfg.validate()?;
 
-    let dir = rules_dir(&app)?;
+    // Check the local runtime before attempting to lock again: re-locking the
+    // same file from one process has platform-specific semantics.
     {
-        let mut orch = state.sockscap.orch.write().await;
+        let orch = state.sockscap.orch.read().await;
         if matches!(
             orch.status().phase,
             orchestrator::EnginePhase::RecoveryRequired
@@ -395,6 +422,18 @@ pub async fn sockscap_start(
         if orch.is_running() {
             return Err("sockscap already running".into());
         }
+    }
+
+    let activation_lock = ModuleLock::try_acquire_for_app(
+        &app,
+        "sockscap",
+        "global",
+        "SocksCap",
+    )?;
+
+    let dir = rules_dir(&app)?;
+    {
+        let mut orch = state.sockscap.orch.write().await;
         orch.apply_config(cfg.clone());
         orch.set_preparing("starting");
     }
@@ -519,8 +558,16 @@ pub async fn sockscap_start(
                 .write()
                 .await
                 .set_start_failed(message.clone());
+        } else {
+            // Teardown could not prove the machine-wide state is clean. Keep
+            // ownership until Recover succeeds or this process exits.
+            state.sockscap.install_activation_lock(activation_lock);
         }
         return Err(message);
+    }
+
+    if status.is_ok() {
+        state.sockscap.install_activation_lock(activation_lock);
     }
 
     // Start the xray health monitor once capture is up, so a core that crashes
@@ -1477,7 +1524,12 @@ pub async fn sockscap_stop(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<SocksCapStatus, String> {
+    if !state.sockscap.has_activation_lock() {
+        let orch = state.sockscap.orch.read().await;
+        return Ok(orch.status());
+    }
     full_teardown(&app, &state, true).await?;
+    state.sockscap.release_activation_lock();
     let orch = state.sockscap.orch.read().await;
     Ok(orch.status())
 }
@@ -1505,18 +1557,35 @@ pub async fn sockscap_prepare_for_update(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
+    if !state.sockscap.has_activation_lock() {
+        let lock = ModuleLock::try_acquire_for_app(
+            &app,
+            "sockscap",
+            "global",
+            "SocksCap update preparation",
+        )?;
+        state.sockscap.install_activation_lock(lock);
+    }
+
     // 1) Stop capture: closes WinDivert NETWORK/FLOW handles → driver unloads →
     //    `WinDivert64.sys` becomes writable. Also stops relay + xray sidecars.
     //    A teardown error here is not fatal to the update — the helper shutdown
     //    below and the installer's own preinstall hook are the further backstops.
-    if let Err(e) = full_teardown(&app, &state, true).await {
-        tracing::warn!("sockscap: prepare-for-update teardown incomplete: {e}");
-    }
+    let teardown_ok = match full_teardown(&app, &state, true).await {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!("sockscap: prepare-for-update teardown incomplete: {e}");
+            false
+        }
+    };
 
     // 2) Ask the elevated helper to exit, freeing `sockscap-helper.exe` and
     //    `WinDivert.dll`. Reuses the same shutdown path as the Stop button.
     if let Err(e) = helper::sockscap_helper_stop(state.clone()).await {
         tracing::warn!("sockscap: prepare-for-update helper stop failed: {e}");
+    }
+    if teardown_ok {
+        state.sockscap.release_activation_lock();
     }
 
     // 3) The driver unload is asynchronous, so poll until the files the installer
@@ -1594,6 +1663,16 @@ fn is_file_locked(path: &std::path::Path) -> bool {
 
 #[tauri::command]
 pub async fn sockscap_recover(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
+    if !state.sockscap.has_activation_lock() {
+        let lock = ModuleLock::try_acquire_for_app(
+            &app,
+            "sockscap",
+            "global",
+            "SocksCap recovery",
+        )?;
+        state.sockscap.install_activation_lock(lock);
+    }
+
     // Even if stopping the active session was incomplete, recovery gets one
     // more independent chance to remove the platform-owned state.
     let teardown_error = full_teardown(&app, &state, false).await.err();
@@ -1615,6 +1694,7 @@ pub async fn sockscap_recover(app: AppHandle, state: State<'_, AppState>) -> Res
                     needs_elevation.len()
                 );
             }
+            state.sockscap.release_activation_lock();
             Ok(())
         }
         Err(recovery_error) => {
@@ -2334,6 +2414,21 @@ fn read_ready_files(dir: &std::path::Path) -> Vec<StaleReadyFile> {
 /// they are elevated and this process is not — are queued for the next helper
 /// launch, which runs under UAC. Nothing else in the system can do it.
 pub async fn boot_repair(app: &AppHandle, state: &AppState) {
+    // Another live instance may own the dirty journal. Never repair global
+    // network state underneath its active capture session.
+    let _repair_lock = match ModuleLock::try_acquire_for_app(
+        app,
+        "sockscap",
+        "global",
+        "SocksCap recovery",
+    ) {
+        Ok(lock) => lock,
+        Err(error) => {
+            tracing::info!("sockscap: boot repair skipped: {error}");
+            return;
+        }
+    };
+
     let Ok(dir) = data_dir(app) else {
         return;
     };

--- a/src-tauri/src/tunnel/mod.rs
+++ b/src-tauri/src/tunnel/mod.rs
@@ -23,6 +23,7 @@ use tokio::net::TcpListener;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::JoinHandle;
 
+use crate::module_lock::ModuleLock;
 use crate::state::AppState;
 use crate::terminal::ssh::{connect_ssh_authenticated, SshAuth, SshHandler};
 
@@ -729,6 +730,12 @@ pub async fn start_tunnel(
         .cloned();
     resolve_tunnel_creds(&mut config, &state.vault, session_pwd)?;
 
+    // The same persisted tunnel may autostart in several Taomni processes.
+    // Own it by tunnel id for the task lifetime; a different tunnel id can run
+    // concurrently, with the OS listener still enforcing endpoint uniqueness.
+    let process_lock =
+        ModuleLock::try_acquire_for_app(&app, "tunnel", &id, &format!("Tunnel {id}"))?;
+
     let starting = TunnelStatusInfo {
         id: id.clone(),
         status: TunnelStatus::Starting,
@@ -745,6 +752,7 @@ pub async fn start_tunnel(
     let bridges: Arc<AsyncMutex<Vec<JoinHandle<()>>>> = Arc::new(AsyncMutex::new(Vec::new()));
     let bridges_for_task = bridges.clone();
     let task = tokio::spawn(async move {
+        let _process_lock = process_lock;
         let result = match kind {
             TunnelKind::Local => {
                 run_local_forward(


### PR DESCRIPTION
Keep Taomni itself multi-instance while rejecting unsafe duplicate activation of resources shared by all processes.

Add a reusable app-data OS file lock with stable resource keys, owner metadata, RAII release, and tests for exclusion, reacquisition, and independent resources. Apply a global lock to SocksCap lifecycle and recovery, including boot-repair protection; serialize the LanChat background identity and discovery service; lock tunnels by tunnel ID; and lock local servers by server type.

Validation: cargo check --lib passed; module_lock unit tests passed 2/2; full cargo test --lib completed with 1023 passed, 3 pre-existing failures, and 11 ignored.