### PR TITLE
fix(codespace): support Maven JVM options for Java run

### DIFF
--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -2,6 +2,7 @@ use crate::state::AppState;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -74,6 +75,18 @@ pub struct WorkspaceTaskExecution {
     pub error: Option<String>,
 }
 
+/// A task-scoped environment value. The terminal renderer applies it only to
+/// the launched task, rather than mutating the user's interactive shell.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceTaskEnvironmentVariable {
+    pub value: String,
+    /// `append` preserves an existing value (used for MAVEN_OPTS).
+    pub mode: String,
+}
+
+type WorkspaceTaskEnvironment = BTreeMap<String, WorkspaceTaskEnvironmentVariable>;
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceTask {
@@ -86,6 +99,8 @@ pub struct WorkspaceTask {
     pub module_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub execution: Option<WorkspaceTaskExecution>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment: Option<WorkspaceTaskEnvironment>,
 }
 
 /// A runnable Java `public static void main` entry point discovered from source.
@@ -106,6 +121,8 @@ pub struct JavaRunTarget {
     /// Workspace-relative build/module directory (`.` for the root project).
     pub module_path: String,
     pub execution: WorkspaceTaskExecution,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment: Option<WorkspaceTaskEnvironment>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
@@ -115,6 +132,18 @@ pub struct WorkspaceToolConfig {
     pub maven: Option<String>,
     #[serde(default, alias = "gradleExecutable")]
     pub gradle: Option<String>,
+    /// Explicit JVM options for Maven `exec:java`, configured per workspace.
+    #[serde(default)]
+    pub maven_jvm_args: Vec<String>,
+    /// Omitted means enabled, preserving automatic support for existing users.
+    #[serde(default)]
+    pub inherit_maven_arg_line: Option<bool>,
+}
+
+impl WorkspaceToolConfig {
+    fn inherits_maven_arg_line(&self) -> bool {
+        self.inherit_maven_arg_line.unwrap_or(true)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -293,6 +322,7 @@ fn push_task(
         source: source.to_string(),
         module_path: None,
         execution: None,
+        environment: None,
     });
 }
 
@@ -868,6 +898,7 @@ fn build_workspace_task_tree(
                             source: "Maven".into(),
                             module_path: Some(module_path.clone()),
                             execution: Some(resolution.execution(&[phase])),
+                            environment: None,
                         },
                     );
                 }
@@ -882,6 +913,7 @@ fn build_workspace_task_tree(
                         source: "Maven".into(),
                         module_path: Some(module_path),
                         execution: Some(resolution.execution(&["clean", "compile"])),
+                        environment: None,
                     },
                 );
             }
@@ -903,6 +935,7 @@ fn build_workspace_task_tree(
                             source: "Gradle".into(),
                             module_path: Some(module_path.clone()),
                             execution: Some(resolution.execution(&[&selector])),
+                            environment: None,
                         },
                     );
                 }
@@ -923,6 +956,7 @@ fn build_workspace_task_tree(
                         source: "Gradle".into(),
                         module_path: Some(module_path),
                         execution: Some(resolution.execution(&[&clean, &classes])),
+                        environment: None,
                     },
                 );
             }
@@ -1138,6 +1172,140 @@ fn java_package_regex() -> &'static Regex {
     })
 }
 
+fn maven_arg_line_regex() -> &'static Regex {
+    static ARG_LINE: OnceLock<Regex> = OnceLock::new();
+    ARG_LINE.get_or_init(|| {
+        Regex::new(r"(?is)<argLine(?:\s[^>]*)?>(.*?)</argLine\s*>")
+            .expect("valid Maven argLine regex")
+    })
+}
+
+fn xml_comment_regex() -> &'static Regex {
+    static XML_COMMENT: OnceLock<Regex> = OnceLock::new();
+    XML_COMMENT.get_or_init(|| Regex::new(r"(?s)<!--.*?-->").expect("valid XML comment regex"))
+}
+
+fn is_inheritable_maven_jvm_option(value: &str) -> bool {
+    [
+        "--add-opens",
+        "--add-exports",
+        "--add-reads",
+        "--add-modules",
+        "--enable-native-access",
+    ]
+    .iter()
+    .any(|option| value == *option || value.starts_with(&format!("{option}=")))
+}
+
+/// Read JPMS/native-access options from Maven test-plugin `argLine` elements.
+///
+/// `exec:java` runs the application inside Maven's JVM, while Surefire/Failsafe
+/// normally fork a JVM and apply `argLine` only there. Reusing only these
+/// module-access options through MAVEN_OPTS makes Run behave like the project's
+/// tests without also inheriting agents, heap limits, or arbitrary properties.
+fn maven_inherited_jvm_args(workspace_root: &Path, build_dir: &Path) -> Vec<String> {
+    let mut directories = Vec::new();
+    let mut current = Some(build_dir);
+    while let Some(directory) = current {
+        if !directory.starts_with(workspace_root) {
+            break;
+        }
+        directories.push(directory.to_path_buf());
+        if directory == workspace_root {
+            break;
+        }
+        current = directory.parent();
+    }
+    directories.reverse();
+
+    let mut result = Vec::new();
+    let mut seen = HashSet::new();
+    for directory in directories {
+        let Ok(pom) = fs::read_to_string(directory.join("pom.xml")) else {
+            continue;
+        };
+        let pom = xml_comment_regex().replace_all(&pom, "");
+        for captures in maven_arg_line_regex().captures_iter(&pom) {
+            let Some(arg_line) = captures.get(1) else {
+                continue;
+            };
+            let tokens = arg_line
+                .as_str()
+                .replace("<![CDATA[", "")
+                .replace("]]>", "")
+                .replace("&quot;", "\"")
+                .replace("&apos;", "'")
+                .replace("&gt;", ">")
+                .replace("&lt;", "<")
+                .replace("&amp;", "&")
+                .split_whitespace()
+                .map(|value| value.trim_matches(['"', '\'']).to_string())
+                .collect::<Vec<_>>();
+            let mut index = 0;
+            while index < tokens.len() {
+                let token = &tokens[index];
+                if !is_inheritable_maven_jvm_option(token) {
+                    index += 1;
+                    continue;
+                }
+                let option = if token.contains('=') {
+                    token.clone()
+                } else if let Some(value) = tokens.get(index + 1).filter(|value| {
+                    !value.starts_with('-') && !value.starts_with('$') && !value.starts_with('@')
+                }) {
+                    index += 1;
+                    format!("{token}={value}")
+                } else {
+                    index += 1;
+                    continue;
+                };
+                if seen.insert(option.clone()) {
+                    result.push(option);
+                }
+                index += 1;
+            }
+        }
+    }
+    result
+}
+
+fn maven_run_environment(
+    workspace_root: &Path,
+    build_dir: &Path,
+    tool_config: Option<&WorkspaceToolConfig>,
+) -> Option<WorkspaceTaskEnvironment> {
+    let mut args = if tool_config
+        .map(WorkspaceToolConfig::inherits_maven_arg_line)
+        .unwrap_or(true)
+    {
+        maven_inherited_jvm_args(workspace_root, build_dir)
+    } else {
+        Vec::new()
+    };
+    if let Some(config) = tool_config {
+        args.extend(
+            config
+                .maven_jvm_args
+                .iter()
+                .map(|value| value.trim())
+                .filter(|value| !value.is_empty())
+                .map(str::to_string),
+        );
+    }
+    let mut seen = HashSet::new();
+    args.retain(|value| seen.insert(value.clone()));
+    if args.is_empty() {
+        return None;
+    }
+    Some(BTreeMap::from([(
+        "MAVEN_OPTS".into(),
+        WorkspaceTaskEnvironmentVariable {
+            value: args.join(" "),
+            mode: "append".into(),
+        },
+    )]))
+}
+
 /// Strip comments and string/char/text-block contents before looking for a
 /// main signature. This avoids presenting a Run action for examples embedded
 /// in Javadoc or string literals while keeping line structure irrelevant.
@@ -1325,7 +1493,8 @@ fn java_run_target_for_path(
         .unwrap_or_else(|| class_name.to_string());
     let relative_file = relative_path(workspace_root, source_file)?;
     let (build_system, build_dir) = nearest_java_build(workspace_root, source_file);
-    let (command, cwd, module_path, build_system_name, execution) = match build_system {
+    let (command, cwd, module_path, build_system_name, execution, environment) = match build_system
+    {
         JavaBuildSystem::Maven => {
             let resolution =
                 resolve_build_tool(&build_dir, workspace_root, BuildTool::Maven, tool_config);
@@ -1351,6 +1520,7 @@ fn java_run_target_for_path(
                 relative_path(workspace_root, &build_dir).unwrap_or_else(|_| ".".into()),
                 "maven",
                 resolution.execution_owned(args),
+                maven_run_environment(workspace_root, &build_dir, tool_config),
             )
         }
         JavaBuildSystem::Gradle => {
@@ -1399,6 +1569,7 @@ fn java_run_target_for_path(
                 relative_path(workspace_root, &build_dir).unwrap_or_else(|_| ".".into()),
                 "gradle",
                 resolution.execution_owned(args),
+                None,
             )
         }
         JavaBuildSystem::SourceFile => {
@@ -1414,6 +1585,7 @@ fn java_run_target_for_path(
                     source: "path".into(),
                     error: None,
                 },
+                None,
             )
         }
     };
@@ -1432,6 +1604,7 @@ fn java_run_target_for_path(
         build_system: build_system_name.into(),
         module_path,
         execution,
+        environment,
     })
 }
 
@@ -3029,6 +3202,98 @@ runtimeClasspath - Runtime classpath of source set 'main'.
     }
 
     #[test]
+    fn applies_maven_run_jvm_options_through_task_environment() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pom.xml"),
+            r#"
+                <project>
+                  <build><plugins><plugin><configuration>
+                    <argLine>
+                      @{argLine}
+                      --add-exports java.base/sun.nio.ch=ALL-UNNAMED
+                      --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                      --enable-native-access=ALL-UNNAMED
+                      -javaagent:should-not-be-inherited.jar
+                      -Xmx512m
+                      --add-reads -Xms256m
+                    </argLine>
+                    <!-- <argLine>--add-opens=java.base/java.net=ALL-UNNAMED</argLine> -->
+                  </configuration></plugin></plugins></build>
+                </project>
+            "#,
+        )
+        .unwrap();
+        fs::write(dir.path().join("mvnw"), "#!/bin/sh").unwrap();
+        let module = dir.path().join("server");
+        let source_dir = module.join("src/main/java/demo");
+        fs::create_dir_all(&source_dir).unwrap();
+        fs::write(module.join("pom.xml"), "<project />").unwrap();
+        fs::write(
+            source_dir.join("Main.java"),
+            "package demo; class Main { public static void main(String... args) {} }",
+        )
+        .unwrap();
+
+        let target = java_run_target_for_path(
+            dir.path(),
+            &source_dir.join("Main.java"),
+            Some(&WorkspaceToolConfig {
+                maven_jvm_args: vec![
+                    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED".into(),
+                    "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED".into(),
+                ],
+                ..WorkspaceToolConfig::default()
+            }),
+        )
+        .unwrap();
+        let maven_opts = &target.environment.unwrap()["MAVEN_OPTS"];
+        assert_eq!(maven_opts.mode, "append");
+        assert_eq!(
+            maven_opts.value,
+            "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
+             --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+             --enable-native-access=ALL-UNNAMED \
+             --add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+        );
+        assert!(!maven_opts.value.contains("-javaagent"));
+        assert!(!maven_opts.value.contains("-Xmx"));
+        assert!(!maven_opts.value.contains("java.net"));
+    }
+
+    #[test]
+    fn can_disable_maven_arg_line_inheritance() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pom.xml"),
+            "<project><argLine>--add-opens=java.base/java.io=ALL-UNNAMED</argLine></project>",
+        )
+        .unwrap();
+        let source_dir = dir.path().join("src/main/java/demo");
+        fs::create_dir_all(&source_dir).unwrap();
+        fs::write(
+            source_dir.join("Main.java"),
+            "package demo; class Main { public static void main(String... args) {} }",
+        )
+        .unwrap();
+
+        let target = java_run_target_for_path(
+            dir.path(),
+            &source_dir.join("Main.java"),
+            Some(&WorkspaceToolConfig {
+                maven_jvm_args: vec!["--add-opens=java.base/sun.nio.ch=ALL-UNNAMED".into()],
+                inherit_maven_arg_line: Some(false),
+                ..WorkspaceToolConfig::default()
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            target.environment.unwrap()["MAVEN_OPTS"].value,
+            "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+        );
+    }
+
+    #[test]
     fn builds_gradle_subproject_main_command_and_module_tasks() {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("settings.gradle"), "include 'app'").unwrap();
@@ -3101,6 +3366,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         let config = WorkspaceToolConfig {
             maven: Some("C:/tools/mvn.cmd".into()),
             gradle: None,
+            ..WorkspaceToolConfig::default()
         };
         let resolution = resolve_build_tool_with_path(
             dir.path(),
@@ -3149,6 +3415,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         let config = WorkspaceToolConfig {
             maven: Some("./custom-mvn".into()),
             gradle: None,
+            ..WorkspaceToolConfig::default()
         };
         let resolution = resolve_build_tool_with_path(
             dir.path(),
@@ -3167,6 +3434,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         let missing = WorkspaceToolConfig {
             maven: Some("nope-not-here".into()),
             gradle: None,
+            ..WorkspaceToolConfig::default()
         };
         let resolution = resolve_build_tool_with_path(
             dir.path(),

--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -383,7 +383,7 @@ import {
   type WorkspaceTreeCommandPayload,
   readWorkspaceBuildRunTools,
   writeWorkspaceBuildRunTools,
-  workspaceToolExecutables,
+  workspaceToolConfig,
   CODE_WORKSPACE_DEFAULT_TREE_FONT_SIZE,
   CODE_WORKSPACE_MAX_FONT_SIZE,
   CODE_WORKSPACE_MAX_TREE_FONT_SIZE,
@@ -969,10 +969,10 @@ export function CodeWorkspaceTab({
   useEffect(() => {
     setBuildRunTools(readWorkspaceBuildRunTools(workspaceInstanceId));
   }, [workspaceInstanceId]);
-  const toolConfig = useMemo<WorkspaceToolConfig | undefined>(() => {
-    const executables = workspaceToolExecutables(buildRunTools);
-    return Object.keys(executables).length > 0 ? executables : undefined;
-  }, [buildRunTools]);
+  const toolConfig = useMemo<WorkspaceToolConfig | undefined>(
+    () => workspaceToolConfig(buildRunTools),
+    [buildRunTools],
+  );
   const toolConfigRef = useRef(toolConfig);
   toolConfigRef.current = toolConfig;
 
@@ -984,6 +984,7 @@ export function CodeWorkspaceTab({
         task.cwd,
         `Run: ${task.label}`,
         onExit,
+        task.environment,
       );
       setBottomDockTab("terminal");
       setBottomDockOpen(true);
@@ -5129,6 +5130,7 @@ export function CodeWorkspaceTab({
           rootId: root.id,
           rootName: root.name,
           execution: target.execution,
+          environment: target.environment,
         });
         setStatusMessage(`Running ${target.mainClass}`);
       } catch (error) {

--- a/src/components/editor/workspace/WorkspaceBuildRunToolsDialog.test.tsx
+++ b/src/components/editor/workspace/WorkspaceBuildRunToolsDialog.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { WorkspaceBuildRunToolsDialog } from "./WorkspaceBuildRunToolsDialog";
+
+describe("WorkspaceBuildRunToolsDialog", () => {
+  it("saves Maven JVM options and project argLine inheritance", () => {
+    const onSave = vi.fn();
+    render(
+      <WorkspaceBuildRunToolsDialog
+        config={{
+          tools: {},
+          mavenRun: { jvmArgs: [], inheritProjectJvmArgs: true },
+        }}
+        onSave={onSave}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Maven Run JVM options"), {
+      target: {
+        value: [
+          " --add-opens=java.base/sun.nio.ch=ALL-UNNAMED ",
+          "",
+          "--enable-native-access=ALL-UNNAMED",
+        ].join("\n"),
+      },
+    });
+    fireEvent.click(screen.getByTestId("workspace-maven-inherit-argline"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSave).toHaveBeenCalledWith({
+      tools: {},
+      mavenRun: {
+        jvmArgs: [
+          "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+          "--enable-native-access=ALL-UNNAMED",
+        ],
+        inheritProjectJvmArgs: false,
+      },
+    });
+  });
+});

--- a/src/components/editor/workspace/WorkspaceBuildRunToolsDialog.tsx
+++ b/src/components/editor/workspace/WorkspaceBuildRunToolsDialog.tsx
@@ -21,6 +21,10 @@ export function WorkspaceBuildRunToolsDialog({
   const [values, setValues] = useState<Record<string, string>>(() => Object.fromEntries(
     TOOLS.map(({ id }) => [id, config.tools[id]?.executable ?? ""]),
   ));
+  const [mavenJvmArgs, setMavenJvmArgs] = useState(() => config.mavenRun.jvmArgs.join("\n"));
+  const [inheritProjectJvmArgs, setInheritProjectJvmArgs] = useState(
+    () => config.mavenRun.inheritProjectJvmArgs,
+  );
 
   return (
     <div
@@ -33,7 +37,8 @@ export function WorkspaceBuildRunToolsDialog({
         role="dialog"
         aria-modal="true"
         aria-label="Build and run tools"
-        className="w-[520px] max-w-[calc(100vw-32px)] rounded-md border border-[var(--taomni-code-border)] bg-[var(--taomni-code-bg)] shadow-xl"
+        data-testid="workspace-build-run-tools-dialog"
+        className="w-[620px] max-w-[calc(100vw-32px)] rounded-md border border-[var(--taomni-code-border)] bg-[var(--taomni-code-bg)] shadow-xl"
         onMouseDown={(event) => event.stopPropagation()}
       >
         <div className="flex h-10 items-center border-b border-[var(--taomni-code-border)] px-3">
@@ -59,6 +64,34 @@ export function WorkspaceBuildRunToolsDialog({
               />
             </label>
           ))}
+          <div className="space-y-1 pt-1">
+            <label className="block" htmlFor="workspace-maven-run-jvm-args">Maven Run JVM options</label>
+            <textarea
+              id="workspace-maven-run-jvm-args"
+              data-testid="workspace-maven-run-jvm-args"
+              aria-label="Maven Run JVM options"
+              value={mavenJvmArgs}
+              placeholder="One JVM option per line, for example: --add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+              onChange={(event) => setMavenJvmArgs(event.target.value)}
+              rows={4}
+              className="block w-full resize-y rounded border border-[var(--taomni-code-border)] bg-[var(--taomni-code-gutter-bg)] px-2 py-1 font-mono text-[11px]"
+            />
+            <p className="text-[var(--taomni-code-muted)]">
+              Applied to the Maven JVM through MAVEN_OPTS, one option per line.
+              For Chronicle on recent JDKs, add
+              {" "}
+              <code>--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</code>.
+            </p>
+          </div>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              data-testid="workspace-maven-inherit-argline"
+              checked={inheritProjectJvmArgs}
+              onChange={(event) => setInheritProjectJvmArgs(event.target.checked)}
+            />
+            <span>Inherit module-access options from Maven test configuration</span>
+          </label>
         </div>
         <div className="flex justify-end gap-2 border-t border-[var(--taomni-code-border)] p-3">
           <button type="button" className="taomni-btn h-7 px-3" onClick={onClose}>Cancel</button>
@@ -72,7 +105,13 @@ export function WorkspaceBuildRunToolsDialog({
                 if (executable) tools[id] = { executable };
                 else delete tools[id];
               }
-              onSave({ tools });
+              onSave({
+                tools,
+                mavenRun: {
+                  jvmArgs: mavenJvmArgs.split(/\r?\n/).map((value) => value.trim()).filter(Boolean),
+                  inheritProjectJvmArgs,
+                },
+              });
             }}
           >
             Save

--- a/src/components/editor/workspace/codeWorkspaceModel.buildRunTools.test.ts
+++ b/src/components/editor/workspace/codeWorkspaceModel.buildRunTools.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   normalizeWorkspaceBuildRunTools,
   readWorkspaceBuildRunTools,
+  workspaceToolConfig,
   workspaceToolExecutables,
   writeWorkspaceBuildRunTools,
 } from "./codeWorkspaceModel";
@@ -12,17 +13,25 @@ afterEach(() => {
 
 describe("workspace build/run tool persistence", () => {
   it("defaults to automatic tool discovery", () => {
-    expect(readWorkspaceBuildRunTools("workspace-a")).toEqual({ tools: {} });
+    expect(readWorkspaceBuildRunTools("workspace-a")).toEqual({
+      tools: {},
+      mavenRun: { jvmArgs: [], inheritProjectJvmArgs: true },
+    });
   });
 
   it("isolates executable overrides by workspace", () => {
     writeWorkspaceBuildRunTools("workspace-a", {
       tools: { maven: { executable: " C:\\Tools\\mvn.cmd " } },
+      mavenRun: { jvmArgs: [], inheritProjectJvmArgs: true },
     });
     expect(readWorkspaceBuildRunTools("workspace-a")).toEqual({
       tools: { maven: { executable: "C:\\Tools\\mvn.cmd" } },
+      mavenRun: { jvmArgs: [], inheritProjectJvmArgs: true },
     });
-    expect(readWorkspaceBuildRunTools("workspace-b")).toEqual({ tools: {} });
+    expect(readWorkspaceBuildRunTools("workspace-b")).toEqual({
+      tools: {},
+      mavenRun: { jvmArgs: [], inheritProjectJvmArgs: true },
+    });
   });
 
   it("keeps generic tool ids and drops malformed entries", () => {
@@ -37,20 +46,54 @@ describe("workspace build/run tool persistence", () => {
         gradle: { executable: "gradle" },
         cargo: { executable: "/opt/rust/bin/cargo" },
       },
+      mavenRun: { jvmArgs: [], inheritProjectJvmArgs: true },
     });
   });
 
-  it("recovers from corrupt JSON and flattens backend overrides", () => {
+  it("normalizes Maven Run JVM options and flattens the backend config", () => {
+    const normalized = normalizeWorkspaceBuildRunTools({
+      tools: { maven: { executable: "mvn-custom" } },
+      mavenRun: {
+        jvmArgs: [" --add-opens=java.base/sun.nio.ch=ALL-UNNAMED ", 42, ""],
+        inheritProjectJvmArgs: false,
+      },
+    });
+    expect(normalized).toEqual({
+      tools: { maven: { executable: "mvn-custom" } },
+      mavenRun: {
+        jvmArgs: ["--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"],
+        inheritProjectJvmArgs: false,
+      },
+    });
+    expect(workspaceToolConfig(normalized)).toEqual({
+      maven: "mvn-custom",
+      mavenJvmArgs: ["--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"],
+      inheritMavenArgLine: false,
+    });
+  });
+
+  it("recovers from corrupt JSON and flattens executable overrides", () => {
     window.localStorage.setItem(
       "taomni.codeWorkspace.buildRunTools.v1.workspace-a",
       "{broken",
     );
-    expect(readWorkspaceBuildRunTools("workspace-a")).toEqual({ tools: {} });
+    expect(readWorkspaceBuildRunTools("workspace-a")).toEqual({
+      tools: {},
+      mavenRun: { jvmArgs: [], inheritProjectJvmArgs: true },
+    });
     expect(workspaceToolExecutables({
       tools: {
         maven: { executable: "mvn-custom" },
         gradle: { executable: "gradle-custom" },
       },
+      mavenRun: { jvmArgs: [], inheritProjectJvmArgs: true },
     })).toEqual({ maven: "mvn-custom", gradle: "gradle-custom" });
+  });
+
+  it("omits the default backend config so automatic argLine inheritance still applies", () => {
+    expect(workspaceToolConfig({
+      tools: {},
+      mavenRun: { jvmArgs: [], inheritProjectJvmArgs: true },
+    })).toBeUndefined();
   });
 });

--- a/src/components/editor/workspace/codeWorkspaceModel.ts
+++ b/src/components/editor/workspace/codeWorkspaceModel.ts
@@ -3,7 +3,7 @@
  * Extracted from CodeWorkspaceTab to shrink the shell and share with store/UI units.
  */
 import type { CodeWorkspaceFileRef, CodeWorkspaceLooseFileInfo, CodeWorkspaceRootInfo, CodeWorkspaceTabInfo } from "../../../types";
-import type { WorkspaceEntry, WorkspaceGitRoot } from "../../../lib/editor/workspace";
+import type { WorkspaceEntry, WorkspaceGitRoot, WorkspaceToolConfig } from "../../../lib/editor/workspace";
 import type { LspCustomServerCommand, LspDocumentStatus, LspDiagnostic, LspJavaSettings, LspJavaBundleConfig } from "../../../lib/editor/lsp";
 import type { GitChange } from "../../../lib/git";
 import { DEFAULT_CODE_VIEW_PROFILE } from "../../../lib/codeViewProfile";
@@ -26,12 +26,24 @@ export interface WorkspaceBuildRunTool {
   executable: string;
 }
 
+export interface WorkspaceMavenRunOptions {
+  /** Extra JVM options, one option per item, used only by Maven Java Run tasks. */
+  jvmArgs: string[];
+  /** Inherit safe JPMS options declared in the Maven test-plugin argLine. */
+  inheritProjectJvmArgs: boolean;
+}
+
 export interface WorkspaceBuildRunTools {
   tools: Record<string, WorkspaceBuildRunTool>;
+  mavenRun: WorkspaceMavenRunOptions;
 }
 
 export const DEFAULT_WORKSPACE_BUILD_RUN_TOOLS: WorkspaceBuildRunTools = {
   tools: {},
+  mavenRun: {
+    jvmArgs: [],
+    inheritProjectJvmArgs: true,
+  },
 };
 
 export interface DirectoryState {
@@ -797,21 +809,38 @@ export function subscribeLspServerPrefs(listener: () => void): () => void {
 
 export function normalizeWorkspaceBuildRunTools(raw: unknown): WorkspaceBuildRunTools {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return { tools: {} };
+    return DEFAULT_WORKSPACE_BUILD_RUN_TOOLS;
   }
-  const rawTools = (raw as { tools?: unknown }).tools;
-  if (!rawTools || typeof rawTools !== "object" || Array.isArray(rawTools)) {
-    return { tools: {} };
-  }
+  const config = raw as {
+    tools?: unknown;
+    mavenRun?: { jvmArgs?: unknown; inheritProjectJvmArgs?: unknown };
+  };
+  const rawTools = config.tools;
   const tools: Record<string, WorkspaceBuildRunTool> = {};
-  for (const [toolId, value] of Object.entries(rawTools)) {
-    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
-    const executable = (value as { executable?: unknown }).executable;
-    if (typeof executable === "string" && executable.trim()) {
-      tools[toolId] = { executable: executable.trim() };
+  if (rawTools && typeof rawTools === "object" && !Array.isArray(rawTools)) {
+    for (const [toolId, value] of Object.entries(rawTools)) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+      const executable = (value as { executable?: unknown }).executable;
+      if (typeof executable === "string" && executable.trim()) {
+        tools[toolId] = { executable: executable.trim() };
+      }
     }
   }
-  return { tools };
+  const rawJvmArgs = config.mavenRun?.jvmArgs;
+  const jvmArgs = Array.isArray(rawJvmArgs)
+    ? rawJvmArgs.filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+      .filter(Boolean)
+    : [];
+  return {
+    tools,
+    mavenRun: {
+      jvmArgs,
+      inheritProjectJvmArgs: typeof config.mavenRun?.inheritProjectJvmArgs === "boolean"
+        ? config.mavenRun.inheritProjectJvmArgs
+        : true,
+    },
+  };
 }
 
 function workspaceBuildRunToolsKey(workspaceInstanceId: string): string {
@@ -821,9 +850,9 @@ function workspaceBuildRunToolsKey(workspaceInstanceId: string): string {
 export function readWorkspaceBuildRunTools(workspaceInstanceId: string): WorkspaceBuildRunTools {
   try {
     const stored = window.localStorage.getItem(workspaceBuildRunToolsKey(workspaceInstanceId));
-    return stored ? normalizeWorkspaceBuildRunTools(JSON.parse(stored)) : { tools: {} };
+    return stored ? normalizeWorkspaceBuildRunTools(JSON.parse(stored)) : DEFAULT_WORKSPACE_BUILD_RUN_TOOLS;
   } catch {
-    return { tools: {} };
+    return DEFAULT_WORKSPACE_BUILD_RUN_TOOLS;
   }
 }
 
@@ -842,6 +871,24 @@ export function writeWorkspaceBuildRunTools(
 
 export function workspaceToolExecutables(config: WorkspaceBuildRunTools): Record<string, string> {
   return Object.fromEntries(Object.entries(config.tools).map(([id, tool]) => [id, tool.executable]));
+}
+
+/**
+ * Omit the default-only shape to preserve the existing wrapper/PATH-only IPC
+ * contract. The backend treats an omitted config as project-argument inheritance
+ * enabled, so Java Run gets safe Maven module flags without changing Build tasks.
+ */
+export function workspaceToolConfig(config: WorkspaceBuildRunTools): WorkspaceToolConfig | undefined {
+  const executables = workspaceToolExecutables(config);
+  const { jvmArgs, inheritProjectJvmArgs } = config.mavenRun;
+  if (Object.keys(executables).length === 0 && jvmArgs.length === 0 && inheritProjectJvmArgs) {
+    return undefined;
+  }
+  return {
+    ...executables,
+    mavenJvmArgs: jvmArgs,
+    inheritMavenArgLine: inheritProjectJvmArgs,
+  };
 }
 
 export function readLspCommandPrefs(): Record<string, string> {

--- a/src/components/editor/workspace/panels/RunPanel.tsx
+++ b/src/components/editor/workspace/panels/RunPanel.tsx
@@ -108,6 +108,7 @@ export const RunPanel = forwardRef<RunPanelHandle, RunPanelProps>(function RunPa
           rootId: root.id,
           rootName: root.name,
           execution: target.execution,
+          environment: target.environment,
         }));
         return [...java, ...detected];
       }));

--- a/src/components/editor/workspace/panels/TerminalDockPanel.test.tsx
+++ b/src/components/editor/workspace/panels/TerminalDockPanel.test.tsx
@@ -113,4 +113,28 @@ describe("TerminalDockPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "task-exit" }));
     expect(onExit).toHaveBeenCalledWith(0);
   });
+
+  it("forwards task-scoped environment values to registered terminals", async () => {
+    const runTask = vi.fn();
+    registryMocks.getTerminal.mockReturnValue({ runTask });
+    const handle = createRef<TerminalDockHandle>();
+    render(
+      <TerminalDockPanel
+        ref={handle}
+        workspaceInstanceId="ws"
+        roots={roots}
+        defaultCwd="/repo/app"
+        active={false}
+      />,
+    );
+    const environment = {
+      MAVEN_OPTS: {
+        value: "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+        mode: "append" as const,
+      },
+    };
+    handle.current?.runCommand("./mvnw exec:java", "/repo/app", "run", undefined, environment);
+    fireEvent.click(await screen.findByRole("button", { name: "ready" }));
+    await waitFor(() => expect(runTask).toHaveBeenCalledWith("./mvnw exec:java", environment));
+  });
 });

--- a/src/components/editor/workspace/panels/TerminalDockPanel.tsx
+++ b/src/components/editor/workspace/panels/TerminalDockPanel.tsx
@@ -10,7 +10,11 @@ import {
 import { Plus, TerminalSquare, X } from "lucide-react";
 import { TerminalPanel } from "../../../terminal/TerminalPanel";
 import { getTerminal } from "../../../../lib/terminal/terminalRegistry";
-import { buildInteractiveCommandInput, renderTerminalTask } from "../../../../lib/terminal/commandInput";
+import {
+  buildInteractiveCommandInput,
+  renderTerminalTask,
+  type TerminalTaskVariables,
+} from "../../../../lib/terminal/commandInput";
 import { getAppPlatform } from "../../../../lib/runtime";
 import type { CodeWorkspaceRootInfo } from "../../../../types";
 
@@ -21,6 +25,7 @@ interface WorkspaceTerminalInstance {
   workspaceRoot: string | null;
   cwd: string;
   pendingCommand: string | null;
+  pendingEnvironment: TerminalTaskVariables | undefined;
   onTaskExit: ((exitCode: number) => void) | null;
 }
 
@@ -46,6 +51,7 @@ export interface TerminalDockHandle {
     cwd: string,
     title?: string,
     onExit?: (exitCode: number) => void,
+    environment?: TerminalTaskVariables,
   ) => string;
   focus: () => void;
 }
@@ -79,6 +85,7 @@ export const TerminalDockPanel = forwardRef<TerminalDockHandle, TerminalDockPane
       title?: string,
       pendingCommand: string | null = null,
       onTaskExit: ((exitCode: number) => void) | null = null,
+      pendingEnvironment: TerminalTaskVariables | undefined = undefined,
     ) => {
       sequenceRef.current += 1;
       const id = terminalId(workspaceInstanceId, sequenceRef.current);
@@ -89,6 +96,7 @@ export const TerminalDockPanel = forwardRef<TerminalDockHandle, TerminalDockPane
         workspaceRoot: rootForCwd(roots, cwd),
         cwd,
         pendingCommand,
+        pendingEnvironment,
         onTaskExit,
       };
       setInstances((current) => [...current, next]);
@@ -103,11 +111,12 @@ export const TerminalDockPanel = forwardRef<TerminalDockHandle, TerminalDockPane
 
     useImperativeHandle(ref, () => ({
       openAt: (cwd, title) => createInstance(cwd, title),
-      runCommand: (command, cwd, title, onExit) => createInstance(
+      runCommand: (command, cwd, title, onExit, environment) => createInstance(
         cwd,
         title,
         command,
         onExit ?? null,
+        environment,
       ),
       focus: () => {
         if (instances.length > 0) setActiveId((current) => current ?? instances[0].id);
@@ -133,12 +142,13 @@ export const TerminalDockPanel = forwardRef<TerminalDockHandle, TerminalDockPane
         const terminal = getTerminal(id);
         if (terminal) {
           if (terminal.runTask) {
-            terminal.runTask(instance.pendingCommand);
+            terminal.runTask(instance.pendingCommand, instance.pendingEnvironment);
           } else {
             // Backward-compatible path for lightweight registrants and tests.
             const task = renderTerminalTask(
               instance.pendingCommand,
               terminal.localEnvironment ?? { platform: getAppPlatform() },
+              instance.pendingEnvironment,
             );
             terminal.writeInput(buildInteractiveCommandInput(task.input));
           }

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -3401,13 +3401,13 @@ export function TerminalPanel({
         }
         writeTerminal(registeredSessionId, encodeBase64(data)).catch(console.error);
       },
-      runTask: (command: string) => {
+      runTask: (command: string, taskVariables) => {
         if (readOnlyRef.current) return;
         const task = renderTerminalTask(command, {
           platform: getAppPlatform(),
           shellId: resolvedLocalShellId ?? localShell?.id ?? null,
           shellName: localShell?.name ?? null,
-        });
+        }, taskVariables);
         const suppressor = createTaskStartOutputSuppressor(
           task.startMarker,
           task.displayCommand,

--- a/src/lib/editor/workspace.ts
+++ b/src/lib/editor/workspace.ts
@@ -51,6 +51,14 @@ export interface WorkspaceTaskExecution {
   error?: string;
 }
 
+/** A temporary environment variable applied only while a workspace task runs. */
+export interface WorkspaceTaskEnvironmentVariable {
+  value: string;
+  mode: "append" | "replace";
+}
+
+export type WorkspaceTaskEnvironment = Record<string, WorkspaceTaskEnvironmentVariable>;
+
 export interface WorkspaceTask {
   id: string;
   label: string;
@@ -60,6 +68,7 @@ export interface WorkspaceTask {
   /** Workspace-relative Maven/Gradle module directory when applicable. */
   modulePath?: string;
   execution?: WorkspaceTaskExecution;
+  environment?: WorkspaceTaskEnvironment;
 }
 
 /** A Java `static void main` entry point with a ready-to-run terminal command. */
@@ -73,6 +82,7 @@ export interface JavaRunTarget {
   buildSystem: "maven" | "gradle" | "source-file";
   modulePath: string;
   execution: WorkspaceTaskExecution;
+  environment?: WorkspaceTaskEnvironment;
 }
 
 /**
@@ -82,6 +92,10 @@ export interface JavaRunTarget {
 export interface WorkspaceToolConfig {
   maven?: string;
   gradle?: string;
+  /** Explicit JVM options applied to Maven `exec:java` through MAVEN_OPTS. */
+  mavenJvmArgs?: string[];
+  /** Auto-inherit safe runtime options from Maven test plugin `argLine`. */
+  inheritMavenArgLine?: boolean;
 }
 
 export function workspaceListDir(

--- a/src/lib/terminal/commandInput.test.ts
+++ b/src/lib/terminal/commandInput.test.ts
@@ -63,4 +63,45 @@ describe("terminal task rendering", () => {
     expect(task.input.split("\n")).toHaveLength(2);
     expect(buildInteractiveCommandInput(task.input)).not.toContain("\n");
   });
+
+  it("scopes appended task variables to a POSIX command", () => {
+    const task = renderTerminalTask("./mvnw exec:java", {
+      platform: "linux",
+      shellId: "bash",
+    }, {
+      MAVEN_OPTS: {
+        value: "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED 'quoted'",
+        mode: "append",
+      },
+      "invalid-name": { value: "ignored", mode: "replace" },
+    });
+    expect(task.input).toContain("( export MAVEN_OPTS=");
+    expect(task.input).toContain("${MAVEN_OPTS:+${MAVEN_OPTS} }");
+    expect(task.input).toContain(`'"'"'quoted'"'"'`);
+    expect(task.input).not.toContain("invalid-name");
+  });
+
+  it("restores PowerShell task variables and uses setlocal for cmd", () => {
+    const variables = {
+      MAVEN_OPTS: {
+        value: "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+        mode: "append" as const,
+      },
+    };
+    const powershell = renderTerminalTask("mvn.cmd exec:java", {
+      platform: "windows",
+      shellId: "powershell",
+    }, variables);
+    expect(powershell.input).toContain("$taomniEnvironment['MAVEN_OPTS']");
+    expect(powershell.input).toContain("$env:MAVEN_OPTS=");
+    expect(powershell.input).toContain("finally");
+
+    const cmd = renderTerminalTask("mvn.cmd exec:java", {
+      platform: "windows",
+      shellId: "command-prompt",
+    }, variables);
+    expect(cmd.input).toContain("setlocal DisableDelayedExpansion");
+    expect(cmd.input).toContain('set "MAVEN_OPTS=%MAVEN_OPTS% --add-opens=');
+    expect(cmd.input).toContain("endlocal");
+  });
 });

--- a/src/lib/terminal/commandInput.ts
+++ b/src/lib/terminal/commandInput.ts
@@ -6,6 +6,17 @@ export interface TerminalTaskEnvironment {
   shellName?: string | null;
 }
 
+/**
+ * Environment values scoped to one rendered task. `append` preserves a value
+ * the interactive shell already has, which is essential for MAVEN_OPTS.
+ */
+export interface TerminalTaskVariable {
+  value: string;
+  mode?: "append" | "replace";
+}
+
+export type TerminalTaskVariables = Record<string, TerminalTaskVariable>;
+
 export interface RenderedTerminalTask {
   input: string;
   displayCommand: string;
@@ -34,13 +45,23 @@ export function terminalTaskShell(environment?: TerminalTaskEnvironment | null):
 export function renderTerminalTask(
   command: string,
   environment?: TerminalTaskEnvironment | null,
+  taskVariables?: TerminalTaskVariables,
 ): RenderedTerminalTask {
   const source = command.replace(/\r\n|\r/g, "\n").trim();
   const displayCommand = source.replace(/\s*\n\s*/g, " ");
   const shell = terminalTaskShell(environment);
+  const variables = normalizeTaskVariables(taskVariables);
 
   if (shell === "powershell") {
     const script = source.replace(/'/g, "''");
+    if (variables.length > 0) {
+      return {
+        shell,
+        displayCommand,
+        startMarker: TASK_START_BEL,
+        input: renderPowerShellTaskWithVariables(script, variables),
+      };
+    }
     return {
       shell,
       displayCommand,
@@ -51,6 +72,14 @@ export function renderTerminalTask(
 
   if (shell === "cmd") {
     const escaped = escapeCmdCall(source);
+    if (variables.length > 0) {
+      return {
+        shell,
+        displayCommand,
+        startMarker: TASK_START_ST,
+        input: renderCmdTaskWithVariables(escaped, variables),
+      };
+    }
     return {
       shell,
       displayCommand,
@@ -60,12 +89,90 @@ export function renderTerminalTask(
   }
 
   const script = source.replace(/'/g, `'"'"'`);
+  if (variables.length > 0) {
+    return {
+      shell,
+      displayCommand,
+      startMarker: TASK_START_BEL,
+      input: `printf '\\033]633;TaomniTaskStart\\a'; ( ${renderPosixVariableSetup(variables)}; eval '${script}' ); __taomni_status=$?; printf '\\033]633;TaomniTaskExit=%s\\a' "$__taomni_status"`,
+    };
+  }
   return {
     shell,
     displayCommand,
     startMarker: TASK_START_BEL,
     input: `printf '\\033]633;TaomniTaskStart\\a'; eval '${script}'; __taomni_status=$?; printf '\\033]633;TaomniTaskExit=%s\\a' "$__taomni_status"`,
   };
+}
+
+interface NormalizedTaskVariable {
+  name: string;
+  value: string;
+  mode: "append" | "replace";
+}
+
+function normalizeTaskVariables(taskVariables?: TerminalTaskVariables): NormalizedTaskVariable[] {
+  if (!taskVariables) return [];
+  return Object.entries(taskVariables)
+    .filter(([name, variable]) => (
+      /^[A-Za-z_][A-Za-z0-9_]*$/.test(name)
+      && !!variable
+      && typeof variable.value === "string"
+    ))
+    .map(([name, variable]) => ({
+      name,
+      value: variable.value,
+      mode: variable.mode === "replace" ? "replace" : "append",
+    }));
+}
+
+function quotePosix(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function renderPosixVariableSetup(variables: NormalizedTaskVariable[]): string {
+  return variables.map(({ name, value, mode }) => {
+    const quoted = quotePosix(value);
+    if (mode === "replace") return `export ${name}=${quoted}`;
+    return `export ${name}="\${${name}:+\${${name}} }"${quoted}`;
+  }).join("; ");
+}
+
+function quotePowerShell(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function renderPowerShellTaskWithVariables(
+  script: string,
+  variables: NormalizedTaskVariable[],
+): string {
+  const remember = variables.map(({ name }) => (
+    `$taomniEnvironment['${name}']=[Environment]::GetEnvironmentVariable('${name}','Process')`
+  )).join("; ");
+  const setup = variables.map(({ name, value, mode }) => {
+    const quoted = quotePowerShell(value);
+    if (mode === "replace") return `$env:${name}=${quoted}`;
+    return `$env:${name}=if ([string]::IsNullOrWhiteSpace($taomniEnvironment['${name}'])) { ${quoted} } else { $taomniEnvironment['${name}']+' '+${quoted} }`;
+  }).join("; ");
+  const restore = variables.map(({ name }) => (
+    `if ($null -eq $taomniEnvironment['${name}']) { Remove-Item Env:${name} -ErrorAction SilentlyContinue } else { $env:${name}=$taomniEnvironment['${name}'] }`
+  )).join("; ");
+  return `[Console]::Write([char]27+']633;TaomniTaskStart'+[char]7); $taomniStatus=1; $taomniEnvironment=@{}; try { ${remember}; ${setup}; & ([scriptblock]::Create('${script}')); $taomniSucceeded=$?; $taomniStatus=if ($taomniSucceeded) { 0 } elseif ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) { $LASTEXITCODE } else { 1 } } finally { ${restore} }; [Console]::Write([char]27+']633;TaomniTaskExit='+$taomniStatus+[char]7)`;
+}
+
+function escapeCmdSetValue(value: string): string {
+  return value.replace(/\^/g, "^^").replace(/%/g, "%%").replace(/"/g, '""');
+}
+
+function renderCmdTaskWithVariables(
+  escapedCommand: string,
+  variables: NormalizedTaskVariable[],
+): string {
+  const setup = variables.map(({ name, value, mode }) => {
+    const prefix = mode === "append" ? `%${name}% ` : "";
+    return `set "${name}=${prefix}${escapeCmdSetValue(value)}"`;
+  }).join(" & ");
+  return `for /F "delims=" %A in ('echo prompt $E^| cmd') do @set "taomniEsc=%A"\n<nul set /p "=%taomniEsc%]633;TaomniTaskStart%taomniEsc%\\" & setlocal DisableDelayedExpansion & ${setup} & call ${escapedCommand} & call set "taomniStatus=%%errorlevel%%" & call <nul set /p "=%%taomniEsc%%]633;TaomniTaskExit=%%taomniStatus%%%%taomniEsc%%\\" & endlocal`;
 }
 
 function escapeCmdCall(command: string): string {

--- a/src/lib/terminal/terminalRegistry.ts
+++ b/src/lib/terminal/terminalRegistry.ts
@@ -46,7 +46,10 @@ export interface TerminalRegistryEntry {
    * syntax. The implementation reports completion through OSC 633 while
    * leaving the interactive shell alive. Optional for legacy/test registrants.
    */
-  runTask?: (command: string) => void;
+  runTask?: (
+    command: string,
+    environment?: import("./commandInput").TerminalTaskVariables,
+  ) => void;
   /**
    * Write display-only text directly to the terminal screen (xterm `write`),
    * WITHOUT sending it to the backend pty/ssh stdin. Used to mirror Claude


### PR DESCRIPTION
Maven exec:java runs the selected application inside Maven's own JVM, so module-access flags configured only for Surefire or Failsafe do not apply. This caused libraries such as Chronicle to fail during Spring bean creation on recent JDKs.

- persist per-workspace Maven Run JVM options and the project-argLine inheritance preference
- collect safe JPMS and native-access options from module and ancestor POM argLine elements
- merge inherited and explicit options into task-scoped MAVEN_OPTS without replacing the user's existing value
- propagate temporary task environments through toolbar runs, the Run panel, and integrated terminals
- render scoped environment setup and restoration for POSIX shells, PowerShell, and cmd.exe
- expose the configuration in Build and Run Tools with guidance for Chronicle sun.nio.ch access
- preserve legacy workspace settings and add Rust, model, dialog, terminal, and panel regression coverage

Validated with:
- pnpm build
- 64 focused Vitest tests
- cargo test --lib workspace::tests::
- git diff --check