### PR TITLE
fix(terminal): report cwd for local zsh on macOS

### DIFF
--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -108,7 +108,7 @@ import { getAppPlatform, isTauriRuntime } from "../../lib/runtime";
 import { extractTerminalCommand } from "../../lib/terminalCommand";
 import { normalizeLocalStartCwd } from "../../lib/terminalCwd";
 import { inferTerminalProgram } from "../../lib/terminalActivity";
-import { buildSshCwdIntegration } from "../../lib/terminalShellIntegration";
+import { buildSshCwdIntegration, buildLocalZshCwdIntegration } from "../../lib/terminalShellIntegration";
 import { buildInteractiveCommandInput, renderTerminalTask } from "../../lib/terminal/commandInput";
 import { registerTerminal, consumeTerminalDetachPending } from "../../lib/terminal/terminalRegistry";
 import {
@@ -2820,6 +2820,60 @@ export function TerminalPanel({
         `${adopted ? "Reattached" : mode === "reconnect" ? "Reconnected" : "Connected"} (${connectedSid})`,
       );
       scheduleTerminalFitAndSync(true);
+      // Install continuous OSC 7 cwd reporting by writing a one-shot setup
+      // command into the shell, but only once it shows a real, idle prompt —
+      // never into a blank/initializing shell (a slow rc / conda init), a
+      // streaming MOTD, or a half-typed line. Injecting early is what leaked the
+      // raw command: the input got buffered, the echo came back after the
+      // suppressor's TTL, and the whole line printed. Poll for the prompt over
+      // several seconds; if login init or a startup command outlives that window,
+      // retain an event-driven installer that runs when output later settles at
+      // an idle prompt. The terminal is usable immediately; this only defers the
+      // background hook. Shared by the SSH remote shell and the local macOS zsh.
+      const scheduleCwdIntegrationInstall = (targetSid: string, integrationCommand: string) => {
+        let integrationAttempts = 0;
+        let integrationInstalling = false;
+        const MAX_INTEGRATION_ATTEMPTS = 12; // ~6s of polling for a slow login
+        const installCwdIntegration = (): boolean => {
+          if (destroyed || sessionIdRef.current !== targetSid) {
+            if (installSshCwdIntegrationRef.current === installCwdIntegration) {
+              installSshCwdIntegrationRef.current = null;
+            }
+            return false;
+          }
+          if (integrationInstalling) return true;
+          const liveTerm = termRef.current;
+          if (!liveTerm || !terminalAtIdlePrompt(liveTerm)) return false;
+          integrationInstalling = true;
+          if (installSshCwdIntegrationRef.current === installCwdIntegration) {
+            installSshCwdIntegrationRef.current = null;
+          }
+          // Generous TTL so a laggy link's echo round-trip still arrives while
+          // the suppressor is dropping (we only get here at a ready prompt, so
+          // it's just network latency, not shell startup). Bounded so a
+          // non-POSIX shell — which never emits the OSC 7 — isn't blacked out
+          // for too long before output resumes.
+          injectedInputEchoSuppressorRef.current = createOsc7BlankingSuppressor(4000);
+          writeTerminal(targetSid, encodeBase64(`${integrationCommand}\r`)).catch(() => {
+            if (sessionIdRef.current === targetSid) {
+              integrationInstalling = false;
+              installSshCwdIntegrationRef.current = installCwdIntegration;
+              injectedInputEchoSuppressorRef.current = null;
+            }
+          });
+          return true;
+        };
+        installSshCwdIntegrationRef.current = installCwdIntegration;
+        const pollForCwdIntegration = () => {
+          if (installCwdIntegration()) return;
+          if (destroyed || sessionIdRef.current !== targetSid) return;
+          if (integrationAttempts < MAX_INTEGRATION_ATTEMPTS) {
+            integrationAttempts += 1;
+            window.setTimeout(pollForCwdIntegration, 500);
+          }
+        };
+        window.setTimeout(pollForCwdIntegration, 500);
+      };
       if (ssh && !adopted) {
         if (mode === "reconnect") {
           term.write(`\r\n\x1b[32m[Reconnected to ${ssh.username}@${ssh.host}:${ssh.port}]\x1b[0m\r\n`);
@@ -2841,59 +2895,19 @@ export function TerminalPanel({
         // source's cwd, the setup cd's there first (SSH can't set a start dir).
         // Best-effort POSIX (bash/zsh); a non-POSIX remote just errors on the
         // line, which the blanking suppressor hides up to its TTL.
-        //
-        // Only inject once the remote shows a real, idle prompt — never into a
-        // blank/initializing shell (a slow .bashrc / conda init), a streaming
-        // MOTD, or a half-typed line. Injecting early on a slow server is what
-        // leaked the raw command: the input got buffered, the echo came back
-        // after the suppressor's TTL, and the whole line printed. Poll for the
-        // prompt over several seconds. If login initialization or a configured
-        // startup command outlives that polling window, retain an event-driven
-        // installer and run it when any later output settles at an idle prompt.
-        // The terminal is usable immediately; this only defers the background hook.
-        const integrationCommand = buildSshCwdIntegration(initialCwd);
-        let integrationAttempts = 0;
-        let integrationInstalling = false;
-        const MAX_INTEGRATION_ATTEMPTS = 12; // ~6s of polling for a slow login
-        const installCwdIntegration = (): boolean => {
-          if (destroyed || sessionIdRef.current !== connectedSid) {
-            if (installSshCwdIntegrationRef.current === installCwdIntegration) {
-              installSshCwdIntegrationRef.current = null;
-            }
-            return false;
-          }
-          if (integrationInstalling) return true;
-          const liveTerm = termRef.current;
-          if (!liveTerm || !terminalAtIdlePrompt(liveTerm)) return false;
-          integrationInstalling = true;
-          if (installSshCwdIntegrationRef.current === installCwdIntegration) {
-            installSshCwdIntegrationRef.current = null;
-          }
-          // Generous TTL so a laggy link's echo round-trip still arrives while
-          // the suppressor is dropping (we only get here at a ready prompt, so
-          // it's just network latency, not shell startup). Bounded so a
-          // non-POSIX remote — which never emits the OSC 7 — isn't blacked out
-          // for too long before output resumes.
-          injectedInputEchoSuppressorRef.current = createOsc7BlankingSuppressor(4000);
-          writeTerminal(connectedSid, encodeBase64(`${integrationCommand}\r`)).catch(() => {
-            if (sessionIdRef.current === connectedSid) {
-              integrationInstalling = false;
-              installSshCwdIntegrationRef.current = installCwdIntegration;
-              injectedInputEchoSuppressorRef.current = null;
-            }
-          });
-          return true;
-        };
-        installSshCwdIntegrationRef.current = installCwdIntegration;
-        const pollForCwdIntegration = () => {
-          if (installCwdIntegration()) return;
-          if (destroyed || sessionIdRef.current !== connectedSid) return;
-          if (integrationAttempts < MAX_INTEGRATION_ATTEMPTS) {
-            integrationAttempts += 1;
-            window.setTimeout(pollForCwdIntegration, 500);
-          }
-        };
-        window.setTimeout(pollForCwdIntegration, 500);
+        scheduleCwdIntegrationInstall(connectedSid, buildSshCwdIntegration(initialCwd));
+      } else if (
+        !commandTerminal &&
+        !adopted &&
+        getAppPlatform() === "macos"
+      ) {
+        // macOS-only: the default local shell is zsh, and the backend's
+        // shell_integration.rs installs a bash `PROMPT_COMMAND` that zsh
+        // ignores — so a local zsh never reports its cwd and tab-duplication /
+        // the git panel have nothing to work with. Inject a zsh `precmd_functions`
+        // hook the same way the SSH path does. No-op on bash (already covered by
+        // the backend `PROMPT_COMMAND`). Linux/Windows locals are left untouched.
+        scheduleCwdIntegrationInstall(connectedSid, buildLocalZshCwdIntegration());
       }
 
       unlistenExit = await listenTerminalExit(connectedSid, () => markDisconnected(connectedSid));

--- a/src/lib/terminalShellIntegration.test.ts
+++ b/src/lib/terminalShellIntegration.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildSshCwdIntegration, SSH_CWD_INTEGRATION_BODY } from "./terminalShellIntegration";
+import {
+  buildLocalZshCwdIntegration,
+  buildSshCwdIntegration,
+  LOCAL_ZSH_CWD_INTEGRATION_BODY,
+  SSH_CWD_INTEGRATION_BODY,
+} from "./terminalShellIntegration";
 
 describe("buildSshCwdIntegration", () => {
   it("emits a printf OSC 7 form matching the frontend parser", () => {
@@ -47,5 +52,41 @@ describe("buildSshCwdIntegration", () => {
   it("single-quote-escapes the directory to resist injection", () => {
     const out = buildSshCwdIntegration("/tmp/O'Brien");
     expect(out).toContain(" cd '/tmp/O'\\''Brien' 2>/dev/null;");
+  });
+});
+
+describe("buildLocalZshCwdIntegration", () => {
+  it("emits a printf OSC 7 form matching the frontend parser", () => {
+    // Real backslashes so the local printf produces ESC ] 7 ; ... ESC \.
+    expect(LOCAL_ZSH_CWD_INTEGRATION_BODY).toContain("\\033]133;A\\033\\\\");
+    expect(LOCAL_ZSH_CWD_INTEGRATION_BODY).toContain("\\033]7;file://%s%s\\033\\\\'");
+    expect(LOCAL_ZSH_CWD_INTEGRATION_BODY).toContain('"$PWD"');
+  });
+
+  it("only acts under zsh so a local bash keeps the backend PROMPT_COMMAND path", () => {
+    expect(LOCAL_ZSH_CWD_INTEGRATION_BODY).toMatch(/^ if \[ -n "\$ZSH_VERSION" \]; then/);
+    expect(LOCAL_ZSH_CWD_INTEGRATION_BODY.trimEnd()).toMatch(/fi;$/);
+    // No bash PROMPT_COMMAND branch — that shell is already covered by the backend.
+    expect(LOCAL_ZSH_CWD_INTEGRATION_BODY).not.toContain("PROMPT_COMMAND");
+  });
+
+  it("registers the zsh precmd hook and runs it once at the end", () => {
+    expect(LOCAL_ZSH_CWD_INTEGRATION_BODY).toContain("precmd_functions+=(__taomni_osc7)");
+    expect(LOCAL_ZSH_CWD_INTEGRATION_BODY).toContain(" __taomni_osc7;");
+  });
+
+  it("is idempotent so a re-injection doesn't stack the hook", () => {
+    expect(LOCAL_ZSH_CWD_INTEGRATION_BODY).toContain(
+      'case " ${precmd_functions[*]} " in *" __taomni_osc7 "*)',
+    );
+  });
+
+  it("never cd's — the local PTY already spawns in the right directory", () => {
+    expect(buildLocalZshCwdIntegration()).toBe(LOCAL_ZSH_CWD_INTEGRATION_BODY);
+    expect(buildLocalZshCwdIntegration()).not.toContain(" cd ");
+  });
+
+  it("leads with a space as a cheap HIST_IGNORE_SPACE guard", () => {
+    expect(buildLocalZshCwdIntegration()).toMatch(/^ /);
   });
 });

--- a/src/lib/terminalShellIntegration.ts
+++ b/src/lib/terminalShellIntegration.ts
@@ -47,3 +47,36 @@ export function buildSshCwdIntegration(cwd?: string): string {
   const cd = cwd ? " cd '" + cwd.replace(/'/g, "'\\''") + "' 2>/dev/null;" : "";
   return SSH_CWD_HISTORY_GUARD + cd + SSH_CWD_INTEGRATION_INSTALL + SSH_CWD_HISTORY_RESTORE;
 }
+
+/**
+ * Continuous OSC 7 cwd reporting for a LOCAL shell, injected once after the
+ * shell comes up. Used on macOS only, where the default shell is zsh: the
+ * backend's `shell_integration.rs` installs a bash `PROMPT_COMMAND`, which zsh
+ * silently ignores, so a local zsh never reports its cwd and tab-duplication /
+ * the git panel have no directory to work with. This mirrors the zsh half of
+ * the SSH integration but:
+ *   - never `cd`s (the local PTY already spawns in the right dir via `cmd.cwd`),
+ *   - is a no-op on bash (it already works via the backend `PROMPT_COMMAND`),
+ *     so injecting it on a bash login shell changes nothing.
+ *
+ * The trailing `__taomni_osc7` emits the real OSC 7 the blanking suppressor
+ * keys on to know the injected line is done. The install is idempotent — if
+ * `__taomni_osc7` is already in `precmd_functions` it isn't added twice — so a
+ * stray re-injection can't duplicate the hook. The leading space is a cheap
+ * guard for the (non-default) `HIST_IGNORE_SPACE`; like the SSH zsh path, we
+ * otherwise accept that one setup line may land in history.
+ *
+ * Assembled from plain strings (not template literals) so `${...}` shell
+ * expansions are emitted verbatim.
+ */
+export const LOCAL_ZSH_CWD_INTEGRATION_BODY =
+  " if [ -n \"$ZSH_VERSION\" ]; then" +
+  " __taomni_osc7(){ printf '\\033]133;A\\033\\\\\\033]7;file://%s%s\\033\\\\' \"${HOST:-localhost}\" \"$PWD\"; };" +
+  " typeset -ag precmd_functions 2>/dev/null;" +
+  " case \" ${precmd_functions[*]} \" in *\" __taomni_osc7 \"*) ;; *) precmd_functions+=(__taomni_osc7);; esac;" +
+  " __taomni_osc7;" +
+  " fi;";
+
+export function buildLocalZshCwdIntegration(): string {
+  return LOCAL_ZSH_CWD_INTEGRATION_BODY;
+}


### PR DESCRIPTION
On macOS the default local shell is zsh, but the backend shell integration (src-tauri/src/terminal/shell_integration.rs) installs a bash-only `PROMPT_COMMAND` to emit OSC 7 cwd reports. zsh has no `PROMPT_COMMAND` (it uses `precmd_functions`), so it silently ignores it and a local zsh session never reports its working directory.

Two user-visible symptoms both trace back to this single gap:

- Duplicating a local tab (复制) landed in the wrong directory intermittently. With no continuous OSC 7, `terminalCwds[tabId]` is usually empty, so duplication falls back to a racy one-shot probe that (a) misses its 1200ms deadline while ~/.zshrc is still loading (oh-my-zsh / powerlevel10k / nvm / conda), (b) is skipped entirely when the prompt line looks non-empty (RPROMPT / multi-line prompt), or (c) serves a stale cached cwd once a probe ever succeeds. bash was reliable because it honors PROMPT_COMMAND and reports continuously.

- The right-click "Open Git Panel" item was greyed out even in a real repo root. Its `disabled` flag is wired purely to `!gitToggle.cwd` (the git-repo probe only picks the label text), so with no cwd the item is permanently disabled regardless of whether the dir is a git repo.

Fix — macOS only, mirroring the zsh half of the existing SSH integration:

- terminalShellIntegration.ts: add LOCAL_ZSH_CWD_INTEGRATION_BODY / buildLocalZshCwdIntegration(). It registers a `precmd_functions` OSC 7 emitter, minus the SSH path's `cd` (the local PTY already spawns in the right dir via cmd.cwd). Self-gated on `$ZSH_VERSION` so it is a no-op on bash (still covered by the backend PROMPT_COMMAND) and idempotent so a re-injection can't stack the hook.

- TerminalPanel.tsx: extract the SSH installer's poll-until-idle-prompt + echo-suppress machinery into a shared scheduleCwdIntegrationInstall(sid, command) helper (no behavior change for SSH), then add one branch gated on `!commandTerminal && !adopted && getAppPlatform() === "macos"` that installs the local zsh hook. Linux and Windows local shells hit neither branch and are left untouched.

The git panel needs no separate change: once the zsh hook emits OSC 7, `terminalCwds[tab.id]` populates, `gitToggle.cwd` becomes non-null, and the menu item enables transitively.

Adds 6 unit tests for the local zsh body; all 70 terminal-lib tests and `tsc -b` pass. Not yet exercised against a live macOS zsh session — worth a manual smoke test (duplicate follows cwd, git panel un-greys, injected line's echo stays suppressed).