### PR TITLE
fix(sockscap): recover safely from pending macOS approval

### DIFF
--- a/src-tauri/src/sockscap/capture/macos/mod.rs
+++ b/src-tauri/src/sockscap/capture/macos/mod.rs
@@ -23,7 +23,7 @@ pub async fn start(
     config: &SocksCapConfig,
     ctx: Arc<RwLock<RelayContext>>,
     session_id: &str,
-) -> Result<MacosCaptureHandle, String> {
+) -> Result<MacosCaptureHandle, runtime::RedirectorStartError> {
     runtime::start(app, config, ctx, session_id).await
 }
 

--- a/src-tauri/src/sockscap/mod.rs
+++ b/src-tauri/src/sockscap/mod.rs
@@ -1141,6 +1141,8 @@ async fn start_macos_capture(
     journal_path: &std::path::Path,
 ) -> Result<SocksCapStatus, String> {
     capture::macos::preflight(cfg)?;
+    redirector::cleanup_stale_sockets()?;
+    redirector::cleanup_stale_launchers().await?;
     let ctx = match build_unix_relay_context(state, cfg).await {
         Ok(ctx) => ctx,
         Err(error) => {
@@ -1171,17 +1173,32 @@ async fn start_macos_capture(
 
     let capture = match capture::macos::start(app, cfg, Arc::clone(&ctx), &session_id).await {
         Ok(capture) => capture,
-        Err(error) => {
+        Err(start_error) => {
             if let Some(manager) = state.sockscap.xray() {
                 manager.shutdown_all().await;
             }
-            state.sockscap.orch.write().await.set_recovery_required(
-                &caps.capture_backend,
-                format!(
-                    "macOS Redirector start did not complete after the dirty journal was written: {error}; run Recover before retrying"
-                ),
-            );
-            return Err(error);
+            if start_error.recovery_required() {
+                state.sockscap.orch.write().await.set_recovery_required(
+                    &caps.capture_backend,
+                    format!(
+                        "macOS Redirector start may have reached the Provider after the dirty journal was written: {}; run Recover before retrying",
+                        start_error.message()
+                    ),
+                );
+            } else if let Err(clear_error) = recovery::mark_clean_and_clear(journal_path) {
+                let message = format!(
+                    "macOS Redirector failed before applying capture scope ({}), but the Preparing journal could not be cleared: {clear_error}",
+                    start_error.message()
+                );
+                state
+                    .sockscap
+                    .orch
+                    .write()
+                    .await
+                    .set_recovery_required(&caps.capture_backend, message.clone());
+                return Err(message);
+            }
+            return Err(start_error.to_string());
         }
     };
 
@@ -1940,6 +1957,67 @@ pub async fn sockscap_recover(
     // Even if stopping the active session was incomplete, recovery gets one
     // more independent chance to remove the platform-owned state.
     let teardown_error = full_teardown(&app, &state, false).await.err();
+    #[cfg(target_os = "macos")]
+    let stale_runtime_clean = {
+        let sockets_clean = match redirector::cleanup_stale_sockets() {
+            Ok(_) => true,
+            Err(error) => {
+                tracing::warn!("sockscap: Recover stale Redirector socket cleanup failed: {error}");
+                false
+            }
+        };
+        let launchers_clean = match redirector::cleanup_stale_launchers().await {
+            Ok(_) => true,
+            Err(error) => {
+                tracing::warn!(
+                    "sockscap: Recover stale Redirector launcher cleanup failed: {error}"
+                );
+                false
+            }
+        };
+        sockets_clean && launchers_clean
+    };
+
+    #[cfg(target_os = "macos")]
+    let pending_approval_journal = data_dir(&app)
+        .ok()
+        .map(|dir| recovery::journal_path(&dir))
+        .filter(|journal| {
+            recovery::read_journal(journal)
+                .as_ref()
+                .is_some_and(pending_approval_never_recorded_scope)
+        });
+
+    #[cfg(target_os = "macos")]
+    if teardown_error.is_none()
+        && stale_runtime_clean
+        && matches!(
+            redirector::installer::system_extension_state(),
+            redirector::installer::RedirectorSystemExtensionState::WaitingForUser
+        )
+        && pending_approval_journal.is_some()
+    {
+        let journal = pending_approval_journal.expect("checked above");
+        if let Err(error) = recovery::mark_clean_and_clear(&journal) {
+            let message = format!(
+                "Redirector never applied capture while System Extension approval was pending, but its journal could not be cleared: {error}"
+            );
+            state
+                .sockscap
+                .orch
+                .write()
+                .await
+                .set_recovery_required("mitmproxy-redirector", message.clone());
+            state.sockscap.release_activation_lock();
+            return Err(message);
+        }
+        state.sockscap.orch.write().await.force_idle();
+        state.sockscap.release_activation_lock();
+        tracing::info!(
+            "sockscap: Recover cleared an aborted first-use approval attempt without starting another launcher"
+        );
+        return Ok(());
+    }
     let sudo_password = sudo_password.map(Zeroizing::new);
     let sudo_pw = sudo_password.as_deref().map(|password| password.as_str());
     match capture::recover_system(sudo_pw).await {
@@ -2008,6 +2086,14 @@ pub async fn sockscap_recover(
 
 fn should_block_exit_for_recovery(recovery_required: bool, owns_capture: bool) -> bool {
     recovery_required && owns_capture
+}
+
+#[cfg(target_os = "macos")]
+fn pending_approval_never_recorded_scope(journal: &recovery::RecoveryJournal) -> bool {
+    matches!(journal.phase, recovery::RecoveryPhase::Preparing)
+        && journal.scope_hash.is_none()
+        && journal.bridge_pid.is_none()
+        && journal.provider_pid.is_none()
 }
 
 /// Thorough capture teardown:
@@ -2758,13 +2844,33 @@ pub async fn boot_repair(app: &AppHandle, state: &AppState) {
     };
 
     #[cfg(target_os = "macos")]
-    match redirector::cleanup_stale_sockets() {
+    let stale_sockets_clean = match redirector::cleanup_stale_sockets() {
         Ok(count) if count > 0 => {
-            tracing::info!(count, "sockscap: removed stale Redirector Unix sockets")
+            tracing::info!(count, "sockscap: removed stale Redirector Unix sockets");
+            true
         }
-        Ok(_) => {}
-        Err(error) => tracing::warn!("sockscap: stale Redirector socket cleanup failed: {error}"),
-    }
+        Ok(_) => true,
+        Err(error) => {
+            tracing::warn!("sockscap: stale Redirector socket cleanup failed: {error}");
+            false
+        }
+    };
+
+    #[cfg(target_os = "macos")]
+    let stale_launchers_clean = match redirector::cleanup_stale_launchers().await {
+        Ok(count) if count > 0 => {
+            tracing::warn!(
+                count,
+                "sockscap: reaped stale Redirector approval launchers"
+            );
+            true
+        }
+        Ok(_) => true,
+        Err(error) => {
+            tracing::warn!("sockscap: stale Redirector launcher cleanup failed: {error}");
+            false
+        }
+    };
 
     let mut orphans: Vec<u32> = Vec::new();
     for ready in read_ready_files(&dir) {
@@ -2815,6 +2921,43 @@ pub async fn boot_repair(app: &AppHandle, state: &AppState) {
                 j.helper_port
             );
         }
+    }
+
+    // If macOS is still waiting for first-use approval, the System Extension
+    // is not enabled and cannot have installed a Provider scope. A Preparing
+    // journal with no recorded bridge/provider/scope is therefore an aborted
+    // approval attempt, not residual capture. Once its dead sockets and exact
+    // coordinator processes are gone, clear it without launching another
+    // coordinator that would only wait for the same approval again.
+    #[cfg(target_os = "macos")]
+    if dirty
+        && stale_sockets_clean
+        && stale_launchers_clean
+        && matches!(
+            redirector::installer::system_extension_state(),
+            redirector::installer::RedirectorSystemExtensionState::WaitingForUser
+        )
+        && recovery::read_journal(&journal_path)
+            .as_ref()
+            .is_some_and(pending_approval_never_recorded_scope)
+    {
+        match recovery::mark_clean_and_clear(&journal_path) {
+            Ok(()) => {
+                tracing::info!(
+                    "sockscap: cleared aborted first-use approval journal; waiting for System Settings approval"
+                );
+                state.sockscap.orch.write().await.force_idle();
+            }
+            Err(error) => {
+                state.sockscap.orch.write().await.set_recovery_required(
+                    "mitmproxy-redirector",
+                    format!(
+                        "Redirector never applied capture while System Extension approval was pending, but its journal could not be cleared: {error}"
+                    ),
+                );
+            }
+        }
+        return;
     }
 
     // The previous helper cannot be contacted without its token, so recovery
@@ -2913,11 +3056,15 @@ pub async fn sockscap_clear_domain_records(state: State<'_, AppState>) -> Result
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os = "macos")]
+    use super::pending_approval_never_recorded_scope;
     use super::{
         Orchestrator, classify_client, ensure_configuration_unlocked, session_password_ref,
         session_proxy_password, session_ssh_auth, should_block_exit_for_recovery,
     };
     use crate::session::models::{AuthMethod, SessionConfig, SessionType};
+    #[cfg(target_os = "macos")]
+    use crate::sockscap::recovery::{RecoveryJournal, RecoveryPhase};
     use crate::terminal::ssh::SshAuth;
     use crate::vault::Vault;
 
@@ -3148,5 +3295,32 @@ mod tests {
             assert_eq!(id, "unknown", "unexpected id for {name}");
             assert!(label.is_empty(), "unexpected label for {name}");
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn only_unapplied_preparing_journal_can_clear_during_pending_approval() {
+        let mut journal = RecoveryJournal {
+            platform: "macos".into(),
+            capture_backend: "mitmproxy-redirector".into(),
+            config_hash: "hash".into(),
+            pid: 1,
+            clean: false,
+            phase: RecoveryPhase::Preparing,
+            session_id: "session".into(),
+            backend_version: Some("0.12.11".into()),
+            scope_hash: None,
+            bridge_pid: None,
+            provider_pid: None,
+            relay_port: None,
+            helper_port: None,
+        };
+        assert!(pending_approval_never_recorded_scope(&journal));
+
+        journal.scope_hash = Some("scope".into());
+        assert!(!pending_approval_never_recorded_scope(&journal));
+        journal.scope_hash = None;
+        journal.phase = RecoveryPhase::Active;
+        assert!(!pending_approval_never_recorded_scope(&journal));
     }
 }

--- a/src-tauri/src/sockscap/redirector/bridge_process.rs
+++ b/src-tauri/src/sockscap/redirector/bridge_process.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::net::{UnixListener, UnixStream};
-use tokio::process::Command;
+use tokio::process::{Child, Command};
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::task::JoinSet;
 use tokio::time::Instant;
@@ -28,6 +28,7 @@ const CONTROL_CONNECT_TIMEOUT: Duration = Duration::from_secs(180);
 const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(10);
 const HEARTBEAT_CHECK: Duration = Duration::from_secs(1);
 const DISABLE_DRAIN: Duration = Duration::from_millis(300);
+const LAUNCHER_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
 
 struct Options {
     provider_socket: PathBuf,
@@ -100,6 +101,10 @@ async fn run() -> Result<(), String> {
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::inherit())
+        // The upstream app can wait indefinitely for macOS user approval.
+        // Every ordinary bridge exit must therefore terminate it; the explicit
+        // cleanup below reaps it, while kill_on_drop covers early unwinding.
+        .kill_on_drop(true)
         .spawn()
         .map_err(|error| {
             format!(
@@ -108,17 +113,36 @@ async fn run() -> Result<(), String> {
             )
         })?;
 
-    let (mut control, provider_pid) =
-        accept_verified_control(&listener, CONTROL_CONNECT_TIMEOUT).await?;
-    tokio::spawn(async move {
-        match launcher.wait().await {
-            Ok(status) if status.success() => {
-                eprintln!("sockscap bridge: Redirector launcher exited successfully")
-            }
-            Ok(status) => eprintln!("sockscap bridge: Redirector launcher exited with {status}"),
-            Err(error) => eprintln!("sockscap bridge: Redirector launcher wait failed: {error}"),
-        }
-    });
+    let result = run_session(&options, &listener, &mut launcher).await;
+    terminate_launcher(&mut launcher).await;
+    result
+}
+
+async fn run_session(
+    options: &Options,
+    listener: &UnixListener,
+    launcher: &mut Child,
+) -> Result<(), String> {
+    // Signals and the parent watchdog must be live during first-use approval,
+    // not only after the Provider connects. Otherwise quitting Taomni while
+    // macOS is waiting for approval strands both bridge and launcher processes.
+    let mut terminate = signal(SignalKind::terminate())
+        .map_err(|error| format!("install SIGTERM handler: {error}"))?;
+    let mut interrupt = signal(SignalKind::interrupt())
+        .map_err(|error| format!("install SIGINT handler: {error}"))?;
+    let mut hangup =
+        signal(SignalKind::hangup()).map_err(|error| format!("install SIGHUP handler: {error}"))?;
+
+    let (mut control, provider_pid) = accept_verified_control(
+        listener,
+        CONTROL_CONNECT_TIMEOUT,
+        launcher,
+        options.parent_pid,
+        &mut terminate,
+        &mut interrupt,
+        &mut hangup,
+    )
+    .await?;
 
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
@@ -133,12 +157,6 @@ async fn run() -> Result<(), String> {
     )
     .await?;
 
-    let mut terminate = signal(SignalKind::terminate())
-        .map_err(|error| format!("install SIGTERM handler: {error}"))?;
-    let mut interrupt = signal(SignalKind::interrupt())
-        .map_err(|error| format!("install SIGINT handler: {error}"))?;
-    let mut hangup =
-        signal(SignalKind::hangup()).map_err(|error| format!("install SIGHUP handler: {error}"))?;
     let mut heartbeat = tokio::time::interval(HEARTBEAT_CHECK);
     heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut last_management = Instant::now();
@@ -148,10 +166,15 @@ async fn run() -> Result<(), String> {
     let mut active = false;
     let mut flows = JoinSet::new();
     let mut stop_reason = "management stop".to_string();
+    let mut launcher_running = launcher
+        .try_wait()
+        .map_err(|error| format!("inspect Redirector launcher: {error}"))?
+        .is_none();
 
-    loop {
-        let mut line = String::new();
-        tokio::select! {
+    let management_result: Result<(), String> = async {
+        loop {
+            let mut line = String::new();
+            tokio::select! {
             read = read_management_line(&mut input, &mut line) => {
                 let size = read.map_err(|error| format!("read management command: {error}"))?;
                 if size == 0 {
@@ -297,12 +320,34 @@ async fn run() -> Result<(), String> {
                     break;
                 }
             }
-            joined = flows.join_next(), if !flows.is_empty() => {
-                if let Some(Err(error)) = joined {
-                    eprintln!("sockscap bridge: flow forwarding task failed: {error}");
+                status = launcher.wait(), if launcher_running => {
+                    launcher_running = false;
+                    match status {
+                        Ok(status) if status.success() => {
+                            eprintln!("sockscap bridge: Redirector launcher exited successfully");
+                        }
+                        Ok(status) => {
+                            return Err(format!("Redirector launcher exited with {status}"));
+                        }
+                        Err(error) => {
+                            return Err(format!("Redirector launcher wait failed: {error}"));
+                        }
+                    }
+                }
+                joined = flows.join_next(), if !flows.is_empty() => {
+                    if let Some(Err(error)) = joined {
+                        eprintln!("sockscap bridge: flow forwarding task failed: {error}");
+                    }
                 }
             }
         }
+        #[allow(unreachable_code)]
+        Ok(())
+    }
+    .await;
+
+    if let Err(error) = &management_result {
+        stop_reason = error.clone();
     }
 
     eprintln!("sockscap bridge: disabling interception ({stop_reason})");
@@ -314,6 +359,10 @@ async fn run() -> Result<(), String> {
     flows.shutdown().await;
 
     if let Err(error) = disable_result {
+        let _ = write_error(&mut output, Some(stop_request_id), error.clone()).await;
+        return Err(error);
+    }
+    if let Err(error) = management_result {
         let _ = write_error(&mut output, Some(stop_request_id), error.clone()).await;
         return Err(error);
     }
@@ -332,26 +381,91 @@ async fn run() -> Result<(), String> {
 async fn accept_verified_control(
     listener: &UnixListener,
     timeout: Duration,
+    launcher: &mut Child,
+    parent_pid: u32,
+    terminate: &mut tokio::signal::unix::Signal,
+    interrupt: &mut tokio::signal::unix::Signal,
+    hangup: &mut tokio::signal::unix::Signal,
 ) -> Result<(UnixStream, u32), String> {
     let deadline = Instant::now() + timeout;
+    let mut parent_check = tokio::time::interval(HEARTBEAT_CHECK);
+    parent_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut launcher_running = launcher
+        .try_wait()
+        .map_err(|error| format!("inspect Redirector launcher: {error}"))?
+        .is_none();
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             return Err("timed out waiting for a verified Redirector control channel".into());
         }
-        let (stream, _) = tokio::time::timeout(remaining, listener.accept())
-            .await
-            .map_err(|_| {
-                "timed out waiting for Mitmproxy Redirector; approve its System Extension and network configuration in System Settings, then retry"
-                    .to_string()
-            })?
-            .map_err(|error| format!("accept Redirector control channel: {error}"))?;
+        let accepted = tokio::select! {
+            accepted = listener.accept() => Some(
+                accepted.map_err(|error| format!("accept Redirector control channel: {error}"))?
+            ),
+            status = launcher.wait(), if launcher_running => {
+                launcher_running = false;
+                match status {
+                    Ok(status) if status.success() => {
+                        // The upstream coordinator exits after starting the NE
+                        // tunnel; the Provider connection can arrive just after.
+                        eprintln!("sockscap bridge: Redirector launcher exited successfully");
+                        None
+                    }
+                    Ok(status) => return Err(format!("Redirector launcher exited with {status}")),
+                    Err(error) => return Err(format!("Redirector launcher wait failed: {error}")),
+                }
+            }
+            _ = parent_check.tick() => {
+                if !process_exists(parent_pid) {
+                    return Err(format!(
+                        "Taomni parent pid {parent_pid} exited while waiting for Redirector approval"
+                    ));
+                }
+                None
+            }
+            _ = terminate.recv() => return Err("received SIGTERM while waiting for Redirector approval".into()),
+            _ = interrupt.recv() => return Err("received SIGINT while waiting for Redirector approval".into()),
+            _ = hangup.recv() => return Err("received SIGHUP while waiting for Redirector approval".into()),
+            _ = tokio::time::sleep(remaining) => {
+                return Err(
+                    "timed out waiting for Mitmproxy Redirector; approve its System Extension and network configuration in System Settings, then retry"
+                        .into()
+                );
+            }
+        };
+        let Some((stream, _)) = accepted else {
+            continue;
+        };
         match verify_redirector_peer(&stream) {
             Ok(pid) => return Ok((stream, pid)),
             Err(error) => {
                 eprintln!("sockscap bridge: rejected unverified control peer: {error}");
             }
         }
+    }
+}
+
+async fn terminate_launcher(launcher: &mut Child) {
+    match launcher.try_wait() {
+        Ok(Some(_)) => return,
+        Ok(None) => {}
+        Err(error) => {
+            eprintln!("sockscap bridge: inspect Redirector launcher during cleanup: {error}");
+        }
+    }
+    if let Some(pid) = launcher.id() {
+        // Let Swift unwind a pending SystemExtension continuation first.
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
+    }
+    if tokio::time::timeout(LAUNCHER_EXIT_TIMEOUT, launcher.wait())
+        .await
+        .is_err()
+    {
+        let _ = launcher.start_kill();
+        let _ = launcher.wait().await;
     }
 }
 
@@ -502,5 +616,19 @@ mod tests {
         assert!(
             validate_socket_path(Path::new("/var/tmp/taomni-redirector-x.sock"), "flow").is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn pending_approval_launcher_is_terminated_and_reaped() {
+        let mut launcher = Command::new("/bin/sleep")
+            .arg("30")
+            .kill_on_drop(true)
+            .spawn()
+            .unwrap();
+        assert!(launcher.id().is_some());
+
+        terminate_launcher(&mut launcher).await;
+
+        assert!(launcher.try_wait().unwrap().is_some());
     }
 }

--- a/src-tauri/src/sockscap/redirector/installer.rs
+++ b/src-tauri/src/sockscap/redirector/installer.rs
@@ -30,12 +30,24 @@ pub struct RedirectorInstallStatus {
     pub state: RedirectorInstallState,
     pub package_version: String,
     pub resource_available: bool,
+    pub system_extension_state: RedirectorSystemExtensionState,
     pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RedirectorSystemExtensionState {
+    Enabled,
+    WaitingForUser,
+    NotRegistered,
+    Other,
+    Unavailable,
 }
 
 pub fn status(app: &tauri::AppHandle) -> RedirectorInstallStatus {
     let resource_available = resolve_archive(app).is_some();
     let installed = installed_app_path();
+    let system_extension_state = system_extension_state();
     let (state, message) = if !installed.exists() {
         if resource_available {
             (
@@ -50,12 +62,19 @@ pub fn status(app: &tauri::AppHandle) -> RedirectorInstallStatus {
         }
     } else {
         match verify_bundle(&installed) {
-            Ok(()) => match extension_is_active() {
-                Some(false) => (
+            Ok(()) => match system_extension_state {
+                RedirectorSystemExtensionState::WaitingForUser => (
+                    RedirectorInstallState::PendingSystemApproval,
+                    "Mitmproxy Redirector is waiting for approval in System Settings. Approve its System Extension, then retry Start or Recover; repeated attempts cannot bypass macOS approval."
+                        .into(),
+                ),
+                RedirectorSystemExtensionState::NotRegistered
+                | RedirectorSystemExtensionState::Other => (
                     RedirectorInstallState::PendingSystemApproval,
                     "Mitmproxy Redirector is installed and verified. Start SocksCap once, then approve its System Extension and network configuration in System Settings.".into(),
                 ),
-                Some(true) | None => (
+                RedirectorSystemExtensionState::Enabled
+                | RedirectorSystemExtensionState::Unavailable => (
                     RedirectorInstallState::Ready,
                     format!("Mitmproxy Redirector {REDIRECTOR_VERSION} is installed and verified."),
                 ),
@@ -86,6 +105,7 @@ pub fn status(app: &tauri::AppHandle) -> RedirectorInstallStatus {
         state,
         package_version: REDIRECTOR_VERSION.into(),
         resource_available,
+        system_extension_state,
         message,
     }
 }
@@ -140,19 +160,40 @@ pub fn install(app: &tauri::AppHandle) -> Result<RedirectorInstallStatus, String
     Ok(status(app))
 }
 
-fn extension_is_active() -> Option<bool> {
+pub(crate) fn system_extension_state() -> RedirectorSystemExtensionState {
     let output = Command::new("/usr/bin/systemextensionsctl")
         .arg("list")
         .output()
-        .ok()?;
+        .ok();
+    let Some(output) = output else {
+        return RedirectorSystemExtensionState::Unavailable;
+    };
     if !output.status.success() {
-        return None;
+        return RedirectorSystemExtensionState::Unavailable;
     }
-    let text = String::from_utf8_lossy(&output.stdout);
-    let line = text
+    parse_system_extension_state(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_system_extension_state(output: &str) -> RedirectorSystemExtensionState {
+    let matching = output
         .lines()
-        .find(|line| line.contains(REDIRECTOR_EXTENSION_BUNDLE_ID));
-    Some(line.is_some_and(|line| line.contains("[activated enabled]") && line.starts_with('*')))
+        .filter(|line| line.contains(REDIRECTOR_EXTENSION_BUNDLE_ID))
+        .collect::<Vec<_>>();
+    if matching
+        .iter()
+        .any(|line| line.contains("[activated enabled]"))
+    {
+        RedirectorSystemExtensionState::Enabled
+    } else if matching
+        .iter()
+        .any(|line| line.contains("waiting for user"))
+    {
+        RedirectorSystemExtensionState::WaitingForUser
+    } else if matching.is_empty() {
+        RedirectorSystemExtensionState::NotRegistered
+    } else {
+        RedirectorSystemExtensionState::Other
+    }
 }
 
 fn resolve_archive(app: &tauri::AppHandle) -> Option<PathBuf> {
@@ -342,5 +383,24 @@ mod tests {
         if installed_app_path().exists() {
             verify_supply_chain(&installed_app_path()).unwrap();
         }
+    }
+
+    #[test]
+    fn parses_system_extension_approval_states() {
+        let waiting = "\t*\tS8XHQB96PW\torg.mitmproxy.macos-redirector.network-extension (2.0/1)\tnetwork-extension\t[activated waiting for user]";
+        assert_eq!(
+            parse_system_extension_state(waiting),
+            RedirectorSystemExtensionState::WaitingForUser
+        );
+
+        let enabled = "*\t*\tS8XHQB96PW\torg.mitmproxy.macos-redirector.network-extension (2.0/1)\tnetwork-extension\t[activated enabled]";
+        assert_eq!(
+            parse_system_extension_state(enabled),
+            RedirectorSystemExtensionState::Enabled
+        );
+        assert_eq!(
+            parse_system_extension_state("no matching extensions"),
+            RedirectorSystemExtensionState::NotRegistered
+        );
     }
 }

--- a/src-tauri/src/sockscap/redirector/mod.rs
+++ b/src-tauri/src/sockscap/redirector/mod.rs
@@ -115,6 +115,137 @@ pub fn cleanup_stale_sockets() -> Result<usize, String> {
     Ok(removed)
 }
 
+/// Reap only orphaned Redirector coordinator apps launched by Taomni whose
+/// private provider socket is already gone. The caller must hold the global
+/// SocksCap module lock. Exact uid, executable path, argument shape, and socket
+/// namespace checks keep the cleanup away from the System Extension Provider
+/// and from independently launched processes.
+#[cfg(target_os = "macos")]
+pub async fn cleanup_stale_launchers() -> Result<usize, String> {
+    let output = Command::new("/bin/ps")
+        .args(["-ww", "-axo", "pid=,uid=,args="])
+        .output()
+        .map_err(|error| format!("enumerate stale Redirector launchers: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "enumerate stale Redirector launchers: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    let executable = installed_executable_path();
+    let current_uid = unsafe { libc::geteuid() };
+    let mut candidates = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| parse_launcher_process(line, current_uid, &executable))
+        .filter(|(_, socket)| !socket.exists())
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|(pid, _)| *pid);
+    candidates.dedup_by_key(|(pid, _)| *pid);
+
+    let mut signalled = Vec::new();
+    for (pid, socket) in candidates {
+        // Revalidate the executable immediately before signalling to avoid a
+        // stale process-list row ever targeting a reused pid.
+        if process_path(pid).ok().as_deref() != Some(executable.as_path()) || socket.exists() {
+            continue;
+        }
+        let result = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
+        if result == 0 {
+            signalled.push(pid);
+        } else {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return Err(format!(
+                    "terminate stale Redirector launcher pid {pid}: {error}"
+                ));
+            }
+        }
+    }
+
+    let reaped = signalled.len();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        signalled.retain(|pid| process_path(*pid).ok().as_deref() == Some(executable.as_path()));
+        if signalled.is_empty() || tokio::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    for pid in &signalled {
+        // A pending Swift continuation should normally exit on SIGTERM. Use a
+        // final SIGKILL only for the same still-verified executable.
+        if process_path(*pid).ok().as_deref() == Some(executable.as_path()) {
+            let result = unsafe { libc::kill(*pid as libc::pid_t, libc::SIGKILL) };
+            if result != 0 {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() != Some(libc::ESRCH) {
+                    return Err(format!("kill stale Redirector launcher pid {pid}: {error}"));
+                }
+            }
+        }
+    }
+    let kill_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+    loop {
+        signalled.retain(|pid| process_path(*pid).ok().as_deref() == Some(executable.as_path()));
+        if signalled.is_empty() {
+            break;
+        }
+        if tokio::time::Instant::now() >= kill_deadline {
+            return Err(format!(
+                "stale Redirector launcher pid(s) did not exit: {:?}",
+                signalled
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    Ok(reaped)
+}
+
+#[cfg(target_os = "macos")]
+fn parse_launcher_process(
+    line: &str,
+    current_uid: libc::uid_t,
+    executable: &Path,
+) -> Option<(u32, PathBuf)> {
+    let (pid, rest) = take_process_field(line.trim_start())?;
+    let (uid, command) = take_process_field(rest.trim_start())?;
+    if uid.parse::<libc::uid_t>().ok()? != current_uid {
+        return None;
+    }
+    let pid = pid.parse::<u32>().ok()?;
+    let executable = executable.to_str()?;
+    let remainder = command.trim_start().strip_prefix(executable)?;
+    if !remainder.chars().next().is_some_and(char::is_whitespace) {
+        return None;
+    }
+    let socket = remainder.trim_start();
+    if socket.is_empty() || socket.chars().any(char::is_whitespace) {
+        return None;
+    }
+    let socket = PathBuf::from(socket);
+    is_taomni_provider_socket(&socket).then_some((pid, socket))
+}
+
+#[cfg(target_os = "macos")]
+fn take_process_field(value: &str) -> Option<(&str, &str)> {
+    let split = value.find(char::is_whitespace)?;
+    Some((&value[..split], &value[split..]))
+}
+
+#[cfg(target_os = "macos")]
+fn is_taomni_provider_socket(path: &Path) -> bool {
+    if path.parent() != Some(Path::new("/tmp")) {
+        return false;
+    }
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    (name.starts_with("taomni-redirector-provider-")
+        || name.starts_with("taomni-redirector-recovery-provider-"))
+        && name.ends_with(".sock")
+}
+
 /// Refuse lookalike/replaced apps at the well-known path. The exact executable
 /// hashes pin v0.12.11, while codesign verifies the intact nested signature and
 /// the Team/bundle identities establish the upstream publisher boundary.
@@ -373,6 +504,32 @@ mod tests {
         assert_eq!(REDIRECTOR_EXTENSION_EXECUTABLE_SHA256.len(), 64);
         assert_eq!(REDIRECTOR_TEAM_ID.len(), 10);
         assert!(!REDIRECTOR_VERSION.is_empty());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn stale_launcher_parser_requires_exact_identity_and_socket_namespace() {
+        let executable = installed_executable_path();
+        let valid = format!(
+            " 2059 501 {} /tmp/taomni-redirector-provider-384689e4563143f7a19bc9635e033314.sock",
+            executable.display()
+        );
+        assert_eq!(
+            parse_launcher_process(&valid, 501, &executable),
+            Some((
+                2059,
+                PathBuf::from(
+                    "/tmp/taomni-redirector-provider-384689e4563143f7a19bc9635e033314.sock"
+                )
+            ))
+        );
+
+        let foreign_uid = valid.replacen("501", "502", 1);
+        assert!(parse_launcher_process(&foreign_uid, 501, &executable).is_none());
+        let unrelated_socket = valid.replace("taomni-redirector-provider-", "unrelated-");
+        assert!(parse_launcher_process(&unrelated_socket, 501, &executable).is_none());
+        let extra_argument = format!("{valid} --unexpected");
+        assert!(parse_launcher_process(&extra_argument, 501, &executable).is_none());
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/sockscap/redirector/runtime.rs
+++ b/src-tauri/src/sockscap/redirector/runtime.rs
@@ -69,6 +69,51 @@ pub struct RedirectorCaptureHandle {
     telemetry: Arc<RuntimeTelemetry>,
 }
 
+/// A failed Start distinguishes errors that happened before any business scope
+/// could be written from errors after the Apply frame may have reached the
+/// Provider. Only the latter requires durable network recovery.
+#[derive(Debug)]
+pub struct RedirectorStartError {
+    message: String,
+    scope_may_be_active: bool,
+}
+
+impl RedirectorStartError {
+    fn before_scope(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            scope_may_be_active: false,
+        }
+    }
+
+    fn after_apply(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            scope_may_be_active: true,
+        }
+    }
+
+    pub fn recovery_required(&self) -> bool {
+        self.scope_may_be_active
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl std::fmt::Display for RedirectorStartError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl From<String> for RedirectorStartError {
+    fn from(message: String) -> Self {
+        Self::before_scope(message)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RedirectorTelemetrySnapshot {
@@ -171,7 +216,7 @@ pub async fn start(
     config: &SocksCapConfig,
     ctx: Arc<RwLock<RelayContext>>,
     session_id: &str,
-) -> Result<RedirectorCaptureHandle, String> {
+) -> Result<RedirectorCaptureHandle, RedirectorStartError> {
     preflight(config)?;
     let file_descriptor_limit = prepare_file_descriptor_budget()?;
     let flow_capacity = relay_flow_capacity(file_descriptor_limit);
@@ -256,6 +301,18 @@ pub async fn start(
 /// relay context is constructed on this path.
 pub async fn recover() -> Result<(), String> {
     super::verify_installed()?;
+    match super::installer::system_extension_state() {
+        super::installer::RedirectorSystemExtensionState::WaitingForUser => {
+            return Err(
+                "Mitmproxy Redirector System Extension approval is pending in System Settings. Approve it first, then retry Recover."
+                    .into(),
+            );
+        }
+        super::installer::RedirectorSystemExtensionState::Enabled
+        | super::installer::RedirectorSystemExtensionState::NotRegistered
+        | super::installer::RedirectorSystemExtensionState::Other
+        | super::installer::RedirectorSystemExtensionState::Unavailable => {}
+    }
     let flow_socket_path = random_socket_path("recovery-flow");
     let provider_socket_path = random_socket_path("recovery-provider");
     let listener = bind_private_listener(&flow_socket_path)?;
@@ -267,7 +324,8 @@ pub async fn recover() -> Result<(), String> {
         &inert_actions(),
         &uuid::Uuid::new_v4().to_string(),
     )
-    .await?;
+    .await
+    .map_err(|error| error.to_string())?;
     stop_bridge(&mut bridge).await?;
     drop(listener);
     drop(cleanup);
@@ -366,6 +424,18 @@ pub fn preflight(config: &SocksCapConfig) -> Result<(), String> {
     let _ = config;
     super::verify_installed()
         .map_err(|error| format!("{error}; no system-proxy fallback is available"))?;
+    match super::installer::system_extension_state() {
+        super::installer::RedirectorSystemExtensionState::WaitingForUser => {
+            return Err(
+                "Mitmproxy Redirector System Extension approval is pending in System Settings. Approve it first, then retry Start or Recover."
+                    .into(),
+            );
+        }
+        super::installer::RedirectorSystemExtensionState::Enabled
+        | super::installer::RedirectorSystemExtensionState::NotRegistered
+        | super::installer::RedirectorSystemExtensionState::Other
+        | super::installer::RedirectorSystemExtensionState::Unavailable => {}
+    }
     prepare_file_descriptor_budget()?;
     Ok(())
 }
@@ -578,12 +648,16 @@ async fn launch_bridge(
     flow_socket: &std::path::Path,
     actions: &[String],
     session_id: &str,
-) -> Result<BridgeSession, String> {
+) -> Result<BridgeSession, RedirectorStartError> {
     if actions.is_empty() {
-        return Err("Redirector bridge actions must not be empty".into());
+        return Err(RedirectorStartError::before_scope(
+            "Redirector bridge actions must not be empty",
+        ));
     }
     if session_id.trim().is_empty() {
-        return Err("Redirector bridge session id must not be empty".into());
+        return Err(RedirectorStartError::before_scope(
+            "Redirector bridge session id must not be empty",
+        ));
     }
     let executable = std::env::current_exe()
         .map_err(|error| format!("resolve Taomni bridge executable: {error}"))?;
@@ -605,11 +679,15 @@ async fn launch_bridge(
         .map_err(|error| format!("launch isolated Redirector bridge: {error}"))?;
     let Some(stdin) = child.stdin.take() else {
         terminate_bridge_child(&mut child).await;
-        return Err("Redirector bridge stdin is unavailable".into());
+        return Err(RedirectorStartError::before_scope(
+            "Redirector bridge stdin is unavailable",
+        ));
     };
     let Some(stdout) = child.stdout.take() else {
         terminate_bridge_child(&mut child).await;
-        return Err("Redirector bridge stdout is unavailable".into());
+        return Err(RedirectorStartError::before_scope(
+            "Redirector bridge stdout is unavailable",
+        ));
     };
     let mut input = BufWriter::new(stdin);
     let mut output = BufReader::new(stdout);
@@ -619,11 +697,13 @@ async fn launch_bridge(
             Ok(Ok(event)) => event,
             Ok(Err(error)) => {
                 terminate_bridge_child(&mut child).await;
-                return Err(error);
+                return Err(RedirectorStartError::before_scope(error));
             }
             Err(_) => {
                 terminate_bridge_child(&mut child).await;
-                return Err("timed out waiting for Redirector bridge control readiness".into());
+                return Err(RedirectorStartError::before_scope(
+                    "timed out waiting for Redirector bridge control readiness",
+                ));
             }
         };
     let provider_pid = match ready {
@@ -633,13 +713,13 @@ async fn launch_bridge(
         } if version == BRIDGE_PROTOCOL_VERSION => provider_pid,
         BridgeEvent::Error { message, .. } => {
             terminate_bridge_child(&mut child).await;
-            return Err(message);
+            return Err(RedirectorStartError::before_scope(message));
         }
         event => {
             terminate_bridge_child(&mut child).await;
-            return Err(format!(
+            return Err(RedirectorStartError::before_scope(format!(
                 "unexpected Redirector bridge readiness event: {event:?}"
-            ));
+            )));
         }
     };
 
@@ -657,17 +737,19 @@ async fn launch_bridge(
     .await
     {
         terminate_bridge_child(&mut child).await;
-        return Err(error);
+        return Err(RedirectorStartError::after_apply(error));
     }
     let applied = match tokio::time::timeout(STOP_TIMEOUT, read_bridge_event(&mut output)).await {
         Ok(Ok(event)) => event,
         Ok(Err(error)) => {
             terminate_bridge_child(&mut child).await;
-            return Err(error);
+            return Err(RedirectorStartError::after_apply(error));
         }
         Err(_) => {
             terminate_bridge_child(&mut child).await;
-            return Err("timed out waiting for Redirector bridge scope apply".into());
+            return Err(RedirectorStartError::after_apply(
+                "timed out waiting for Redirector bridge scope apply",
+            ));
         }
     };
     match applied {
@@ -682,13 +764,13 @@ async fn launch_bridge(
             && generation == 1 => {}
         BridgeEvent::Error { message, .. } => {
             terminate_bridge_child(&mut child).await;
-            return Err(message);
+            return Err(RedirectorStartError::after_apply(message));
         }
         event => {
             terminate_bridge_child(&mut child).await;
-            return Err(format!(
+            return Err(RedirectorStartError::after_apply(format!(
                 "unexpected Redirector bridge apply event: {event:?}"
-            ));
+            )));
         }
     }
 

--- a/src/components/sockscap/SocksCapPanel.test.tsx
+++ b/src/components/sockscap/SocksCapPanel.test.tsx
@@ -4,6 +4,7 @@ import { SocksCapPanel } from "./SocksCapPanel";
 import {
   sockscapCapabilities,
   sockscapRecover,
+  sockscapRedirectorInstallStatus,
   sockscapStart,
   sockscapStatus,
   sockscapParseShareLink,
@@ -109,6 +110,13 @@ vi.mock("../../lib/sockscap", async (importOriginal) => {
     sockscapDetectLocalProxies: vi.fn(async () => []),
     sockscapDetectTunConflicts: vi.fn(async () => []),
     sockscapImportSubscription: vi.fn(),
+    sockscapRedirectorInstallStatus: vi.fn(async () => ({
+      state: "ready",
+      packageVersion: "0.12.11",
+      resourceAvailable: true,
+      systemExtensionState: "enabled",
+      message: "ready",
+    })),
   };
 });
 
@@ -148,6 +156,14 @@ describe("SocksCapPanel Multi-Profile UI", () => {
     vi.mocked(sockscapTestUpstream).mockResolvedValue("SOCKS5 ok");
     vi.mocked(sockscapDetectTunConflicts).mockReset();
     vi.mocked(sockscapDetectTunConflicts).mockResolvedValue([]);
+    vi.mocked(sockscapRedirectorInstallStatus).mockReset();
+    vi.mocked(sockscapRedirectorInstallStatus).mockResolvedValue({
+      state: "ready",
+      packageVersion: "0.12.11",
+      resourceAvailable: true,
+      systemExtensionState: "enabled",
+      message: "ready",
+    });
   });
 
   afterEach(() => {
@@ -649,6 +665,42 @@ describe("SocksCapPanel Multi-Profile UI", () => {
     ).toBeInTheDocument();
     expect(screen.queryByTestId("sockscap-root-prompt-dialog")).not.toBeInTheDocument();
     expect(vi.mocked(sockscapStart)).toHaveBeenCalledWith(undefined);
+  });
+
+  it("blocks repeated Start attempts while macOS System Extension approval is waiting", async () => {
+    currentPlatform = "macos";
+    vi.mocked(sockscapRedirectorInstallStatus).mockResolvedValue({
+      state: "pendingSystemApproval",
+      packageVersion: "0.12.11",
+      resourceAvailable: true,
+      systemExtensionState: "waitingForUser",
+      message: "Mitmproxy Redirector is waiting for approval in System Settings.",
+    });
+    render(<SocksCapPanel />);
+
+    const start = await screen.findByTestId("sockscap-start");
+    expect(start).toBeDisabled();
+    expect(start).toHaveAttribute(
+      "title",
+      expect.stringContaining("Approve the Mitmproxy Redirector System Extension"),
+    );
+    expect(await screen.findByTestId("sockscap-redirector-action")).toHaveTextContent(
+      "Refresh approval",
+    );
+  });
+
+  it("keeps first Start available before Redirector has registered its approval request", async () => {
+    currentPlatform = "macos";
+    vi.mocked(sockscapRedirectorInstallStatus).mockResolvedValue({
+      state: "pendingSystemApproval",
+      packageVersion: "0.12.11",
+      resourceAvailable: true,
+      systemExtensionState: "notRegistered",
+      message: "Start SocksCap once, then approve its System Extension.",
+    });
+    render(<SocksCapPanel />);
+
+    expect(await screen.findByTestId("sockscap-start")).not.toBeDisabled();
   });
 
   it("disables app scope and shows the backend notes when app filtering is unavailable", async () => {

--- a/src/components/sockscap/SocksCapPanel.tsx
+++ b/src/components/sockscap/SocksCapPanel.tsx
@@ -496,6 +496,9 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
     status?.phase === "active" ||
     status?.phase === "degraded" ||
     status?.phase === "preparing";
+  const redirectorApprovalWaiting =
+    caps?.platform === "macos" &&
+    redirectorInstall?.systemExtensionState === "waitingForUser";
 
   // A capture session is an immutable snapshot on every platform. This also
   // covers the short Stopping phase so edits cannot race teardown.
@@ -811,18 +814,20 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
   const onRefreshStatus = async () => {
     setBusy(true);
     try {
-      const [st, sn, hp, gf, drs] = await Promise.all([
+      const [st, sn, hp, gf, drs, ri] = await Promise.all([
         sockscapStatus().catch(() => null),
         sockscapStatsSnapshot().catch(() => null),
         sockscapHelperStatus().catch(() => null),
         sockscapGfwlistStatus().catch(() => null),
         sockscapGetDomainRecords().catch(() => null),
+        sockscapRedirectorInstallStatus().catch(() => null),
       ]);
       if (st) setStatus(st);
       if (sn) setStats(sn);
       if (hp) setHelper(hp);
       if (gf) setGfw(gf);
       if (drs) setDomainRecords(drs);
+      if (ri) setRedirectorInstall(ri);
       report(t("sockscap.statusRefreshed"));
     } finally {
       setBusy(false);
@@ -1754,7 +1759,12 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
             data-testid="sockscap-start"
             className="inline-flex items-center gap-1 px-3 py-1.5 rounded text-[12px] bg-[var(--taomni-accent)] text-white hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed"
             onClick={() => void preflightAndStart()}
-            disabled={busy || probing}
+            disabled={busy || probing || redirectorApprovalWaiting}
+            title={
+              redirectorApprovalWaiting
+                ? t("sockscap.redirectorApprovalPendingHint")
+                : undefined
+            }
           >
             {probing ? (
               <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -1821,17 +1831,30 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
           <span>{redirectorInstall?.message || t("sockscap.redirectorMissing")}</span>
           <button
             type="button"
+            data-testid="sockscap-redirector-action"
             className="inline-flex items-center gap-1 px-2 py-1 rounded border border-amber-500/40 hover:bg-amber-500/10 disabled:opacity-50"
             disabled={
               busy ||
-              !redirectorInstall?.resourceAvailable ||
-              redirectorInstall?.state === "conflict" ||
-              redirectorInstall?.state === "pendingSystemApproval"
+              (redirectorInstall?.state !== "pendingSystemApproval" &&
+                (!redirectorInstall?.resourceAvailable ||
+                  redirectorInstall?.state === "conflict"))
             }
-            onClick={() => void installRedirector()}
+            onClick={() =>
+              void (redirectorInstall?.state === "pendingSystemApproval"
+                ? onRefreshStatus()
+                : installRedirector())
+            }
           >
-            {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <Shield className="w-3 h-3" />}
-            {t("sockscap.installRedirector")}
+            {busy ? (
+              <Loader2 className="w-3 h-3 animate-spin" />
+            ) : redirectorInstall?.state === "pendingSystemApproval" ? (
+              <RefreshCw className="w-3 h-3" />
+            ) : (
+              <Shield className="w-3 h-3" />
+            )}
+            {redirectorInstall?.state === "pendingSystemApproval"
+              ? t("sockscap.refreshRedirectorApproval")
+              : t("sockscap.installRedirector")}
           </button>
         </div>
       )}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1176,6 +1176,9 @@ const dict = {
     diagnosticsCopied: "SocksCap diagnostics copied.",
     redirectorMissing: "Mitmproxy Redirector is required for macOS capture.",
     installRedirector: "Install Redirector…",
+    refreshRedirectorApproval: "Refresh approval",
+    redirectorApprovalPendingHint:
+      "Approve the Mitmproxy Redirector System Extension in System Settings before starting.",
     refreshStatus: "Refresh status & traffic counters",
     statusRefreshed: "Status refreshed",
     saved: "Configuration saved",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -1174,6 +1174,9 @@ export const zhCN: DeepPartial<typeof en> = {
     diagnosticsCopied: "已复制 SocksCap 诊断信息。",
     redirectorMissing: "macOS 捕获需要安装 Mitmproxy Redirector。",
     installRedirector: "安装 Redirector…",
+    refreshRedirectorApproval: "刷新批准状态",
+    redirectorApprovalPendingHint:
+      "请先在系统设置中批准 Mitmproxy Redirector 系统扩展，再启动 SocksCap。",
     refreshStatus: "刷新状态与流量计数",
     statusRefreshed: "状态已刷新",
     saved: "配置已保存",

--- a/src/lib/sockscap.ts
+++ b/src/lib/sockscap.ts
@@ -181,6 +181,12 @@ export interface RedirectorInstallStatus {
     | "resourceMissing";
   packageVersion: string;
   resourceAvailable: boolean;
+  systemExtensionState:
+    | "enabled"
+    | "waitingForUser"
+    | "notRegistered"
+    | "other"
+    | "unavailable";
   message: string;
 }
 


### PR DESCRIPTION
Detect the Mitmproxy Redirector System Extension state and distinguish a first-use approval wait from a capture scope that may already be active.
Install bridge signal and parent-process watchdogs before waiting for the Provider, terminate and reap the coordinator on every bridge exit, and remove only exact stale Taomni coordinator processes whose private sockets are gone.
Clear a Preparing recovery journal only when no bridge, provider, or scope was recorded and macOS still reports waiting for user approval. Preserve RecoveryRequired for failures after Apply may have reached the Provider.
Expose pending approval in the SocksCap UI, disable repeated Start attempts until approval is refreshed, and add focused Rust and React coverage for approval parsing, orphan matching, journal safety, launcher cleanup, and UI behavior.