### PR TITLE
feat(sockscap): prompt sudo elevation for Linux transparent capture

### DIFF
--- a/src-tauri/src/sockscap/capture/linux/mod.rs
+++ b/src-tauri/src/sockscap/capture/linux/mod.rs
@@ -25,6 +25,13 @@ use zeroize::Zeroizing;
 use crate::sockscap::config::{AppLaunchPreparation, AppSelector, ScopeMode, SocksCapConfig};
 use crate::sockscap::relay::RelayContext;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum TransparentCapability {
+    Available,
+    ElevationRequired,
+    Unavailable(String),
+}
+
 /// A running Linux capture session. Dropping it is intentionally inert: callers
 /// must call [`Self::stop`] so failures are visible and recovery can be offered.
 pub struct TransparentCaptureHandle {
@@ -87,6 +94,47 @@ pub struct LinuxCaptureImpl;
 /// not create cgroups or mutate nftables state.
 pub fn transparent_preflight() -> Result<(), String> {
     LinuxCaptureImpl.preflight(None)
+}
+
+/// Classify the read-only transparent-capture probe for UI/backend selection.
+/// A normal desktop user cannot list nftables tables until sudo authenticates;
+/// that is an elevation requirement, not evidence that the backend is absent.
+pub(super) fn transparent_capability() -> TransparentCapability {
+    classify_transparent_preflight(
+        transparent_preflight(),
+        crate::sockscap::elevate::is_effective_root(),
+        is_containerized(),
+        sudo_available(),
+    )
+}
+
+fn classify_transparent_preflight(
+    preflight: Result<(), String>,
+    effective_root: bool,
+    containerized: bool,
+    sudo_available: bool,
+) -> TransparentCapability {
+    match preflight {
+        Ok(()) => TransparentCapability::Available,
+        Err(error)
+            if !effective_root
+                && !containerized
+                && sudo_available
+                && error.to_ascii_lowercase().contains("cap_net_admin") =>
+        {
+            TransparentCapability::ElevationRequired
+        }
+        Err(error) => TransparentCapability::Unavailable(error),
+    }
+}
+
+fn sudo_available() -> bool {
+    ["/usr/bin/sudo", "/bin/sudo"]
+        .iter()
+        .any(|path| std::path::Path::new(path).is_file())
+        || std::env::var_os("PATH").is_some_and(|path| {
+            std::env::split_paths(&path).any(|directory| directory.join("sudo").is_file())
+        })
 }
 
 /// Container detection is explanatory only; backend selection is driven by
@@ -529,6 +577,48 @@ fn capture_scope(config: &SocksCapConfig) -> Result<CaptureScope, String> {
 mod tests {
     use super::*;
     use crate::sockscap::config::SocksCapConfig;
+
+    #[test]
+    fn nft_permission_failure_requests_elevation_for_a_desktop_user() {
+        let capability = classify_transparent_preflight(
+            Err("nftables is present but unavailable: Operation not permitted. Linux capture requires CAP_NET_ADMIN".into()),
+            false,
+            false,
+            true,
+        );
+
+        assert_eq!(capability, TransparentCapability::ElevationRequired);
+    }
+
+    #[test]
+    fn nft_permission_failure_stays_unavailable_when_elevation_cannot_help() {
+        for (effective_root, containerized, sudo_available) in [
+            (true, false, true),
+            (false, true, true),
+            (false, false, false),
+        ] {
+            let capability = classify_transparent_preflight(
+                Err("Linux capture requires CAP_NET_ADMIN".into()),
+                effective_root,
+                containerized,
+                sudo_available,
+            );
+
+            assert!(matches!(capability, TransparentCapability::Unavailable(_)));
+        }
+    }
+
+    #[test]
+    fn non_permission_preflight_failure_stays_unavailable() {
+        let capability = classify_transparent_preflight(
+            Err("nftables is required for Linux SocksCap; install the nft package".into()),
+            false,
+            false,
+            true,
+        );
+
+        assert!(matches!(capability, TransparentCapability::Unavailable(_)));
+    }
 
     #[test]
     fn default_config_uses_global_capture() {

--- a/src-tauri/src/sockscap/capture/mod.rs
+++ b/src-tauri/src/sockscap/capture/mod.rs
@@ -35,8 +35,13 @@ pub fn capabilities() -> SocksCapCapabilities {
     }
     #[cfg(target_os = "linux")]
     {
-        let transparent = linux::transparent_preflight();
-        let transparent_available = transparent.is_ok();
+        let transparent = linux::transparent_capability();
+        let transparent_available =
+            !matches!(&transparent, linux::TransparentCapability::Unavailable(_));
+        let privileged_required = matches!(
+            &transparent,
+            linux::TransparentCapability::ElevationRequired
+        );
         let launched = if transparent_available {
             Ok(())
         } else {
@@ -55,24 +60,31 @@ pub fn capabilities() -> SocksCapCapabilities {
                 "unavailable".into()
             },
             notes: if transparent_available {
-                vec!["Linux nftables and cgroup transparent capture is available without additional elevation.".into()]
+                vec![if privileged_required {
+                    "Linux nftables and cgroup transparent capture is available after sudo authentication.".into()
+                } else {
+                    "Linux nftables and cgroup transparent capture is available without additional elevation.".into()
+                }]
             } else if launched_application_available {
                 vec!["Linux transparent capture is unavailable. Launch selected applications from SocksCap to capture their TCP process tree without sudo or proxy environment variables.".into()]
             } else {
                 vec!["The current Linux container or kernel does not allow unprivileged application capture.".into()]
             },
-            // Linux only requests elevation when the caller explicitly chooses
-            // the existing nftables/cgroup backend.
-            privileged_required: false,
+            privileged_required,
             linux: Some(crate::sockscap::LinuxCaptureCapabilities {
                 transparent_available,
                 launched_application_available,
                 launch_only: !transparent_available,
                 containerized: linux::is_containerized(),
-                transparent_unavailable_reason: if launched_application_available {
-                    transparent.err()
-                } else {
-                    launched.err()
+                transparent_unavailable_reason: match transparent {
+                    linux::TransparentCapability::Unavailable(error)
+                        if launched_application_available =>
+                    {
+                        Some(error)
+                    }
+                    linux::TransparentCapability::Unavailable(_) => launched.err(),
+                    linux::TransparentCapability::Available
+                    | linux::TransparentCapability::ElevationRequired => None,
                 },
             }),
         }

--- a/src-tauri/src/sockscap/mod.rs
+++ b/src-tauri/src/sockscap/mod.rs
@@ -1127,6 +1127,7 @@ async fn start_linux_capture(
         let backend = LinuxCaptureImpl;
         match backend.start(cfg, Arc::clone(&ctx), None).await {
             Ok(capture) => LinuxCaptureHandle::Transparent(capture),
+            Err(error) if caps.privileged_required => return Err(error),
             Err(error) => {
                 tracing::warn!(
                     "Linux transparent capture became unavailable after preflight; falling back to launch-only capture: {error}"

--- a/src/components/sockscap/SocksCapPanel.test.tsx
+++ b/src/components/sockscap/SocksCapPanel.test.tsx
@@ -66,6 +66,7 @@ const defaultTestCfg: SocksCapConfig = {
 
 let currentCfg = { ...defaultTestCfg };
 let currentPlatform = "windows";
+let linuxTransparentRequiresElevation = false;
 
 vi.mock("../../lib/sockscap", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../lib/sockscap")>();
@@ -77,7 +78,23 @@ vi.mock("../../lib/sockscap", async (importOriginal) => {
     }),
     sockscapCapabilities: vi.fn(async () =>
       currentPlatform === "linux"
-        ? {
+        ? linuxTransparentRequiresElevation
+          ? {
+              platform: "linux",
+              globalTcp: true,
+              appFilter: true,
+              captureBackend: "nft-cgroup-redirect",
+              notes: ["Transparent capture is available after sudo authentication."],
+              privilegedRequired: true,
+              linux: {
+                transparentAvailable: true,
+                launchedApplicationAvailable: true,
+                launchOnly: false,
+                containerized: false,
+                transparentUnavailableReason: null,
+              },
+            }
+          : {
             platform: "linux",
             globalTcp: false,
             appFilter: true,
@@ -193,6 +210,7 @@ describe("SocksCapPanel Multi-Profile UI", () => {
     window.localStorage.removeItem(SOCKSCAP_MACOS_SETUP_STORAGE_KEY);
     currentCfg = JSON.parse(JSON.stringify(defaultTestCfg));
     currentPlatform = "windows";
+    linuxTransparentRequiresElevation = false;
     vi.mocked(sockscapStart).mockReset();
     vi.mocked(sockscapStart).mockResolvedValue({
       phase: "active",
@@ -645,6 +663,31 @@ describe("SocksCapPanel Multi-Profile UI", () => {
 
     expect(vi.mocked(sockscapStart)).not.toHaveBeenCalled();
     expect(screen.queryByTestId("sockscap-root-prompt-dialog")).not.toBeInTheDocument();
+  });
+
+  it("prompts for sudo before starting Linux transparent capture", async () => {
+    currentPlatform = "linux";
+    linuxTransparentRequiresElevation = true;
+    render(<SocksCapPanel />);
+
+    fireEvent.click(await screen.findByTestId("sockscap-start"));
+
+    const prompt = await screen.findByTestId("sockscap-root-prompt-dialog");
+    expect(prompt).toHaveTextContent("Root Authorization Required");
+    expect(vi.mocked(sockscapStart)).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByTestId("sockscap-root-password-input"), {
+      target: { value: "sudo-secret" },
+    });
+    fireEvent.click(screen.getByTestId("sockscap-root-prompt-submit"));
+
+    await waitFor(() => {
+      expect(vi.mocked(sockscapStart)).toHaveBeenCalledOnce();
+      expect(vi.mocked(sockscapStart)).toHaveBeenCalledWith("sudo-secret");
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("sockscap-root-prompt-dialog")).not.toBeInTheDocument();
+    });
   });
 
   it("launches and stops a configured Linux application from the launch-only UI", async () => {

--- a/src/components/sockscap/SocksCapPanel.tsx
+++ b/src/components/sockscap/SocksCapPanel.tsx
@@ -990,6 +990,11 @@ export function SocksCapPanel({ onStatusMessage, onClose }: Props) {
     }
 
     // 3) All probes passed → start.
+    if (needsStartElevation(caps)) {
+      setRootPromptIntent("start");
+      setRootPromptError(null);
+      return false;
+    }
     return onStart(undefined, startConfig);
   };
 


### PR DESCRIPTION
- Classify CAP_NET_ADMIN preflight errors as ElevationRequired on non-root Linux desktops with sudo available
- Expose privileged_required in SocksCapCapabilities so UI reports elevation requirement rather than full backend unavailability
- Trigger root authentication prompt in SocksCapPanel prior to launching Linux transparent capture when elevation is required
- Add Rust unit tests for preflight classification and Vitest UI test for sudo prompt flow