### PR TITLE
feat(sockscap): add Linux mixed capture topology and runtime config lock

### DIFF
--- a/.agents/skills/qa-ui-auto/references/testid-catalog.md
+++ b/.agents/skills/qa-ui-auto/references/testid-catalog.md
@@ -449,6 +449,8 @@
 - `[data-testid="sidebar-tools-panel"]` — display — F-Sockscap-1.tools-panel
 - `[data-testid="sidebar-tool-sockscap"]` — interactive — F-Sockscap-1.sidebar-entry
 - `[data-testid="sockscap-panel"]` — display — F-Sockscap-1.panel
+- `[data-testid="sockscap-locked-banner"]` — display [optional] — F-Sockscap-1.locked-banner
+- `[data-testid="sockscap-add-profile"]` — interactive — F-Sockscap-1.add-profile
 - `[data-testid="sockscap-start"]` — interactive — F-Sockscap-1.start
 - `[data-testid="sockscap-stop"]` — interactive [optional] — F-Sockscap-1.stop
 - `[data-testid="sockscap-refresh-status"]` — interactive — F-Sockscap-1.refresh-status
@@ -470,6 +472,9 @@
 - `[data-testid="sockscap-root-prompt-cancel"]` — interactive [optional] — F-Sockscap-1.root-prompt-cancel
 - `[data-testid="sockscap-root-prompt-close"]` — interactive [optional] — F-Sockscap-1.root-prompt-close
 - `[data-testid="sockscap-refresh-gfw"]` — interactive [optional] — F-Sockscap-1.refresh-gfw
+- `[data-testid="sockscap-import-gfw"]` — interactive [optional] — F-Sockscap-1.import-gfw
+- `[data-testid="sockscap-rules-editor"]` — display [optional] — F-Sockscap-1.rules-editor
+- `[data-testid="sockscap-block-quic"]` — interactive [optional] — F-Sockscap-1.block-quic
 - `[data-testid="sockscap-test-host"]` — interactive — F-Sockscap-1.test-host
 - `[data-testid="sockscap-test-target"]` — interactive — F-Sockscap-1.test-target
 - `[data-testid="sockscap-helper-start"]` — interactive [optional] — F-Sockscap-1.helper-start

--- a/qa-ui-auto-tests/cases/_sockscap_linux_harness.py
+++ b/qa-ui-auto-tests/cases/_sockscap_linux_harness.py
@@ -227,8 +227,10 @@ class CaptureSession:
     against it) are identical:
 
         /sys/fs/cgroup/taomni-sockscap-<pid>/
+            bypass/             <- harness + relay sockets in mixed/global mode
             capture-profile-0/   <- curl for profile 0 goes here
             capture-profile-1/   <- (multiprofile)
+            global-test/         <- unmatched curl used to exercise catch-all
     """
 
     def __init__(self, sudo, session_pid=None):
@@ -239,6 +241,10 @@ class CaptureSession:
         )
         self.profile_dirs = []      # index -> absolute cgroup dir
         self.profile_matches = []   # index -> (relative_path, level)
+        self.bypass_dir = None
+        self.bypass_match = None
+        self.global_test_dir = None
+        self.original_dir = None
         self._nft_installed = False
 
     # --- cgroup ---------------------------------------------------------
@@ -247,7 +253,7 @@ class CaptureSession:
         level = len([c for c in rel.split("/") if c])
         return rel, level
 
-    def create_cgroups(self, profile_count):
+    def create_cgroups(self, profile_count, mixed=False):
         if os.path.exists(self.root):
             raise RuntimeError(
                 f"stale cgroup session at {self.root}; run recover first"
@@ -258,14 +264,33 @@ class CaptureSession:
             self.sudo.check(["mkdir", "-p", group_dir])
             self.profile_dirs.append(group_dir)
             self.profile_matches.append(self._relative_match(group_dir))
+        if mixed:
+            self.bypass_dir = os.path.join(self.root, "bypass")
+            self.global_test_dir = os.path.join(self.root, "global-test")
+            self.sudo.check(["mkdir", "-p", self.bypass_dir])
+            self.sudo.check(["mkdir", "-p", self.global_test_dir])
+            self.bypass_match = self._relative_match(self.bypass_dir)
+            with open(f"/proc/{self.session_pid}/cgroup", encoding="utf-8") as handle:
+                unified = next(
+                    (line.split(":", 2)[2].strip() for line in handle if line.startswith("0::")),
+                    None,
+                )
+            if unified is None:
+                raise RuntimeError("cannot resolve the harness cgroup v2 path")
+            self.original_dir = os.path.join(ENV.CGROUP_ROOT, unified.lstrip("/"))
+            self.sudo.check(
+                ["tee", os.path.join(self.bypass_dir, "cgroup.procs")],
+                input_text=f"{self.session_pid}\n",
+            )
 
     # --- nft ------------------------------------------------------------
-    def _render_nft(self, routes, bypass_cidrs):
+    def _render_nft(self, routes, bypass_cidrs, global_relay_port=None):
         """Render the same inet table the Rust `RedirectPlan` produces.
 
-        `routes` is a list of (profile_index, relay_port). App mode only: each
-        capture cgroup redirects to its relay port. IPv4-only (`ip protocol
-        tcp`) keeps the test deterministic; curl is pinned to -4.
+        `routes` is a list of (profile_index, relay_port). In mixed mode the
+        app routes are followed by `global_relay_port` as the catch-all.
+        IPv4-only (`ip protocol tcp`) keeps the test deterministic; curl is
+        pinned to -4.
         """
         lines = [f"table {ENV.NFT_FAMILY} {ENV.NFT_TABLE} {{",
                  "  chain output {",
@@ -275,17 +300,27 @@ class CaptureSession:
         for cidr in bypass_cidrs:
             fam = "ip6" if ":" in cidr else "ip"
             lines.append(f"    {fam} daddr {cidr} return")
+        if global_relay_port is not None:
+            if self.bypass_match is None:
+                raise RuntimeError("mixed capture requires a bypass cgroup")
+            rel, level = self.bypass_match
+            lines.append(f'    socket cgroupv2 level {level} "{rel}" return')
         for index, relay_port in routes:
             rel, level = self.profile_matches[index]
             lines.append(
                 f'    socket cgroupv2 level {level} "{rel}" ip protocol tcp '
                 f'redirect to :{relay_port} comment "{ENV.OWNERSHIP_MARKER}"'
             )
+        if global_relay_port is not None:
+            lines.append(
+                f'    ip protocol tcp redirect to :{global_relay_port} '
+                f'comment "{ENV.OWNERSHIP_MARKER}"'
+            )
         lines += ["  }", "}", ""]
         return "\n".join(lines)
 
-    def install_nft(self, routes, bypass_cidrs):
-        script = self._render_nft(routes, bypass_cidrs)
+    def install_nft(self, routes, bypass_cidrs, global_relay_port=None):
+        script = self._render_nft(routes, bypass_cidrs, global_relay_port)
         self.sudo.check([ENV.NFT, "-f", "-"], input_text=script)
         self._nft_installed = True
         return script
@@ -305,6 +340,15 @@ class CaptureSession:
         shell = f'echo $$ > "{procs}" && exec {quoted}'
         return self.sudo.run(["sh", "-c", shell], timeout=timeout)
 
+    def run_global(self, argv, timeout=25):
+        """Run `argv` outside app and bypass cgroups to hit the catch-all."""
+        if self.global_test_dir is None:
+            raise RuntimeError("global test cgroup is unavailable outside mixed mode")
+        procs = os.path.join(self.global_test_dir, "cgroup.procs")
+        quoted = " ".join("'" + a.replace("'", "'\\''") + "'" for a in argv)
+        shell = f'echo $$ > "{procs}" && exec {quoted}'
+        return self.sudo.run(["sh", "-c", shell], timeout=timeout)
+
     # --- teardown -------------------------------------------------------
     def cleanup(self):
         """Rules first, then cgroups — the safe order the Rust backend uses."""
@@ -317,8 +361,16 @@ class CaptureSession:
                 errors.append(f"nft delete: {err.strip()}")
             else:
                 self._nft_installed = False
+        if self.bypass_dir is not None and self.original_dir is not None:
+            rc, _o, err = self.sudo.run(
+                ["tee", os.path.join(self.original_dir, "cgroup.procs")],
+                input_text=f"{self.session_pid}\n",
+            )
+            if rc != 0:
+                errors.append(f"restore harness cgroup: {err.strip()}")
         # Remove leaf profile dirs then the session root (must be empty).
-        for group_dir in reversed(self.profile_dirs):
+        extra_dirs = [d for d in [self.global_test_dir, self.bypass_dir] if d]
+        for group_dir in reversed(self.profile_dirs + extra_dirs):
             rc, _o, err = self.sudo.run(["rmdir", group_dir])
             if rc != 0 and "No such file" not in err:
                 errors.append(f"rmdir {group_dir}: {err.strip()}")
@@ -327,6 +379,10 @@ class CaptureSession:
             errors.append(f"rmdir {self.root}: {err.strip()}")
         self.profile_dirs = []
         self.profile_matches = []
+        self.bypass_dir = None
+        self.bypass_match = None
+        self.global_test_dir = None
+        self.original_dir = None
         return errors
 
     def residue(self):
@@ -415,10 +471,11 @@ class Relay:
     routed connection appends to `audit` for the test to assert against.
     """
 
-    def __init__(self, http=None, socks5=None):
+    def __init__(self, http=None, socks5=None, rule_mode="gfwList"):
         self.http = http        # (host, port) or None
         self.socks5 = socks5    # (host, port) or None
         self.upstream_mode = "HTTP"
+        self.rule_mode = rule_mode
         self.audit = []
         self.port = pick_free_port()
         self._stop = threading.Event()
@@ -478,7 +535,7 @@ class Relay:
             mode = self.upstream_mode
             target_host = sni if sni else orig_ip
 
-            if is_gfw:
+            if self.rule_mode == "proxyAll" or is_gfw:
                 decision = "PROXY"
                 upstream = self._connect_upstream(mode, target_host, orig_port)
             else:
@@ -527,6 +584,5 @@ class Relay:
                 break
             resp += c
         return up
-
 
 

--- a/qa-ui-auto-tests/cases/auto/TC-auto-F-Sockscap-1-control-panel.testcase.yaml
+++ b/qa-ui-auto-tests/cases/auto/TC-auto-F-Sockscap-1-control-panel.testcase.yaml
@@ -66,8 +66,20 @@ steps:
       selector: '[data-testid="sockscap-test-host"]'
       value: www.google.com
   - click: '[data-testid="sockscap-test-target"]'
+  - click: '[data-testid="sockscap-add-profile"]'
+  - assert_text:
+      selector: '[data-testid="sockscap-panel"]'
+      contains: 方案 2
   - click: '[data-testid="sockscap-start"]'
   - wait_for: '[data-testid="sockscap-stop"]'
+  - assert_visible: '[data-testid="sockscap-locked-banner"]'
+  - assert_disabled: '[data-testid="sockscap-add-profile"]'
+  - click: '[data-testid="sockscap-section-rules-toggle"]'
+  - assert_disabled: '[data-testid="sockscap-rules-editor"]'
+  - click: '[data-testid="sockscap-section-gfwlist-toggle"]'
+  - assert_disabled: '[data-testid="sockscap-refresh-gfw"]'
+  - assert_disabled: '[data-testid="sockscap-import-gfw"]'
+  - assert_disabled: '[data-testid="sockscap-block-quic"]'
   - click: '[data-testid="sockscap-stop"]'
   - wait_for: '[data-testid="sockscap-start"]'
   - click: '[data-testid="sockscap-recover"]'

--- a/qa-ui-auto-tests/cases/test_sockscap_linux_multiprofile_e2e.py
+++ b/qa-ui-auto-tests/cases/test_sockscap_linux_multiprofile_e2e.py
@@ -1,17 +1,12 @@
-"""SocksCap Linux multi-profile E2E (distinct cgroups -> distinct relay ports).
+"""SocksCap Linux mixed-profile E2E (app relay -> global catch-all relay).
 
-The Linux analogue of test_sockscap_multiprofile_e2e.py. Windows shares one
-WinDivert helper and hot-swaps a single relay port; Linux instead gives each
-app profile its own capture cgroup and its own relay port, wired by a single
-nft table (the `RedirectPlan::new_app_routes` shape in the Rust backend):
+This reproduces the production priority topology from the original regression:
 
-    capture-profile-0  -> redirect to :<relay0>   (HTTP upstream)
-    capture-profile-1  -> redirect to :<relay1>   (SOCKS5 upstream)
+    priority 1 application + proxyAll -> dedicated app relay (HTTP upstream)
+    priority 2 global + gfwList       -> final catch-all relay (SOCKS5 upstream)
 
-The test proves per-profile isolation: a request made from inside profile-0's
-cgroup lands only on relay0 and egresses via HTTP; a request from profile-1's
-cgroup lands only on relay1 and egresses via SOCKS5. Cross-contamination (a
-request showing up on the wrong relay) fails the test.
+The test proves the application cgroup rule precedes the bare global redirect,
+and that both routes work simultaneously without cross-contamination.
 
 Exit codes: 0 all passed · 1 a leg failed · 77 skipped (prereqs unmet).
 """
@@ -26,12 +21,12 @@ import _sockscap_linux_harness as H
 SKIP = 77
 
 print("=" * 82)
-print(" Taomni SocksCap Linux — Multi-Profile E2E (2 cgroups, 2 relay ports)")
+print(" Taomni SocksCap Linux — Mixed-Profile E2E (app relay + global fallback)")
 print("=" * 82)
 
-# One GFWList target per profile so each must be PROXIED through its own relay.
-PROFILE0_TARGET = "https://www.google.com"       # via relay0 (HTTP)
-PROFILE1_TARGET = "https://en.wikipedia.org"     # via relay1 (SOCKS5)
+# The app target intentionally misses GFWList: proxyAll must still proxy it.
+APP_TARGET = "https://www.baidu.com"             # app relay (HTTP)
+GLOBAL_TARGET = "https://en.wikipedia.org"       # global GFWList (SOCKS5)
 
 stats = {"total": 0, "passed": 0, "failed": 0}
 
@@ -47,10 +42,17 @@ def record(name, ok, detail=""):
     print(f"  [{s}] {name:<52} {detail}")
 
 
-def curl_in(session, index, url):
+def curl_in_app(session, url):
     argv = [ENV.CURL, "-4", "-s", "-o", "/dev/null",
             "-w", "%{http_code}", "--max-time", "20", url]
-    _rc, out, _err = session.run_in_cgroup(index, argv, timeout=25)
+    _rc, out, _err = session.run_in_cgroup(0, argv, timeout=25)
+    return out.strip()
+
+
+def curl_in_global(session, url):
+    argv = [ENV.CURL, "-4", "-s", "-o", "/dev/null",
+            "-w", "%{http_code}", "--max-time", "20", url]
+    _rc, out, _err = session.run_global(argv, timeout=25)
     return out.strip()
 
 
@@ -75,57 +77,68 @@ def main():
     for err in H.recover(sudo):
         print(f"  WARN: {err}")
 
-    print("\n[Step 2/5] Starting two relays (profile0=HTTP, profile1=SOCKS5)...")
-    relay0 = H.Relay(http=(ENV.HTTP_HOST, ENV.HTTP_PORT))
-    relay0.upstream_mode = "HTTP"
-    relay1 = H.Relay(socks5=(ENV.SOCKS5_HOST, ENV.SOCKS5_PORT))
-    relay1.upstream_mode = "SOCKS5"
-    p0 = relay0.start()
-    p1 = relay1.start()
-    print(f"  relay0 (HTTP)   127.0.0.1:{p0}")
-    print(f"  relay1 (SOCKS5) 127.0.0.1:{p1}")
+    print("\n[Step 2/5] Starting app proxyAll + global GFWList relays...")
+    app_relay = H.Relay(
+        http=(ENV.HTTP_HOST, ENV.HTTP_PORT), rule_mode="proxyAll"
+    )
+    app_relay.upstream_mode = "HTTP"
+    global_relay = H.Relay(socks5=(ENV.SOCKS5_HOST, ENV.SOCKS5_PORT))
+    global_relay.upstream_mode = "SOCKS5"
+    app_port = app_relay.start()
+    global_port = global_relay.start()
+    print(f"  app relay (HTTP/proxyAll)       127.0.0.1:{app_port}")
+    print(f"  global relay (SOCKS5/gfwList)  127.0.0.1:{global_port}")
 
     session = H.CaptureSession(sudo)
     try:
-        print("\n[Step 3/5] Creating 2 capture cgroups + single nft table with 2 routes...")
-        session.create_cgroups(profile_count=2)
-        print(f"  profile-0: {session.profile_dirs[0]} -> :{p0}")
-        print(f"  profile-1: {session.profile_dirs[1]} -> :{p1}")
-        session.install_nft([(0, p0), (1, p1)], ENV.DEFAULT_BYPASS_CIDRS)
-        # Both cgroup routes must be present in the one table.
+        print("\n[Step 3/5] Creating mixed cgroups + ordered nft routes...")
+        session.create_cgroups(profile_count=1, mixed=True)
+        print(f"  app profile: {session.profile_dirs[0]} -> :{app_port}")
+        print(f"  global catch-all -> :{global_port}")
+        session.install_nft(
+            [(0, app_port)],
+            ENV.DEFAULT_BYPASS_CIDRS,
+            global_relay_port=global_port,
+        )
         rc, out, _e = sudo.run([ENV.NFT, "list", "table", ENV.NFT_FAMILY, ENV.NFT_TABLE])
-        record("route 0 present (profile-0 -> relay0)",
-               f"capture-profile-0\" ip protocol tcp redirect to :{p0}" in out)
-        record("route 1 present (profile-1 -> relay1)",
-               f"capture-profile-1\" ip protocol tcp redirect to :{p1}" in out)
+        app_rule = f"capture-profile-0\" ip protocol tcp redirect to :{app_port}"
+        global_rule = f"ip protocol tcp redirect to :{global_port}"
+        record("application route present", app_rule in out)
+        record("global catch-all route present", global_rule in out)
+        record(
+            "application route precedes global catch-all",
+            out.find(app_rule) >= 0 and out.find(app_rule) < out.find(global_rule),
+        )
 
-        print("\n[Step 4/5] Driving each profile and checking isolation...")
-        c0 = curl_in(session, 0, PROFILE0_TARGET)
-        c1 = curl_in(session, 1, PROFILE1_TARGET)
+        print("\n[Step 4/5] Driving application and global traffic...")
+        app_code = curl_in_app(session, APP_TARGET)
+        global_code = curl_in_global(session, GLOBAL_TARGET)
         time.sleep(0.2)
 
-        a0 = [e for e in relay0.audit if "error" not in e]
-        a1 = [e for e in relay1.audit if "error" not in e]
+        app_audit = [e for e in app_relay.audit if "error" not in e]
+        global_audit = [e for e in global_relay.audit if "error" not in e]
 
-        record("profile-0 request reachable", ENV.http_reachable(c0), f"code={c0}")
-        record("profile-1 request reachable", ENV.http_reachable(c1), f"code={c1}")
-        record("relay0 saw exactly profile-0's request", len(a0) == 1,
-               f"count={len(a0)} sni={a0[-1].get('sni') if a0 else None}")
-        record("relay1 saw exactly profile-1's request", len(a1) == 1,
-               f"count={len(a1)} sni={a1[-1].get('sni') if a1 else None}")
-        record("relay0 egressed via HTTP",
-               bool(a0) and a0[-1].get("mode") == "HTTP" and a0[-1].get("decision") == "PROXY")
-        record("relay1 egressed via SOCKS5",
-               bool(a1) and a1[-1].get("mode") == "SOCKS5" and a1[-1].get("decision") == "PROXY")
-        # No cross-contamination: neither relay saw the other's SNI.
-        record("no cross-contamination relay0",
-               all("wikipedia" not in (e.get("sni") or "") for e in a0))
-        record("no cross-contamination relay1",
-               all("google" not in (e.get("sni") or "") for e in a1))
+        record("application request reachable", ENV.http_reachable(app_code), f"code={app_code}")
+        record("global request reachable", ENV.http_reachable(global_code), f"code={global_code}")
+        record("app relay saw only the app request", len(app_audit) == 1,
+               f"count={len(app_audit)} sni={app_audit[-1].get('sni') if app_audit else None}")
+        record("global relay saw only fallback traffic", len(global_audit) == 1,
+               f"count={len(global_audit)} sni={global_audit[-1].get('sni') if global_audit else None}")
+        record("app proxyAll proxied a GFWList miss",
+               bool(app_audit) and not app_audit[-1].get("gfwlist_match")
+               and app_audit[-1].get("decision") == "PROXY")
+        record("global GFWList used SOCKS5",
+               bool(global_audit) and global_audit[-1].get("gfwlist_match")
+               and global_audit[-1].get("mode") == "SOCKS5"
+               and global_audit[-1].get("decision") == "PROXY")
+        record("app relay did not see global traffic",
+               all("wikipedia" not in (e.get("sni") or "") for e in app_audit))
+        record("global relay did not see app traffic",
+               all("baidu" not in (e.get("sni") or "") for e in global_audit))
     finally:
         print("\n[Step 5/5] Teardown + verify clean...")
-        relay0.stop()
-        relay1.stop()
+        app_relay.stop()
+        global_relay.stop()
         for e in session.cleanup():
             print(f"  WARN: {e}")
         table_present, dir_present = session.residue()
@@ -142,4 +155,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/qa-ui-auto-tests/feature-list.md
+++ b/qa-ui-auto-tests/feature-list.md
@@ -4556,6 +4556,13 @@ controls:
   - id: panel
     selector: '[data-testid="sockscap-panel"]'
     kind: display
+  - id: locked-banner
+    selector: '[data-testid="sockscap-locked-banner"]'
+    kind: display
+    optional: true       # shown only while capture is preparing/running/stopping
+  - id: add-profile
+    selector: '[data-testid="sockscap-add-profile"]'
+    kind: interactive
   - id: start
     selector: '[data-testid="sockscap-start"]'
     kind: interactive
@@ -4630,6 +4637,18 @@ controls:
     selector: '[data-testid="sockscap-refresh-gfw"]'
     kind: interactive
     optional: true       # shown only while the GFWList rule mode is selected
+  - id: import-gfw
+    selector: '[data-testid="sockscap-import-gfw"]'
+    kind: interactive
+    optional: true       # shown inside the collapsible GFWList section
+  - id: rules-editor
+    selector: '[data-testid="sockscap-rules-editor"]'
+    kind: display
+    optional: true       # shown inside the collapsible rules section
+  - id: block-quic
+    selector: '[data-testid="sockscap-block-quic"]'
+    kind: interactive
+    optional: true       # shown inside the collapsible GFWList section
   - id: test-host
     selector: '[data-testid="sockscap-test-host"]'
     kind: interactive

--- a/scripts/run-sockscap-tests.sh
+++ b/scripts/run-sockscap-tests.sh
@@ -134,7 +134,7 @@ menu_file=(
 menu_desc=(
   "Direct connectivity smoke (no sudo/capture)"
   "Full-link app-mode E2E (nft + cgroup + soak)"
-  "Multi-profile (2 cgroups -> 2 relay ports)"
+  "Mixed profiles (app relay -> global fallback relay)"
   "Extended matrix + soak + ssh -D egress (no sudo)"
 )
 
@@ -175,4 +175,3 @@ while true; do
       ;;
   esac
 done
-

--- a/src-tauri/src/sockscap/capture/linux/cgroup.rs
+++ b/src-tauri/src/sockscap/capture/linux/cgroup.rs
@@ -83,8 +83,9 @@ impl CgroupV2Match {
 ///
 /// In global mode, Taomni itself is moved to a bypass cgroup while all other
 /// local TCP traffic is redirected. In app mode, only selected target PIDs are
-/// moved into capture cgroups; children inherit their parent's cgroup. The
-/// relay stays in the caller's cgroup and is therefore naturally excluded.
+/// moved into capture cgroups; children inherit their parent's cgroup. Mixed
+/// mode combines both arrangements so higher-priority apps can use dedicated
+/// relays before the final global catch-all relay.
 #[derive(Debug)]
 pub struct CgroupSession {
     root: PathBuf,
@@ -125,6 +126,22 @@ impl CgroupSession {
         }
         let mut session = Self::create(self_pid, sudo_password)?;
         let setup = session.setup_app_groups(target_pid_groups, sudo_password);
+        session.finish_setup(setup, sudo_password)
+    }
+
+    pub fn prepare_mixed(
+        target_pid_groups: &[BTreeSet<u32>],
+        self_pid: u32,
+        sudo_password: Option<&str>,
+    ) -> Result<Self, String> {
+        if target_pid_groups.is_empty() {
+            return Err("Mixed mode requires at least one application profile".into());
+        }
+        let mut session = Self::create(self_pid, sudo_password)?;
+        let setup = session
+            .move_pid(self_pid, session.root.join("bypass"), sudo_password)
+            .map(|cgroup_match| session.bypass_match = Some(cgroup_match))
+            .and_then(|()| session.setup_app_groups(target_pid_groups, sudo_password));
         session.finish_setup(setup, sudo_password)
     }
 

--- a/src-tauri/src/sockscap/capture/linux/mod.rs
+++ b/src-tauri/src/sockscap/capture/linux/mod.rs
@@ -91,6 +91,9 @@ struct AppCaptureProfile {
 enum CaptureScope {
     Global,
     Apps(Vec<AppCaptureProfile>),
+    /// Higher-priority application profiles followed by the first active
+    /// global profile, which is the final catch-all by policy semantics.
+    Mixed(Vec<AppCaptureProfile>),
 }
 
 struct AppProcessMonitor {
@@ -194,6 +197,14 @@ impl LinuxCapture for LinuxCaptureImpl {
                 let target_groups = pid_filter::resolve_target_pid_groups(&selector_groups)?;
                 cgroup::CgroupSession::prepare_apps(&target_groups, std::process::id(), sudo_pw)?
             }
+            CaptureScope::Mixed(profiles) => {
+                let selector_groups = profiles
+                    .iter()
+                    .map(|profile| profile.selectors.clone())
+                    .collect::<Vec<_>>();
+                let target_groups = pid_filter::resolve_target_pid_groups(&selector_groups)?;
+                cgroup::CgroupSession::prepare_mixed(&target_groups, std::process::id(), sudo_pw)?
+            }
         };
         let cgroups = Arc::new(Mutex::new(cgroups));
 
@@ -220,6 +231,26 @@ impl LinuxCapture for LinuxCaptureImpl {
                 }
                 result
             }
+            CaptureScope::Mixed(profiles) => {
+                let mut result = Ok(());
+                for profile in profiles {
+                    match relay::start_linux_relay(Arc::clone(&ctx), Some(profile.id.clone())).await
+                    {
+                        Ok(relay) => relays.push(relay),
+                        Err(error) => {
+                            result = Err(error);
+                            break;
+                        }
+                    }
+                }
+                if result.is_ok() {
+                    match relay::start_linux_relay(Arc::clone(&ctx), None).await {
+                        Ok(relay) => relays.push(relay),
+                        Err(error) => result = Err(error),
+                    }
+                }
+                result
+            }
         };
         if let Err(error) = relay_result {
             stop_relays(relays).await;
@@ -228,7 +259,10 @@ impl LinuxCapture for LinuxCaptureImpl {
         }
 
         let relay_port = relays
-            .first()
+            .get(match &scope {
+                CaptureScope::Mixed(profiles) => profiles.len(),
+                CaptureScope::Global | CaptureScope::Apps(_) => 0,
+            })
             .map(|relay| relay.handle.port)
             .ok_or_else(|| "Linux capture did not create a relay".to_string())?;
         let redirect_ipv6 = relays.iter().all(|relay| relay.ipv6_ready);
@@ -254,6 +288,27 @@ impl LinuxCapture for LinuxCaptureImpl {
                     tunnel::RedirectPlan::new_app_routes(
                         redirect_ipv6,
                         &config.bypass_cidrs,
+                        &routes,
+                        config.block_quic,
+                    )
+                }
+                CaptureScope::Mixed(profiles) => {
+                    let routes = session
+                        .capture_matches()
+                        .iter()
+                        .cloned()
+                        .zip(
+                            relays
+                                .iter()
+                                .take(profiles.len())
+                                .map(|relay| relay.handle.port),
+                        )
+                        .collect::<Vec<_>>();
+                    tunnel::RedirectPlan::new_mixed_routes(
+                        relay_port,
+                        redirect_ipv6,
+                        &config.bypass_cidrs,
+                        session.bypass_match(),
                         &routes,
                         config.block_quic,
                     )
@@ -284,6 +339,11 @@ impl LinuxCapture for LinuxCaptureImpl {
                 Arc::clone(&cgroups),
                 sudo_password.clone(),
             )),
+            CaptureScope::Mixed(profiles) => Some(AppProcessMonitor::spawn(
+                profiles.clone(),
+                Arc::clone(&cgroups),
+                sudo_password.clone(),
+            )),
         };
 
         tracing::info!(
@@ -291,7 +351,7 @@ impl LinuxCapture for LinuxCaptureImpl {
             mode = ?scope,
             app_profiles = match &scope {
                 CaptureScope::Global => 0,
-                CaptureScope::Apps(profiles) => profiles.len(),
+                CaptureScope::Apps(profiles) | CaptureScope::Mixed(profiles) => profiles.len(),
             },
             "sockscap Linux nftables transparent capture started"
         );
@@ -329,21 +389,18 @@ fn capture_scope(config: &SocksCapConfig) -> Result<CaptureScope, String> {
     if active_profiles.is_empty() {
         return Err("At least one profile must be enabled and active".into());
     }
-    if active_profiles
-        .iter()
-        .any(|profile| matches!(profile.mode, ScopeMode::Global))
-    {
-        return Ok(CaptureScope::Global);
-    }
-    Ok(CaptureScope::Apps(
-        active_profiles
-            .into_iter()
-            .map(|profile| AppCaptureProfile {
+    let mut app_profiles = Vec::new();
+    for profile in active_profiles {
+        match profile.mode {
+            ScopeMode::Apps => app_profiles.push(AppCaptureProfile {
                 id: profile.id.clone(),
                 selectors: profile.apps.clone(),
-            })
-            .collect(),
-    ))
+            }),
+            ScopeMode::Global if app_profiles.is_empty() => return Ok(CaptureScope::Global),
+            ScopeMode::Global => return Ok(CaptureScope::Mixed(app_profiles)),
+        }
+    }
+    Ok(CaptureScope::Apps(app_profiles))
 }
 
 #[cfg(test)]
@@ -375,5 +432,58 @@ mod tests {
         };
         assert_eq!(profiles.len(), 1);
         assert_eq!(profiles[0].id, "default");
+    }
+
+    #[test]
+    fn mixed_capture_keeps_only_apps_before_the_global_catch_all() {
+        let mut config = SocksCapConfig::default();
+        config.profiles[0].id = "agy".into();
+        config.profiles[0].priority = 1;
+        config.profiles[0].mode = ScopeMode::Apps;
+        config.profiles[0].apps = vec![AppSelector {
+            path: "/opt/agy/agy".into(),
+            bundle_id: String::new(),
+            name: "agy".into(),
+            macos_identity: None,
+        }];
+
+        let mut global = config.profiles[0].clone();
+        global.id = "global".into();
+        global.priority = 2;
+        global.mode = ScopeMode::Global;
+        global.apps.clear();
+        let mut unreachable_app = config.profiles[0].clone();
+        unreachable_app.id = "lower-app".into();
+        unreachable_app.priority = 3;
+        config.profiles.extend([global, unreachable_app]);
+        config.active_profile_ids = vec!["agy".into(), "global".into(), "lower-app".into()];
+
+        let CaptureScope::Mixed(profiles) = capture_scope(&config).unwrap() else {
+            panic!("expected mixed capture scope");
+        };
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].id, "agy");
+    }
+
+    #[test]
+    fn a_highest_priority_global_profile_is_the_only_capture_scope() {
+        let mut config = SocksCapConfig::default();
+        let mut lower_app = config.profiles[0].clone();
+        lower_app.id = "lower-app".into();
+        lower_app.priority = 10;
+        lower_app.mode = ScopeMode::Apps;
+        lower_app.apps = vec![AppSelector {
+            path: "/opt/example/example".into(),
+            bundle_id: String::new(),
+            name: "Example".into(),
+            macos_identity: None,
+        }];
+        config.profiles.push(lower_app);
+        config.active_profile_ids = vec!["default".into(), "lower-app".into()];
+
+        assert!(matches!(
+            capture_scope(&config).unwrap(),
+            CaptureScope::Global
+        ));
     }
 }

--- a/src-tauri/src/sockscap/capture/linux/tunnel.rs
+++ b/src-tauri/src/sockscap/capture/linux/tunnel.rs
@@ -144,6 +144,46 @@ impl RedirectPlan {
         Ok(plan)
     }
 
+    pub fn new_mixed_routes(
+        global_relay_port: u16,
+        redirect_ipv6: bool,
+        bypass_cidrs: &[String],
+        bypass_cgroup: Option<CgroupV2Match>,
+        app_routes: &[(CgroupV2Match, u16)],
+        block_quic: bool,
+    ) -> Result<Self, String> {
+        if global_relay_port == 0 {
+            return Err("Linux relay port must be non-zero".into());
+        }
+        if app_routes.is_empty() {
+            return Err("mixed Linux capture requires at least one application route".into());
+        }
+        let capture_cgroups = app_routes
+            .iter()
+            .map(|(cgroup, _)| cgroup.clone())
+            .collect();
+        let capture_relay_ports = app_routes
+            .iter()
+            .map(|(_, relay_port)| *relay_port)
+            .collect();
+        let bypass_cidrs = bypass_cidrs
+            .iter()
+            .map(|cidr| ValidatedCidr::parse(cidr))
+            .collect::<Result<Vec<_>, _>>()?;
+        let plan = Self {
+            mode: ScopeMode::Global,
+            relay_port: global_relay_port,
+            redirect_ipv6,
+            bypass_cidrs,
+            bypass_cgroup,
+            capture_cgroups,
+            capture_relay_ports,
+            block_quic,
+        };
+        plan.validate()?;
+        Ok(plan)
+    }
+
     fn validate(&self) -> Result<(), String> {
         if self.capture_cgroups.len() != self.capture_relay_ports.len() {
             return Err("Linux app capture cgroup/relay route count mismatch".into());
@@ -181,6 +221,15 @@ impl RedirectPlan {
                     .as_ref()
                     .expect("validated global cgroup");
                 script.push_str(&format!("    {} return\n", cgroup.nft_expression()));
+                for (cgroup, relay_port) in
+                    self.capture_cgroups.iter().zip(&self.capture_relay_ports)
+                {
+                    self.render_redirect_rule(
+                        &mut script,
+                        &format!("{} ", cgroup.nft_expression()),
+                        *relay_port,
+                    );
+                }
                 self.render_redirect_rule(&mut script, "", self.relay_port);
             }
             ScopeMode::Apps => {
@@ -497,6 +546,49 @@ mod tests {
     }
 
     #[test]
+    fn mixed_routes_apps_in_priority_order_before_global_fallback() {
+        let bypass = CgroupV2Match::from_relative_path("taomni-sockscap-42/bypass").unwrap();
+        let routes = [
+            (
+                CgroupV2Match::from_relative_path("taomni-sockscap-42/capture-profile-0").unwrap(),
+                15000,
+            ),
+            (
+                CgroupV2Match::from_relative_path("taomni-sockscap-42/capture-profile-1").unwrap(),
+                16000,
+            ),
+        ];
+        let plan =
+            RedirectPlan::new_mixed_routes(17000, true, &[], Some(bypass), &routes, false).unwrap();
+        let script = plan.render_nft_script();
+        let bypass_rule = "socket cgroupv2 level 2 \"taomni-sockscap-42/bypass\" return";
+        let first_app = "socket cgroupv2 level 2 \"taomni-sockscap-42/capture-profile-0\" meta l4proto tcp redirect to :15000";
+        let second_app = "socket cgroupv2 level 2 \"taomni-sockscap-42/capture-profile-1\" meta l4proto tcp redirect to :16000";
+        let global = "    meta l4proto tcp redirect to :17000";
+
+        assert!(script.find(bypass_rule).unwrap() < script.find(first_app).unwrap());
+        assert!(script.find(first_app).unwrap() < script.find(second_app).unwrap());
+        assert!(script.find(second_app).unwrap() < script.find(global).unwrap());
+    }
+
+    #[test]
+    fn mixed_routes_require_an_application_route() {
+        let bypass = CgroupV2Match::from_relative_path("taomni-sockscap-42/bypass").unwrap();
+        assert!(
+            RedirectPlan::new_mixed_routes(17000, true, &[], Some(bypass.clone()), &[], false)
+                .is_err()
+        );
+        let route = CgroupV2Match::from_relative_path(
+            "taomni-sockscap-42/capture-profile-0",
+        )
+        .unwrap();
+        assert!(
+            RedirectPlan::new_mixed_routes(0, true, &[], Some(bypass), &[(route, 15000)], false)
+                .is_err()
+        );
+    }
+
+    #[test]
     fn recognizes_only_marked_tables_as_managed() {
         assert!(managed_table_output(
             b"table inet taomni_sockscap {\n  comment \"taomni-sockscap-managed-v1\"\n}"
@@ -522,9 +614,16 @@ mod tests {
     fn no_quic_block_chain_when_block_quic_is_off() {
         // Regression guard: block_quic=false must render exactly as before.
         let bypass = CgroupV2Match::from_relative_path("taomni-sockscap-42/bypass").unwrap();
-        let plan =
-            RedirectPlan::new(ScopeMode::Global, 18443, true, &[], Some(bypass), &[], false)
-                .unwrap();
+        let plan = RedirectPlan::new(
+            ScopeMode::Global,
+            18443,
+            true,
+            &[],
+            Some(bypass),
+            &[],
+            false,
+        )
+        .unwrap();
         let script = plan.render_nft_script();
         assert!(!script.contains("quic_block"));
         assert!(!script.contains("udp dport 443"));
@@ -549,11 +648,13 @@ mod tests {
         assert!(script.contains("udp dport 443 drop"));
         // The drop must come after the bypass-cgroup return, or the relay's own
         // (and xray's) UDP egress would be dropped.
-        let bypass_return =
-            "socket cgroupv2 level 2 \"taomni-sockscap-42/bypass\" return";
+        let bypass_return = "socket cgroupv2 level 2 \"taomni-sockscap-42/bypass\" return";
         let block_body = &script[script.find("chain quic_block").unwrap()..];
         assert!(block_body.contains(bypass_return));
-        assert!(block_body.find(bypass_return).unwrap() < block_body.find("udp dport 443 drop").unwrap());
+        assert!(
+            block_body.find(bypass_return).unwrap()
+                < block_body.find("udp dport 443 drop").unwrap()
+        );
         // Loopback + bypass CIDR returns are present in the block chain too.
         assert!(block_body.contains("ip daddr 127.0.0.0/8 return"));
         assert!(block_body.contains("ip daddr 10.0.0.0/8 return"));

--- a/src-tauri/src/sockscap/mod.rs
+++ b/src-tauri/src/sockscap/mod.rs
@@ -20,7 +20,6 @@ pub mod ingress;
 pub mod listener_pid;
 pub mod orchestrator;
 pub mod paths;
-pub mod tun_detect;
 pub mod policy;
 pub mod process;
 pub mod recovery;
@@ -28,6 +27,7 @@ pub mod redirector;
 pub mod relay;
 pub mod rules;
 pub mod stats;
+pub mod tun_detect;
 
 pub use config::{Decision, RuleMode, SocksCapConfig};
 pub use orchestrator::{Orchestrator, SocksCapStatus};
@@ -265,13 +265,19 @@ pub async fn sockscap_set_config(
 ) -> Result<(), String> {
     config.validate()?;
     let path = config_path(&app)?;
-    config.save(&path)?;
     let mut orch = state.sockscap.orch.write().await;
-    orch.apply_config(config.clone());
-    // Hot-reload into running relay without restarting capture.
-    let rules = orch.rules().map(|r| r.clone());
-    orch.hot_reload_policy(config, rules).await;
+    ensure_configuration_unlocked(&orch)?;
+    config.save(&path)?;
+    orch.apply_config(config);
     Ok(())
+}
+
+fn ensure_configuration_unlocked(orch: &Orchestrator) -> Result<(), String> {
+    if orch.configuration_locked() {
+        Err("SocksCap configuration is locked while capture is running; stop capture before making changes".into())
+    } else {
+        Ok(())
+    }
 }
 
 /* ---------------------------- rules ------------------------------------- */
@@ -331,6 +337,10 @@ pub async fn sockscap_refresh_gfwlist(
     state: State<'_, AppState>,
     url: Option<String>,
 ) -> Result<GfwListStatus, String> {
+    // Hold the write lock for the complete mutation so Start cannot snapshot
+    // the old rules while a refresh is being committed.
+    let mut orch = state.sockscap.orch.write().await;
+    ensure_configuration_unlocked(&orch)?;
     let cfg_path = config_path(&app)?;
     let mut cfg = SocksCapConfig::load(&cfg_path);
     let fetch_url = url
@@ -346,10 +356,8 @@ pub async fn sockscap_refresh_gfwlist(
         Ok(compiled) => {
             let meta = compiled.meta.clone();
             cfg.save(&cfg_path)?;
-            let mut orch = state.sockscap.orch.write().await;
-            orch.apply_config(cfg.clone());
-            orch.set_rules(compiled.clone());
-            orch.hot_reload_policy(cfg, Some(compiled)).await;
+            orch.apply_config(cfg);
+            orch.set_rules(compiled);
             Ok(GfwListStatus {
                 loaded: true,
                 rule_count: meta.rule_count,
@@ -361,7 +369,6 @@ pub async fn sockscap_refresh_gfwlist(
         }
         Err(e) => {
             // Keep previous rules if any; surface error for UI.
-            let orch = state.sockscap.orch.read().await;
             if let Some(meta) = orch.gfwlist_meta() {
                 Ok(GfwListStatus {
                     loaded: true,
@@ -391,14 +398,12 @@ pub async fn sockscap_import_rules(
     state: State<'_, AppState>,
     path: String,
 ) -> Result<GfwListStatus, String> {
+    let mut orch = state.sockscap.orch.write().await;
+    ensure_configuration_unlocked(&orch)?;
     let dir = rules_dir(&app)?;
     let compiled = rules::source::import_from_path(std::path::Path::new(&path), &dir)?;
     let meta = compiled.meta.clone();
-    let mut orch = state.sockscap.orch.write().await;
-    orch.set_rules(compiled.clone());
-    if let Some(cfg) = orch.config().cloned() {
-        orch.hot_reload_policy(cfg, Some(compiled)).await;
-    }
+    orch.set_rules(compiled);
     Ok(GfwListStatus {
         loaded: true,
         rule_count: meta.rule_count,
@@ -585,12 +590,7 @@ pub async fn sockscap_start(
         }
     }
 
-    let activation_lock = ModuleLock::try_acquire_for_app(
-        &app,
-        "sockscap",
-        "global",
-        "SocksCap",
-    )?;
+    let activation_lock = ModuleLock::try_acquire_for_app(&app, "sockscap", "global", "SocksCap")?;
 
     let dir = rules_dir(&app)?;
     {
@@ -605,20 +605,15 @@ pub async fn sockscap_start(
         let mut orch = state.sockscap.orch.write().await;
         if orch.rules().is_none() {
             if let Some(c) = rules::source::load_cached(&dir) {
-                gfw_start_note = format!(
-                    "using cached GFWList ({} rules)",
-                    c.meta.rule_count
-                );
+                gfw_start_note = format!("using cached GFWList ({} rules)", c.meta.rule_count);
                 orch.set_rules(c);
             } else if !cfg.gfwlist.url.trim().is_empty() {
                 let url = cfg.gfwlist.url.clone();
                 drop(orch);
                 match rules::source::refresh_from_url(&url, &dir).await {
                     Ok(compiled) => {
-                        gfw_start_note = format!(
-                            "downloaded GFWList ({} rules)",
-                            compiled.meta.rule_count
-                        );
+                        gfw_start_note =
+                            format!("downloaded GFWList ({} rules)", compiled.meta.rule_count);
                         state.sockscap.orch.write().await.set_rules(compiled);
                     }
                     Err(e) => {
@@ -887,7 +882,10 @@ async fn ensure_core_port(
     match mgr.ensure(profile_key, &spec).await {
         Ok(local_port) => Some(local_port),
         Err(e) => {
-            tracing::warn!("sockscap: xray core for '{profile_key}' ({}) failed: {e}", kind.as_tag());
+            tracing::warn!(
+                "sockscap: xray core for '{profile_key}' ({}) failed: {e}",
+                kind.as_tag()
+            );
             None
         }
     }
@@ -914,9 +912,7 @@ async fn build_unix_relay_context(
     if !cfg.upstream.session_id.is_empty() {
         let session = {
             let db = state.db.lock().ok();
-            db.and_then(|db| {
-                crate::session::db::get_session(&db, &cfg.upstream.session_id).ok()
-            })
+            db.and_then(|db| crate::session::db::get_session(&db, &cfg.upstream.session_id).ok())
         };
         if let Some(session) = session {
             upstream_host = session.host.clone();
@@ -986,9 +982,7 @@ async fn build_unix_relay_context(
                 if let Some(session) = session {
                     host = session.host.clone();
                     port = session.port;
-                    if let Some(username) =
-                        session.username.clone().filter(|u| !u.is_empty())
-                    {
+                    if let Some(username) = session.username.clone().filter(|u| !u.is_empty()) {
                         user = username;
                     }
                     if let Some(pass) = session_proxy_password(&state.vault, &session) {
@@ -1119,14 +1113,12 @@ async fn start_linux_capture(
         .map(|meta| format!(", gfw={}", meta.rule_count))
         .unwrap_or_default();
     let active_profiles = cfg.active_profiles();
-    let app_watch_note = if active_profiles
+    let application_count = active_profiles
         .iter()
-        .all(|profile| matches!(profile.mode, config::ScopeMode::Apps))
-    {
-        let application_count = active_profiles
-            .iter()
-            .map(|profile| profile.apps.len())
-            .sum::<usize>();
+        .take_while(|profile| matches!(profile.mode, config::ScopeMode::Apps))
+        .map(|profile| profile.apps.len())
+        .sum::<usize>();
+    let app_watch_note = if application_count > 0 {
         format!(", watching {application_count} application selector(s)")
     } else {
         String::new()
@@ -1259,8 +1251,7 @@ async fn start_windows_capture(
     }
 
     // 2) Resolve upstream credentials (manual fields; vault password_ref).
-    let (mut up_host, mut up_port, mut up_user, mut up_pass) =
-        relay::upstream_from_config(cfg);
+    let (mut up_host, mut up_port, mut up_user, mut up_pass) = relay::upstream_from_config(cfg);
     if !cfg.upstream.password_ref.is_empty() {
         if let Ok(Some(p)) = state.vault.resolve(&cfg.upstream.password_ref) {
             up_pass = (*p).clone();
@@ -1273,9 +1264,7 @@ async fn start_windows_capture(
     if !cfg.upstream.session_id.is_empty() {
         let sess = {
             let db = state.db.lock().ok();
-            db.and_then(|db| {
-                crate::session::db::get_session(&db, &cfg.upstream.session_id).ok()
-            })
+            db.and_then(|db| crate::session::db::get_session(&db, &cfg.upstream.session_id).ok())
         };
         if let Some(sess) = sess {
             up_host = sess.host.clone();
@@ -1343,7 +1332,9 @@ async fn start_windows_capture(
                 session_ssh_auth(&state.vault, sess)
             } else if !ppass.is_empty() {
                 SshAuth::Password(ppass.clone())
-            } else if !p.upstream.password_ref.is_empty() && p.upstream.password_ref.starts_with("key:") {
+            } else if !p.upstream.password_ref.is_empty()
+                && p.upstream.password_ref.starts_with("key:")
+            {
                 SshAuth::PrivateKey(p.upstream.password_ref.clone())
             } else {
                 SshAuth::Agent
@@ -1404,8 +1395,7 @@ async fn start_windows_capture(
     // Global native loopback proxy → remember its port for PID-bypass below.
     if matches!(
         cfg.upstream.kind,
-        crate::sockscap::config::UpstreamKind::Http
-            | crate::sockscap::config::UpstreamKind::Socks5
+        crate::sockscap::config::UpstreamKind::Http | crate::sockscap::config::UpstreamKind::Socks5
     ) && up_port != 0
         && listener_pid::is_loopback(&up_host)
         && !loopback_proxy_ports.contains(&up_port)
@@ -1414,8 +1404,10 @@ async fn start_windows_capture(
     }
 
     // Optional SSH pool for capture-path PROXY via direct-tcpip.
-    let ssh_pool = if matches!(cfg.upstream.kind, crate::sockscap::config::UpstreamKind::Ssh)
-    {
+    let ssh_pool = if matches!(
+        cfg.upstream.kind,
+        crate::sockscap::config::UpstreamKind::Ssh
+    ) {
         use crate::sockscap::egress::ssh_pool::SshPool;
         use crate::terminal::ssh::SshAuth;
         let auth = if let Some(sess) = &up_session {
@@ -1547,9 +1539,7 @@ async fn start_windows_capture(
             for pid in listener_pid::resolve_listener_pids(*port) {
                 if !bypass_pids.contains(&pid) {
                     bypass_pids.push(pid);
-                    tracing::info!(
-                        "sockscap: bypassing local proxy pid {pid} on 127.0.0.1:{port}"
-                    );
+                    tracing::info!("sockscap: bypassing local proxy pid {pid} on 127.0.0.1:{port}");
                 }
                 if let Some(path) = procs
                     .iter()
@@ -1688,7 +1678,9 @@ fn spawn_xray_bypass_updater(
             })
             .await;
             match sent {
-                Ok(Ok(_)) => tracing::info!("sockscap: pushed refreshed bypass list after xray respawn"),
+                Ok(Ok(_)) => {
+                    tracing::info!("sockscap: pushed refreshed bypass list after xray respawn")
+                }
                 Ok(Err(e)) => tracing::warn!("sockscap: bypass refresh failed: {e}"),
                 Err(e) => tracing::warn!("sockscap: bypass refresh task failed: {e}"),
             }
@@ -1726,10 +1718,7 @@ pub async fn sockscap_stop(
 /// macOS teardown must happen while the async runtime and the stored sudo
 /// credential are still available. If teardown fails, the exit command returns
 /// an error and the UI keeps the process alive so the user can retry or Recover.
-pub async fn prepare_for_exit(
-    app: &AppHandle,
-    state: State<'_, AppState>,
-) -> Result<(), String> {
+pub async fn prepare_for_exit(app: &AppHandle, state: State<'_, AppState>) -> Result<(), String> {
     let owns_capture = state.sockscap.has_activation_lock();
     let recovery_required = matches!(
         state.sockscap.orch.read().await.status().phase,
@@ -1936,12 +1925,8 @@ pub async fn sockscap_recover(
     sudo_password: Option<String>,
 ) -> Result<(), String> {
     if !state.sockscap.has_activation_lock() {
-        let lock = ModuleLock::try_acquire_for_app(
-            &app,
-            "sockscap",
-            "global",
-            "SocksCap recovery",
-        )?;
+        let lock =
+            ModuleLock::try_acquire_for_app(&app, "sockscap", "global", "SocksCap recovery")?;
         state.sockscap.install_activation_lock(lock);
     }
 
@@ -2114,10 +2099,7 @@ async fn full_teardown(
         let mut orch = state.sockscap.orch.write().await;
         orch.finish_stop();
         if !errors.is_empty() {
-            orch.set_recovery_required(
-                &capture::capabilities().capture_backend,
-                errors.join("; "),
-            );
+            orch.set_recovery_required(&capture::capabilities().capture_backend, errors.join("; "));
         }
     }
     if errors.is_empty() {
@@ -2212,7 +2194,8 @@ pub async fn sockscap_test_upstream(
 
     match kind.as_str() {
         "http" => {
-            egress::http_connect::dial(&host, port, &target_host, target_port, &user, &pass).await?;
+            egress::http_connect::dial(&host, port, &target_host, target_port, &user, &pass)
+                .await?;
             Ok(format!(
                 "HTTP CONNECT via {}:{} to {}:{} ok",
                 host, port, target_host, target_port
@@ -2238,9 +2221,7 @@ pub async fn sockscap_test_upstream(
                 SshAuth::Password(pass)
             };
             let pool = SshPool::connect(&host, port, &user, auth).await?;
-            let stream = pool
-                .dial(&target_host, target_port, "127.0.0.1", 0)
-                .await?;
+            let stream = pool.dial(&target_host, target_port, "127.0.0.1", 0).await?;
             // Drop after successful open.
             drop(stream);
             Ok(format!(
@@ -2443,26 +2424,35 @@ async fn probe_local_proxy_kind(port: u16) -> Option<String> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
-    let connect = tokio::time::timeout(std::time::Duration::from_millis(300), TcpStream::connect(addr));
+    let connect = tokio::time::timeout(
+        std::time::Duration::from_millis(300),
+        TcpStream::connect(addr),
+    );
     let mut s = connect.await.ok()?.ok()?;
     // SOCKS5 greeting: VER=5, NMETHODS=1, METHOD=0 (no auth).
     if s.write_all(&[0x05, 0x01, 0x00]).await.is_ok() {
         let mut buf = [0u8; 2];
-        if tokio::time::timeout(std::time::Duration::from_millis(300), s.read_exact(&mut buf))
-            .await
-            .ok()
-            .and_then(Result::ok)
-            .is_some()
+        if tokio::time::timeout(
+            std::time::Duration::from_millis(300),
+            s.read_exact(&mut buf),
+        )
+        .await
+        .ok()
+        .and_then(Result::ok)
+        .is_some()
             && buf[0] == 0x05
         {
             return Some("socks5".into());
         }
     }
     // Not SOCKS5 — try a fresh connection for an HTTP CONNECT probe.
-    let mut s = tokio::time::timeout(std::time::Duration::from_millis(300), TcpStream::connect(addr))
-        .await
-        .ok()?
-        .ok()?;
+    let mut s = tokio::time::timeout(
+        std::time::Duration::from_millis(300),
+        TcpStream::connect(addr),
+    )
+    .await
+    .ok()?
+    .ok()?;
     let req = "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
     s.write_all(req.as_bytes()).await.ok()?;
     let mut buf = [0u8; 16];
@@ -2563,13 +2553,22 @@ pub async fn sockscap_detect_local_proxies() -> Result<Vec<LocalProxyCandidate>,
             continue;
         };
         let (pid, process, client, client_label) = match port_meta.get(&port) {
-            Some(m) => (m.pid, m.process.clone(), m.client.clone(), m.client_label.clone()),
+            Some(m) => (
+                m.pid,
+                m.process.clone(),
+                m.client.clone(),
+                m.client_label.clone(),
+            ),
             None => {
                 let pid = listener_pid::resolve_listener_pids(port)
                     .into_iter()
                     .next()
                     .unwrap_or(0);
-                let process = if pid != 0 { name_of(pid) } else { String::new() };
+                let process = if pid != 0 {
+                    name_of(pid)
+                } else {
+                    String::new()
+                };
                 let (client, client_label) = classify_client(&process);
                 (pid, process, client, client_label)
             }
@@ -2685,7 +2684,10 @@ fn read_ready_files(dir: &std::path::Path) -> Vec<StaleReadyFile> {
         if let Ok(text) = std::fs::read_to_string(&path) {
             if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
                 pid = v.get("pid").and_then(|x| x.as_u64()).map(|n| n as u32);
-                parent_pid = v.get("parentPid").and_then(|x| x.as_u64()).map(|n| n as u32);
+                parent_pid = v
+                    .get("parentPid")
+                    .and_then(|x| x.as_u64())
+                    .map(|n| n as u32);
             }
         }
         out.push(StaleReadyFile {
@@ -2721,18 +2723,14 @@ pub async fn boot_repair(app: &AppHandle, state: &AppState) {
 
     // Another live instance may own the dirty journal. Never repair global
     // network state underneath its active capture session.
-    let _repair_lock = match ModuleLock::try_acquire_for_app(
-        app,
-        "sockscap",
-        "global",
-        "SocksCap recovery",
-    ) {
-        Ok(lock) => lock,
-        Err(error) => {
-            tracing::info!("sockscap: boot repair skipped: {error}");
-            return;
-        }
-    };
+    let _repair_lock =
+        match ModuleLock::try_acquire_for_app(app, "sockscap", "global", "SocksCap recovery") {
+            Ok(lock) => lock,
+            Err(error) => {
+                tracing::info!("sockscap: boot repair skipped: {error}");
+                return;
+            }
+        };
 
     let Ok(dir) = data_dir(app) else {
         return;
@@ -2885,9 +2883,7 @@ pub async fn sockscap_get_domain_records(
 }
 
 #[tauri::command]
-pub async fn sockscap_clear_domain_records(
-    state: State<'_, AppState>,
-) -> Result<(), String> {
+pub async fn sockscap_clear_domain_records(state: State<'_, AppState>) -> Result<(), String> {
     let orch = state.sockscap.orch.read().await;
     let mut guard = orch.domains.lock().map_err(|e| e.to_string())?;
     guard.clear();
@@ -2896,7 +2892,10 @@ pub async fn sockscap_clear_domain_records(
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_client, session_password_ref, session_proxy_password, session_ssh_auth};
+    use super::{
+        Orchestrator, classify_client, ensure_configuration_unlocked, session_password_ref,
+        session_proxy_password, session_ssh_auth,
+    };
     use crate::session::models::{AuthMethod, SessionConfig, SessionType};
     use crate::terminal::ssh::SshAuth;
     use crate::vault::Vault;
@@ -2922,8 +2921,23 @@ mod tests {
     fn fresh_vault() -> (tempfile::TempDir, Vault) {
         let dir = tempfile::tempdir().expect("tempdir");
         let vault = Vault::open(&dir.path().join("vault.db")).expect("open vault");
-        vault.init("correct-horse-battery-staple").expect("init vault");
+        vault
+            .init("correct-horse-battery-staple")
+            .expect("init vault");
         (dir, vault)
+    }
+
+    #[test]
+    fn configuration_mutations_are_rejected_during_capture() {
+        let mut orchestrator = Orchestrator::new();
+        assert!(ensure_configuration_unlocked(&orchestrator).is_ok());
+
+        orchestrator.set_active("test", "active");
+        let error = ensure_configuration_unlocked(&orchestrator).unwrap_err();
+        assert!(error.contains("stop capture before making changes"));
+
+        orchestrator.finish_stop();
+        assert!(ensure_configuration_unlocked(&orchestrator).is_ok());
     }
 
     #[test]
@@ -2983,7 +2997,10 @@ mod tests {
             .reference;
         vault.lock().expect("lock");
         let options = format!(r#"{{"passwordRef":"{reference}"}}"#);
-        assert_eq!(session_proxy_password(&vault, &proxy_session(&options)), None);
+        assert_eq!(
+            session_proxy_password(&vault, &proxy_session(&options)),
+            None
+        );
     }
 
     fn ssh_session(auth_method: AuthMethod, options_json: &str) -> SessionConfig {
@@ -3050,7 +3067,12 @@ mod tests {
         assert!(matches!(
             session_ssh_auth(
                 &vault,
-                &ssh_session(AuthMethod::PrivateKey { key_path: "  ".into() }, "{}")
+                &ssh_session(
+                    AuthMethod::PrivateKey {
+                        key_path: "  ".into()
+                    },
+                    "{}"
+                )
             ),
             SshAuth::Agent
         ));

--- a/src-tauri/src/sockscap/orchestrator.rs
+++ b/src-tauri/src/sockscap/orchestrator.rs
@@ -51,7 +51,8 @@ pub struct Orchestrator {
     /// unit, including clearing the interception scope before shutdown.
     #[cfg(target_os = "macos")]
     macos_capture: Option<MacosCaptureHandle>,
-    /// Shared with the relay task so config/rules can hot-reload while Active.
+    /// Shared with the relay task for the lifetime of one immutable capture
+    /// session. Configuration changes require Stop before the next Start.
     pub relay_ctx:
         Option<std::sync::Arc<tokio::sync::RwLock<crate::sockscap::relay::RelayContext>>>,
     /// Signal DNS cache refresher to exit when capture stops.
@@ -347,28 +348,20 @@ impl Orchestrator {
         }
     }
 
-    /// Hot-update policy surface used by the running relay.
-    pub async fn hot_reload_policy(
-        &self,
-        cfg: SocksCapConfig,
-        rules: Option<crate::sockscap::rules::CompiledRules>,
-    ) {
-        if let Some(ctx) = &self.relay_ctx {
-            let mut g = ctx.write().await;
-            g.config = cfg;
-            if let Some(r) = rules {
-                g.rules = Some(r);
-            }
-            // The engine is a compiled snapshot of both; without this, live
-            // flows would keep being judged by the previous configuration.
-            g.rebuild_engine();
-        }
-    }
-
     pub fn is_running(&self) -> bool {
         matches!(
             self.phase,
             EnginePhase::Active | EnginePhase::Preparing | EnginePhase::Degraded
+        )
+    }
+
+    pub fn configuration_locked(&self) -> bool {
+        matches!(
+            self.phase,
+            EnginePhase::Preparing
+                | EnginePhase::Active
+                | EnginePhase::Degraded
+                | EnginePhase::Stopping
         )
     }
 }
@@ -395,5 +388,25 @@ mod tests {
         assert_eq!(status.capture_backend, "none");
         assert_eq!(status.message, "authorization required");
         assert!(!orchestrator.is_running());
+    }
+
+    #[test]
+    fn configuration_is_locked_for_every_live_capture_phase() {
+        let mut orchestrator = Orchestrator::new();
+        assert!(!orchestrator.configuration_locked());
+
+        orchestrator.set_preparing("test");
+        assert!(orchestrator.configuration_locked());
+        orchestrator.set_active("test", "active");
+        assert!(orchestrator.configuration_locked());
+        orchestrator.set_degraded("test", "degraded");
+        assert!(orchestrator.configuration_locked());
+        orchestrator.take_relay_for_stop();
+        assert!(orchestrator.configuration_locked());
+
+        orchestrator.finish_stop();
+        assert!(!orchestrator.configuration_locked());
+        orchestrator.set_recovery_required("test", "recover");
+        assert!(!orchestrator.configuration_locked());
     }
 }

--- a/src-tauri/src/sockscap/policy.rs
+++ b/src-tauri/src/sockscap/policy.rs
@@ -612,4 +612,47 @@ mod tests {
         assert_eq!(trace.decision, Decision::Proxy);
         assert_eq!(trace.profile_id.as_deref(), Some("default"));
     }
+
+    #[test]
+    fn linux_mixed_relays_preserve_app_priority_and_global_fallback() {
+        let mut config = SocksCapConfig::default();
+        config.profiles[0].id = "agy".into();
+        config.profiles[0].name = "agy".into();
+        config.profiles[0].mode = ScopeMode::Apps;
+        config.profiles[0].apps = vec![AppSelector {
+            path: "/opt/agy/agy".into(),
+            bundle_id: String::new(),
+            name: "agy".into(),
+            macos_identity: None,
+        }];
+        config.profiles[0].rule_mode = RuleMode::ProxyAll;
+
+        let mut global = config.profiles[0].clone();
+        global.id = "global".into();
+        global.name = "Global GFWList".into();
+        global.priority = 1;
+        global.mode = ScopeMode::Global;
+        global.apps.clear();
+        global.rule_mode = RuleMode::GfwList;
+        config.profiles.push(global);
+        config.active_profile_ids = vec!["agy".into(), "global".into()];
+
+        let rules = CompiledRules::compile("||wikipedia.org\n", "test").unwrap();
+        let engine = PolicyEngine::from_config(&config, Some(&rules));
+        let input = PolicyInput {
+            host: Some("en.wikipedia.org".into()),
+            ip: None,
+            port: 443,
+            process_path: None,
+            pid: None,
+        };
+
+        let app = engine.decide_with_profile_hint(&input, Some("agy"));
+        assert_eq!(app.decision, Decision::Proxy);
+        assert_eq!(app.profile_id.as_deref(), Some("agy"));
+
+        let fallback = engine.decide_with_profile_hint(&input, None);
+        assert_eq!(fallback.decision, Decision::Proxy);
+        assert_eq!(fallback.profile_id.as_deref(), Some("global"));
+    }
 }

--- a/src/components/sockscap/SocksCapPanel.test.tsx
+++ b/src/components/sockscap/SocksCapPanel.test.tsx
@@ -439,7 +439,7 @@ describe("SocksCapPanel Multi-Profile UI", () => {
     expect(currentCfg.activeProfileIds).not.toContain(a.id);
   });
 
-  it("locks scope/upstream/profile edits while running but keeps Add profile", async () => {
+  it("locks every profile and routing-rule mutation while running", async () => {
     // Report the engine as Active so the panel enters the locked state.
     vi.mocked(sockscapStatus).mockResolvedValue({
       phase: "active",
@@ -453,14 +453,21 @@ describe("SocksCapPanel Multi-Profile UI", () => {
       expect(screen.getByTestId("sockscap-locked-banner")).toBeInTheDocument(),
     );
     expect(within(screen.getByTestId("sockscap-header")).getByTestId("sockscap-locked-banner")).toBeInTheDocument();
-    // Restart-requiring controls are disabled…
+    // Capture topology and profile controls are disabled.
     expect(screen.getByTestId("sockscap-upstream-kind")).toBeDisabled();
     expect(screen.getByTestId("sockscap-mode-global")).toBeDisabled();
     expect(screen.getByTestId("sockscap-upstream-source")).toBeDisabled();
     expect(screen.getByTestId("sockscap-profile-checkbox-default")).toBeDisabled();
     expect(screen.getByTestId("sockscap-profile-priority-input-default")).toBeDisabled();
-    // …but adding a new profile is still allowed.
-    expect(screen.getByTestId("sockscap-add-profile")).not.toBeDisabled();
+    expect(screen.getByTestId("sockscap-add-profile")).toBeDisabled();
+
+    // Policy and shared routing-rule mutations are disabled as well.
+    fireEvent.click(screen.getByTestId("sockscap-section-rules-toggle"));
+    expect(await screen.findByTestId("sockscap-rules-editor")).toBeDisabled();
+    fireEvent.click(screen.getByTestId("sockscap-section-gfwlist-toggle"));
+    expect(await screen.findByTestId("sockscap-refresh-gfw")).toBeDisabled();
+    expect(screen.getByTestId("sockscap-import-gfw")).toBeDisabled();
+    expect(screen.getByTestId("sockscap-block-quic")).toBeDisabled();
   });
 
   it("shows a copyable detail modal after testing the upstream", async () => {

--- a/src/components/sockscap/SocksCapPanel.tsx
+++ b/src/components/sockscap/SocksCapPanel.tsx
@@ -74,7 +74,6 @@ import {
   type UpstreamParams,
   type UserRule,
 } from "../../lib/sockscap";
-import { requiresRestart } from "../../lib/sockscapRestart";
 import {
   collectProbeTargets,
   collectUpstreamConfigIssues,
@@ -317,12 +316,6 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
   const [downSpeed, setDownSpeed] = useState(0);
   const lastBytesRef = useRef<{ up: number; down: number; ts: number } | null>(null);
 
-  // Config as it was when capture last started successfully. Used to detect
-  // scope/upstream edits that the running backend will not apply until a
-  // Stop+Start (see lib/sockscapRestart).
-  const startedCfgRef = useRef<SocksCapConfig | null>(null);
-  const [needsRestart, setNeedsRestart] = useState(false);
-
   // Resizable profile sidebar & ribbon collapse state
   const [sidebarWidth, setSidebarWidth] = useState(230);
   const [isRibbon, setIsRibbon] = useState(false);
@@ -504,13 +497,9 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
     status?.phase === "degraded" ||
     status?.phase === "preparing";
 
-  // While capture is running the backend only hot-reloads the rule surface
-  // (ruleMode / userRules / defaultAction / bypassCidrs / GFWList). Scope, app
-  // list, upstream, and the active-profile set are snapshotted at Start and
-  // ignored until the next Stop+Start (see lib/sockscapRestart + orchestrator
-  // hot_reload_policy). So lock every "needs restart" control while running and
-  // tell the user to stop first. Adding a NEW profile stays allowed.
-  const locked = running;
+  // A capture session is an immutable snapshot on every platform. This also
+  // covers the short Stopping phase so edits cannot race teardown.
+  const locked = running || status?.phase === "stopping";
 
   const selectedProf = useMemo(() => {
     if (!cfg) return DEFAULT_PROFILE;
@@ -529,24 +518,19 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
     [cfg],
   );
 
-  // While capture is running, editing scope/upstream (mode, apps, active
-  // profiles, upstream) does not take effect until Stop+Start — the backend
-  // only hot-reloads the rule policy. Flag that so the UI can offer a restart.
-  useEffect(() => {
-    if (!running || !cfg || !startedCfgRef.current) {
-      setNeedsRestart(false);
-      return;
-    }
-    setNeedsRestart(requiresRestart(startedCfgRef.current, cfg));
-  }, [cfg, running]);
-
   const persistConfig = async (next: SocksCapConfig) => {
-    setCfg(next);
+    if (locked) {
+      report(t("sockscap.lockedTooltip"), false);
+      return false;
+    }
     try {
       await sockscapSetConfig(next);
+      setCfg(next);
       report(t("sockscap.saved"));
+      return true;
     } catch (e) {
       report(String(e), false);
+      return false;
     }
   };
 
@@ -642,7 +626,7 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
   };
 
   const addProfile = async () => {
-    if (!cfg) return;
+    if (!cfg || locked) return;
     const newId = "prof-" + Date.now().toString(36);
     const newProf: SocksCapProfile = {
       id: newId,
@@ -681,7 +665,7 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
    *  are NOT auto-activated (avoids spawning many cores at once); the user
    *  activates the one they want. Selects the first imported node. */
   const onImportSubscription = async () => {
-    if (!cfg || !subInput.trim()) return;
+    if (!cfg || locked || !subInput.trim()) return;
     setBusy(true);
     try {
       const nodes = await sockscapImportSubscription(subInput.trim());
@@ -769,7 +753,7 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
   };
 
   const duplicateProfile = async (prof: SocksCapProfile) => {
-    if (!cfg) return;
+    if (!cfg || locked) return;
     const newId = "prof-" + Date.now().toString(36);
     const newProf: SocksCapProfile = {
       ...prof,
@@ -796,6 +780,7 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
   };
 
   const deleteProfile = async (id: string) => {
+    if (locked) return;
     if (!cfg || cfg.profiles.length <= 1) {
       report(t("sockscap.atLeastOneProfile"), false);
       return;
@@ -929,9 +914,6 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
       await sockscapSetConfig(cfg);
       const st = await sockscapStart(sudoPassword);
       setStatus(st);
-      // Snapshot the capture scope so later edits can flag a needed restart.
-      startedCfgRef.current = cfg;
-      setNeedsRestart(false);
       setRootPromptIntent(null);
       setRootPromptError(null);
       report(st.message || t("sockscap.started"), st.phase !== "idle");
@@ -967,8 +949,6 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
     try {
       const st = await sockscapStop();
       setStatus(st);
-      startedCfgRef.current = null;
-      setNeedsRestart(false);
       const [sn, hp] = await Promise.all([
         sockscapStatsSnapshot().catch(() => null),
         sockscapHelperStatus().catch(() => null),
@@ -976,32 +956,6 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
       if (sn) setStats(sn);
       if (hp) setHelper(hp);
       report(t("sockscap.stopped"));
-    } catch (e) {
-      report(String(e), false);
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  // Apply scope/upstream edits to a running capture: Stop then Start so the
-  // backend rebuilds the capture plan and upstream connections.
-  const onRestart = async () => {
-    setBusy(true);
-    try {
-      await sockscapStop().catch(() => null);
-      startedCfgRef.current = null;
-      setNeedsRestart(false);
-      if (cfg) await sockscapSetConfig(cfg);
-      const st = await sockscapStart();
-      setStatus(st);
-      startedCfgRef.current = cfg;
-      const [sn, hp] = await Promise.all([
-        sockscapStatsSnapshot().catch(() => null),
-        sockscapHelperStatus().catch(() => null),
-      ]);
-      if (sn) setStats(sn);
-      if (hp) setHelper(hp);
-      report(t("sockscap.restarted"), st.phase !== "idle");
     } catch (e) {
       report(String(e), false);
     } finally {
@@ -1066,7 +1020,7 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
   };
 
   const onRefreshGfw = async () => {
-    if (!cfg) return;
+    if (!cfg || locked) return;
     setBusy(true);
     try {
       const res = await sockscapRefreshGfwlist(cfg.gfwlist.url);
@@ -1083,6 +1037,7 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
   };
 
   const onImportGfw = async () => {
+    if (locked) return;
     try {
       if (!isTauriRuntime()) {
         report(t("sockscap.importDesktopOnly"), false);
@@ -1107,7 +1062,6 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
   const onTestTarget = async () => {
     setTesting(true);
     try {
-      if (cfg) await sockscapSetConfig(cfg);
       const res = await sockscapTestTarget(testHost.trim(), 443);
       setTestResult(res);
       const summary = t("sockscap.testTargetResult", {
@@ -1639,7 +1593,7 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
   };
 
   const addUserRule = async () => {
-    if (!cfg || !newRule.pattern.trim()) return;
+    if (!cfg || locked || !newRule.pattern.trim()) return;
     await patchSelectedProfile({
       userRules: [...selectedProf.userRules, { ...newRule, pattern: newRule.pattern.trim() }],
     });
@@ -1882,29 +1836,6 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
         </div>
       )}
 
-      {/* Scope/upstream edited while running — needs Stop+Start to apply */}
-      {needsRestart && running && (
-        <div
-          data-testid="sockscap-restart-banner"
-          className="px-4 py-2 bg-amber-500/10 border-b border-amber-500/30 text-[11px] flex flex-wrap items-center justify-between gap-2 text-amber-700 dark:text-amber-400"
-        >
-          <span className="flex items-center gap-1.5">
-            <AlertCircle className="w-3.5 h-3.5 shrink-0" />
-            {t("sockscap.restartNeeded")}
-          </span>
-          <button
-            type="button"
-            data-testid="sockscap-restart"
-            className="inline-flex items-center gap-1 px-3 py-1 rounded text-[11px] bg-amber-600 text-white hover:bg-amber-500 disabled:opacity-60"
-            onClick={() => void onRestart()}
-            disabled={busy}
-          >
-            <RefreshCw className={`w-3 h-3 ${busy ? "animate-spin" : ""}`} />
-            {t("sockscap.restartNow")}
-          </button>
-        </div>
-      )}
-
       {/* Main Dual-Column Content Area */}
       <div className="flex-1 min-h-0 flex overflow-hidden">
         {/* Left Column: Profile Manager Sidebar */}
@@ -1926,9 +1857,10 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
               <button
                 type="button"
                 data-testid="sockscap-add-profile"
-                className="p-1.5 rounded text-[var(--taomni-text-muted)] hover:text-[var(--taomni-accent)] hover:bg-[var(--taomni-hover)] transition-colors"
+                className="p-1.5 rounded text-[var(--taomni-text-muted)] hover:text-[var(--taomni-accent)] hover:bg-[var(--taomni-hover)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 onClick={() => void addProfile()}
-                title={t("sockscap.newProfileTooltip")}
+                disabled={locked}
+                title={locked ? t("sockscap.lockedTooltip") : t("sockscap.newProfileTooltip")}
                 aria-label={t("sockscap.newProfileTooltip")}
               >
                 <Plus className="w-4 h-4" />
@@ -1975,9 +1907,10 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                 <button
                   type="button"
                   data-testid="sockscap-add-profile"
-                  className="p-1 rounded text-[var(--taomni-text-muted)] hover:text-[var(--taomni-text)] hover:bg-[var(--taomni-hover)] transition-colors flex items-center justify-center"
+                  className="p-1 rounded text-[var(--taomni-text-muted)] hover:text-[var(--taomni-text)] hover:bg-[var(--taomni-hover)] transition-colors flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
                   onClick={() => void addProfile()}
-                  title={t("sockscap.newProfileTooltip")}
+                  disabled={locked}
+                  title={locked ? t("sockscap.lockedTooltip") : t("sockscap.newProfileTooltip")}
                   aria-label={t("sockscap.newProfileTooltip")}
                 >
                   <Plus className="w-4 h-4" />
@@ -2013,6 +1946,8 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                     className="w-full text-[11px] px-2 py-1.5 rounded border border-[var(--taomni-divider)] bg-[var(--taomni-bg)] resize-y min-h-[48px]"
                     placeholder={t("sockscap.subImportPlaceholder")}
                     value={subInput}
+                    disabled={locked}
+                    title={locked ? t("sockscap.lockedTooltip") : undefined}
                     onChange={(e) => setSubInput(e.target.value)}
                   />
                   <button
@@ -2515,6 +2450,12 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
 
           {/* Rules Strategy */}
           <Section sectionId="rules" title={t("sockscap.section.rules")}>
+            <fieldset
+              data-testid="sockscap-rules-editor"
+              disabled={locked}
+              title={locked ? t("sockscap.lockedTooltip") : undefined}
+              className="disabled:opacity-60"
+            >
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
               <Field label={t("sockscap.ruleMode")}>
                 <select
@@ -2605,6 +2546,7 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                 </ul>
               )}
             </div>
+            </fieldset>
           </Section>
 
           {/* Test Target Dry-run */}
@@ -2655,18 +2597,22 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
               <div className="flex gap-2">
                 <button
                   type="button"
-                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)]"
+                  data-testid="sockscap-refresh-gfw"
+                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
                   onClick={() => void onRefreshGfw()}
-                  disabled={busy}
+                  disabled={busy || locked}
+                  title={locked ? t("sockscap.lockedTooltip") : undefined}
                 >
                   <RefreshCw className={`w-3 h-3 ${busy ? "animate-spin" : ""}`} />
                   {t("sockscap.refreshGfw")}
                 </button>
                 <button
                   type="button"
-                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)]"
+                  data-testid="sockscap-import-gfw"
+                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded text-[11px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
                   onClick={() => void onImportGfw()}
-                  disabled={busy}
+                  disabled={busy || locked}
+                  title={locked ? t("sockscap.lockedTooltip") : undefined}
                 >
                   {t("sockscap.importGfw")}
                 </button>
@@ -2849,7 +2795,9 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
                             <td className="py-1.5 px-2 text-right">
                               <button
                                 type="button"
-                                className="px-1.5 py-0.5 rounded text-[9px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] transition-colors"
+                                className="px-1.5 py-0.5 rounded text-[9px] border border-[var(--taomni-divider)] hover:bg-[var(--taomni-hover)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                disabled={locked}
+                                title={locked ? t("sockscap.lockedTooltip") : undefined}
                                 onClick={() => {
                                   if (!cfg) return;
                                   const pattern = rec.domainOrIp;

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1187,7 +1187,7 @@ const dict = {
       "Scope or upstream changes won't apply until capture restarts.",
     restartNow: "Restart capture",
     lockedHint:
-      "Running — scope, upstream, and profile structure are locked. Only rules hot-reload. Stop capture to edit them (adding a new profile is still allowed).",
+      "Running — profiles, routing rules, upstreams, and shared settings are locked. Stop capture to edit.",
     lockedTooltip: "Locked while running — stop capture to edit.",
     testing: "Testing…",
     probing: "Probing…",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -1184,7 +1184,7 @@ export const zhCN: DeepPartial<typeof en> = {
     restartNeeded: "作用域或上游的修改需重启捕获后才会生效。",
     restartNow: "重启捕获",
     lockedHint:
-      "运行中 — 作用域、上游与方案结构已锁定，仅规则可热更新。需先停止捕获再修改（仍可新增方案）。",
+      "运行中 — Profile、路由规则、上游与共享设置均已锁定，请先停止捕获再修改。",
     lockedTooltip: "运行中已锁定 — 请先停止捕获再修改。",
     testing: "测试中…",
     probing: "探测中…",

--- a/src/lib/sockscapRestart.test.ts
+++ b/src/lib/sockscapRestart.test.ts
@@ -57,7 +57,7 @@ describe("requiresRestart", () => {
     expect(requiresRestart(a, b)).toBe(false);
   });
 
-  it("is false for hot-reloadable rule changes (ruleMode/userRules/defaultAction)", () => {
+  it("keeps routing-policy changes outside the topology-only signature", () => {
     const a = cfg([profile()]);
     const b = cfg([
       profile({

--- a/src/lib/sockscapRestart.ts
+++ b/src/lib/sockscapRestart.ts
@@ -1,20 +1,10 @@
 /**
- * Detect whether a SocksCap config change requires the running capture to be
- * restarted (Stop + Start) rather than being picked up live.
+ * Compare the capture-topology portion of two SocksCap configs.
  *
- * Backend behaviour (see src-tauri/src/sockscap):
- * - `sockscap_set_config` hot-reloads ONLY the relay policy surface into the
- *   running RelayContext: `rule_mode`, `user_rules`, `default_action`,
- *   `bypass_cidrs`, and the GFWList ruleset. Those take effect immediately.
- * - The resolved upstream connections (host/port/kind/credentials/SSH pool) and
- *   — on Windows — the elevated helper's WinDivert capture plan (`mode`,
- *   `app_paths`, the active-profile set) are captured at Start and are NOT
- *   re-pushed by `set_config`. Changing any of them while Active silently has
- *   no effect until the next Start.
- *
- * This module computes, from two configs, whether the "scope + upstream"
- * surface changed so the UI can prompt for a restart. It is intentionally a
- * pure function so it can be unit-tested without the Tauri backend.
+ * Running sessions are immutable: backend commands reject every config/rule
+ * mutation until capture stops. This pure helper remains useful to callers
+ * comparing two idle snapshots, but the UI no longer offers live edits or an
+ * automatic restart path.
  */
 import type { SocksCapConfig, SocksCapProfile, UpstreamRef } from "./sockscap";
 
@@ -44,7 +34,8 @@ function profileScopeKey(p: SocksCapProfile): string {
 /**
  * Signature of everything a running capture would need restarted to apply:
  * the set of active profiles (by id, order-independent) and, for each, its
- * scope mode, app list, and upstream. Hot-reloadable rule fields are excluded.
+ * scope mode, app list, and upstream. Routing-policy fields are outside this
+ * topology-only signature.
  */
 export function captureScopeSignature(cfg: SocksCapConfig): string {
   const activeIds = new Set(
@@ -58,8 +49,7 @@ export function captureScopeSignature(cfg: SocksCapConfig): string {
 }
 
 /**
- * True when moving from `prev` to `next` changes the capture scope/upstream in
- * a way the running backend will not pick up live (needs Stop + Start).
+ * True when moving from `prev` to `next` changes capture topology.
  */
 export function requiresRestart(
   prev: SocksCapConfig,


### PR DESCRIPTION
Implement Linux Mixed capture for priority-ordered profiles: each application profile before the first Global profile receives its own cgroup and dedicated relay, followed by a final Global catch-all relay. Render nftables rules in the same order so application traffic keeps its selected profile policy while all remaining TCP traffic reaches the Global fallback.

Make a running capture session immutable on every platform. Remove live policy hot reload and reject config writes, profile activation changes, rule updates, GFWList refreshes/imports, and QUIC changes in Preparing, Active, Degraded, and Stopping phases. Mirror the backend guard in the UI by disabling all profile and routing mutation controls until capture stops.

Add unit coverage for Mixed capture selection, ordered nft routes, and profile-hinted policy fallback; extend the Linux privileged harness for application-plus-global routing; and update control-panel regression coverage, feature catalog, and generated test-id catalog.