### PR TITLE
fix(sockscap): stabilize macOS global capture and GFWList

### DIFF
--- a/src-tauri/src/sockscap/config.rs
+++ b/src-tauri/src/sockscap/config.rs
@@ -437,7 +437,10 @@ impl SocksCapConfig {
             }
         }
         if self.selected_profile_id.is_empty()
-            || !self.profiles.iter().any(|p| p.id == self.selected_profile_id)
+            || !self
+                .profiles
+                .iter()
+                .any(|p| p.id == self.selected_profile_id)
         {
             if let Some(first) = self.profiles.first() {
                 self.selected_profile_id = first.id.clone();
@@ -485,6 +488,12 @@ impl SocksCapConfig {
             .collect();
         list.sort_by_key(|p| p.priority);
         list
+    }
+
+    pub fn requires_gfwlist(&self) -> bool {
+        self.active_profiles()
+            .iter()
+            .any(|profile| matches!(profile.rule_mode, RuleMode::GfwList))
     }
 
     pub fn validate(&self) -> Result<(), String> {
@@ -641,5 +650,22 @@ mod tests {
         assert_eq!(loaded.profiles[0].upstream.host, "1.2.3.4");
         assert_eq!(loaded.profiles[0].rule_mode, RuleMode::ProxyAll);
         assert!(loaded.validate().is_ok());
+    }
+
+    #[test]
+    fn gfwlist_requirement_covers_every_active_profile() {
+        let mut config = SocksCapConfig::default();
+        config.profiles[0].rule_mode = RuleMode::ProxyAll;
+        let mut gfw = config.profiles[0].clone();
+        gfw.id = "gfw".into();
+        gfw.rule_mode = RuleMode::GfwList;
+        gfw.priority = 10;
+        config.profiles.push(gfw);
+        config.active_profile_ids = vec!["default".into(), "gfw".into()];
+        config.selected_profile_id = "default".into();
+
+        assert!(config.requires_gfwlist());
+        config.active_profile_ids = vec!["default".into()];
+        assert!(!config.requires_gfwlist());
     }
 }

--- a/src-tauri/src/sockscap/egress/http_connect.rs
+++ b/src-tauri/src/sockscap/egress/http_connect.rs
@@ -70,8 +70,12 @@ async fn handshake_inner(
     user: &str,
     pass: &str,
 ) -> Result<(), String> {
+    let authority = match host.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V6(ip)) => format!("[{ip}]:{port}"),
+        _ => format!("{host}:{port}"),
+    };
     let mut req = format!(
-        "CONNECT {host}:{port} HTTP/1.1\r\nHost: {host}:{port}\r\nProxy-Connection: keep-alive\r\n"
+        "CONNECT {authority} HTTP/1.1\r\nHost: {authority}\r\nProxy-Connection: keep-alive\r\n"
     );
     if !user.is_empty() {
         let token = B64.encode(format!("{user}:{pass}"));
@@ -137,5 +141,33 @@ mod tests {
 
         assert!(error.contains("timed out"));
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn ipv6_connect_authority_is_bracketed() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut byte = [0u8; 1];
+            while !request.ends_with(b"\r\n\r\n") {
+                socket.read_exact(&mut byte).await.unwrap();
+                request.push(byte[0]);
+            }
+            socket
+                .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                .await
+                .unwrap();
+            String::from_utf8(request).unwrap()
+        });
+        let mut client = TcpStream::connect(address).await.unwrap();
+
+        handshake(&mut client, "2001:db8::1", 443, "", "")
+            .await
+            .unwrap();
+        let request = server.await.unwrap();
+        assert!(request.starts_with("CONNECT [2001:db8::1]:443 HTTP/1.1\r\n"));
+        assert!(request.contains("\r\nHost: [2001:db8::1]:443\r\n"));
     }
 }

--- a/src-tauri/src/sockscap/mod.rs
+++ b/src-tauri/src/sockscap/mod.rs
@@ -601,7 +601,7 @@ pub async fn sockscap_start(
 
     // GFWList mode: require rules (cache or fresh fetch) before capture.
     let mut gfw_start_note = String::new();
-    if matches!(cfg.rule_mode, RuleMode::GfwList) {
+    if cfg.requires_gfwlist() {
         let mut orch = state.sockscap.orch.write().await;
         if orch.rules().is_none() {
             if let Some(c) = rules::source::load_cached(&dir) {

--- a/src-tauri/src/sockscap/policy.rs
+++ b/src-tauri/src/sockscap/policy.rs
@@ -1,10 +1,10 @@
-use std::net::IpAddr;
 use serde::Serialize;
+use std::net::IpAddr;
 
-use crate::sockscap::config::{RuleMode, ScopeMode, SocksCapConfig, SocksCapProfile, UserRule, UserRuleAction};
+use crate::sockscap::Decision;
+use crate::sockscap::config::{RuleMode, ScopeMode, SocksCapConfig, UserRule, UserRuleAction};
 use crate::sockscap::paths::{normalize_exe_path, paths_match_exe};
 use crate::sockscap::rules::{CompiledRules, RuleMatch};
-use crate::sockscap::Decision;
 
 #[derive(Debug, Clone)]
 pub struct PolicyInput {
@@ -69,22 +69,14 @@ impl IpNetwork {
         match (self.addr, ip) {
             (IpAddr::V4(n), IpAddr::V4(a)) => {
                 let shift = 32u32.saturating_sub(self.prefix as u32);
-                let mask = if shift >= 32 {
-                    0
-                } else {
-                    u32::MAX << shift
-                };
+                let mask = if shift >= 32 { 0 } else { u32::MAX << shift };
                 (u32::from(n) & mask) == (u32::from(a) & mask)
             }
             (IpAddr::V6(n), IpAddr::V6(a)) => {
                 let n = u128::from(n);
                 let a = u128::from(a);
                 let shift = 128u32.saturating_sub(self.prefix as u32);
-                let mask = if shift >= 128 {
-                    0
-                } else {
-                    u128::MAX << shift
-                };
+                let mask = if shift >= 128 { 0 } else { u128::MAX << shift };
                 (n & mask) == (a & mask)
             }
             _ => false,
@@ -132,7 +124,11 @@ impl PolicyEngine {
         if self.profiles.is_empty() {
             return false;
         }
-        if self.profiles.iter().any(|p| matches!(p.mode, ScopeMode::Global)) {
+        if self
+            .profiles
+            .iter()
+            .any(|p| matches!(p.mode, ScopeMode::Global))
+        {
             return true;
         }
         let Some(p) = process_path else {
@@ -146,6 +142,57 @@ impl PolicyEngine {
 
     pub fn decide(&self, input: &PolicyInput) -> MatchTrace {
         self.decide_with_profile_hint(input, None)
+    }
+
+    /// Return a final decision when hostname attribution cannot affect it.
+    ///
+    /// Transparent capture receives an IP before any application bytes. Global
+    /// ProxyAll profiles and hard bypasses can be routed immediately instead of
+    /// holding every connection open for the hostname sniff budget. A profile
+    /// with a domain user rule or GFWList still returns `None` and waits for SNI,
+    /// HTTP Host, or the DNS observation cache.
+    pub(crate) fn decide_without_hostname(
+        &self,
+        input: &PolicyInput,
+        profile_id_hint: Option<&str>,
+    ) -> Option<MatchTrace> {
+        if input.host.is_some() {
+            return Some(self.decide_with_profile_hint(input, profile_id_hint));
+        }
+
+        if let Some(ip) = input.ip
+            && self.bypass_cidrs.iter().any(|network| network.contains(ip))
+        {
+            return Some(self.decide_with_profile_hint(input, profile_id_hint));
+        }
+
+        for profile in &self.profiles {
+            if matches!(profile.mode, ScopeMode::Apps) {
+                let in_scope = profile_id_hint
+                    .map(|profile_id| profile_id == profile.id)
+                    .unwrap_or_else(|| match input.process_path.as_deref() {
+                        Some(path) => {
+                            let normalized = normalize_path(path);
+                            profile.apps.iter().any(|app| paths_match(&normalized, app))
+                        }
+                        None => false,
+                    });
+                if !in_scope {
+                    continue;
+                }
+            }
+
+            let has_domain_rule = profile.user_rules.iter().any(|rule| {
+                let pattern = rule.pattern.trim();
+                !pattern.is_empty() && IpNetwork::parse(pattern).is_none()
+            });
+            if has_domain_rule || matches!(profile.rule_mode, RuleMode::GfwList) {
+                return None;
+            }
+            return Some(self.decide_with_profile_hint(input, profile_id_hint));
+        }
+
+        Some(self.decide_with_profile_hint(input, profile_id_hint))
     }
 
     /// Evaluate a flow already scoped by an OS capture backend to one app
@@ -196,17 +243,23 @@ impl PolicyEngine {
             }
 
             // User rules in this profile — Block > Proxy > Direct
-            if let Some(mut t) = self.match_user_rules(prof, host.as_deref(), input.ip, UserRuleAction::Block) {
+            if let Some(mut t) =
+                self.match_user_rules(prof, host.as_deref(), input.ip, UserRuleAction::Block)
+            {
                 t.profile_id = Some(prof.id.clone());
                 t.profile_name = Some(prof.name.clone());
                 return t;
             }
-            if let Some(mut t) = self.match_user_rules(prof, host.as_deref(), input.ip, UserRuleAction::Proxy) {
+            if let Some(mut t) =
+                self.match_user_rules(prof, host.as_deref(), input.ip, UserRuleAction::Proxy)
+            {
                 t.profile_id = Some(prof.id.clone());
                 t.profile_name = Some(prof.name.clone());
                 return t;
             }
-            if let Some(mut t) = self.match_user_rules(prof, host.as_deref(), input.ip, UserRuleAction::Direct) {
+            if let Some(mut t) =
+                self.match_user_rules(prof, host.as_deref(), input.ip, UserRuleAction::Direct)
+            {
                 t.profile_id = Some(prof.id.clone());
                 t.profile_name = Some(prof.name.clone());
                 return t;
@@ -263,7 +316,10 @@ impl PolicyEngine {
                         Some(RuleMatch::Miss) | None => {
                             return MatchTrace {
                                 decision: prof.default_action,
-                                reason: format!("profile '{}' gfwlist miss; default_action", prof.name),
+                                reason: format!(
+                                    "profile '{}' gfwlist miss; default_action",
+                                    prof.name
+                                ),
                                 matched_rule: None,
                                 profile_id: Some(prof.id.clone()),
                                 profile_name: Some(prof.name.clone()),
@@ -347,9 +403,11 @@ fn paths_match(process: &str, selector: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sockscap::config::{AppSelector, RuleMode, ScopeMode, SocksCapConfig, SocksCapProfile, UserRule};
-    use crate::sockscap::rules::CompiledRules;
     use crate::sockscap::Decision;
+    use crate::sockscap::config::{
+        AppSelector, RuleMode, ScopeMode, SocksCapConfig, SocksCapProfile, UserRule,
+    };
+    use crate::sockscap::rules::CompiledRules;
 
     fn cfg_gfw() -> SocksCapConfig {
         let mut c = SocksCapConfig::default();
@@ -393,6 +451,60 @@ mod tests {
             pid: None,
         });
         assert!(matches!(miss.decision, Decision::Direct));
+    }
+
+    #[test]
+    fn hostname_free_decisions_skip_sniff_only_when_safe() {
+        let mut config = cfg_gfw();
+        let input = PolicyInput {
+            host: None,
+            ip: Some("8.8.8.8".parse().unwrap()),
+            port: 443,
+            process_path: None,
+            pid: None,
+        };
+        let gfw = PolicyEngine::from_config(&config, None);
+        assert!(gfw.decide_without_hostname(&input, None).is_none());
+
+        config.profiles[0].rule_mode = RuleMode::ProxyAll;
+        let proxy_all = PolicyEngine::from_config(&config, None);
+        assert!(matches!(
+            proxy_all
+                .decide_without_hostname(&input, None)
+                .unwrap()
+                .decision,
+            Decision::Proxy
+        ));
+
+        config.profiles[0].user_rules.push(UserRule {
+            pattern: "example.com".into(),
+            action: UserRuleAction::Direct,
+            comment: String::new(),
+        });
+        let domain_override = PolicyEngine::from_config(&config, None);
+        assert!(
+            domain_override
+                .decide_without_hostname(&input, None)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn bypass_ip_never_waits_for_a_hostname() {
+        let engine = PolicyEngine::from_config(&cfg_gfw(), None);
+        let trace = engine
+            .decide_without_hostname(
+                &PolicyInput {
+                    host: None,
+                    ip: Some("192.168.0.110".parse().unwrap()),
+                    port: 31028,
+                    process_path: None,
+                    pid: None,
+                },
+                None,
+            )
+            .unwrap();
+        assert!(matches!(trace.decision, Decision::Direct));
     }
 
     #[test]

--- a/src-tauri/src/sockscap/redirector/runtime.rs
+++ b/src-tauri/src/sockscap/redirector/runtime.rs
@@ -34,6 +34,7 @@ use crate::sockscap::paths;
 use crate::sockscap::relay::{
     CapturedFlow, MAX_ACTIVE_RELAY_FLOWS, RelayContext, handle_captured_stream,
 };
+use crate::sockscap::rules::dns::extract_ip_answers;
 
 const CONTROL_CONNECT_TIMEOUT: Duration = Duration::from_secs(180);
 const FLOW_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(15);
@@ -44,8 +45,13 @@ const BRIDGE_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
 const MAX_PENDING_HEARTBEATS: usize = 3;
 const UDP_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+const DNS_UDP_IDLE_TIMEOUT: Duration = Duration::from_secs(10);
 const UDP_DATAGRAM_RATE_PER_SECOND: u64 = 2_048;
 const UDP_DATAGRAM_BURST: u64 = 4_096;
+const TARGET_NOFILE_LIMIT: libc::rlim_t = 4_096;
+const RESERVED_FILE_DESCRIPTORS: u64 = 128;
+const FILE_DESCRIPTORS_PER_FLOW: u64 = 2;
+const MIN_RELAY_FLOW_CAPACITY: usize = 32;
 
 struct SocketCleanup(PathBuf);
 
@@ -74,6 +80,8 @@ pub struct RedirectorTelemetrySnapshot {
     pub started_at: u64,
     pub last_heartbeat_at: Option<u64>,
     pub last_error: Option<String>,
+    pub file_descriptor_limit: u64,
+    pub flow_capacity: usize,
 }
 
 struct RuntimeTelemetry {
@@ -85,6 +93,8 @@ struct RuntimeTelemetry {
     started_at: u64,
     last_heartbeat_at: AtomicU64,
     last_error: Mutex<Option<String>>,
+    file_descriptor_limit: u64,
+    flow_capacity: usize,
 }
 
 impl RuntimeTelemetry {
@@ -103,6 +113,8 @@ impl RuntimeTelemetry {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .clone(),
+            file_descriptor_limit: self.file_descriptor_limit,
+            flow_capacity: self.flow_capacity,
         }
     }
 
@@ -161,6 +173,8 @@ pub async fn start(
     session_id: &str,
 ) -> Result<RedirectorCaptureHandle, String> {
     preflight(config)?;
+    let file_descriptor_limit = prepare_file_descriptor_budget()?;
+    let flow_capacity = relay_flow_capacity(file_descriptor_limit);
 
     let executable = installed_executable_path();
     let mut exclusions = vec![
@@ -193,6 +207,8 @@ pub async fn start(
         started_at: now_unix(),
         last_heartbeat_at: AtomicU64::new(now_unix()),
         last_error: Mutex::new(None),
+        file_descriptor_limit,
+        flow_capacity,
     });
 
     tracing::info!(
@@ -201,6 +217,8 @@ pub async fn start(
         provider_pid = bridge.provider_pid,
         provider_socket = %provider_socket_path.display(),
         flow_socket = %flow_socket_path.display(),
+        file_descriptor_limit,
+        flow_capacity,
         "sockscap: isolated Redirector bridge active"
     );
 
@@ -213,6 +231,7 @@ pub async fn start(
             bridge,
             scope,
             block_quic,
+            flow_capacity,
             ctx,
             stop_rx,
             cleanup,
@@ -325,7 +344,49 @@ pub fn preflight(config: &SocksCapConfig) -> Result<(), String> {
     let _ = config;
     super::verify_installed()
         .map_err(|error| format!("{error}; no system-proxy fallback is available"))?;
+    prepare_file_descriptor_budget()?;
     Ok(())
+}
+
+/// Raise launchd's conservative per-process soft limit before global capture.
+/// A macOS GUI app commonly starts at 256 descriptors, while every active flow
+/// needs one Redirector IPC socket and one egress socket in addition to the
+/// desktop app's normal files, terminals, and database handles.
+fn prepare_file_descriptor_budget() -> Result<u64, String> {
+    let mut limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) } != 0 {
+        return Err(format!(
+            "read macOS file descriptor limit: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    let desired = TARGET_NOFILE_LIMIT.min(limit.rlim_max);
+    if limit.rlim_cur < desired {
+        let raised = libc::rlimit {
+            rlim_cur: desired,
+            rlim_max: limit.rlim_max,
+        };
+        if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &raised) } != 0 {
+            return Err(format!(
+                "raise macOS file descriptor limit from {} to {desired}: {}",
+                limit.rlim_cur,
+                std::io::Error::last_os_error()
+            ));
+        }
+        limit.rlim_cur = desired;
+    }
+    Ok(limit.rlim_cur)
+}
+
+fn relay_flow_capacity(file_descriptor_limit: u64) -> usize {
+    let descriptor_capacity =
+        file_descriptor_limit.saturating_sub(RESERVED_FILE_DESCRIPTORS) / FILE_DESCRIPTORS_PER_FLOW;
+    usize::try_from(descriptor_capacity)
+        .unwrap_or(MAX_ACTIVE_RELAY_FLOWS)
+        .clamp(MIN_RELAY_FLOW_CAPACITY, MAX_ACTIVE_RELAY_FLOWS)
 }
 
 async fn run_capture(
@@ -333,13 +394,15 @@ async fn run_capture(
     mut bridge: BridgeSession,
     scope: Arc<ScopeSnapshot>,
     block_quic: bool,
+    flow_capacity: usize,
     ctx: Arc<RwLock<RelayContext>>,
     mut stop_rx: oneshot::Receiver<()>,
     _cleanup: SocketCleanup,
     telemetry: Arc<RuntimeTelemetry>,
 ) -> Result<(), String> {
     let mut flows = JoinSet::new();
-    let limiter = Arc::new(tokio::sync::Semaphore::new(MAX_ACTIVE_RELAY_FLOWS));
+    let limiter = Arc::new(tokio::sync::Semaphore::new(flow_capacity));
+    let stats = Arc::clone(&ctx.read().await.stats);
     let mut accept_error = None;
     let mut pending_heartbeats = BTreeSet::new();
     let mut heartbeat = tokio::time::interval(HEARTBEAT_INTERVAL);
@@ -406,11 +469,11 @@ async fn run_capture(
                     }
                 }
             }
-            accepted = listener.accept() => {
-                let (stream, _) = match accepted {
+            accepted = accept_with_capacity(&listener, Arc::clone(&limiter)) => {
+                let (stream, permit) = match accepted {
                     Ok(accepted) => accepted,
                     Err(error) => {
-                        accept_error = Some(format!("accept Redirector flow: {error}"));
+                        accept_error = Some(error);
                         break;
                     }
                 };
@@ -429,22 +492,13 @@ async fn run_capture(
                         continue;
                     }
                 }
-                let permit = match Arc::clone(&limiter).try_acquire_owned() {
-                    Ok(permit) => permit,
-                    Err(_) => {
-                        tracing::warn!(
-                            max_flows = MAX_ACTIVE_RELAY_FLOWS,
-                            "sockscap: Redirector flow limit reached; refusing flow"
-                        );
-                        drop(stream);
-                        continue;
-                    }
-                };
                 let scope = Arc::clone(&scope);
                 let ctx = Arc::clone(&ctx);
+                let flow_stats = Arc::clone(&stats);
                 flows.spawn(async move {
                     let _permit = permit;
                     if let Err(error) = serve_flow(stream, scope, block_quic, ctx).await {
+                        flow_stats.record_flow_failure();
                         tracing::warn!("sockscap: Redirector flow failed: {error}");
                     }
                 });
@@ -461,6 +515,24 @@ async fn run_capture(
     }
     tracing::info!("sockscap: Redirector bridge disabled interception with inert scope");
     Ok(())
+}
+
+/// Apply backpressure at the Unix listener instead of accepting and then
+/// refusing excess flows. Redirector can keep the connection in its socket
+/// backlog briefly while an existing browser flow releases a permit.
+async fn accept_with_capacity(
+    listener: &UnixListener,
+    limiter: Arc<tokio::sync::Semaphore>,
+) -> Result<(UnixStream, tokio::sync::OwnedSemaphorePermit), String> {
+    let permit = limiter
+        .acquire_owned()
+        .await
+        .map_err(|_| "Redirector flow limiter closed".to_string())?;
+    let (stream, _) = listener
+        .accept()
+        .await
+        .map_err(|error| format!("accept Redirector flow: {error}"))?;
+    Ok((stream, permit))
 }
 
 fn random_socket_path(label: &str) -> PathBuf {
@@ -819,7 +891,10 @@ async fn serve_udp(
         return Ok(());
     };
     let remote = resolve_required_address(first.remote_address.as_ref(), "UDP remote").await?;
-    let stats = Arc::clone(&ctx.read().await.stats);
+    let (stats, dns_map) = {
+        let context = ctx.read().await;
+        (Arc::clone(&context.stats), Arc::clone(&context.dns_map))
+    };
     if !in_scope {
         stats.record_scope_mismatch();
         tracing::warn!(
@@ -859,7 +934,15 @@ async fn serve_udp(
     let (mut reader, mut writer) = ipc.into_split();
     let mut receive_buf = vec![0u8; 65_535];
     let mut rate_limiter = DatagramRateLimiter::new();
-    let idle = tokio::time::sleep(UDP_IDLE_TIMEOUT);
+    // macOS commonly opens a fresh UDP socket for each DNS lookup. Keeping
+    // those one-shot Redirector flows for a full minute amplifies startup DNS
+    // bursts and needlessly consumes IPC/file-descriptor capacity.
+    let idle_timeout = if remote.port() == 53 {
+        DNS_UDP_IDLE_TIMEOUT
+    } else {
+        UDP_IDLE_TIMEOUT
+    };
+    let idle = tokio::time::sleep(idle_timeout);
     tokio::pin!(idle);
     loop {
         tokio::select! {
@@ -871,7 +954,7 @@ async fn serve_udp(
                 let Some(packet) = packet.map_err(|error| format!("read Redirector UDP packet: {error}"))? else {
                     break;
                 };
-                idle.as_mut().reset(tokio::time::Instant::now() + UDP_IDLE_TIMEOUT);
+                idle.as_mut().reset(tokio::time::Instant::now() + idle_timeout);
                 if !rate_limiter.allow() {
                     tracing::warn!(?pid, "sockscap: UDP source rate limit reached; dropping datagram");
                     continue;
@@ -891,7 +974,18 @@ async fn serve_udp(
             }
             received = udp.recv_from(&mut receive_buf) => {
                 let (size, peer) = received.map_err(|error| format!("receive relayed UDP: {error}"))?;
-                idle.as_mut().reset(tokio::time::Instant::now() + UDP_IDLE_TIMEOUT);
+                idle.as_mut().reset(tokio::time::Instant::now() + idle_timeout);
+                if remote.port() == 53 || peer.port() == 53 {
+                    let answers = extract_ip_answers(&receive_buf[..size]);
+                    if !answers.is_empty()
+                        && let Ok(mut map) = dns_map.lock()
+                    {
+                        for answer in &answers {
+                            map.insert(answer.ip, answer.host.clone(), Some(answer.ttl));
+                        }
+                        stats.record_dns_answers(answers.len() as u64);
+                    }
+                }
                 let response = UdpPacket {
                     data: bytes::Bytes::copy_from_slice(&receive_buf[..size]),
                     remote_address: Some(Address {
@@ -1016,5 +1110,13 @@ mod tests {
         assert_eq!(targets.len(), 2);
         assert!(parse_recovery_probe_targets("example.com:443").is_err());
         assert!(parse_recovery_probe_targets("  ").is_err());
+    }
+
+    #[test]
+    fn relay_capacity_reserves_descriptors_for_the_desktop_app() {
+        assert_eq!(relay_flow_capacity(256), 64);
+        assert_eq!(relay_flow_capacity(1_024), 448);
+        assert_eq!(relay_flow_capacity(4_096), MAX_ACTIVE_RELAY_FLOWS);
+        assert_eq!(relay_flow_capacity(u64::MAX), MAX_ACTIVE_RELAY_FLOWS);
     }
 }

--- a/src-tauri/src/sockscap/relay.rs
+++ b/src-tauri/src/sockscap/relay.rs
@@ -50,6 +50,13 @@ const RELAY_FIRST_BYTE_TIMEOUT: Duration = Duration::from_secs(300);
 /// Start probing an idle connection after this long, then every interval.
 const RELAY_KEEPALIVE_IDLE: Duration = Duration::from_secs(60);
 const RELAY_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
+/// ProxyAll/off/bypass decisions do not need a hostname. Give already-buffered
+/// SNI/HTTP Host a small chance to arrive for better diagnostics and proxy-side
+/// DNS, but do not put it on the critical path.
+const HOSTNAME_SNIFF_OPPORTUNISTIC: Duration = Duration::from_millis(75);
+/// GFWList and hostname user rules require attribution. DNS observation is the
+/// fallback, so a long per-connection stall is no longer useful.
+const HOSTNAME_SNIFF_REQUIRED: Duration = Duration::from_millis(350);
 
 pub struct RelayHandle {
     pub port: u16,
@@ -399,47 +406,90 @@ where
 {
     let dest_ip = flow.dest_ip;
     let dest_port = flow.dest_port;
+    let authoritative_host = flow.dest_host;
     let process_path = flow.process_path;
     let pid = flow.pid;
     let origin = flow.origin;
     let profile_id_hint = flow.profile_id_hint;
 
-    if dest_ip.is_none() && flow.dest_host.is_none() {
+    if dest_ip.is_none() && authoritative_host.is_none() {
         return Err("captured flow carried neither a destination address nor a hostname".into());
     }
 
-    let (prefix, hostname) = match flow.dest_host {
+    let (preliminary_engine, cached_hostname) = {
+        let context = ctx.read().await;
+        let cached_hostname = dest_ip.and_then(|ip| {
+            context
+                .dns_map
+                .lock()
+                .ok()
+                .and_then(|mut map| map.lookup(ip))
+        });
+        (Arc::clone(&context.engine), cached_hostname)
+    };
+    let hostname_free_decision = if authoritative_host.is_none() && cached_hostname.is_none() {
+        preliminary_engine.decide_without_hostname(
+            &PolicyInput {
+                host: None,
+                ip: dest_ip,
+                port: dest_port,
+                process_path: process_path.clone(),
+                pid,
+            },
+            profile_id_hint.as_deref(),
+        )
+    } else {
+        None
+    };
+    let sniff_budget = if cached_hostname.is_some() || hostname_free_decision.is_some() {
+        HOSTNAME_SNIFF_OPPORTUNISTIC
+    } else {
+        HOSTNAME_SNIFF_REQUIRED
+    };
+
+    let (prefix, observed_hostname) = match authoritative_host {
         // A proxy handshake already named the target. Skipping the sniff also
         // avoids stalling server-first protocols (SMTP, IMAP, SSH), where the
         // client sends nothing until the server has greeted it.
         Some(host) => (Vec::new(), Some(host)),
         // Multi-read peek for SNI / HTTP Host (ClientHello may span packets).
-        None => peek_for_hostname(&mut client, dest_port).await,
+        None => peek_for_hostname(&mut client, dest_port, sniff_budget).await,
     };
 
     let snap = {
         let g = ctx.read().await;
         // Learn IP→host from this flow for later pure-IP connections.
-        if let (Some(host), Some(ip)) = (hostname.as_ref(), dest_ip) {
+        if let (Some(host), Some(ip)) = (observed_hostname.as_ref(), dest_ip) {
             if let Ok(mut map) = g.dns_map.lock() {
                 map.insert(ip, host.clone(), None);
             }
         }
 
-        // Prefer live SNI/Host, then dns_map, then none.
-        let host_for_policy = hostname.clone().or_else(|| {
-            dest_ip.and_then(|ip| g.dns_map.lock().ok().and_then(|mut m| m.lookup(ip)))
-        });
+        // Prefer authoritative/live SNI/Host, then the observed DNS response.
+        // DNS attribution is especially important for TLS ECH, where SNI is
+        // intentionally unavailable to a transparent, non-MITM relay.
+        let host_for_policy = observed_hostname
+            .clone()
+            .or_else(|| cached_hostname.clone())
+            .or_else(|| {
+                dest_ip.and_then(|ip| g.dns_map.lock().ok().and_then(|mut m| m.lookup(ip)))
+            });
 
         let engine = Arc::clone(&g.engine);
         let input = PolicyInput {
-            host: host_for_policy,
+            host: host_for_policy.clone(),
             ip: dest_ip,
             port: dest_port,
             process_path: process_path.clone(),
             pid,
         };
-        let trace = engine.decide_with_profile_hint(&input, profile_id_hint.as_deref());
+        let trace = if host_for_policy.is_none() {
+            hostname_free_decision.unwrap_or_else(|| {
+                engine.decide_with_profile_hint(&input, profile_id_hint.as_deref())
+            })
+        } else {
+            engine.decide_with_profile_hint(&input, profile_id_hint.as_deref())
+        };
 
         let (kind, up_host, up_port, up_user, up_pass, ssh_pool, xray_port) =
             match trace.profile_id.as_deref() {
@@ -467,7 +517,8 @@ where
             };
 
         (
-            hostname,
+            observed_hostname,
+            host_for_policy,
             trace,
             kind,
             up_host,
@@ -482,7 +533,8 @@ where
     };
 
     let (
-        hostname,
+        observed_hostname,
+        policy_hostname,
         trace,
         kind,
         up_host,
@@ -495,19 +547,30 @@ where
         xray_port,
     ) = snap;
 
-    // Prefer hostname for dial when known (proxy-side DNS).
-    let dial_host = match (hostname, dest_ip) {
-        (Some(host), _) => host,
-        (None, Some(ip)) => ip.to_string(),
-        (None, None) => return Err("captured flow had no dialable destination".into()),
+    // A direct transparent flow already has the exact destination address; do
+    // not repeat local DNS and possibly select a different CDN edge. Proxied
+    // flows prefer the recovered hostname so the upstream performs DNS and is
+    // not constrained by a locally poisoned answer.
+    let dial_host = match trace.decision {
+        Decision::Proxy => observed_hostname
+            .clone()
+            .or_else(|| policy_hostname.clone())
+            .or_else(|| dest_ip.map(|ip| ip.to_string())),
+        Decision::Direct | Decision::Block => dest_ip
+            .map(|ip| ip.to_string())
+            .or_else(|| observed_hostname.clone())
+            .or_else(|| policy_hostname.clone()),
     };
+    let dial_host =
+        dial_host.ok_or_else(|| "captured flow had no dialable destination".to_string())?;
+    let record_host = policy_hostname.clone().unwrap_or_else(|| dial_host.clone());
 
     let res = match trace.decision {
         Decision::Block => {
             stats.record_decision(false, true);
             if let Ok(mut doms) = domains.lock() {
                 doms.record(
-                    dial_host.clone(),
+                    record_host.clone(),
                     trace.decision,
                     trace.matched_rule.clone(),
                     trace.profile_name.clone(),
@@ -518,7 +581,7 @@ where
                 );
             }
             return Err(format!(
-                "blocked {dial_host}:{dest_port} ({})",
+                "blocked {record_host}:{dest_port} ({})",
                 trace.reason
             ));
         }
@@ -635,7 +698,7 @@ where
             stats.add_bytes(up, down);
             if let Ok(mut doms) = domains.lock() {
                 doms.record(
-                    dial_host,
+                    record_host,
                     trace.decision,
                     trace.matched_rule,
                     trace.profile_name,
@@ -674,15 +737,19 @@ fn server_speaks_first(port: u16) -> bool {
 }
 
 /// Read until we extract a hostname, TLS record is complete, or budget exhausted.
-async fn peek_for_hostname<S>(client: &mut S, dest_port: u16) -> (Vec<u8>, Option<String>)
+async fn peek_for_hostname<S>(
+    client: &mut S,
+    dest_port: u16,
+    budget: Duration,
+) -> (Vec<u8>, Option<String>)
 where
     S: AsyncRead + Unpin,
 {
-    use std::time::{Duration, Instant};
+    use std::time::Instant;
     if server_speaks_first(dest_port) {
         return (Vec::new(), None);
     }
-    let deadline = Instant::now() + Duration::from_millis(900);
+    let deadline = Instant::now() + budget;
     let mut prefix: Vec<u8> = Vec::new();
     while Instant::now() < deadline && prefix.len() < 16 * 1024 {
         if let Some(h) = extract_hostname_from_prefix(&prefix) {

--- a/src-tauri/src/sockscap/rules/dns.rs
+++ b/src-tauri/src/sockscap/rules/dns.rs
@@ -1,0 +1,210 @@
+//! Minimal, read-only DNS response parsing for transparent hostname attribution.
+//!
+//! macOS Redirector exposes the resolved socket address, not the hostname that
+//! produced it. Observing ordinary DNS replies lets the relay recover that
+//! association without changing DNS servers or performing TLS interception.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::time::Duration;
+
+const DNS_HEADER_LEN: usize = 12;
+const MAX_NAME_POINTERS: usize = 32;
+const MAX_CACHE_TTL: u32 = 24 * 60 * 60;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsIpAnswer {
+    pub host: String,
+    pub ip: IpAddr,
+    pub ttl: Duration,
+}
+
+/// Extract A/AAAA answers from a successful DNS response.
+///
+/// Answers are associated with the echoed question name rather than a CDN's
+/// terminal CNAME. That is the name policy rules and the client actually used.
+/// Malformed or unrelated packets simply produce no entries.
+pub fn extract_ip_answers(packet: &[u8]) -> Vec<DnsIpAnswer> {
+    if packet.len() < DNS_HEADER_LEN {
+        return Vec::new();
+    }
+    let flags = u16::from_be_bytes([packet[2], packet[3]]);
+    let is_response = flags & 0x8000 != 0;
+    let truncated = flags & 0x0200 != 0;
+    let response_code = flags & 0x000f;
+    if !is_response || truncated || response_code != 0 {
+        return Vec::new();
+    }
+
+    let question_count = u16::from_be_bytes([packet[4], packet[5]]) as usize;
+    let answer_count = u16::from_be_bytes([packet[6], packet[7]]) as usize;
+    if question_count == 0 || answer_count == 0 {
+        return Vec::new();
+    }
+
+    let mut offset = DNS_HEADER_LEN;
+    let mut question_host = None;
+    for question_index in 0..question_count {
+        let Some(name) = read_name(packet, &mut offset) else {
+            return Vec::new();
+        };
+        if offset.checked_add(4).is_none_or(|end| end > packet.len()) {
+            return Vec::new();
+        }
+        offset += 4; // QTYPE + QCLASS
+        if question_index == 0 && !name.is_empty() {
+            question_host = Some(name);
+        }
+    }
+    let Some(question_host) = question_host else {
+        return Vec::new();
+    };
+
+    let mut answers = Vec::new();
+    for _ in 0..answer_count {
+        if read_name(packet, &mut offset).is_none() {
+            return answers;
+        }
+        if offset.checked_add(10).is_none_or(|end| end > packet.len()) {
+            return answers;
+        }
+        let record_type = u16::from_be_bytes([packet[offset], packet[offset + 1]]);
+        let class = u16::from_be_bytes([packet[offset + 2], packet[offset + 3]]);
+        let ttl = u32::from_be_bytes([
+            packet[offset + 4],
+            packet[offset + 5],
+            packet[offset + 6],
+            packet[offset + 7],
+        ]);
+        let data_len = u16::from_be_bytes([packet[offset + 8], packet[offset + 9]]) as usize;
+        offset += 10;
+        let Some(data_end) = offset.checked_add(data_len) else {
+            return answers;
+        };
+        if data_end > packet.len() {
+            return answers;
+        }
+
+        let ip = match (class, record_type, data_len) {
+            (1, 1, 4) => Some(IpAddr::V4(Ipv4Addr::new(
+                packet[offset],
+                packet[offset + 1],
+                packet[offset + 2],
+                packet[offset + 3],
+            ))),
+            (1, 28, 16) => {
+                let mut octets = [0u8; 16];
+                octets.copy_from_slice(&packet[offset..data_end]);
+                Some(IpAddr::V6(Ipv6Addr::from(octets)))
+            }
+            _ => None,
+        };
+        if let Some(ip) = ip {
+            answers.push(DnsIpAnswer {
+                host: question_host.clone(),
+                ip,
+                ttl: Duration::from_secs(u64::from(ttl.clamp(1, MAX_CACHE_TTL))),
+            });
+        }
+        offset = data_end;
+    }
+    answers
+}
+
+fn read_name(packet: &[u8], offset: &mut usize) -> Option<String> {
+    let mut cursor = *offset;
+    let mut resume = None;
+    let mut labels = Vec::new();
+    let mut pointers = 0usize;
+
+    loop {
+        let length = *packet.get(cursor)?;
+        if length & 0xc0 == 0xc0 {
+            let next = *packet.get(cursor + 1)?;
+            let pointer = (((length & 0x3f) as usize) << 8) | next as usize;
+            if pointer >= packet.len() || pointers >= MAX_NAME_POINTERS {
+                return None;
+            }
+            resume.get_or_insert(cursor + 2);
+            cursor = pointer;
+            pointers += 1;
+            continue;
+        }
+        if length & 0xc0 != 0 || length > 63 {
+            return None;
+        }
+        cursor += 1;
+        if length == 0 {
+            *offset = resume.unwrap_or(cursor);
+            return Some(labels.join(".").to_ascii_lowercase());
+        }
+        let end = cursor.checked_add(length as usize)?;
+        let label = std::str::from_utf8(packet.get(cursor..end)?).ok()?;
+        if label.is_empty() || label.bytes().any(|byte| byte == b'.' || byte == 0) {
+            return None;
+        }
+        labels.push(label);
+        cursor = end;
+        if labels.iter().map(|label| label.len() + 1).sum::<usize>() > 255 {
+            return None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn response_with_a_and_aaaa() -> Vec<u8> {
+        let mut packet = vec![
+            0x12, 0x34, 0x81, 0x80, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x03, b'w',
+            b'w', b'w', 0x06, b'g', b'o', b'o', b'g', b'l', b'e', 0x03, b'c', b'o', b'm', 0x00,
+            0x00, 0x01, 0x00, 0x01,
+        ];
+        // Compressed owner name, A, IN, TTL 300, 1.2.3.4.
+        packet.extend_from_slice(&[
+            0xc0, 0x0c, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01, 0x2c, 0x00, 0x04, 1, 2, 3, 4,
+        ]);
+        // Compressed owner name, AAAA, IN, TTL 60, 2001:db8::1.
+        packet.extend_from_slice(&[
+            0xc0, 0x0c, 0x00, 0x1c, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3c, 0x00, 0x10, 0x20, 0x01,
+            0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]);
+        packet
+    }
+
+    #[test]
+    fn extracts_ipv4_and_ipv6_for_the_question_name() {
+        let answers = extract_ip_answers(&response_with_a_and_aaaa());
+        assert_eq!(answers.len(), 2);
+        assert!(answers.iter().all(|answer| answer.host == "www.google.com"));
+        assert_eq!(answers[0].ip, "1.2.3.4".parse::<IpAddr>().unwrap());
+        assert_eq!(answers[0].ttl, Duration::from_secs(300));
+        assert_eq!(answers[1].ip, "2001:db8::1".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn rejects_queries_truncated_responses_and_pointer_loops() {
+        let mut query = response_with_a_and_aaaa();
+        query[2] &= 0x7f;
+        assert!(extract_ip_answers(&query).is_empty());
+
+        let mut truncated = response_with_a_and_aaaa();
+        truncated[2] |= 0x02;
+        assert!(extract_ip_answers(&truncated).is_empty());
+
+        let mut looped = response_with_a_and_aaaa();
+        looped[12] = 0xc0;
+        looped[13] = 0x0c;
+        assert!(extract_ip_answers(&looped).is_empty());
+    }
+
+    #[test]
+    fn malformed_packets_fail_closed() {
+        for len in 0..DNS_HEADER_LEN {
+            assert!(extract_ip_answers(&vec![0; len]).is_empty());
+        }
+        let mut cut = response_with_a_and_aaaa();
+        cut.truncate(cut.len() - 3);
+        assert_eq!(extract_ip_answers(&cut).len(), 1);
+    }
+}

--- a/src-tauri/src/sockscap/rules/mod.rs
+++ b/src-tauri/src/sockscap/rules/mod.rs
@@ -1,6 +1,7 @@
 //! Rule compilation and matching (GFWList / AutoProxy + user helpers).
 
 mod autopxy;
+pub mod dns;
 pub mod dns_map;
 mod gfwlist;
 pub mod source;

--- a/src-tauri/src/sockscap/stats.rs
+++ b/src-tauri/src/sockscap/stats.rs
@@ -17,6 +17,8 @@ pub struct StatsCounters {
     pub last_quic_drop_at: AtomicU64,
     pub scope_mismatch_flows: AtomicU64,
     pub last_scope_mismatch_at: AtomicU64,
+    pub flow_failures: AtomicU64,
+    pub dns_answers_learned: AtomicU64,
 }
 
 impl StatsCounters {
@@ -36,6 +38,8 @@ impl StatsCounters {
             last_scope_mismatch_at: nonzero_timestamp(
                 self.last_scope_mismatch_at.load(Ordering::Relaxed),
             ),
+            flow_failures: self.flow_failures.load(Ordering::Relaxed),
+            dns_answers_learned: self.dns_answers_learned.load(Ordering::Relaxed),
         }
     }
 
@@ -78,6 +82,14 @@ impl StatsCounters {
             .store(now_unix(), Ordering::Relaxed);
     }
 
+    pub fn record_flow_failure(&self) {
+        self.flow_failures.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_dns_answers(&self, count: u64) {
+        self.dns_answers_learned.fetch_add(count, Ordering::Relaxed);
+    }
+
     pub fn reset(&self) {
         self.flows_total.store(0, Ordering::Relaxed);
         self.flows_proxy.store(0, Ordering::Relaxed);
@@ -91,6 +103,8 @@ impl StatsCounters {
         self.last_quic_drop_at.store(0, Ordering::Relaxed);
         self.scope_mismatch_flows.store(0, Ordering::Relaxed);
         self.last_scope_mismatch_at.store(0, Ordering::Relaxed);
+        self.flow_failures.store(0, Ordering::Relaxed);
+        self.dns_answers_learned.store(0, Ordering::Relaxed);
     }
 }
 
@@ -121,6 +135,10 @@ pub struct StatsSnapshot {
     #[serde(default)]
     #[cfg_attr(not(target_os = "macos"), serde(skip_serializing))]
     pub last_scope_mismatch_at: Option<u64>,
+    #[serde(default)]
+    pub flow_failures: u64,
+    #[serde(default)]
+    pub dns_answers_learned: u64,
 }
 
 fn now_unix() -> u64 {
@@ -241,7 +259,13 @@ impl DomainTracker {
         }
     }
 
-    pub fn add_traffic(&mut self, domain_or_ip: &str, decision: Decision, bytes_up: u64, bytes_down: u64) {
+    pub fn add_traffic(
+        &mut self,
+        domain_or_ip: &str,
+        decision: Decision,
+        bytes_up: u64,
+        bytes_down: u64,
+    ) {
         let key = format!("{domain_or_ip}:{:?}", decision);
         if let Some(entry) = self.records.get_mut(&key) {
             entry.bytes_up += bytes_up;

--- a/src/lib/sockscap.ts
+++ b/src/lib/sockscap.ts
@@ -229,6 +229,8 @@ export interface StatsSnapshot {
   lastQuicDropAt?: number | null;
   scopeMismatchFlows?: number;
   lastScopeMismatchAt?: number | null;
+  flowFailures?: number;
+  dnsAnswersLearned?: number;
 }
 
 export interface ProcessInfo {

--- a/src/stubs/tauri-core.ts
+++ b/src/stubs/tauri-core.ts
@@ -2348,6 +2348,8 @@ export async function invoke<T>(cmd: string, args?: any, options?: InvokeOptions
         udpDirectDatagrams: 0,
         lastQuicDropAt: null,
         scopeMismatchFlows: 0,
+        flowFailures: 0,
+        dnsAnswersLearned: 0,
         lastScopeMismatchAt: null,
       } as T;
     }


### PR DESCRIPTION
Recover domain attribution for macOS transparent flows by observing DNS A/AAAA responses with TTL-bounded caching. Prefer cached DNS names before SNI/HTTP Host sniffing so GFWList can route ECH or hostname-less flows correctly, while still preserving live SNI when present.

Reduce unnecessary connection latency by using short hostname-sniff budgets for hostname-independent decisions, preserving the original IP for direct dials, and allowing proxy-side DNS for proxied flows. Correct HTTP CONNECT formatting for IPv6 literals.

Harden Redirector runtime behavior under global traffic: raise the process file-descriptor soft limit, calculate relay capacity from available descriptors, apply listener backpressure instead of rejecting saturated flows, and expire one-shot DNS UDP flows sooner. Expose flow failure, DNS learning, descriptor-limit, and capacity diagnostics.

Require GFWList initialization when any active profile uses it, rather than relying only on the legacy selected-profile field. Add focused DNS, policy, profile, capacity, and IPv6 CONNECT coverage.

Validated with cargo test --lib sockscap:: -- --test-threads=1 (127 passed), pnpm test (227 files / 1944 tests), pnpm build, and the macOS Redirector signed-resource verification script.