### PR TITLE
feat(database): unify query and result tab limits

### DIFF
--- a/.agents/skills/qa-ui-auto/references/testid-catalog.md
+++ b/.agents/skills/qa-ui-auto/references/testid-catalog.md
@@ -166,6 +166,7 @@
 - `[data-testid="hbase-schema-tree-filter"]` — interactive [optional] — F-DB-3.schema-filter
 - `[data-testid="hbase-query-library-tab"]` — interactive [optional] — F-DB-3.query-library-tab
 - `[data-testid="hbase-save-query"]` — interactive [optional] — F-DB-3.save-query
+- `[data-testid="hbase-tab-limit"]` — interactive [optional] — F-DB-3.tab-limit
 - `[data-testid="hbase-run-current-statement"]` — interactive [optional] — F-DB-3.run-current
 - `[data-testid="hbase-help-dialog"]` — display [optional] — F-DB-3.help-dialog
 - `[data-testid="hbase-sidebar-drawer-handle"]` — interactive [optional] — F-DB-3.sidebar-drawer
@@ -255,6 +256,7 @@
 - `[data-testid="db-schema-drawer-handle"]` — interactive [optional] — F-DB-1.schema-drawer-handle
 - `[data-testid="db-query-library-tab"]` — interactive [optional] — F-DB-1.query-library-tab
 - `[data-testid="db-save-query"]` — interactive [optional] — F-DB-1.save-query
+- `[data-testid="db-tab-limit"]` — interactive [optional] — F-DB-1.tab-limit
 - `[data-testid="db-connection-error-banner"]` — display [optional] — F-DB-1.connection-error-banner
 - `[data-testid="db-chat-toggle"]` — interactive [optional] — F-DB-1.chat-toggle
 - `[data-testid="db-detach"]` — interactive [optional] — F-DB-1.detach

--- a/qa-ui-auto-tests/feature-list.md
+++ b/qa-ui-auto-tests/feature-list.md
@@ -3657,6 +3657,7 @@ files:
   - src/lib/sqlLocalRelations.ts
   - src/lib/sqlMetadataCompletions.ts
   - src/lib/sqlQueryScope.ts
+  - src/lib/databaseTabLimit.ts
   - src/lib/ipc.ts
   - src-tauri/src/database/mod.rs
   - src-tauri/src/database/sql.rs
@@ -3821,6 +3822,10 @@ controls:
     selector: '[data-testid="db-save-query"]'
     kind: interactive
     optional: true
+  - id: tab-limit
+    selector: '[data-testid="db-tab-limit"]'
+    kind: interactive
+    optional: true       # only inside an open SQL DB tab
   - id: connection-error-banner
     selector: '[data-testid="db-connection-error-banner"]'
     kind: display
@@ -3841,7 +3846,7 @@ controls:
 -->
 
 - DB 会话（MySQL/PostgreSQL/PanWeiDB/Oracle/SQLServer/StarRocks/ClickHouse/Presto）经 `SessionEditor` 创建（proto 选择器 + database section 由 F6.3 拥有），打开后 `MainLayout.openDbTab` 挂载 `DbClientTab`（`type:"database"`），与 SFTP/VNC 一样常驻挂载以便查询跨标签存活
-- 左侧 `SchemaTree`：懒加载 schema→table→column/index 展开（`db-schema-drawer-handle` 抽屉折叠）；右侧查询工作区为多 query 面板（最多 4 个）的 tab 布局
+- 左侧 `SchemaTree`：懒加载 schema→table→column/index 展开（`db-schema-drawer-handle` 抽屉折叠）；右侧查询工作区为多 query 面板的 tab 布局，`Tab limit` 同时限制每个 session 的 query tabs 和每个 query 的 result tabs（默认 50）
 - `SqlEditorPanel` 封装 CodeMirror 6：按引擎选 dialect，提供语法上下文感知的本地 CTE/函数补全与有界、可缓存的远端元数据补全，覆盖表/列、读取光标后 `FROM/JOIN` 的 `SELECT` 字段补全、通配符展开、`INSERT` 列和外键优先的 `JOIN ON`；补全触发键、输入自动弹出及 Tab/Enter 接受行为可在全局设置中修改，运行中的主/分离窗口会动态重配 keymap；加载、截断与错误会通过 `sql-completion-status` 反馈
 - SQL 历史持久化到 SQLite `sql_history`，按 workspace/session + engine 查询；History 面板支持 Run / Select / +Tab / JSON / Ask AI / Refresh / Clear / Delete；当前 editor 语句面板用 cursor/selection 定位多 SQL 文档中的单条语句，并提供同一套 Run / Select / +Tab / JSON / Ask AI 交互
 - `QueryResultGrid` 为手写虚拟化网格（行高 24 + overscan）：NULL 徽标、数值右对齐、排序、CSV/单元格复制、完整值查看（Ctrl+Enter / 右键菜单，保留长文本和换行）、列显隐、聚合统计、行筛选、Table/List/Chart 视图、增删改行 + 提交/撤销；过滤/排序先本地生效，显式 `Query` 后优先把 `WHERE` / `ORDER BY` 原位写回仍匹配的来源语句并刷新当前 result sheet，复杂 SQL fallback 为包裹源 SQL 的 derived SQL，`Sync` 可创建/复用 `Generated SQL` query 面板作为草稿
@@ -4001,6 +4006,7 @@ files:
   - src/lib/hbaseCommands.ts
   - src/lib/hbaseCompletions.ts
   - src/lib/hbaseStatements.ts
+  - src/lib/databaseTabLimit.ts
 controls:
   - id: remote-host
     selector: 'input[aria-label="Remote host"]'
@@ -4026,6 +4032,10 @@ controls:
     selector: '[data-testid="hbase-save-query"]'
     kind: interactive
     optional: true
+  - id: tab-limit
+    selector: '[data-testid="hbase-tab-limit"]'
+    kind: interactive
+    optional: true
   - id: run-current
     selector: '[data-testid="hbase-run-current-statement"]'
     kind: interactive
@@ -4044,7 +4054,7 @@ controls:
     optional: true
 -->
 
-- HBase REST/native/thrift 会话使用同一多面板 shell 工作区、命令补全、写操作确认与结果表格；连接失败时工作区和 Query Library 继续可用。
+- HBase REST/native/thrift 会话使用同一多面板 shell 工作区、命令补全、写操作确认与结果表格；`Tab limit` 同时限制每个 session 的 query tabs 和每个 query 的 result tabs（默认 50）；连接失败时工作区和 Query Library 继续可用。
 - Query Library 以稳定 HBase session id + namespace 过滤命令，打开后仍通过原 HBase statement runner 执行并参与退出 flush。
 
 ### 24.3 数据库 Query Library 与草稿持久化 ✅

--- a/src/components/database/DbClientTab.test.tsx
+++ b/src/components/database/DbClientTab.test.tsx
@@ -542,6 +542,27 @@ describe("DbClientTab connection lifecycle", () => {
     });
   });
 
+  it("uses the shared tab limit for query tabs and result tabs", async () => {
+    localStorage.setItem("taomni.db.PostgreSQL.tabLimit", "2");
+    ipcMock.dbConnect.mockResolvedValue({ ok: true });
+
+    render(<DbClientTab tabId="tab-1" info={postgresInfo} visible />);
+
+    await waitFor(() => expect(screen.getByTestId("schema-tree")).toBeInTheDocument());
+    expect(screen.getByTestId("db-tab-limit")).toHaveValue(2);
+
+    fireEvent.click(screen.getByTitle("New query panel"));
+    await waitFor(() => expect(screen.getByTitle("Query 2")).toBeInTheDocument());
+    expect(screen.queryByTitle("New query panel")).not.toBeInTheDocument();
+
+    for (let run = 0; run < 3; run += 1) {
+      fireEvent.click(screen.getByTitle("Run (F5)"));
+      await waitFor(() => {
+        expect(screen.getAllByTestId("result-sheet-tab")).toHaveLength(Math.min(run + 1, 2));
+      });
+    }
+  });
+
   it("supports batch close actions from the result sheet context menu", async () => {
     ipcMock.dbConnect.mockResolvedValue({ ok: true });
 
@@ -716,4 +737,3 @@ describe("DbClientTab connection lifecycle", () => {
     });
   });
 });
-

--- a/src/components/database/DbClientTab.tsx
+++ b/src/components/database/DbClientTab.tsx
@@ -107,6 +107,13 @@ import { writeText } from "../../lib/clipboard";
 import { createDbMetadataCache } from "../../lib/dbMetadataCache";
 import { sqlNamespaceFromMetadata } from "../../lib/sqlMetadataCompletions";
 import {
+  MAX_DATABASE_TAB_LIMIT,
+  MIN_DATABASE_TAB_LIMIT,
+  clampDatabaseTabLimit,
+  readDatabaseTabLimit,
+  writeDatabaseTabLimit,
+} from "../../lib/databaseTabLimit";
+import {
   asSqlEngine,
   quoteIdent as dialectQuoteIdent,
   qualifiedName as dialectQualifiedName,
@@ -132,10 +139,6 @@ interface DbClientTabProps {
 }
 
 const MAX_HISTORY = 200;
-const MAX_PANELS = 4;
-const DEFAULT_MAX_RESULT_SHEETS = 50;
-const MIN_RESULT_SHEETS = 1;
-const MAX_RESULT_SHEETS_LIMIT = 200;
 const DEFAULT_ROW_LIMIT = 1000;
 const MIN_ROW_LIMIT = 1;
 const MAX_ROW_LIMIT = 1_000_000;
@@ -570,15 +573,7 @@ export default function DbClientTab({
   const [rowLimit, setRowLimit] = useState(() =>
     readIntSetting(info.engine, "rowLimit", DEFAULT_ROW_LIMIT, MIN_ROW_LIMIT, MAX_ROW_LIMIT),
   );
-  const [maxResultSheets, setMaxResultSheets] = useState(() =>
-    readIntSetting(
-      info.engine,
-      "maxResultSheets",
-      DEFAULT_MAX_RESULT_SHEETS,
-      MIN_RESULT_SHEETS,
-      MAX_RESULT_SHEETS_LIMIT,
-    ),
-  );
+  const [tabLimit, setTabLimit] = useState(() => readDatabaseTabLimit(info.engine));
   const [schemas, setSchemas] = useState<string[]>([]);
   const [activeSchema, setActiveSchema] = useState<string | null>(() => initialActiveSchema(info));
   const [schemaMap, setSchemaMap] = useState<Record<string, string[]>>({});
@@ -599,6 +594,7 @@ export default function DbClientTab({
   const echoPanelIdRef = useRef<string | null>(null);
   const timersRef = useRef<Record<string, ReturnType<typeof setInterval>>>({});
   const panelsRef = useRef<PanelState[]>(panels);
+  const tabLimitRef = useRef(tabLimit);
   const activePanelIdRef = useRef(activePanelId);
   const autoSaveInFlightRef = useRef<Promise<void> | null>(null);
   const autoSaveDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -637,6 +633,10 @@ export default function DbClientTab({
   useEffect(() => {
     panelsRef.current = panels;
   }, [panels]);
+
+  useEffect(() => {
+    tabLimitRef.current = tabLimit;
+  }, [tabLimit]);
 
   useEffect(() => {
     activePanelIdRef.current = activePanelId;
@@ -706,7 +706,7 @@ export default function DbClientTab({
           return;
         }
         const restored = await Promise.all(
-          workspace.tabs.slice(0, MAX_PANELS).map(async (entry) => {
+          workspace.tabs.slice(0, tabLimitRef.current).map(async (entry) => {
             const savedQuery = entry.savedQueryId
               ? await dbGetSavedQuery(entry.savedQueryId).catch(() => null)
               : null;
@@ -760,8 +760,8 @@ export default function DbClientTab({
             createdAt: Date.now() + index,
           }),
         );
-        if (restored.length >= MAX_PANELS) break;
-        if (index >= MAX_PANELS - 1) break;
+        if (restored.length >= tabLimitRef.current) break;
+        if (index >= tabLimitRef.current - 1) break;
       }
       if (cancelled) return;
       if (restored.length === 0) {
@@ -809,8 +809,8 @@ export default function DbClientTab({
   }, [info.engine, rowLimit]);
 
   useEffect(() => {
-    writeIntSetting(info.engine, "maxResultSheets", maxResultSheets);
-  }, [info.engine, maxResultSheets]);
+    writeDatabaseTabLimit(info.engine, tabLimit);
+  }, [info.engine, tabLimit]);
 
   const patchPanel = useCallback((id: string, patch: Partial<PanelState>) => {
     setPanels((prev) => prev.map((p) => (p.id === id ? { ...p, ...patch } : p)));
@@ -1200,7 +1200,7 @@ export default function DbClientTab({
         setPanels((prev) =>
           prev.map((p) => {
             if (p.id !== panelId) return p;
-            const sheets = [...p.sheets, sheet].slice(-maxResultSheets);
+            const sheets = [...p.sheets, sheet].slice(-tabLimit);
             return {
               ...p,
               sheets,
@@ -1213,7 +1213,7 @@ export default function DbClientTab({
         if (!summary.ok) break;
       }
     },
-    [appendSqlHistory, maxResultSheets, rowLimit, statementRangesForRun, streamQueryIntoSheet],
+    [appendSqlHistory, rowLimit, statementRangesForRun, streamQueryIntoSheet, tabLimit],
   );
 
   const insertQueryFromOutside = useCallback(
@@ -1227,7 +1227,7 @@ export default function DbClientTab({
     ) => {
       const text = sql.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
       if (!text.trim()) return;
-      if (options?.destination === "new" && panels.length < MAX_PANELS) {
+      if (options?.destination === "new" && panels.length < tabLimit) {
         const panel = newPanel({ doc: text, dirty: true });
         setPanels((prev) => [...prev, panel]);
         setActivePanelId(panel.id);
@@ -1259,7 +1259,7 @@ export default function DbClientTab({
         void runQuery(panelId, next ?? text);
       }
     },
-    [activePanelId, panels, patchPanel, runQuery],
+    [activePanelId, panels, patchPanel, runQuery, tabLimit],
   );
 
   // Append a statement echoed from an AI/Claude Code SQL execution to a stable
@@ -1288,7 +1288,7 @@ export default function DbClientTab({
       const panel = newPanel({ doc: block, dirty: true });
       echoPanelIdRef.current = panel.id;
       setPanels((prev) => {
-        const next = [...prev, panel].slice(-MAX_PANELS);
+        const next = [...prev, panel].slice(-tabLimit);
         panelsRef.current = next;
         return next;
       });
@@ -1309,7 +1309,7 @@ export default function DbClientTab({
     patchPanel(targetId, { doc: joined, dirty: true });
     setActivePanelId(targetId);
     editor?.focus();
-  }, [patchPanel]);
+  }, [patchPanel, tabLimit]);
 
   const queryRegistryTitle = useMemo(() => {
     const database = info.engine === "Presto"
@@ -1551,7 +1551,7 @@ export default function DbClientTab({
                       warnings: [],
                       resultTab: "messages" as ResultSubTab,
                     },
-                  ].slice(-maxResultSheets),
+                  ].slice(-tabLimit),
                   activeSheetId: sheet.id,
                 }
               : p,
@@ -1560,7 +1560,7 @@ export default function DbClientTab({
         setStatusMessage(`Schema switch failed: ${String(err)}`);
       }
     },
-    [activePanelId, activeSchema, connectionSessionId, info.catalog, info.engine, maxResultSheets, panels, rowLimit],
+    [activePanelId, activeSchema, connectionSessionId, info.catalog, info.engine, panels, rowLimit, tabLimit],
   );
   const insertIntoActive = useCallback(
     (text: string) => {
@@ -1599,7 +1599,7 @@ export default function DbClientTab({
   );
 
   const addPanel = () => {
-    if (panels.length >= MAX_PANELS) return;
+    if (panels.length >= tabLimit) return;
     const p = newPanel();
     setPanels((prev) => [...prev, p]);
     setActivePanelId(p.id);
@@ -1790,7 +1790,7 @@ export default function DbClientTab({
         label: "New query tab",
         icon: <Plus className="w-3 h-3" />,
         onClick: addPanel,
-        disabled: panels.length >= MAX_PANELS,
+        disabled: panels.length >= tabLimit,
       },
       {
         label: "Close",
@@ -1859,7 +1859,7 @@ export default function DbClientTab({
               sheets: [
                 ...p.sheets,
                 { ...sheet, running: false, result: null, error: message, resultTab: "messages" as ResultSubTab },
-              ].slice(-maxResultSheets),
+              ].slice(-tabLimit),
               activeSheetId: sheet.id,
             }
           : p,
@@ -1944,8 +1944,8 @@ export default function DbClientTab({
       return existingTargetId;
     }
 
-    if (livePanels.length >= MAX_PANELS) {
-      setStatusMessage(`Maximum query panels reached (${MAX_PANELS}).`);
+    if (livePanels.length >= tabLimit) {
+      setStatusMessage(`Maximum query panels reached (${tabLimit}).`);
       return null;
     }
 
@@ -2148,8 +2148,8 @@ export default function DbClientTab({
     origin: SqlStatementSourceRef["origin"] = "history",
     savedQuery: DbSavedQuery | null = null,
   ) => {
-    if (panelsRef.current.length >= MAX_PANELS) {
-      setStatusMessage(`Maximum query panels reached (${MAX_PANELS}).`);
+    if (panelsRef.current.length >= tabLimit) {
+      setStatusMessage(`Maximum query panels reached (${tabLimit}).`);
       return;
     }
     const panel = newPanel({ doc: sql, savedQuery, dirty: !savedQuery });
@@ -2634,7 +2634,7 @@ export default function DbClientTab({
                   </button>
                 );
               })}
-              {panels.length < MAX_PANELS && (
+              {panels.length < tabLimit && (
                 <button
                   type="button"
                   title="New query panel"
@@ -2678,12 +2678,12 @@ export default function DbClientTab({
                 onSaveQuery={() => addQueryTriggerRef.current?.()}
                 onSchemaChange={(schema) => void switchSchema(schema)}
                 rowLimit={rowLimit}
-                maxResultSheets={maxResultSheets}
+                tabLimit={tabLimit}
                 onRowLimitChange={(value) =>
                   setRowLimit(clampInt(value, MIN_ROW_LIMIT, MAX_ROW_LIMIT))
                 }
-                onMaxResultSheetsChange={(value) =>
-                  setMaxResultSheets(clampInt(value, MIN_RESULT_SHEETS, MAX_RESULT_SHEETS_LIMIT))
+                onTabLimitChange={(value) =>
+                  setTabLimit(clampDatabaseTabLimit(value))
                 }
               />
               {historyPanelId === activePanel.id && (
@@ -2792,9 +2792,9 @@ function EditorToolbar({
   onSaveQuery,
   onSchemaChange,
   rowLimit,
-  maxResultSheets,
+  tabLimit,
   onRowLimitChange,
-  onMaxResultSheetsChange,
+  onTabLimitChange,
 }: {
   engine: string;
   schemas: string[];
@@ -2816,9 +2816,9 @@ function EditorToolbar({
   onSaveQuery: () => void;
   onSchemaChange: (schema: string) => void;
   rowLimit: number;
-  maxResultSheets: number;
+  tabLimit: number;
   onRowLimitChange: (value: number) => void;
-  onMaxResultSheetsChange: (value: number) => void;
+  onTabLimitChange: (value: number) => void;
 }) {
   const t = useT();
   const [langMenuOpen, setLangMenuOpen] = useState(false);
@@ -2915,15 +2915,16 @@ function EditorToolbar({
         />
       </label>
       <label className="h-6 inline-flex items-center gap-1 text-[11px] text-[var(--taomni-text-muted)]">
-        Sheets
+        Tab limit
         <input
+          data-testid="db-tab-limit"
           className={input}
           type="number"
-          min={MIN_RESULT_SHEETS}
-          max={MAX_RESULT_SHEETS_LIMIT}
-          value={maxResultSheets}
-          title="Maximum open result sheets in this DB tab"
-          onChange={(event) => onMaxResultSheetsChange(Number(event.target.value))}
+          min={MIN_DATABASE_TAB_LIMIT}
+          max={MAX_DATABASE_TAB_LIMIT}
+          value={tabLimit}
+          title="Maximum query tabs per session and result tabs per query"
+          onChange={(event) => onTabLimitChange(Number(event.target.value))}
         />
       </label>
       <div className="flex-1" />

--- a/src/components/database/HBaseShellTab.test.tsx
+++ b/src/components/database/HBaseShellTab.test.tsx
@@ -121,6 +121,25 @@ describe("HBaseShellTab workspace", () => {
     expect(await screen.findByTestId("query-result-grid")).toHaveTextContent("1 rows");
   });
 
+  it("uses the shared tab limit for query tabs and result tabs", async () => {
+    localStorage.setItem("taomni.db.HBaseShell.tabLimit", "2");
+
+    render(<HBaseShellTab tabId="t1" info={info} visible />);
+    await waitFor(() => expect(ipcMock.hbaseConnect).toHaveBeenCalled());
+    expect(screen.getByTestId("hbase-tab-limit")).toHaveValue(2);
+
+    fireEvent.click(screen.getByTitle("New query panel"));
+    await waitFor(() => expect(screen.getByTitle("Query 2")).toBeInTheDocument());
+    expect(screen.queryByTitle("New query panel")).not.toBeInTheDocument();
+
+    for (let run = 0; run < 3; run += 1) {
+      fireEvent.click(screen.getByTestId("mock-editor"));
+      await waitFor(() => {
+        expect(screen.getAllByTestId("result-sheet-tab")).toHaveLength(Math.min(run + 1, 2));
+      });
+    }
+  });
+
   it("forces a confirmation popup before a write command and runs it on confirm", async () => {
     editorState.value = "drop 'users'";
     render(<HBaseShellTab tabId="t1" info={info} visible />);

--- a/src/components/database/HBaseShellTab.tsx
+++ b/src/components/database/HBaseShellTab.tsx
@@ -78,6 +78,13 @@ import { HBaseSchemaTree } from "./HBaseSchemaTree";
 import { useDbSessionFontSize } from "./useDbSessionFontSize";
 import { QueryLibraryPanel } from "./QueryLibraryPanel";
 import { registerQueryTab } from "../../lib/queryRegistry";
+import {
+  MAX_DATABASE_TAB_LIMIT,
+  MIN_DATABASE_TAB_LIMIT,
+  clampDatabaseTabLimit,
+  readDatabaseTabLimit,
+  writeDatabaseTabLimit,
+} from "../../lib/databaseTabLimit";
 
 interface HBaseShellTabProps {
   tabId: string;
@@ -90,10 +97,9 @@ interface HBaseShellTabProps {
   };
 }
 
-const MAX_PANELS = 4;
 const MAX_HISTORY = 200;
-const MAX_RESULT_SHEETS = 50;
 const DEFAULT_ROW_LIMIT = 50;
+const HBASE_TAB_LIMIT_SCOPE = "HBaseShell";
 
 type ResultSubTab = "results" | "messages";
 
@@ -466,6 +472,7 @@ export default function HBaseShellTab({ tabId, info, visible, chatToggle }: HBas
   const [connectionSessionId, setConnectionSessionId] = useState<string | null>(null);
   const [connError, setConnError] = useState<string | null>(null);
   const [hasBeenVisible, setHasBeenVisible] = useState(false);
+  const [tabLimit, setTabLimit] = useState(() => readDatabaseTabLimit(HBASE_TAB_LIMIT_SCOPE));
 
   // --- workspace state (restored from localStorage) ---
   const workspaceKey = `taomni.hbase.workspace.v1.${info.sessionId}`;
@@ -478,13 +485,13 @@ export default function HBaseShellTab({ tabId, info, visible, chatToggle }: HBas
           panels?: Array<{ doc?: string; savedQueryId?: string | null }>;
         };
         if (Array.isArray(parsed.panels) && parsed.panels.length > 0) {
-          return parsed.panels.slice(0, MAX_PANELS).map((panel) => ({
+          return parsed.panels.slice(0, tabLimit).map((panel) => ({
             ...newPanel(typeof panel.doc === "string" ? panel.doc : ""),
             savedQueryId: panel.savedQueryId ?? null,
           }));
         }
         if (Array.isArray(parsed.docs) && parsed.docs.length > 0) {
-          return parsed.docs.slice(0, MAX_PANELS).map((doc) => newPanel(doc));
+          return parsed.docs.slice(0, tabLimit).map((doc) => newPanel(doc));
         }
       }
     } catch {
@@ -523,6 +530,10 @@ export default function HBaseShellTab({ tabId, info, visible, chatToggle }: HBas
   useEffect(() => {
     panelsRef.current = panels;
   }, [panels]);
+
+  useEffect(() => {
+    writeDatabaseTabLimit(HBASE_TAB_LIMIT_SCOPE, tabLimit);
+  }, [tabLimit]);
 
   // Persist panel docs + active panel for restore-on-mount.
   useEffect(() => {
@@ -679,7 +690,7 @@ export default function HBaseShellTab({ tabId, info, visible, chatToggle }: HBas
         const sheet = newSheet(statement, ordinal);
         setPanels((prev) =>
           prev.map((p) =>
-            p.id !== panelId ? p : { ...p, sheets: [...p.sheets, sheet].slice(-MAX_RESULT_SHEETS), activeSheetId: sheet.id },
+            p.id !== panelId ? p : { ...p, sheets: [...p.sheets, sheet].slice(-tabLimit), activeSheetId: sheet.id },
           ),
         );
         const success = await executeIntoSheet(panelId, sheet.id, statement);
@@ -688,7 +699,7 @@ export default function HBaseShellTab({ tabId, info, visible, chatToggle }: HBas
       }
       if (mutated) setRefreshSignal((s) => s + 1);
     },
-    [connectionSessionId, panels, confirmWrite, executeIntoSheet],
+    [connectionSessionId, panels, confirmWrite, executeIntoSheet, tabLimit],
   );
 
   const runCurrentStatement = useCallback(
@@ -859,13 +870,13 @@ export default function HBaseShellTab({ tabId, info, visible, chatToggle }: HBas
 
   const addPanel = useCallback(
     (doc = "", savedQuery: DbSavedQuery | null = null) => {
-      if (panels.length >= MAX_PANELS) return null;
+      if (panels.length >= tabLimit) return null;
       const panel = newPanel(doc, savedQuery);
       setPanels((prev) => [...prev, panel]);
       setActivePanelId(panel.id);
       return panel.id;
     },
-    [panels.length],
+    [panels.length, tabLimit],
   );
 
   const openQuerySave = useCallback(() => {
@@ -980,7 +991,7 @@ export default function HBaseShellTab({ tabId, info, visible, chatToggle }: HBas
   const onRunCommand = useCallback((stmt: string) => void runStatements(activePanelId, stmt), [runStatements, activePanelId]);
   const onInsert = useCallback(
     (stmt: string, target: "cursor" | "newPanel" = "cursor") => {
-      if (target === "newPanel" && panels.length < MAX_PANELS) {
+      if (target === "newPanel" && panels.length < tabLimit) {
         addPanel(stmt);
         return;
       }
@@ -992,7 +1003,7 @@ export default function HBaseShellTab({ tabId, info, visible, chatToggle }: HBas
         patchPanel(activePanelId, { doc: `${activePanel?.doc ?? ""}${activePanel?.doc ? "\n" : ""}${stmt}` });
       }
     },
-    [panels.length, addPanel, activePanelId, activePanel, patchPanel],
+    [panels.length, addPanel, activePanelId, activePanel, patchPanel, tabLimit],
   );
 
   const onTablesLoaded = useCallback((tables: string[]) => {
@@ -1213,7 +1224,7 @@ export default function HBaseShellTab({ tabId, info, visible, chatToggle }: HBas
                   </button>
                 );
               })}
-              {panels.length < MAX_PANELS && (
+              {panels.length < tabLimit && (
                 <button type="button" title="New query panel" className="h-5 w-5 inline-flex items-center justify-center rounded hover:bg-[var(--taomni-hover)]" onClick={() => addPanel("")}>
                   <Plus className="w-3 h-3" />
                 </button>
@@ -1317,6 +1328,19 @@ export default function HBaseShellTab({ tabId, info, visible, chatToggle }: HBas
                   <input className="taomni-input h-6 w-[68px] text-[11px]" type="number" min={1} max={10000} value={rowLimit}
                     title="Default scan row limit" onChange={(e) => setRowLimit(Math.max(1, Math.min(10000, Number(e.target.value) || DEFAULT_ROW_LIMIT)))} />
                 </label>
+                <label className="h-6 inline-flex items-center gap-1 text-[11px] text-[var(--taomni-text-muted)]">
+                  Tab limit
+                  <input
+                    data-testid="hbase-tab-limit"
+                    className="taomni-input h-6 w-[68px] text-[11px]"
+                    type="number"
+                    min={MIN_DATABASE_TAB_LIMIT}
+                    max={MAX_DATABASE_TAB_LIMIT}
+                    value={tabLimit}
+                    title="Maximum query tabs per session and result tabs per query"
+                    onChange={(event) => setTabLimit(clampDatabaseTabLimit(Number(event.target.value)))}
+                  />
+                </label>
                 <span className="text-[10px] text-[var(--taomni-text-muted)]">HBase ({transport})</span>
                 {showCommands && <CommandsMenu transport={transport} onPick={(ex) => onInsert(ex, "cursor")} onClose={() => setShowCommands(false)} />}
                 {showHistory && <HistoryDropdown history={historyRef.current[activePanel.id] ?? []} onPick={(cmd) => { editorHandles.current[activePanel.id]?.setValue(cmd); setShowHistory(false); }} onClose={() => setShowHistory(false)} />}
@@ -1369,7 +1393,6 @@ export default function HBaseShellTab({ tabId, info, visible, chatToggle }: HBas
     </div>
   );
 }
-
 
 
 

--- a/src/lib/databaseTabLimit.test.ts
+++ b/src/lib/databaseTabLimit.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_DATABASE_TAB_LIMIT,
+  MAX_DATABASE_TAB_LIMIT,
+  readDatabaseTabLimit,
+  writeDatabaseTabLimit,
+} from "./databaseTabLimit";
+
+const engine = "PostgreSQL";
+const currentKey = `taomni.db.${engine}.tabLimit`;
+const legacyKey = `taomni.db.${engine}.maxResultSheets`;
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("database tab limit preferences", () => {
+  it("defaults to 50 and clamps persisted values", () => {
+    expect(readDatabaseTabLimit(engine)).toBe(DEFAULT_DATABASE_TAB_LIMIT);
+
+    writeDatabaseTabLimit(engine, MAX_DATABASE_TAB_LIMIT + 50);
+
+    expect(localStorage.getItem(currentKey)).toBe(String(MAX_DATABASE_TAB_LIMIT));
+    expect(readDatabaseTabLimit(engine)).toBe(MAX_DATABASE_TAB_LIMIT);
+  });
+
+  it("migrates the legacy result sheet limit to the shared tab limit", () => {
+    localStorage.setItem(legacyKey, "12");
+
+    expect(readDatabaseTabLimit(engine)).toBe(12);
+    expect(localStorage.getItem(currentKey)).toBe("12");
+  });
+
+  it("preserves the legacy one-time correction for the former accidental minimum", () => {
+    localStorage.setItem(legacyKey, "1");
+
+    expect(readDatabaseTabLimit(engine)).toBe(DEFAULT_DATABASE_TAB_LIMIT);
+    expect(localStorage.getItem(currentKey)).toBe(String(DEFAULT_DATABASE_TAB_LIMIT));
+  });
+});

--- a/src/lib/databaseTabLimit.ts
+++ b/src/lib/databaseTabLimit.ts
@@ -1,0 +1,66 @@
+export const DEFAULT_DATABASE_TAB_LIMIT = 50;
+export const MIN_DATABASE_TAB_LIMIT = 1;
+export const MAX_DATABASE_TAB_LIMIT = 200;
+
+const TAB_LIMIT_SETTING = "tabLimit";
+const LEGACY_RESULT_SHEET_SETTING = "maxResultSheets";
+
+function settingKey(engine: string, name: string): string {
+  return `taomni.db.${engine}.${name}`;
+}
+
+export function clampDatabaseTabLimit(value: number): number {
+  if (!Number.isFinite(value)) return MIN_DATABASE_TAB_LIMIT;
+  return Math.min(
+    MAX_DATABASE_TAB_LIMIT,
+    Math.max(MIN_DATABASE_TAB_LIMIT, Math.round(value)),
+  );
+}
+
+function parseStoredLimit(rawValue: string | null): number | null {
+  if (rawValue === null || rawValue.trim() === "") return null;
+  const value = Number(rawValue);
+  return Number.isFinite(value) ? clampDatabaseTabLimit(value) : null;
+}
+
+/**
+ * Load the shared Query/Result tab limit for one database engine.
+ *
+ * `maxResultSheets` was the original setting name. Migrate it lazily so users
+ * keep their existing limit while new code and UI can use the broader name.
+ */
+export function readDatabaseTabLimit(engine: string): number {
+  try {
+    const currentKey = settingKey(engine, TAB_LIMIT_SETTING);
+    const current = parseStoredLimit(localStorage.getItem(currentKey));
+    if (current !== null) return current;
+
+    const legacyKey = settingKey(engine, LEGACY_RESULT_SHEET_SETTING);
+    const legacy = parseStoredLimit(localStorage.getItem(legacyKey));
+    if (legacy === null) return DEFAULT_DATABASE_TAB_LIMIT;
+
+    // Preserve the old one-time default correction: an unmigrated value of 1
+    // represented the former accidental default, not an explicit user choice.
+    const legacyMigrationKey = `${legacyKey}.defaultsFixed.v1`;
+    const legacyWasCorrected = localStorage.getItem(legacyMigrationKey) === "1";
+    localStorage.setItem(legacyMigrationKey, "1");
+    const migrated = !legacyWasCorrected && legacy === MIN_DATABASE_TAB_LIMIT
+      ? DEFAULT_DATABASE_TAB_LIMIT
+      : legacy;
+    localStorage.setItem(currentKey, String(migrated));
+    return migrated;
+  } catch {
+    return DEFAULT_DATABASE_TAB_LIMIT;
+  }
+}
+
+export function writeDatabaseTabLimit(engine: string, value: number): void {
+  try {
+    localStorage.setItem(
+      settingKey(engine, TAB_LIMIT_SETTING),
+      String(clampDatabaseTabLimit(value)),
+    );
+  } catch {
+    /* ignore unavailable/quota-limited storage */
+  }
+}


### PR DESCRIPTION
Replace the hard-coded four-query-panel cap with a shared per-engine tab limit. The existing result sheet preference now governs both query tabs per session and result tabs per query, with the default remaining 50 and the supported range remaining 1-200.

Introduce a shared databaseTabLimit preference helper and lazily migrate existing maxResultSheets values to the broader tabLimit key. Preserve the previous one-time default correction so existing user preferences continue to behave consistently.

Apply the limit across workspace restoration, direct panel creation, generated SQL, history and saved-query entry points for every SQL database engine handled by DbClientTab. Add the same configurable behavior to HBase query panels and result retention.

Rename the toolbar control to Tab limit, add focused SQL/HBase and preference migration tests, and update the qa-ui-auto feature controls and generated testid catalog.

Verified with focused Vitest suites, pnpm build, and clean F-DB-1/F-DB-3 qa-ui-auto audits.