### PR TITLE
ci(macos): harden Redirector release gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,7 +319,9 @@ jobs:
   # ---------------------------------------------------------------------------
   build-macos:
     name: Bundle (macOS)
-    runs-on: macos-latest          # arm64 (Apple Silicon) runner
+    # Pin the major runner image instead of following the moving `macos-latest`
+    # label. GitHub's macos-15 standard image is arm64 (Apple Silicon).
+    runs-on: macos-15
 
     steps:
       - name: Checkout
@@ -368,6 +370,10 @@ jobs:
 
       - name: Install MIT Kerberos (x86_64 – Rosetta 2)
         run: |
+          set -euo pipefail
+          if ! arch -x86_64 /usr/bin/true 2>/dev/null; then
+            sudo softwareupdate --install-rosetta --agree-to-license
+          fi
           # Bootstrap x86_64 Homebrew if it isn't already present
           if [ ! -x /usr/local/bin/brew ]; then
             arch -x86_64 /bin/bash -c \
@@ -378,13 +384,19 @@ jobs:
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 
-      # Stage xray-core (MPL-2.0, Apple silicon) into resources so the macOS
-      # bundle can serve core-backed upstreams. Runner has pwsh preinstalled.
-      - name: Stage xray-core (macos arm64)
-        run: pwsh scripts/fetch-xray.ps1 -Platform macos-arm64
-
-      - name: Stage and verify signed Mitmproxy Redirector
+      # Keep Redirector v0.12.11 as an opaque, upstream-signed universal app
+      # archive. Taomni never rebuilds or re-signs its nested System Extension.
+      - name: Stage and verify signed Mitmproxy Redirector v0.12.11
         run: bash scripts/stage-mitmproxy-redirector-macos.sh --stage
+
+      - name: Verify macOS Redirector protocol and recovery gates
+        env:
+          LIBGSSAPI_IMPL: mit
+          LIBGSSAPI_PREFIX: /opt/homebrew/opt/krb5
+          PKG_CONFIG_PATH: /opt/homebrew/opt/krb5/lib/pkgconfig
+        run: |
+          cargo test --manifest-path src-tauri/Cargo.toml --lib sockscap::redirector -- --test-threads=1
+          cargo test --manifest-path src-tauri/Cargo.toml --lib sockscap::recovery -- --test-threads=1
 
       - name: Resolve release version
         id: version
@@ -407,7 +419,47 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
+      # Tauri updater signing and Apple Developer ID signing are independent
+      # trust chains. Workflow-only artifacts may remain unsigned, but a tag or
+      # GitHub Release must never publish a non-notarized macOS bundle.
+      - name: Require macOS release signing and notarization secrets
+        if: steps.version.outputs.tag != ''
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in \
+            TAURI_SIGNING_PRIVATE_KEY \
+            APPLE_CERTIFICATE \
+            APPLE_CERTIFICATE_PASSWORD \
+            APPLE_ID \
+            APPLE_PASSWORD \
+            APPLE_TEAM_ID; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "Missing required macOS release secrets: ${missing[*]}" >&2
+            echo "Tagged macOS releases require updater signing, Developer ID signing and Apple notarization." >&2
+            exit 1
+          fi
+
       # ---------- aarch64-apple-darwin (native) ----------
+      - name: Stage and verify xray-core (aarch64)
+        shell: bash
+        run: |
+          set -euo pipefail
+          pwsh scripts/fetch-xray.ps1 -Platform macos-arm64 -Force
+          test "$(lipo -archs src-tauri/resources/sockscap/macos/xray)" = "arm64"
+
       - name: Build and upload release bundle (aarch64)
         id: tauri_macos_aarch64_release
         if: steps.version.outputs.tag != ''
@@ -416,6 +468,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           # Point libgssapi-sys at Homebrew MIT Kerberos (arm64)
           LIBGSSAPI_IMPL: mit
           LIBGSSAPI_PREFIX: /opt/homebrew/opt/krb5
@@ -427,6 +484,12 @@ jobs:
           generateReleaseNotes: true
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
           args: --target aarch64-apple-darwin
+
+      - name: Verify signed and notarized release bundle (aarch64)
+        if: steps.version.outputs.tag != ''
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: bash scripts/verify-macos-release-bundle.sh aarch64-apple-darwin arm64
 
       - name: Collect release workflow artifacts (aarch64)
         if: steps.version.outputs.tag != ''
@@ -475,6 +538,13 @@ jobs:
           if-no-files-found: error
 
       # ---------- x86_64-apple-darwin (cross-compile) ----------
+      - name: Stage and verify xray-core (x86_64)
+        shell: bash
+        run: |
+          set -euo pipefail
+          pwsh scripts/fetch-xray.ps1 -Platform macos -Force
+          test "$(lipo -archs src-tauri/resources/sockscap/macos/xray)" = "x86_64"
+
       - name: Build and upload release bundle (x86_64)
         id: tauri_macos_x86_64_release
         if: steps.version.outputs.tag != ''
@@ -483,6 +553,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           # Point libgssapi-sys at x86_64 MIT Kerberos under /usr/local
           LIBGSSAPI_IMPL: mit
           LIBGSSAPI_PREFIX: /usr/local/opt/krb5
@@ -495,6 +570,12 @@ jobs:
           generateReleaseNotes: true
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
           args: --target x86_64-apple-darwin
+
+      - name: Verify signed and notarized release bundle (x86_64)
+        if: steps.version.outputs.tag != ''
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: bash scripts/verify-macos-release-bundle.sh x86_64-apple-darwin x86_64
 
       - name: Collect release workflow artifacts (x86_64)
         if: steps.version.outputs.tag != ''

--- a/claudedocs/sockscap-macos-redirector-implementation-analysis.md
+++ b/claudedocs/sockscap-macos-redirector-implementation-analysis.md
@@ -2,7 +2,7 @@
 
 > 日期：2026-08-01
 >
-> 状态：P0–P2 代码切片已实现；真实双架构故障注入/soak 与上游 v2 发布仍是 release gate
+> 状态：P0–P2 代码切片已实现；Redirector v0.12.11 是当前受支持且固定的生产基线版本；真实双架构故障注入/soak 等仍是 release gate，上游 v2 是非阻塞路线图
 >
 > 目标方案：[`sockscap-macos-transparent-only-plan.md`](./sockscap-macos-transparent-only-plan.md)
 >
@@ -108,7 +108,13 @@
 - 启动恢复仅删除当前用户、固定命名、类型为 Unix socket 且已经无法连接的遗留节点；不会删除普通文件、外来 owner 或活跃 socket。
 - UI 提供 Recover、macOS 系统设置手动关闭步骤和去敏诊断复制；恢复失败会阻止 Start、更新和静默宣称成功。
 
-仍有一个无法在 Taomni v1 适配层内消除的上游边界：Redirector v0.12.11 没有 Provider applied ACK、typed identity selector 或 control EOF atomic fail-open。因此本地 `Applied/Active` 只表示 bridge 已把完整 v1 frame 写入经验证的 Provider control；真正 Provider ACK 需要上游 protocol v2。完整异常注入矩阵仍是 production release gate。
+仍有一个无法在 Taomni v1 适配层内消除的上游边界：Redirector v0.12.11 没有 Provider applied ACK、typed identity selector 或 control EOF atomic fail-open。因此本地 `Applied/Active` 只表示 bridge 已把完整 v1 frame 写入经验证的 Provider control；真正 Provider ACK 需要上游 protocol v2。
+
+这里的“强应用身份隔离”是指 Provider 在每条新 flow 进入时，依据系统观察到的 audit token、bundle ID、Team ID、signing ID/designated requirement 独立验明进程身份，而不是仅判断可执行文件路径是否包含某段字符串。当前 v0.12.11 路径由 Taomni 在 Start 前验签、编译 canonical app path-family，并由 bridge 对 flow 再匹配；它能够支持当前 Application 功能，但不等同于 Provider 内部的不可伪造身份授权。
+
+“任何崩溃均原子 fail-open”是指 control EOF、Provider/bridge crash 或进程被 `SIGKILL` 的同一状态转换中，Provider 立即停止把新连接导向旧 listener，让新连接直接联网，不存在中间残留拦截窗口。当前实现对正常退出、可处理信号、父进程消失和心跳中断执行 `inert -> drain -> close`，并用 dirty journal 在下次启动恢复；但 v0.12.11 不承诺 control EOF 原子 fail-open，所以极端 crash 到下次恢复/手动关闭之间仍可能存在残留窗口。
+
+这些是 v0.12.11 的已知协议边界，不阻塞当前固定版本发布。当前 production release gate 是完整异常注入、双架构/Application 真机矩阵、稳定性、供应链和 Taomni 自身签名公证；如果产品未来要求 Provider 级强身份授权或协议层零残留窗口，再推进 protocol v2。
 
 ## 9. 后续待办清单
 
@@ -184,7 +190,7 @@ Application v1 的真实能力边界是“经签名重验证的 canonical app pa
 - [x] 已安装正确版本时幂等；同签名旧版本使用随机 stage/backup 和失败回滚升级；同名但 bundle/Team/签名不匹配时拒绝覆盖并提示冲突。
 - [ ] 把“缺失”、“待 System Extension 批准”、“待 Network Configuration 批准”、“签名错误”和“版本不支持”建模为不同状态和 UI 操作，而不是统一 Start 错误。
 - [x] 在 staging/release 脚本的固定下载、hash、签名、universal arch 和 MIT notice 检查上补齐 entitlement/Gatekeeper、双架构与 stapler gate；协议 golden fixture 进入 Rust 测试。
-- [ ] 明确 Taomni updater 签名与 Apple Developer ID/notarization 是两套独立信任链；正式 Gatekeeper 分发前完成 Taomni 自身签名和公证。
+- [ ] Taomni updater 签名与 Apple Developer ID/notarization 是两套独立信任链；release workflow 已要求两套 secrets，并在两个架构构建后验证 Taomni Developer ID、Team ID、Gatekeeper notarization 和 stapled ticket。正式 Gatekeeper 分发仍需配置真实 Apple 凭据并让首个 tag 构建通过该 gate。
 
 ### 9.8 P1/P2：数据面、可观测性和稳定性
 
@@ -195,12 +201,14 @@ Application v1 的真实能力边界是“经签名重验证的 canonical app pa
 - [ ] 在 Intel/Apple Silicon、IPv4/IPv6、Safari/Chrome/curl/原始 socket client 上完成 Global 矩阵，并验证 Start/Stop 前后 `scutil --proxy` 完全不变。
 - [x] 将当前与本改动无关的全量 Rust 测试失败单独记录；聚焦 macOS Redirector 新增回归必须独立全绿，不得被既有失败掩盖。
 
-### 9.9 P2：推动上游协议 v2
+### 9.9 P2：上游协议 v2 非阻塞路线图
+
+本节不属于 Redirector v0.12.11 的当前发布 gate。v0.12.11 继续作为受支持且固定的生产基线；只有决定采用上游未来版本时，才执行提交、迁移和升级。
 
 - [x] 在仓库内完成 typed selector、identity、version/generation/request、applied ACK、显式 disable、atomic EOF、迁移与测试矩阵的具体提案：[`sockscap-redirector-protocol-v2-proposal.md`](./sockscap-redirector-protocol-v2-proposal.md)。
 - [ ] 向 mitmproxy 上游提交 typed selector（exact path/bundle/signing ID/PID）和 `NewFlow` 身份字段扩展。
 - [ ] 提交 protocol version、generation/applied ACK、显式 disable/stop 和 control EOF 原子 fail-open。
-- [ ] 只接入由上游重新签名发布的 Redirector；固定新版本/hash/协议 fixture，保留 v1 path-family 配置迁移并优先使用 v2 signing identity。
+- [ ] 若未来采用 v2，只接入由 mitmproxy 上游构建、签名并发布的新 Redirector；固定新版本/hash/协议 fixture，保留 v1 path-family 配置迁移并优先使用 v2 signing identity，不修改或自行重签 Provider。
 
 ## 10. 建议实施顺序与发布 gate
 
@@ -208,9 +216,9 @@ Application v1 的真实能力边界是“经签名重验证的 canonical app pa
 2. 完成 §9.2–§9.4，把 control 所有权从 Tauri 迁入 bridge，建立父进程监控和启动前 recovery-only 闭环。
 3. 通过 §9.5 全部 fault injection 后，才允许 Global 进入 production-ready。
 4. 在 P0 生命周期基础上完成 §9.6；identity 和 selected/unselected 矩阵全部通过后才开启 `app_filter=true`。
-5. §9.7–§9.9 可与 Application 工作并行，但安装/升级、供应链、双架构和稳定性验收仍是正式发布的必要条件。
+5. §9.7–§9.8 可与 Application 工作并行；安装/升级、供应链、双架构和稳定性验收仍是正式发布的必要条件。§9.9 v2 是非阻塞路线图，不影响固定 v0.12.11 发布。
 
-任何单元测试或 PoC 成功都不能单独解锁上述 gate；Global/Application 的生产能力以真实已签名 Redirector、已批准 System Extension 和故障注入结果为准。
+任何单元测试或 PoC 成功都不能单独解锁上述 gate；Global/Application 的生产能力以固定且验证通过的官方签名 Redirector v0.12.11、已批准 System Extension 和故障注入结果为准，不依赖上游 v2 发布。
 
 ## 11. P0–P2 本轮交付与验证记录
 
@@ -225,4 +233,4 @@ Application v1 的真实能力边界是“经签名重验证的 canonical app pa
 - Redirector app/extension 都确认是 `x86_64 arm64`，System Extension 为 `[activated enabled]`；验证后 `scutil --proxy` 的 `HTTPEnable`、`HTTPSEnable`、`SOCKSEnable` 仍全部为 `0`。
 - `bash scripts/stage-mitmproxy-redirector-macos.sh --check` 在可访问 macOS 安全服务的环境中通过：app/extension nested codesign、Designated Requirement、entitlement、固定 hash、双架构、Gatekeeper Notarized Developer ID 和 stapled ticket 均验证成功。
 
-本轮没有伪造以下外部结果：Apple Silicon 实机、完整 §9.5 fault injection、Application 多浏览器/Helper/XPC selected-unselected、1–4 小时 soak/高并发，以及 mitmproxy 上游 v2 PR/重新签名发布仍未执行。它们保持未勾选 release gate。
+本轮没有伪造以下外部结果：Apple Silicon 实机、完整 §9.5 fault injection、Application 多浏览器/Helper/XPC selected-unselected、1–4 小时 soak/高并发仍未执行，并保持未勾选 release gate。mitmproxy 上游 v2 PR/官方签名新版本也未执行，但它属于非阻塞路线图，不是 v0.12.11 的当前 release gate。

--- a/claudedocs/sockscap-macos-transparent-only-plan.md
+++ b/claudedocs/sockscap-macos-transparent-only-plan.md
@@ -239,7 +239,7 @@ Hosted macOS Runner 可以完成：
 
 Hosted Runner 不能完成首次 System Extension 人工批准或可靠的持久化真机 E2E。运行态回归使用预批准的 self-hosted Mac 或发布前人工测试。
 
-`TAURI_SIGNING_PRIVATE_KEY` 只负责 Tauri updater，不等于 Apple Developer ID。Taomni 的正式 Gatekeeper 分发仍需要自己的 Developer ID 和 notarization secrets；没有账户时只能发布需要用户手动确认的 Taomni 包，Redirector 本身仍保持上游签名、公证。
+`TAURI_SIGNING_PRIVATE_KEY` 只负责 Tauri updater，不等于 Apple Developer ID。Taomni 的正式 Gatekeeper 分发使用 GitHub Secrets `APPLE_CERTIFICATE`、`APPLE_CERTIFICATE_PASSWORD`、`APPLE_ID`、`APPLE_PASSWORD` 和 `APPLE_TEAM_ID` 完成 Developer ID 签名与公证。无 tag 的 workflow artifact 可以不使用正式 Apple 凭据；tag/GitHub Release 缺少任一 updater/Apple 必需 secret 时必须提前失败，不发布需要用户手动放行的降级包。Redirector 始终保持独立的上游签名、公证和固定 hash。
 
 ## 7. CaptureScopeCompiler
 

--- a/claudedocs/sockscap-redirector-protocol-v2-proposal.md
+++ b/claudedocs/sockscap-redirector-protocol-v2-proposal.md
@@ -1,6 +1,6 @@
 # Mitmproxy macOS Redirector protocol v2 proposal
 
-> Taomni tracking draft, 2026-08-01. This is an upstream design proposal, not a claim that Redirector v0.12.11 implements these fields.
+> Taomni tracking draft, 2026-08-01. This is a non-blocking upstream roadmap, not a claim that Redirector v0.12.11 implements these fields. Redirector v0.12.11 remains Taomni's supported, pinned production baseline and does not depend on this proposal to ship.
 
 ## Goals
 
@@ -83,9 +83,9 @@ message NewFlowIdentity {
 ## Compatibility and rollout
 
 1. Add a version negotiation/status exchange without changing the v1 frame type. A v1-only peer closes or rejects the v2 probe; the client then uses the existing v1 path-family adapter only when the user selected that compatibility mode.
-2. Publish v2 as a newly signed Redirector release. Taomni pins its version, app/extension hashes, Team/bundle identity and golden fixtures; it never patches or re-signs the Provider.
+2. If upstream accepts v2, publish it as a newly built and officially signed Redirector release. Taomni pins its version, app/extension hashes, Team/bundle identity and golden fixtures; it never patches or re-signs the Provider.
 3. Migrate stored selectors by revalidating the `.app`, then emit a v2 `BundleIdentity`. Preserve canonical paths only as diagnostic/fail-open constraints.
-4. Prefer v2 for Global and Applications. Keep v1 recovery support long enough to disable a residual v1 scope, but never translate an ambiguous v1 substring into a broader v2 selector.
+4. If Taomni later adopts that release, prefer v2 for Global and Applications. Keep v1 recovery support long enough to disable a residual v1 scope, but never translate an ambiguous v1 substring into a broader v2 selector.
 5. Remove the v1 compatibility path only after signed Intel and Apple Silicon fault-injection, update/move, EOF and selected/unselected matrices pass.
 
 ## Required upstream tests
@@ -97,4 +97,4 @@ message NewFlowIdentity {
 - Unknown fields, malformed and oversized frames, action/selector limits.
 - 1/32/256 concurrent flows, 1,000–5,000 long-lived flows, UDP flood and sleep/network transitions on arm64 and x86_64.
 
-External submission and the signed upstream release remain outside this repository; Taomni can only integrate v2 after mitmproxy accepts and ships it.
+External submission and an officially signed upstream release remain outside this repository. Taomni can only integrate v2 after mitmproxy accepts and ships it, but neither event blocks the pinned Redirector v0.12.11 release line.

--- a/scripts/verify-macos-release-bundle.sh
+++ b/scripts/verify-macos-release-bundle.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Post-bundle release gate for the Taomni macOS app. This validates Taomni's
+# Developer ID/notarization chain separately from the pinned mitmproxy chain.
+set -euo pipefail
+export LC_ALL=C
+export LANG=C
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <rust-target-triple> <expected-arch>" >&2
+  exit 2
+fi
+
+target_triple="$1"
+expected_arch="$2"
+expected_team_id="${APPLE_TEAM_ID:?APPLE_TEAM_ID is required}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bundle_root="$repo_root/src-tauri/target/$target_triple/release/bundle"
+app="$bundle_root/macos/Taomni.app"
+main_executable="$app/Contents/MacOS/taomni"
+resource_root="$app/Contents/Resources"
+pinned_redirector="$repo_root/src-tauri/resources/sockscap/macos/redirector/0.12.11/Mitmproxy Redirector.app.tar"
+pinned_manifest="$repo_root/src-tauri/resources/sockscap/macos/redirector/0.12.11/manifest.json"
+pinned_license="$repo_root/src-tauri/resources/sockscap/macos/redirector/0.12.11/LICENSE"
+
+test -d "$app" || {
+  echo "Taomni app bundle is missing: $app" >&2
+  exit 1
+}
+test -x "$main_executable" || {
+  echo "Taomni executable is missing: $main_executable" >&2
+  exit 1
+}
+
+codesign --verify --deep --strict --verbose=2 "$app"
+signature="$(codesign -d --verbose=4 "$app" 2>&1)"
+grep -Fq 'Identifier=com.taomni.app' <<<"$signature"
+grep -Fq "TeamIdentifier=$expected_team_id" <<<"$signature"
+grep -Eq 'flags=.*\(runtime\)' <<<"$signature"
+
+main_architectures="$(lipo -archs "$main_executable")"
+test "$main_architectures" = "$expected_arch" || {
+  echo "Expected Taomni architecture $expected_arch, found: $main_architectures" >&2
+  exit 1
+}
+
+xray_count="$(find "$resource_root" -type f -path '*/sockscap/macos/xray' | wc -l | tr -d ' ')"
+test "$xray_count" = "1" || {
+  echo "Expected one bundled macOS xray executable, found $xray_count" >&2
+  exit 1
+}
+xray="$(find "$resource_root" -type f -path '*/sockscap/macos/xray' -print -quit)"
+test -x "$xray" || {
+  echo "Bundled xray is not executable: $xray" >&2
+  exit 1
+}
+xray_architectures="$(lipo -archs "$xray")"
+test "$xray_architectures" = "$expected_arch" || {
+  echo "Expected bundled xray architecture $expected_arch, found: $xray_architectures" >&2
+  exit 1
+}
+
+redirector_count="$(find "$resource_root" -type f -path '*/sockscap/macos/redirector/0.12.11/Mitmproxy Redirector.app.tar' | wc -l | tr -d ' ')"
+test "$redirector_count" = "1" || {
+  echo "Expected one bundled Redirector v0.12.11 archive, found $redirector_count" >&2
+  exit 1
+}
+bundled_redirector="$(find "$resource_root" -type f -path '*/sockscap/macos/redirector/0.12.11/Mitmproxy Redirector.app.tar' -print -quit)"
+cmp "$pinned_redirector" "$bundled_redirector"
+
+bundled_manifest="$(find "$resource_root" -type f -path '*/sockscap/macos/redirector/0.12.11/manifest.json' -print -quit)"
+bundled_license="$(find "$resource_root" -type f -path '*/sockscap/macos/redirector/0.12.11/LICENSE' -print -quit)"
+test -n "$bundled_manifest" && cmp "$pinned_manifest" "$bundled_manifest"
+test -n "$bundled_license" && cmp "$pinned_license" "$bundled_license"
+
+gatekeeper="$(spctl --assess --type execute --verbose=4 "$app" 2>&1)"
+grep -Fq 'source=Notarized Developer ID' <<<"$gatekeeper"
+xcrun stapler validate "$app"
+
+echo "Taomni macOS $expected_arch release verified: Developer ID, notarization, architecture, Xray and Redirector v0.12.11."


### PR DESCRIPTION
Keep the upstream-signed Mitmproxy Redirector v0.12.11 artifact as the pinned production baseline and make protocol v2 an explicitly non-blocking future roadmap.

Update the macOS release job to pin the arm64 macos-15 runner, provision Rosetta for Intel cross-build dependencies, run the focused Redirector and recovery suites, and force architecture-specific Xray staging before each bundle so Intel packages cannot accidentally contain the arm64 core.

Require updater signing plus Apple Developer ID and notarization credentials for tagged releases. Pass the certificate and Apple ID credentials only to release builds while leaving untagged workflow artifacts able to build without production Apple credentials.

Add a post-bundle gate for both Apple Silicon and Intel outputs. It verifies Taomni codesign integrity, bundle and Team identity, hardened runtime, exact executable/Xray architecture, Gatekeeper notarization, stapled ticket, and byte-for-byte preservation of the pinned Redirector archive, manifest, and MIT license.

Document the v0.12.11 application-identity and fail-open boundaries, keep fault-injection/dual-architecture/soak/signing validation as real release gates, and clarify that a future upstream v2 PR or signed v2 release does not block the current release line.

Validation: release.yml YAML parse; shell syntax and git diff checks; Redirector supply-chain codesign/Gatekeeper/stapler check; 24 Redirector unit tests; 3 recovery unit tests. Linux and Windows release jobs are unchanged.