### PR TITLE
fix(statusbar): keep text visible at large UI font sizes and make tru…

### DIFF
--- a/src/components/statusbar/StatusBar.test.tsx
+++ b/src/components/statusbar/StatusBar.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { StatusBar } from "./StatusBar";
 import { useAppStore } from "../../stores/appStore";
+import { useSessionStore } from "../../stores/sessionStore";
 import { useCodeWorkspaceStatusStore } from "../../stores/codeWorkspaceStatusStore";
 
 vi.mock("../../lib/i18n", async (importOriginal) => {
@@ -34,7 +35,7 @@ vi.mock("../../lib/appTheme", () => ({
 }));
 
 vi.mock("../../stores/sessionStore", () => ({
-  useSessionStore: () => ({ sessions: [], selectedSessionId: null }),
+  useSessionStore: vi.fn(() => ({ sessions: [], selectedSessionId: null })),
 }));
 
 vi.mock("../../stores/aiStore", () => ({
@@ -138,5 +139,107 @@ describe("StatusBar code-workspace segments", () => {
 
     render(<StatusBar />);
     expect(screen.getByTestId("status-bar-workspace-large-file")).toBeInTheDocument();
+  });
+});
+
+describe("StatusBar copyable/truncated text", () => {
+  afterEach(() => {
+    cleanup();
+    Reflect.deleteProperty(navigator, "clipboard");
+  });
+
+  function mockClipboard() {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    return writeText;
+  }
+
+  beforeEach(() => {
+    useAppStore.setState({
+      tabs: [],
+      activeTabId: null,
+      xServerEnabled: false,
+      xServerStatus: null,
+      statusMessage: "",
+    } as never);
+    useCodeWorkspaceStatusStore.setState({ status: null, actions: null });
+  });
+
+  it("shows the full status message as tooltip and copies it on click", async () => {
+    const writeText = mockClipboard();
+    const message = "a long status message that would be ellipsized in a narrow window";
+    useAppStore.setState({ statusMessage: message } as never);
+
+    render(<StatusBar />);
+
+    const el = screen.getByTestId("status-bar-message");
+    expect(el).toHaveAttribute("title", message);
+
+    fireEvent.click(el);
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith(message));
+  });
+
+  it("does not render the message segment when the status message is empty", () => {
+    render(<StatusBar />);
+    expect(screen.queryByTestId("status-bar-message")).toBeNull();
+  });
+
+  it("copies the selected session name on click", async () => {
+    const writeText = mockClipboard();
+    vi.mocked(useSessionStore).mockReturnValue({
+      sessions: [{ id: "s1", name: "my-very-long-session-name" } as never],
+      selectedSessionId: "s1",
+    });
+
+    render(<StatusBar />);
+
+    fireEvent.click(screen.getByTestId("status-bar-selected-session"));
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith("my-very-long-session-name"));
+  });
+
+  it("copies truncated workspace text on right-click when the segment has a click action", async () => {
+    const writeText = mockClipboard();
+    const openGitManager = vi.fn();
+    useAppStore.setState({
+      tabs: [{
+        id: "ws-tab",
+        type: "code-workspace",
+        title: "Workspace",
+        codeWorkspace: { repoRoot: "/repo", workspaceId: "ws", workspaceInstanceId: "i", name: "W", roots: [], looseFiles: [] },
+      } as never],
+      activeTabId: "ws-tab",
+    } as never);
+    useCodeWorkspaceStatusStore.setState({
+      status: {
+        tabId: "ws-tab",
+        line: 1,
+        column: 1,
+        encoding: "UTF-8",
+        eol: "LF",
+        languageId: "typescript",
+        lspActive: true,
+        lspLabel: "typescript-language-server",
+        lspError: false,
+        gitBranch: "feature/a-very-long-branch-name",
+        gitAhead: 1,
+        gitBehind: 0,
+        fontSize: 14,
+        largeFile: false,
+      },
+      actions: { openLanguagePanel: vi.fn(), openGitManager },
+    });
+
+    render(<StatusBar />);
+
+    fireEvent.contextMenu(screen.getByTestId("status-bar-workspace-git"));
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith("feature/a-very-long-branch-name"));
+    // Right-click copies but does not trigger the segment's primary click.
+    expect(openGitManager).not.toHaveBeenCalled();
+    // The segment's primary click still opens the Git manager.
+    fireEvent.click(screen.getByTestId("status-bar-workspace-git"));
+    expect(openGitManager).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/statusbar/StatusBar.tsx
+++ b/src/components/statusbar/StatusBar.tsx
@@ -1,5 +1,6 @@
 import {
   Bot,
+  Check,
   GitBranch,
   Monitor,
   Wifi,
@@ -13,8 +14,9 @@ import {
   Sparkles,
   Cpu,
 } from "lucide-react";
-import { useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
 import { useAppTheme } from "../../lib/appTheme";
+import { writeText } from "../../lib/clipboard";
 import { useAppStore } from "../../stores/appStore";
 import { useSessionStore } from "../../stores/sessionStore";
 import { useAiStore } from "../../stores/aiStore";
@@ -22,31 +24,112 @@ import { useCodeWorkspaceStatusStore } from "../../stores/codeWorkspaceStatusSto
 import { useT } from "../../lib/i18n";
 import { useAppThemeI18nLabel } from "../../lib/i18n/labels";
 
+/**
+ * Copy-with-feedback state shared by status-bar text: copies to the clipboard,
+ * then briefly swaps the tooltip to "Copied to clipboard" and appends a check
+ * mark. Right-click copy follows the PathBreadcrumb convention for text that
+ * has a primary click action.
+ */
+function useCopyFeedback() {
+  const t = useT();
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<number | null>(null);
+  useEffect(() => () => {
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+  }, []);
+  const copy = useCallback(async (text: string) => {
+    if (!text) return;
+    try {
+      await writeText(text);
+      setCopied(true);
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+      timerRef.current = window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // Clipboard unavailable — the tooltip still shows the full value.
+    }
+  }, [t]);
+  return { copied, copiedTitle: t("common.copied"), copy };
+}
+
+/**
+ * Text that truncates with an ellipsis when space runs out: hovering shows the
+ * full value in a native tooltip and clicking copies it to the clipboard, so
+ * status-bar info stays reachable at any font size / window width.
+ */
+function CopyableText({
+  text,
+  title,
+  className = "",
+  testId,
+  children,
+}: {
+  /** Value copied to the clipboard on click. */
+  text: string;
+  /** Tooltip text; defaults to the rendered children (or `text`). */
+  title?: string;
+  className?: string;
+  testId?: string;
+  children?: ReactNode;
+}) {
+  const { copied, copiedTitle, copy } = useCopyFeedback();
+  const rendered = children ?? text;
+  return (
+    <span
+      data-testid={testId}
+      className={`${className}${text ? " cursor-pointer" : ""}`}
+      title={copied ? copiedTitle : (title ?? (typeof rendered === "string" ? rendered : text))}
+      onClick={() => copy(text)}
+    >
+      {rendered}
+      {copied && text && <Check className="w-3 h-3 shrink-0 text-emerald-500" />}
+    </span>
+  );
+}
+
 function StatusSegment({
   testId,
   title,
   onClick,
+  copyText,
   children,
 }: {
   testId?: string;
   title?: string;
   onClick?: () => void;
+  /** Full value copied to the clipboard on right-click (e.g. a truncated name). */
+  copyText?: string;
   children: ReactNode;
 }) {
+  const { copied, copiedTitle, copy } = useCopyFeedback();
+  const onContextMenu = copyText
+    ? (e: ReactMouseEvent) => {
+        e.preventDefault();
+        copy(copyText);
+      }
+    : undefined;
   // Primary status text (not muted/slate) so language/LSP labels like "Java"
-  // stay readable on the light status bar background.
-  const className = "flex items-center gap-1 text-[11px] font-medium max-w-[220px] truncate text-[var(--taomni-status-text)]"
+  // stay readable on the light status bar background. Font size is inherited
+  // from .taomni-status so segments scale with the app UI font size.
+  const className = "flex items-center gap-1 font-medium max-w-[220px] truncate text-[var(--taomni-status-text)]"
     + (onClick ? " rounded px-1 hover:bg-[var(--taomni-hover)] cursor-pointer" : "");
+  const common = {
+    "data-testid": testId,
+    title: copied ? copiedTitle : title,
+    className,
+    onContextMenu,
+  };
   if (onClick) {
     return (
-      <button type="button" data-testid={testId} title={title} className={className} onClick={onClick}>
+      <button type="button" {...common} onClick={onClick}>
         {children}
+        {copied && <Check className="w-3 h-3 shrink-0 text-emerald-500" />}
       </button>
     );
   }
   return (
-    <span data-testid={testId} title={title} className={className}>
+    <span {...common}>
       {children}
+      {copied && <Check className="w-3 h-3 shrink-0 text-emerald-500" />}
     </span>
   );
 }
@@ -88,19 +171,36 @@ export function StatusBar() {
   );
 
   return (
-    <div data-testid="status-bar" className="taomni-status h-6 flex items-center px-2 gap-3">
-      <span className="flex items-center gap-1">
-        <Eye className="w-3 h-3" /> {t("statusBar.sessions", { count: sessions.length })} • {selected ? selected.name : t("statusBar.none")}
+    <div data-testid="status-bar" className="taomni-status min-h-6 flex items-center px-2 gap-3">
+      <span className="flex items-center gap-1 min-w-0">
+        <Eye className="w-3 h-3 shrink-0" />
+        <span className="shrink-0">{t("statusBar.sessions", { count: sessions.length })}</span>
+        <span className="shrink-0">•</span>
+        {selected ? (
+          <CopyableText text={selected.name} className="truncate min-w-0" testId="status-bar-selected-session">
+            {selected.name}
+          </CopyableText>
+        ) : (
+          <span className="truncate min-w-0">{t("statusBar.none")}</span>
+        )}
       </span>
       <span className="taomni-divider-v h-3" />
-      <span className="flex items-center gap-1">
-        <Wifi className={`w-3 h-3 ${online ? "text-emerald-600" : "text-red-600"}`} /> {online ? t("statusBar.networkOnline") : t("statusBar.networkOffline")}
+      <span className="flex items-center gap-1 min-w-0" title={online ? t("statusBar.networkOnline") : t("statusBar.networkOffline")}>
+        <Wifi className={`w-3 h-3 shrink-0 ${online ? "text-emerald-600" : "text-red-600"}`} />
+        <span className="truncate min-w-0">{online ? t("statusBar.networkOnline") : t("statusBar.networkOffline")}</span>
       </span>
-      <span className="flex items-center gap-1" title={xServerStatus?.provider ? `${xServerStatus.provider} · ${xServerStatus.endpoint}` : undefined}>
-        <Monitor className={`w-3 h-3 ${xServerEnabled ? "text-emerald-600" : "text-slate-500"}`} /> X11: {xServerEnabled ? (xServerStatus?.display || xServerStatus?.endpoint || "") : t("statusBar.x11Off")}
+      <span className="flex items-center gap-1 min-w-0" title={xServerStatus?.provider ? `${xServerStatus.provider} · ${xServerStatus.endpoint}` : undefined}>
+        <Monitor className={`w-3 h-3 shrink-0 ${xServerEnabled ? "text-emerald-600" : "text-slate-500"}`} />
+        <span className="shrink-0">X11:</span>
+        {xServerEnabled ? (
+          <CopyableText text={xServerStatus?.display || xServerStatus?.endpoint || ""} className="truncate min-w-0" />
+        ) : (
+          <span className="truncate min-w-0">{t("statusBar.x11Off")}</span>
+        )}
       </span>
-      <span className="flex items-center gap-1">
-        <KeyRound className="w-3 h-3 text-slate-500" /> {t("statusBar.auth")}
+      <span className="flex items-center gap-1 min-w-0" title={t("statusBar.auth")}>
+        <KeyRound className="w-3 h-3 shrink-0 text-slate-500" />
+        <span className="truncate min-w-0">{t("statusBar.auth")}</span>
       </span>
 
       {!fullyDisabled && (
@@ -109,67 +209,73 @@ export function StatusBar() {
 
           {/* ASR segment */}
           <span
-            className="flex items-center gap-1 text-[11px]"
+            className="flex items-center gap-1 min-w-0"
             title={t("statusBar.asrTooltip", { provider: activeAsr })}
           >
-            <Mic className="w-3 h-3" />
+            <Mic className="w-3 h-3 shrink-0" />
             {dot(aiConfig ? "bg-green-400" : "bg-gray-400")}
-            <span className="hidden xl:inline">ASR</span>
+            <span className="hidden xl:inline truncate min-w-0">ASR</span>
           </span>
 
           {/* LLM segment */}
           <span
-            className="flex items-center gap-1 text-[11px]"
+            className="flex items-center gap-1 min-w-0"
             title={t("statusBar.llmTooltip", { provider: activeProvider })}
           >
-            <Bot className="w-3 h-3" />
+            <Bot className="w-3 h-3 shrink-0" />
             {dot(aiConfig ? "bg-green-400" : "bg-gray-400")}
-            {t("statusBar.llm", { provider: activeProvider })}
+            <CopyableText
+              text={aiConfig ? activeProvider : ""}
+              title={t("statusBar.llmTooltip", { provider: activeProvider })}
+              className="truncate min-w-0"
+            >
+              {t("statusBar.llm", { provider: activeProvider })}
+            </CopyableText>
           </span>
 
           {/* Web search segment */}
           <span
-            className="flex items-center gap-1 text-[11px]"
+            className="flex items-center gap-1 min-w-0"
             title={t("statusBar.webSearchTooltip", {
               state: searchEnabled ? t("common.enabled") : t("common.disabled"),
               provider: aiConfig?.web_search.client_provider ?? "—",
             })}
           >
-            <Search className="w-3 h-3" />
+            <Search className="w-3 h-3 shrink-0" />
             {dot(searchEnabled ? "bg-green-400" : "bg-gray-400")}
           </span>
 
           {/* Claude Code segment */}
           {ccEnabled && (
             <span
-              className="flex items-center gap-1 text-[11px]"
+              className="flex items-center gap-1 min-w-0"
               title={t("statusBar.claudeCodeTooltip")}
             >
-              <Cpu className="w-3 h-3" />
+              <Cpu className="w-3 h-3 shrink-0" />
               {dot("bg-green-400")}
-              CC
+              <span className="truncate min-w-0">CC</span>
             </span>
           )}
 
           {codexEnabled && (
             <span
-              className="flex items-center gap-1 text-[11px]"
+              className="flex items-center gap-1 min-w-0"
               title="Codex app-server enabled"
             >
-              <Cpu className="w-3 h-3" />
+              <Cpu className="w-3 h-3 shrink-0" />
               {dot("bg-green-400")}
-              Codex
+              <span className="truncate min-w-0">Codex</span>
             </span>
           )}
 
           {/* Privacy segment */}
           {fullLocal && (
             <span
-              className="flex items-center gap-1 text-[11px] text-purple-300"
+              className="flex items-center gap-1 min-w-0 text-purple-300"
               title={t("statusBar.fullLocalTooltip")}
             >
-              <Shield className="w-3 h-3" />
-              {t("statusBar.fullLocalShort")}
+              <Shield className="w-3 h-3 shrink-0" />
+              <span className="truncate min-w-0">{t("statusBar.fullLocalShort")}</span>
             </span>
           )}
         </>
@@ -179,17 +285,19 @@ export function StatusBar() {
         <>
           <span className="taomni-divider-v h-3" />
           <span
-            className="flex items-center gap-1 text-[11px] text-yellow-300"
+            className="flex items-center gap-1 min-w-0 text-yellow-300"
             title={t("statusBar.aiOffTooltip")}
           >
-            <Sparkles className="w-3 h-3" />
-            {t("statusBar.aiOff")}
+            <Sparkles className="w-3 h-3 shrink-0" />
+            <span className="truncate min-w-0">{t("statusBar.aiOff")}</span>
           </span>
         </>
       )}
 
       <div className="flex-1" />
-      <span className="truncate max-w-[260px]">{statusMessage}</span>
+      {statusMessage && (
+        <CopyableText text={statusMessage} className="truncate max-w-[260px]" testId="status-bar-message" />
+      )}
 
       {showWorkspaceSegments && workspaceStatus && (
         <>
@@ -227,6 +335,7 @@ export function StatusBar() {
             testId="status-bar-workspace-lsp"
             title={`${workspaceStatus.lspLabel ?? (workspaceStatus.lspActive ? "LSP active" : "No language server")} · open Language Servers settings`}
             onClick={workspaceActions?.openLanguagePanel}
+            copyText={workspaceStatus.lspLabel ?? ""}
           >
             {dot(workspaceStatus.lspError
               ? "bg-amber-500"
@@ -244,6 +353,7 @@ export function StatusBar() {
                 ? ` · ahead ${workspaceStatus.gitAhead} · behind ${workspaceStatus.gitBehind}`
                 : ""}`}
               onClick={workspaceActions?.openGitManager}
+              copyText={workspaceStatus.gitBranch}
             >
               <GitBranch className="w-3 h-3 shrink-0" />
               <span className="truncate">{workspaceStatus.gitBranch}</span>
@@ -272,17 +382,25 @@ export function StatusBar() {
         </>
       )}
 
-      <span className="taomni-divider-v h-3" />
-      <span className="flex items-center gap-1">
-        {resolvedTheme === "dark" ? <Moon className="w-3 h-3" /> : <Sun className="w-3 h-3" />}
-        {t("statusBar.themeLabel", { mode: themeLabel(mode) })}
+      <span className="taomni-divider-v h-3 shrink-0" />
+      <span
+        className="flex items-center gap-1 min-w-0"
+        title={t("statusBar.themeLabel", { mode: themeLabel(mode) })}
+      >
+        {resolvedTheme === "dark" ? <Moon className="w-3 h-3 shrink-0" /> : <Sun className="w-3 h-3 shrink-0" />}
+        <span className="truncate min-w-0">{t("statusBar.themeLabel", { mode: themeLabel(mode) })}</span>
       </span>
-      <span className="taomni-divider-v h-3" />
-      <span className="taomni-mono">
+      <span className="taomni-divider-v h-3 shrink-0" />
+      <span
+        className="taomni-mono min-w-0 truncate"
+        title={`${activeTab?.type ?? t("statusBar.activeTabNone")} • ${t("statusBar.terminalsCount", { count: tabs.filter((tab) => tab.type === "terminal").length })}`}
+      >
         {activeTab?.type ?? t("statusBar.activeTabNone")} • {t("statusBar.terminalsCount", { count: tabs.filter((tab) => tab.type === "terminal").length })}
       </span>
-      <span className="taomni-divider-v h-3" />
-      <span>{t("statusBar.versionTag", { version: "0.2.0" })}</span>
+      <span className="taomni-divider-v h-3 shrink-0" />
+      <span className="min-w-0 truncate" title={t("statusBar.versionTag", { version: "0.2.0" })}>
+        {t("statusBar.versionTag", { version: "0.2.0" })}
+      </span>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -961,6 +961,9 @@ select.taomni-input:not(.appearance-none):not([multiple]) {
   border-top: 1px solid var(--taomni-divider);
   color: var(--taomni-status-text);
   font-size: calc(var(--taomni-ui-font-size) - 1px);
+  /* Keep the 24px bar tall enough even at the max UI font size (text stays
+     inside the bar instead of spilling over the border). */
+  line-height: 1.3;
 }
 
 .taomni-divider-h { height: 1px; background: var(--taomni-divider); }


### PR DESCRIPTION
…ncated values copyable

The status bar's text scales with --taomni-ui-font-size (font-size calc(ui - 1px)) but the bar was fixed at h-6 (24px) with the default 1.5 line height, so once the app font was enlarged the text spilled past the bar border. Segments without width constraints (selected session name, AI provider, right-side labels) then pushed later segments off the window edge entirely — text effectively invisible. Meanwhile segments with hardcoded text-[11px] stayed small while the rest grew, and ellipsized values (status message, LSP label, git branch) had no way to see or copy the full text.

Changes:
- .taomni-status: add line-height 1.3 so a 24px bar fits the text at the maximum UI font size (18px); the bar container switches from h-6 to min-h-6 so the bar grows instead of clipping if content is ever taller (e.g. CJK fonts with larger natural line boxes)
- drop the hardcoded text-[11px] from segments so all status text scales uniformly with the app UI font size (identical rendering at the 12px default, where inherited size was already 11px)
- every text-bearing segment now carries min-w-0 + truncate + a native title tooltip with the full value, so nothing gets pushed off-screen or hidden at large fonts / narrow windows
- new CopyableText component: single click copies the full value (status message, selected session name, X11 display/endpoint, LLM provider) with a transient check mark and "Copied to clipboard" tooltip; clipboard writes go through src/lib/clipboard.ts writeText (Tauri command first, browser API fallback)
- StatusSegment gains an optional copyText prop: right-click copies the full value (LSP label, git branch) without interfering with the segment's primary click action (open Language Servers / Git manager), matching the PathBreadcrumb right-click-copy convention

Tests: StatusBar.test.tsx gains 4 cases — status-message tooltip and click-to-copy, empty message renders no segment, selected-session-name copy, and git-branch right-click copy that does not trigger the primary click. Full suite passes (217 files / 1787 tests), tsc -b is clean. Existing qa-ui-auto cases only assert on the status-bar testid and keyword text, unaffected.