### PR TITLE
fix(lsp): probe rustup shims before reporting a server available

### DIFF
--- a/src-tauri/src/lsp.rs
+++ b/src-tauri/src/lsp.rs
@@ -5397,10 +5397,69 @@ fn command_available(command: &str) -> bool {
 
 fn command_available_uncached(command: &str) -> bool {
     let path = Path::new(command);
-    if path.is_absolute() || command.contains('/') || command.contains('\\') {
-        return path.is_file();
+    let resolved = if path.is_absolute() || command.contains('/') || command.contains('\\') {
+        if !path.is_file() {
+            return false;
+        }
+        path.to_path_buf()
+    } else {
+        match which::which(command) {
+            Ok(resolved) => resolved,
+            Err(_) => return false,
+        }
+    };
+    // A resolved path is not proof the tool runs: rustup installs *proxy shims*
+    // into `~/.cargo/bin` when rustup itself is installed, independent of which
+    // components exist. `rust-analyzer.exe` is therefore always on PATH, and
+    // `which` reports it available even when the component was never added — the
+    // shim then fails at spawn with `error: Unknown binary 'rust-analyzer' in
+    // official toolchain '…'`. That turned a missing component into a raw stderr
+    // string in the editor instead of the `rustup component add` install hint.
+    if is_rustup_shim(&resolved) {
+        return binary_runs(&resolved);
     }
-    which::which(command).is_ok()
+    true
+}
+
+/// Names rustup proxies out of `<cargo home>/bin` that can appear as a language
+/// server command. A shim is only distinguishable from a real binary by living
+/// next to rustup's own proxy, so require `rustup` as a sibling.
+const RUSTUP_SHIMMED_LSP_BINARIES: &[&str] = &["rust-analyzer"];
+
+fn is_rustup_shim(resolved: &Path) -> bool {
+    let Some(stem) = resolved.file_stem().and_then(|stem| stem.to_str()) else {
+        return false;
+    };
+    if !RUSTUP_SHIMMED_LSP_BINARIES
+        .iter()
+        .any(|name| stem.eq_ignore_ascii_case(name))
+    {
+        return false;
+    }
+    let Some(parent) = resolved.parent() else {
+        return false;
+    };
+    parent
+        .join(format!("rustup{}", std::env::consts::EXE_SUFFIX))
+        .is_file()
+}
+
+/// Spawn `<binary> --version` to confirm the tool actually starts. Only used for
+/// shims, so this costs one short-lived process per [`COMMAND_AVAILABILITY_TTL`]
+/// window rather than on every availability query.
+fn binary_runs(binary: &Path) -> bool {
+    let mut cmd = std::process::Command::new(binary);
+    cmd.arg("--version");
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::null());
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd.status().is_ok_and(|status| status.success())
 }
 
 fn command_availability_cache() -> &'static StdMutex<HashMap<String, CachedCommandAvailability>> {
@@ -7640,6 +7699,59 @@ Java(TM) SE Runtime Environment (build 17.0.4+11-LTS-179)
         std::fs::remove_file(&command_path).unwrap();
         assert!(command_available(&command));
 
+        command_availability_cache()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&command);
+        assert!(!command_available(&command));
+    }
+
+    #[test]
+    fn treats_rust_analyzer_next_to_rustup_as_a_shim() {
+        let directory = tempfile::tempdir().unwrap();
+        let shim = directory
+            .path()
+            .join(format!("rust-analyzer{}", std::env::consts::EXE_SUFFIX));
+        std::fs::write(&shim, b"test").unwrap();
+
+        // No sibling rustup: a plain binary, taken at face value.
+        assert!(!is_rustup_shim(&shim));
+
+        std::fs::write(
+            directory
+                .path()
+                .join(format!("rustup{}", std::env::consts::EXE_SUFFIX)),
+            b"test",
+        )
+        .unwrap();
+        assert!(is_rustup_shim(&shim));
+
+        // Other binaries in the same directory are not rustup proxies.
+        let other = directory
+            .path()
+            .join(format!("gopls{}", std::env::consts::EXE_SUFFIX));
+        std::fs::write(&other, b"test").unwrap();
+        assert!(!is_rustup_shim(&other));
+    }
+
+    #[test]
+    fn reports_unrunnable_rustup_shim_as_unavailable() {
+        let directory = tempfile::tempdir().unwrap();
+        // Not a real executable, so `--version` cannot succeed — stands in for a
+        // shim whose component was never added.
+        let shim = directory
+            .path()
+            .join(format!("rust-analyzer{}", std::env::consts::EXE_SUFFIX));
+        std::fs::write(&shim, b"test").unwrap();
+        std::fs::write(
+            directory
+                .path()
+                .join(format!("rustup{}", std::env::consts::EXE_SUFFIX)),
+            b"test",
+        )
+        .unwrap();
+
+        let command = shim.to_string_lossy().into_owned();
         command_availability_cache()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())


### PR DESCRIPTION
Language server availability was decided by path resolution alone, which misreports every rustup-proxied binary. rustup installs proxy shims into `<cargo home>/bin` as part of installing rustup itself, independent of which toolchain components exist, so `rust-analyzer.exe` is always present on PATH. `which` therefore resolved it and Settings blue-dotted Rust as available on a machine where the component had never been added. The shim only fails later, at spawn, with `error: Unknown binary 'rust-analyzer' in official toolchain 'stable-x86_64-pc-windows-msvc'` — surfacing in the editor as a raw `language server stdout closed (...)` string.

The user-visible cost was the wrong remedy. Because `binary_available` was true, document_status suppressed install guidance (it only advertises a hint when the binary is missing), so the already-configured `rustup component add rust-analyzer` hint on the Rust preset was unreachable exactly when it was the fix. Java avoided this class of bug by pairing binary presence with a runtime probe; the rustup path had no equivalent check.

Resolve the command once, then treat a resolved rustup shim as unproven and run `<binary> --version` to confirm it actually starts. Identify a shim by name plus a sibling `rustup` executable, since a shim is otherwise byte-indistinguishable from a hand-installed binary of the same name in the same directory; a `rust-analyzer` on PATH without rustup next to it is still taken at face value. Probing stays behind the existing 30s availability cache, so it costs one short-lived process per TTL window rather than one per query, and inherits the CREATE_NO_WINDOW handling used elsewhere so packaged Windows builds do not flash a console. Non-shim commands keep the previous cost: no spawn at all.

With availability answered correctly, a missing component now reports the server as unavailable and routes users to the install hint instead of an adapter error string, and the Settings dot self-corrects within one cache window after `rustup component add`.

Scope note: `RUSTUP_SHIMMED_LSP_BINARIES` lists only `rust-analyzer`, the sole rustup-proxied tool among the LSP presets, and is the seam to extend if another is added.

Tests: cd src-tauri && cargo test --lib lsp::tests (53 passed), covering shim identification with/without a sibling rustup, non-proxied binaries in the same directory, and an unrunnable shim reported unavailable through the cache.

Tests: cd src-tauri && cargo clippy --lib (no findings on the added code)

Verified against the reporting environment: the shim resolves, is identified, and now probes successfully once `rustup component add rust-analyzer` supplies the component (rust-analyzer 1.96.0). `cargo clippy --all-features` was not run; it fails to build `audiopus_sys` locally for want of nasm, unrelated to this change. rustfmt was not applied to the file: it reformats roughly forty unrelated pre-existing regions, and the added code is already byte-identical to its rustfmt output.