### PR TITLE
feat(rdp): productionize Linux X11 and Wayland paths

### DIFF
--- a/.agents/skills/qa-ui-auto/references/testid-catalog.md
+++ b/.agents/skills/qa-ui-auto/references/testid-catalog.md
@@ -528,11 +528,11 @@
 ## rdp (F9.7)
 
 - `[data-testid="rdp-panel"]` — display — F9.7.panel-root
-- `[data-testid="rdp-floating-toolbar"]` — display — F9.7.toolbar
 - `[data-testid="rdp-status"]` — display — F9.7.status
 - `[data-testid="rdp-canvas"]` — display — F9.7.canvas
 - `[data-testid="rdp-scale-toggle"]` — interactive — F9.7.scale-toggle
 - `[data-testid="rdp-reconnect"]` — interactive — F9.7.reconnect
+- `[data-testid="rdp-chat-toggle"]` — interactive [optional] — F9.7.chat-toggle
 - `[data-testid="rdp-detach"]` — interactive — F9.7.detach
 - `[data-testid="rdp-view-cycle"]` — interactive — F9.7.view-cycle
 

--- a/claudedocs/ironrdp-server-platform-assessment.md
+++ b/claudedocs/ironrdp-server-platform-assessment.md
@@ -54,8 +54,8 @@ Taomni 当前计划已经明确产品不是 Windows RDS 或 TeamViewer 替代品
 | macOS 当前控制台共享 | **核心链路已实现，发布候选** | IronRDP + ScreenCaptureKit + CoreGraphics/Accessibility + VideoToolbox AVC420；`xcap` 捕获回退 | macOS 本机构建和自动化回归已通过；仍需 mstsc、Windows App、macOS 客户端和 FreeRDP 真机矩阵。需要 Screen Recording 与 Accessibility 权限，不覆盖登录窗口和安全桌面 |
 | Windows 当前控制台共享 | **未达标，阻塞启动** | IronRDP 协议和输入代码可复用；仍需 WGC/DXGI 捕获，建议 WGC 优先、DXGI Desktop Duplication 兜底 | 当前捕获器明确返回错误。UAC secure desktop、锁屏和跨会话还需要服务级能力 |
 | Windows 远程登录 / 独立会话 | **不由 Taomni 内嵌服务器提供** | 使用系统 Remote Desktop Service | 通常要求 Pro/Enterprise；语义是远程登录，不等价于与本地用户同时共享控制台 |
-| Linux X11 控制台共享 | **既有实现可用，本轮未改动** | XShm/XDamage 捕获 + `enigo` X11 输入 + bitmap 更新 | 既有路径已有实测记录；本分支尚未在 Linux 重新做回归。依赖当前 X server，会话锁定、多屏/缩放及高分辨率性能仍需矩阵验证 |
-| Linux Wayland 控制台共享 | **条件支持 / 实验性** | 当前为 X11 优先，X11 不可用时走 `xcap` Portal 回退；目标是统一使用 RemoteDesktop/ScreenCast + PipeWire 输入授权 | 带 XWayland 时可能只捕获 X11 内容；Portal、合成器、输入授权和重连语义仍未收口，不能按 X11 同等级发布 |
+| Linux X11 控制台共享 | **代码与自动化门槛已达标** | XShm/XDamage 区域捕获 + XRandR 几何监听 + `enigo`/XTest 输入 + bitmap 更新 | SHM resize 重建、GetImage 降级、resize-before-frame 和边界测试已通过；仍需真机多屏/旋转/缩放、锁屏及高分辨率性能矩阵 |
+| Linux Wayland 控制台共享 | **代码与自动化门槛已达标** | Wayland 会话优先使用同一个 RemoteDesktop Portal 授权屏幕与键鼠，通过持久 PipeWire stream 捕获并通过 Portal 注入输入 | 像素格式/stride/负 stride、坐标映射、流关闭和 mailbox 已覆盖；仍需 GNOME/KDE 真机授权、合成器兼容性、睡眠唤醒和长稳验证 |
 | Linux 无头 / 多用户 / 登录界面 | **不支持** | 委托 xrdp；固定 GNOME 环境可评估 GNOME Remote Desktop remote-login/headless | Taomni 没有 PAM/GDM/session gateway，不应在应用内重建系统会话生命周期 |
 
 ### macOS
@@ -90,7 +90,9 @@ Windows 原生 RDP 更适合“远程登录到系统会话”的场景。微软�
 
 Linux X11 是当前最接近完整链路的路径。XShm/XDamage 适合做区域级脏帧采集，IronRDP 只负责协议和显示更新，职责边界清晰。
 
-建议保留该实现，并补充：
+本轮已增加 XRandR 事件监听和根窗口几何检查。显示尺寸变化时会重建 MIT-SHM 缓冲；重建失败则降级到 GetImage。显示层先发送 `DisplayUpdate::Resize`，下一次更新才发送新尺寸全帧，避免客户端以旧几何解释像素。
+
+仍需补充：
 
 - XRandR 旋转、缩放和多显示器测试。
 - XTest/uinput 输入失败时的明确错误提示。
@@ -99,12 +101,18 @@ Linux X11 是当前最接近完整链路的路径。XShm/XDamage 适合做区域
 
 ### Linux Wayland
 
-当前 Wayland 路径存在策略风险：创建捕获器时先尝试 X11，只有 X11 不可用才走 Portal 回退；[capture/mod.rs](/Users/zhyhang/code/person/taomni/src-tauri/src/servers/rdp/capture/mod.rs)。在带 XWayland 的桌面中，X11 root 通常只代表 X11/XWayland 内容，不能保证覆盖原生 Wayland 窗口。
+Wayland 路径已改为以会话类型为准：检测到 Wayland 时不会被可用的 XWayland `DISPLAY` 覆盖，而是直接创建 RemoteDesktop Portal session。屏幕源、键盘和指针权限共享同一授权上下文，Portal 返回的 PipeWire FD 由持久 stream 消费。
 
-建议：
+本轮已完成：
 
-- 检测到 Wayland 后优先使用 RemoteDesktop/ScreenCast Portal 和 PipeWire。
-- 让屏幕捕获授权和输入注入共享同一个远程桌面授权上下文。
+- latest-frame mailbox，只保留最新 PipeWire 帧，慢编码端不会反压捕获回调。
+- BGRA/RGBA/BGR/RGB、行 padding、正负 stride 和尺寸上限处理。
+- 键盘 keycode/keysym、指针绝对/相对移动、按钮和滚轮 Portal 注入；绝对坐标按 compositor logical size 映射。
+- 服务启动时预热并跨认证复用 Portal/PipeWire session，避免每个客户端重复弹授权框。
+- PipeWire 线程退出时关闭 mailbox 并唤醒显示端，避免连接停在最后一帧。
+
+仍需：
+
 - 对 GNOME 直接评估 GNOME Remote Desktop；它使用 Mutter、PipeWire 和 libei，能覆盖 remote assistance、headless 和 remote-login。
 - 对 KDE 或其他合成器只在经过实机互操作测试后宣布支持。
 
@@ -172,9 +180,12 @@ Taomni 已升级到 `ironrdp 0.17.0`、`ironrdp-tokio 0.10.0`、vendored `ironrd
 | macOS 可控输入与权限边界 | **代码层已达标** | CoreGraphics 鼠标、Accessibility 预检/请求/撤销检测、无权限时保持可查看但停止控制 |
 | macOS VideoToolbox H.264 | **代码层已达标** | AVC420 默认协商、VideoToolbox 异步编码、原生 pixel buffer 生命周期管理；实际硬件/软件编码器选择待增加观测 |
 | 有界背压和自动降级 | **已达标** | 编码在途帧上限为 2；编码硬超时 250 ms；ACK/解码停滞时销毁 EGFX surface 并恢复 bitmap |
-| 自动化回归 | **已达标** | RDP Rust 聚焦测试 54 个通过；前端构建和权限设置测试通过 |
+| Linux X11 动态显示 | **代码层已达标** | XRandR 监听、根窗口几何检测、SHM 重建/GetImage 降级、resize 先于新尺寸全帧 |
+| Linux Wayland 捕获与控制 | **代码层已达标** | Wayland 优先路由、RemoteDesktop Portal 联合授权、持久 PipeWire stream、Portal 输入与流失败收口 |
+| RDP client 慢消费者背压 | **已达标** | session 与 WebSocket 两层均使用有界控制队列和 latest-complete-frame 批次，旧完整帧可被新帧替换 |
+| 自动化回归 | **已达标** | RDP server 43 个测试、RDP client 225 个测试、完整 Rust lib/integration、前端 build/Vitest 均通过 |
 | macOS 生产发布门槛 | **部分达标** | 编译与回归通过；缺真实客户端兼容矩阵、真机长稳和量化性能数据 |
-| Windows/Linux 达到同等原生性能 | **未达标** | Windows 捕获仍缺失；Linux 本轮没有新增硬件编码或 Wayland 授权整合 |
+| Windows/Linux 达到同等原生性能 | **部分达标** | Windows 捕获仍缺失；Linux 捕获与授权链路已完成，但尚无硬件编码和真机量化性能数据 |
 
 ### 性能表现
 
@@ -196,15 +207,18 @@ Taomni 已升级到 `ironrdp 0.17.0`、`ironrdp-tokio 0.10.0`、vendored `ironrd
 
 ### 验证记录
 
-实施提交 `3fd37189` 已通过：
+截至 2026-08-08，本工作区已通过：
 
 - `cargo check --lib`
-- `cargo test --lib servers::rdp:: --quiet`：54 passed
+- `cargo test --lib servers::rdp:: --quiet`：43 passed
+- `cargo test --lib rdp:: --quiet`：218 passed，7 ignored（需要 live RDP fixture）
+- `cargo test --lib`：1165 passed，18 ignored
+- `cargo test --test integration`：57 passed
 - `pnpm build`
-- `pnpm test -- src/components/servers/settings/RdpSettings.test.tsx`：232 files、1984 tests passed
+- `pnpm test`：232 files、1985 tests passed
 - `git diff --check`
 
-这些结果覆盖编译、状态机、捕获 mailbox、resize 顺序、坐标映射、编码背压/超时/停滞判断和权限设置 UI；它们不替代真实 RDP 客户端、真机图像正确性、硬件编码器和长时间会话验证。
+这些结果覆盖编译、状态机、Wayland PipeWire 像素转换和 stream 关闭、X11 resize/边界、捕获 mailbox、resize 顺序、坐标映射、client/WebSocket 慢消费者背压、编码超时/停滞判断和权限设置 UI；它们不替代真实 RDP 客户端、GNOME/KDE 真机图像与输入、硬件编码器和长时间会话验证。
 
 ## 五、替代方案比较
 
@@ -231,7 +245,7 @@ Taomni 已升级到 `ironrdp 0.17.0`、`ironrdp-tokio 0.10.0`、vendored `ironrd
 
 1. 对 macOS 使用 mstsc、Windows App、macOS Microsoft Remote Desktop 和 FreeRDP 完成真实互操作、长稳和性能基准。
 2. 完成 Windows WGC/DXGI 捕获，并加入 GDI fallback。
-3. 对 Wayland 改为 Portal/PipeWire 优先，验证 GNOME 和 KDE 至少各一套实机环境。
+3. 在已完成 Portal/PipeWire 优先实现的基础上，验证 GNOME 和 KDE 至少各一套实机环境。
 4. 为单连接实现显式 `Reject` 或认证后 `Preempt` 策略。
 
 ### P1：提升性能和协议兼容性

--- a/qa-ui-auto-tests/cases/TC-111-rdp-session-scaffold.testcase.yaml
+++ b/qa-ui-auto-tests/cases/TC-111-rdp-session-scaffold.testcase.yaml
@@ -49,7 +49,6 @@ steps:
       timeout_sec: 5
   # The status chip should be present and show "connecting" or "error" (no real server).
   - assert_visible: '[data-testid="rdp-status"]'
-  - assert_visible: '[data-testid="rdp-floating-toolbar"]'
   - click: '[data-testid="rdp-scale-toggle"]'
   - assert_visible: '[data-testid="rdp-view-cycle"]'
   - click: '[data-testid="rdp-view-cycle"]'

--- a/qa-ui-auto-tests/feature-list.md
+++ b/qa-ui-auto-tests/feature-list.md
@@ -2110,7 +2110,7 @@ controls:
 - VNC tab 常驻挂载，切换标签时连接不主动销毁
 - 已修复 VNC 剪贴板与输入延迟、Windows 11 上的 client→server 文本粘贴
 
-### 9.7 RDP client（IronRDP 0.14）🟡
+### 9.7 RDP client（IronRDP 0.17）🟡
 
 <!-- feature
 id: F9.7
@@ -2131,9 +2131,6 @@ controls:
   - id: panel-root
     selector: '[data-testid="rdp-panel"]'
     kind: display
-  - id: toolbar
-    selector: '[data-testid="rdp-floating-toolbar"]'
-    kind: display
   - id: status
     selector: '[data-testid="rdp-status"]'
     kind: display
@@ -2146,6 +2143,10 @@ controls:
   - id: reconnect
     selector: '[data-testid="rdp-reconnect"]'
     kind: interactive
+  - id: chat-toggle
+    selector: '[data-testid="rdp-chat-toggle"]'
+    kind: interactive
+    optional: true
   - id: detach
     selector: '[data-testid="rdp-detach"]'
     kind: interactive
@@ -2154,7 +2155,7 @@ controls:
     kind: interactive       # one button cycles normal → maximized → fullscreen
 -->
 
-- Tauri desktop 模式下通过 IronRDP 0.14 驱动真实 RDP 会话：CredSSP/NLA、active-stage 图像解码、键盘/鼠标/滚轮输入、画布绘制
+- Tauri desktop 模式下通过 IronRDP 0.17 驱动真实 RDP 会话：CredSSP/NLA、active-stage 图像解码、键盘/鼠标/滚轮输入、画布绘制
 - 传输路径支持 direct TCP、HTTP/SOCKS5 proxy，以及 RD Gateway（MS-TSGU）代码路径；RD Gateway 当前无真实环境，只以 unit test + ignored live smoke 作为验收
 - RDP tab 常驻挂载，保存会话和 `rdp://` QuickConnect 均能打开 RDP panel；密码场景复用 `AuthPrompt`
 - resize 优先使用 DisplayControl DVC；服务器不开放该通道时保持同一 WS/control session 并按新桌面尺寸重连

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -321,6 +321,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a3c86f3fd70c0ffa500ed189abfa90b5a52398a45d5dc372fcc38ebeb7a645"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.4",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "zbus",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10241,6 +10258,7 @@ dependencies = [
  "arboard",
  "argon2 0.5.3",
  "ash",
+ "ashpd",
  "async-stream",
  "async-trait",
  "audiopus",
@@ -10304,6 +10322,7 @@ dependencies = [
  "openh264",
  "oracle",
  "pbkdf2",
+ "pipewire",
  "plist",
  "portable-pty",
  "prost",
@@ -11032,6 +11051,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.6.4",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -12987,6 +13007,7 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",
@@ -13218,6 +13239,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 1.0.3",
  "zvariant_derive",
  "zvariant_utils",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -274,9 +274,16 @@ signal-hook = "0.3"
 # X server reports as changed are read back and encoded — see capture/x11.rs).
 # The `damage` feature transitively enables `xfixes`, which provides the
 # `xfixes::Region` type that `damage_subtract` takes.
-x11rb = { version = "0.13", features = ["shm", "damage"] }
-# Wayland fallback when no usable X11/`DISPLAY` is available: xcap uses the
-# xdg-desktop-portal ScreenCast path on pure Wayland sessions.
+x11rb = { version = "0.13", features = ["shm", "damage", "randr"] }
+# Wayland RDP sharing uses one xdg-desktop-portal RemoteDesktop session for
+# both ScreenCast/PipeWire capture and input injection. Keeping the two
+# permissions in one session is required on GNOME/KDE and avoids accidentally
+# capturing or controlling only XWayland surfaces.
+ashpd = { version = "0.12", default-features = false, features = ["tokio"] }
+pipewire = "0.9"
+# The SOCKS/process capture test harness still enumerates X11 windows through
+# xcap. RDP screen sharing does not use this crate on Linux; its Wayland path
+# is the portal/PipeWire backend above.
 xcap = "0.9.6"
 # Linux WebView (webkit2gtk) media stack. The default webkit2gtk settings ship
 # with media-stream / WebRTC disabled, so navigator.mediaDevices.getUserMedia

--- a/src-tauri/src/mail/mod.rs
+++ b/src-tauri/src/mail/mod.rs
@@ -6417,7 +6417,10 @@ iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAA
             &[folder],
             &[message],
             "INBOX",
-            &MailCacheSettings::default(),
+            &MailCacheSettings {
+                header_retention_days: 0,
+                ..MailCacheSettings::default()
+            },
         )
         .unwrap();
 

--- a/src-tauri/src/rdp/rdpdr.rs
+++ b/src-tauri/src/rdp/rdpdr.rs
@@ -32,10 +32,9 @@ use ironrdp::rdpdr::pdu::esc::{ScardCall, ScardIoCtlCode};
 use ironrdp::rdpdr::{Rdpdr as IronRdpdr, RdpdrBackend};
 use ironrdp::svc::SvcMessage;
 use serde_json::json;
-use tokio::sync::mpsc::UnboundedSender;
 
 use crate::rdp::DriveRedirectOpt;
-use crate::rdp::session::SessionOutput;
+use crate::rdp::session::{SessionOutput, SessionOutputSender};
 
 // ── Component / PacketId pairs ──────────────────────────────────────────
 
@@ -307,7 +306,7 @@ pub struct LocalDriveBackend {
     label: String,
     next_file_id: u32,
     handles: HashMap<u32, OpenedHandle>,
-    status_tx: Option<UnboundedSender<SessionOutput>>,
+    status_tx: Option<SessionOutputSender>,
     read_only: bool,
     written_bytes: u64,
 }
@@ -338,7 +337,7 @@ impl LocalDriveBackend {
     pub fn new_with_status(
         root: impl AsRef<Path>,
         label: impl Into<String>,
-        status_tx: Option<UnboundedSender<SessionOutput>>,
+        status_tx: Option<SessionOutputSender>,
     ) -> Result<Self, String> {
         Self::new_with_policy(root, label, status_tx, false)
     }
@@ -346,7 +345,7 @@ impl LocalDriveBackend {
     fn new_with_policy(
         root: impl AsRef<Path>,
         label: impl Into<String>,
-        status_tx: Option<UnboundedSender<SessionOutput>>,
+        status_tx: Option<SessionOutputSender>,
         read_only: bool,
     ) -> Result<Self, String> {
         let root = root.as_ref();
@@ -974,7 +973,7 @@ impl RdpdrBackend for LocalDriveBackend {
 
 pub fn build_drive_channel(
     options: &DriveRedirectOpt,
-    status_tx: Option<UnboundedSender<SessionOutput>>,
+    status_tx: Option<SessionOutputSender>,
 ) -> Result<Option<IronRdpdr>, String> {
     if !options.enabled {
         return Ok(None);
@@ -1541,10 +1540,10 @@ mod tests {
         assert!(build_drive_channel(&options, None).unwrap().is_none());
     }
 
-    #[test]
-    fn local_drive_backend_reports_server_acceptance() {
+    #[tokio::test]
+    async fn local_drive_backend_reports_server_acceptance() {
         let dir = tempfile::tempdir().unwrap();
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (mut handle, tx, _ctrl_rx) = crate::rdp::session::RdpSessionHandle::new();
         let mut backend =
             LocalDriveBackend::new_with_status(dir.path(), "shared", Some(tx)).unwrap();
 
@@ -1555,7 +1554,7 @@ mod tests {
             })
             .unwrap();
 
-        match rx.try_recv().unwrap() {
+        match handle.next_outgoing().await.unwrap() {
             SessionOutput::Text(text) => {
                 assert!(text.contains(r#""stage":"drive-ready""#));
                 assert!(text.contains("accepted by server"));

--- a/src-tauri/src/rdp/session.rs
+++ b/src-tauri/src/rdp/session.rs
@@ -7,10 +7,11 @@
 
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
 use std::fs::{self, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, Once};
+use std::sync::{Arc, Condvar, Mutex, Once};
 
 use image::{ColorType, ImageEncoder};
 use ironrdp::cliprdr::CliprdrClient;
@@ -49,6 +50,7 @@ use ironrdp::session::{ActiveStage, ActiveStageBuilder, ActiveStageOutput};
 use ironrdp::svc::{ChannelFlags, SvcMessage, SvcProcessorMessages};
 use ironrdp_tokio::{Framed, FramedRead, FramedWrite};
 use serde_json::json;
+use tokio::sync::Notify;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use crate::rdp::RdpOptions;
@@ -64,6 +66,148 @@ pub enum SessionOutput {
     Text(String),
 }
 
+const MAX_PENDING_SESSION_STATUS: usize = 256;
+const MAX_FRAME_BATCH_BYTES: usize = 64 * 1024 * 1024;
+
+enum QueuedSessionOutput {
+    Control(SessionOutput),
+    FrameBatch(Vec<Vec<u8>>),
+}
+
+struct SessionOutputState {
+    control: std::collections::VecDeque<SessionOutput>,
+    building_frame: Vec<Vec<u8>>,
+    building_bytes: usize,
+    drop_building_frame: bool,
+    latest_frame: Option<Vec<Vec<u8>>>,
+    closed: bool,
+}
+
+/// Bounded output relay. Display updates are assembled into a complete frame
+/// batch and replaced by the newest batch; status, cursor, audio and clipboard
+/// messages stay in a bounded reliable queue. A producer only blocks when the
+/// reliable queue is full, so a slow browser cannot accumulate unbounded pixel
+/// memory or make frame age grow without limit.
+struct SessionOutputQueue {
+    state: Mutex<SessionOutputState>,
+    wake: Notify,
+    space: Condvar,
+}
+
+#[derive(Clone)]
+pub struct SessionOutputSender(Arc<SessionOutputQueue>);
+
+impl fmt::Debug for SessionOutputSender {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SessionOutputSender(..)")
+    }
+}
+
+impl SessionOutputQueue {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(SessionOutputState {
+                control: std::collections::VecDeque::new(),
+                building_frame: Vec::new(),
+                building_bytes: 0,
+                drop_building_frame: false,
+                latest_frame: None,
+                closed: false,
+            }),
+            wake: Notify::new(),
+            space: Condvar::new(),
+        })
+    }
+
+    fn send(&self, output: SessionOutput) -> Result<(), String> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "rdp output queue poisoned".to_string())?;
+        match output {
+            SessionOutput::Channel { tag, payload } if tag == channel::FRAME => {
+                if !state.drop_building_frame {
+                    let next_bytes = state.building_bytes.saturating_add(payload.len());
+                    if next_bytes <= MAX_FRAME_BATCH_BYTES {
+                        state.building_bytes = next_bytes;
+                        state.building_frame.push(payload);
+                    } else {
+                        state.drop_building_frame = true;
+                        state.building_frame.clear();
+                    }
+                }
+                return Ok(());
+            }
+            SessionOutput::Channel { tag, .. } if tag == channel::FRAME_END => {
+                if !state.drop_building_frame && !state.building_frame.is_empty() {
+                    let batch = std::mem::take(&mut state.building_frame);
+                    state.latest_frame = Some(batch);
+                } else {
+                    state.building_frame.clear();
+                }
+                state.building_bytes = 0;
+                state.drop_building_frame = false;
+                self.wake.notify_one();
+                return Ok(());
+            }
+            other => {
+                while state.control.len() >= MAX_PENDING_SESSION_STATUS && !state.closed {
+                    state = self
+                        .space
+                        .wait(state)
+                        .map_err(|_| "rdp output queue poisoned".to_string())?;
+                }
+                if state.closed {
+                    return Err("rdp output queue closed".to_string());
+                }
+                state.control.push_back(other);
+                self.wake.notify_one();
+            }
+        }
+        Ok(())
+    }
+
+    async fn recv(&self) -> Option<QueuedSessionOutput> {
+        loop {
+            let notified = self.wake.notified();
+            {
+                let Ok(mut state) = self.state.lock() else {
+                    return None;
+                };
+                if let Some(output) = state.control.pop_front() {
+                    self.space.notify_one();
+                    return Some(QueuedSessionOutput::Control(output));
+                }
+                if let Some(frame) = state.latest_frame.take() {
+                    self.space.notify_one();
+                    return Some(QueuedSessionOutput::FrameBatch(frame));
+                }
+                if state.closed {
+                    return None;
+                }
+            }
+            notified.await;
+        }
+    }
+
+    fn close(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.closed = true;
+            state.control.clear();
+            state.latest_frame = None;
+            state.building_frame.clear();
+        }
+        self.space.notify_all();
+        self.wake.notify_waiters();
+    }
+}
+
+impl SessionOutputSender {
+    pub fn send(&self, output: SessionOutput) -> Result<(), String> {
+        self.0.send(output)
+    }
+}
+
 enum ActiveOutputFlow {
     Continue,
     Terminate,
@@ -71,8 +215,8 @@ enum ActiveOutputFlow {
 }
 
 pub struct RdpSessionHandle {
-    /// Receives outgoing frames produced by the session worker.
-    out_rx: UnboundedReceiver<SessionOutput>,
+    output: Arc<SessionOutputQueue>,
+    active_frame: VecDeque<SessionOutput>,
     /// Sends control input from the relay into the session worker.
     ctrl_tx: UnboundedSender<RdpControl>,
 }
@@ -134,24 +278,53 @@ const RDP_TLS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 const RDP_AUTHENTICATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
 
 impl RdpSessionHandle {
-    pub fn new() -> (
-        Self,
-        UnboundedSender<SessionOutput>,
-        UnboundedReceiver<RdpControl>,
-    ) {
-        let (out_tx, out_rx) = mpsc::unbounded_channel();
+    pub fn new() -> (Self, SessionOutputSender, UnboundedReceiver<RdpControl>) {
+        let output = SessionOutputQueue::new();
         let (ctrl_tx, ctrl_rx) = mpsc::unbounded_channel();
-        (Self { out_rx, ctrl_tx }, out_tx, ctrl_rx)
+        (
+            Self {
+                output: output.clone(),
+                active_frame: VecDeque::new(),
+                ctrl_tx,
+            },
+            SessionOutputSender(output),
+            ctrl_rx,
+        )
     }
 
     pub async fn next_outgoing(&mut self) -> Option<SessionOutput> {
-        self.out_rx.recv().await
+        if let Some(output) = self.active_frame.pop_front() {
+            return Some(output);
+        }
+        match self.output.recv().await? {
+            QueuedSessionOutput::Control(output) => Some(output),
+            QueuedSessionOutput::FrameBatch(batch) => {
+                self.active_frame = batch
+                    .into_iter()
+                    .map(|payload| SessionOutput::Channel {
+                        tag: channel::FRAME,
+                        payload,
+                    })
+                    .collect();
+                self.active_frame.push_back(SessionOutput::Channel {
+                    tag: channel::FRAME_END,
+                    payload: Vec::new(),
+                });
+                self.active_frame.pop_front()
+            }
+        }
     }
 
     pub async fn dispatch_control(&self, ctrl: RdpControl) -> Result<(), String> {
         self.ctrl_tx
             .send(ctrl)
             .map_err(|_| "rdp session: ctrl channel closed".to_string())
+    }
+}
+
+impl Drop for RdpSessionHandle {
+    fn drop(&mut self) {
+        self.output.close();
     }
 }
 
@@ -203,7 +376,7 @@ pub async fn test_ironrdp_connection(
 #[derive(Clone)]
 struct ClipboardBridge {
     state: Arc<Mutex<ClipboardBridgeState>>,
-    out_tx: UnboundedSender<SessionOutput>,
+    out_tx: SessionOutputSender,
 }
 
 struct ClipboardBridgeState {
@@ -280,12 +453,12 @@ struct TaomniCliprdrBackend {
 }
 
 struct RdpsndWsBackend {
-    out_tx: UnboundedSender<SessionOutput>,
+    out_tx: SessionOutputSender,
     formats: Vec<IronAudioFormat>,
 }
 
 impl ClipboardBridge {
-    fn new(out_tx: UnboundedSender<SessionOutput>) -> Self {
+    fn new(out_tx: SessionOutputSender) -> Self {
         cleanup_stale_clipboard_staging();
         Self {
             state: Arc::new(Mutex::new(ClipboardBridgeState {
@@ -602,7 +775,7 @@ impl ClipboardBridge {
 }
 
 impl RdpsndWsBackend {
-    fn new(out_tx: UnboundedSender<SessionOutput>) -> Self {
+    fn new(out_tx: SessionOutputSender) -> Self {
         Self {
             out_tx,
             formats: vec![IronAudioFormat {
@@ -799,7 +972,7 @@ impl RdpsndClientHandler for RdpsndWsBackend {
 
 async fn drive_ironrdp_session(
     cfg: RdpSessionConfig,
-    out_tx: UnboundedSender<SessionOutput>,
+    out_tx: SessionOutputSender,
     mut ctrl_rx: UnboundedReceiver<RdpControl>,
 ) -> Result<(), String> {
     install_rustls_crypto_provider();
@@ -870,7 +1043,7 @@ async fn drive_ironrdp_session(
 async fn drive_ironrdp_connection(
     cfg: &RdpConnectionSettings,
     transport: RdpSessionTransport,
-    out_tx: UnboundedSender<SessionOutput>,
+    out_tx: SessionOutputSender,
     ctrl_rx: &mut UnboundedReceiver<RdpControl>,
 ) -> Result<SessionRunOutcome, String> {
     send_status(
@@ -1130,7 +1303,7 @@ async fn handle_control<S>(
     input_db: &mut InputDatabase,
     last_buttons: &mut u8,
     framed: &mut Framed<S>,
-    out_tx: &UnboundedSender<SessionOutput>,
+    out_tx: &SessionOutputSender,
     clipboard: Option<&ClipboardBridge>,
     activation_factory: &ConnectionActivationFactory,
     reactivation: &mut Option<ConnectionActivationSequence>,
@@ -1330,7 +1503,7 @@ async fn request_full_refresh<S>(
     active_stage: &mut ActiveStage,
     image: &IronDecodedImage,
     framed: &mut Framed<S>,
-    out_tx: &UnboundedSender<SessionOutput>,
+    out_tx: &SessionOutputSender,
 ) -> Result<(), String>
 where
     S: FramedWrite,
@@ -1370,7 +1543,7 @@ async fn drain_clipboard_actions<S>(
     active_stage: &mut ActiveStage,
     clipboard: &ClipboardBridge,
     framed: &mut Framed<S>,
-    out_tx: &UnboundedSender<SessionOutput>,
+    out_tx: &SessionOutputSender,
 ) -> Result<(), String>
 where
     S: FramedWrite,
@@ -1464,7 +1637,7 @@ async fn advertise_clipboard_formats<S>(
     active_stage: &mut ActiveStage,
     formats: Vec<ClipboardFormat>,
     framed: &mut Framed<S>,
-    out_tx: &UnboundedSender<SessionOutput>,
+    out_tx: &SessionOutputSender,
     stage: &str,
 ) -> Result<(), String>
 where
@@ -1516,11 +1689,12 @@ async fn handle_active_outputs<S>(
     framed: &mut Framed<S>,
     image: &IronDecodedImage,
     outputs: Vec<ActiveStageOutput>,
-    out_tx: &UnboundedSender<SessionOutput>,
+    out_tx: &SessionOutputSender,
 ) -> Result<ActiveOutputFlow, String>
 where
     S: FramedWrite,
 {
+    let mut sent_frame = false;
     for out in outputs {
         match out {
             ActiveStageOutput::ResponseFrame(frame) => {
@@ -1539,6 +1713,7 @@ where
                         tag: channel::FRAME,
                         payload,
                     });
+                    sent_frame = true;
                 }
             }
             ActiveStageOutput::PointerDefault => {
@@ -1585,6 +1760,12 @@ where
             }
         }
     }
+    if sent_frame {
+        let _ = out_tx.send(SessionOutput::Channel {
+            tag: channel::FRAME_END,
+            payload: Vec::new(),
+        });
+    }
     Ok(ActiveOutputFlow::Continue)
 }
 
@@ -1594,7 +1775,7 @@ async fn process_reactivation_frame<S>(
     active_stage: &mut ActiveStage,
     image: &mut IronDecodedImage,
     framed: &mut Framed<S>,
-    out_tx: &UnboundedSender<SessionOutput>,
+    out_tx: &SessionOutputSender,
     protocol: &str,
     server_name: &str,
 ) -> Result<bool, String>
@@ -2309,7 +2490,7 @@ fn build_ironrdp_config(cfg: &RdpConnectionSettings) -> connector::Config {
     }
 }
 
-fn send_cursor_payload(out_tx: &UnboundedSender<SessionOutput>, payload: Vec<u8>) {
+fn send_cursor_payload(out_tx: &SessionOutputSender, payload: Vec<u8>) {
     let _ = out_tx.send(SessionOutput::Channel {
         tag: channel::CURSOR,
         payload,
@@ -2406,7 +2587,7 @@ fn platform_type() -> MajorPlatformType {
 }
 
 fn send_connected_event(
-    out_tx: &UnboundedSender<SessionOutput>,
+    out_tx: &SessionOutputSender,
     width: u16,
     height: u16,
     protocol: &str,
@@ -2432,7 +2613,7 @@ fn install_rustls_crypto_provider() {
     });
 }
 
-fn send_status(out_tx: &UnboundedSender<SessionOutput>, stage: &str, detail: &str) {
+fn send_status(out_tx: &SessionOutputSender, stage: &str, detail: &str) {
     send_text(
         out_tx,
         json!({
@@ -2444,7 +2625,7 @@ fn send_status(out_tx: &UnboundedSender<SessionOutput>, stage: &str, detail: &st
     );
 }
 
-fn send_error(out_tx: &UnboundedSender<SessionOutput>, code: &str, message: &str) {
+fn send_error(out_tx: &SessionOutputSender, code: &str, message: &str) {
     let retryable = is_retryable_rdp_error(message);
     send_text(
         out_tx,
@@ -2467,7 +2648,7 @@ fn is_retryable_rdp_error(message: &str) -> bool {
         || lower.contains("broken pipe")
 }
 
-fn send_text(out_tx: &UnboundedSender<SessionOutput>, text: String) {
+fn send_text(out_tx: &SessionOutputSender, text: String) {
     let _ = out_tx.send(SessionOutput::Text(text));
 }
 
@@ -2503,6 +2684,32 @@ mod tests {
             }
             SessionOutput::Text(_) => panic!("expected channel output"),
         }
+    }
+
+    #[tokio::test]
+    async fn slow_output_consumer_gets_only_the_latest_frame_batch() {
+        let (mut handle, out_tx, _ctrl_rx) = RdpSessionHandle::new();
+        for value in [1_u8, 2_u8] {
+            let _ = out_tx.send(SessionOutput::Channel {
+                tag: channel::FRAME,
+                payload: vec![value],
+            });
+            let _ = out_tx.send(SessionOutput::Channel {
+                tag: channel::FRAME_END,
+                payload: Vec::new(),
+            });
+        }
+        assert!(matches!(
+            handle.next_outgoing().await,
+            Some(SessionOutput::Channel { tag: channel::FRAME, payload }) if payload == vec![2]
+        ));
+        assert!(matches!(
+            handle.next_outgoing().await,
+            Some(SessionOutput::Channel {
+                tag: channel::FRAME_END,
+                ..
+            })
+        ));
     }
 
     #[tokio::test]

--- a/src-tauri/src/rdp/ws.rs
+++ b/src-tauri/src/rdp/ws.rs
@@ -25,12 +25,15 @@
 //!    which owns X.224 negotiation, TLS, CredSSP/NLA, active-stage display
 //!    decoding, and input encoding.
 
+use std::collections::VecDeque;
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
 
 use futures::{SinkExt, StreamExt};
 use serde::Deserialize;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::Notify;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio_util::sync::CancellationToken;
 use tungstenite::Message;
@@ -114,6 +117,171 @@ pub enum WsOutgoing {
     Text(String),
 }
 
+const MAX_PENDING_WS_STATUS: usize = 256;
+const MAX_WS_FRAME_BATCH_BYTES: usize = 64 * 1024 * 1024;
+
+enum QueuedWsOutgoing {
+    Control(WsOutgoing),
+    FrameBatch(Vec<Vec<u8>>),
+}
+
+struct WsOutgoingState {
+    control: VecDeque<WsOutgoing>,
+    building_frame: Vec<Vec<u8>>,
+    building_bytes: usize,
+    drop_building_frame: bool,
+    latest_frame: Option<Vec<Vec<u8>>>,
+    closed: bool,
+}
+
+struct WsOutgoingQueue {
+    state: Mutex<WsOutgoingState>,
+    wake: Notify,
+    space: Condvar,
+}
+
+#[derive(Clone)]
+struct WsOutgoingSender(Arc<WsOutgoingQueue>);
+
+struct WsOutgoingReceiver {
+    queue: Arc<WsOutgoingQueue>,
+    active_frame: VecDeque<WsOutgoing>,
+}
+
+impl WsOutgoingQueue {
+    fn new() -> (WsOutgoingSender, WsOutgoingReceiver) {
+        let queue = Arc::new(Self {
+            state: Mutex::new(WsOutgoingState {
+                control: VecDeque::new(),
+                building_frame: Vec::new(),
+                building_bytes: 0,
+                drop_building_frame: false,
+                latest_frame: None,
+                closed: false,
+            }),
+            wake: Notify::new(),
+            space: Condvar::new(),
+        });
+        (
+            WsOutgoingSender(queue.clone()),
+            WsOutgoingReceiver {
+                queue,
+                active_frame: VecDeque::new(),
+            },
+        )
+    }
+
+    fn send(&self, output: WsOutgoing) -> Result<(), String> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "RDP WebSocket output queue poisoned".to_string())?;
+        match output {
+            WsOutgoing::Frame(bytes) if bytes.first() == Some(&channel::FRAME) => {
+                if !state.drop_building_frame {
+                    let next_bytes = state.building_bytes.saturating_add(bytes.len());
+                    if next_bytes <= MAX_WS_FRAME_BATCH_BYTES {
+                        state.building_bytes = next_bytes;
+                        state.building_frame.push(bytes);
+                    } else {
+                        state.drop_building_frame = true;
+                        state.building_frame.clear();
+                    }
+                }
+                Ok(())
+            }
+            WsOutgoing::Frame(bytes) if bytes.first() == Some(&channel::FRAME_END) => {
+                if !state.drop_building_frame && !state.building_frame.is_empty() {
+                    state.latest_frame = Some(std::mem::take(&mut state.building_frame));
+                } else {
+                    state.building_frame.clear();
+                }
+                state.building_bytes = 0;
+                state.drop_building_frame = false;
+                self.wake.notify_one();
+                Ok(())
+            }
+            other => {
+                while state.control.len() >= MAX_PENDING_WS_STATUS && !state.closed {
+                    state = self
+                        .space
+                        .wait(state)
+                        .map_err(|_| "RDP WebSocket output queue poisoned".to_string())?;
+                }
+                if state.closed {
+                    return Err("RDP WebSocket output queue closed".to_string());
+                }
+                state.control.push_back(other);
+                self.wake.notify_one();
+                Ok(())
+            }
+        }
+    }
+
+    async fn recv(&self) -> Option<QueuedWsOutgoing> {
+        loop {
+            let notified = self.wake.notified();
+            {
+                let Ok(mut state) = self.state.lock() else {
+                    return None;
+                };
+                if let Some(output) = state.control.pop_front() {
+                    self.space.notify_one();
+                    return Some(QueuedWsOutgoing::Control(output));
+                }
+                if let Some(frame) = state.latest_frame.take() {
+                    self.space.notify_one();
+                    return Some(QueuedWsOutgoing::FrameBatch(frame));
+                }
+                if state.closed {
+                    return None;
+                }
+            }
+            notified.await;
+        }
+    }
+
+    fn close(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.closed = true;
+            state.control.clear();
+            state.latest_frame = None;
+            state.building_frame.clear();
+        }
+        self.space.notify_all();
+        self.wake.notify_waiters();
+    }
+}
+
+impl WsOutgoingSender {
+    fn send(&self, output: WsOutgoing) -> Result<(), String> {
+        self.0.send(output)
+    }
+}
+
+impl WsOutgoingReceiver {
+    async fn recv(&mut self) -> Option<WsOutgoing> {
+        if let Some(output) = self.active_frame.pop_front() {
+            return Some(output);
+        }
+        match self.queue.recv().await? {
+            QueuedWsOutgoing::Control(output) => Some(output),
+            QueuedWsOutgoing::FrameBatch(batch) => {
+                self.active_frame = batch.into_iter().map(WsOutgoing::Frame).collect();
+                self.active_frame
+                    .push_back(WsOutgoing::Frame(vec![channel::FRAME_END]));
+                self.active_frame.pop_front()
+            }
+        }
+    }
+}
+
+impl Drop for WsOutgoingReceiver {
+    fn drop(&mut self) {
+        self.queue.close();
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
 enum WsIncomingText {
@@ -179,7 +347,7 @@ pub async fn spawn_rdp_relay(cfg: RdpSpawnConfig) -> Result<RdpSession, String> 
         .port();
 
     let (control_tx, control_rx) = mpsc::unbounded_channel::<RdpControl>();
-    let (ws_out_tx, ws_out_rx) = mpsc::unbounded_channel::<WsOutgoing>();
+    let (ws_out_tx, ws_out_rx) = WsOutgoingQueue::new();
 
     // 3. Hand off to IronRDP: connector, TLS, CredSSP, active-stage display
     //    decoding, and input all run behind this handle.
@@ -231,8 +399,8 @@ pub async fn spawn_rdp_relay(cfg: RdpSpawnConfig) -> Result<RdpSession, String> 
 async fn run_relay(
     listener: TcpListener,
     mut session: RdpSessionHandle,
-    ws_out_tx: UnboundedSender<WsOutgoing>,
-    mut ws_out_rx: UnboundedReceiver<WsOutgoing>,
+    ws_out_tx: WsOutgoingSender,
+    mut ws_out_rx: WsOutgoingReceiver,
     _control_tx: UnboundedSender<RdpControl>,
     mut control_rx: UnboundedReceiver<RdpControl>,
     cancel: CancellationToken,
@@ -551,6 +719,23 @@ mod tests {
             }
             _ => panic!(),
         }
+    }
+
+    #[tokio::test]
+    async fn websocket_output_replaces_stale_frame_batches() {
+        let (sender, mut receiver) = WsOutgoingQueue::new();
+        let _ = sender.send(WsOutgoing::Frame(vec![channel::FRAME, 1]));
+        let _ = sender.send(WsOutgoing::Frame(vec![channel::FRAME_END]));
+        let _ = sender.send(WsOutgoing::Frame(vec![channel::FRAME, 2]));
+        let _ = sender.send(WsOutgoing::Frame(vec![channel::FRAME_END]));
+        assert!(matches!(
+            receiver.recv().await,
+            Some(WsOutgoing::Frame(bytes)) if bytes == vec![channel::FRAME, 2]
+        ));
+        assert!(matches!(
+            receiver.recv().await,
+            Some(WsOutgoing::Frame(bytes)) if bytes == vec![channel::FRAME_END]
+        ));
     }
 
     #[test]

--- a/src-tauri/src/servers/rdp.rs
+++ b/src-tauri/src/servers/rdp.rs
@@ -644,6 +644,7 @@ fn build_server(
         log.clone(),
         params.display_id.clone(),
         metrics.clone(),
+        params.view_only,
         #[cfg(target_os = "macos")]
         gfx.clone(),
     )?;
@@ -663,6 +664,8 @@ fn build_server(
         params.view_only,
         control_gate.clone(),
         metrics.clone(),
+        #[cfg(target_os = "linux")]
+        display.portal_input(),
         #[cfg(target_os = "macos")]
         input_mapping,
     );

--- a/src-tauri/src/servers/rdp/capture/mod.rs
+++ b/src-tauri/src/servers/rdp/capture/mod.rs
@@ -29,7 +29,7 @@ use objc2_core_video::{
     CVPixelBufferLockFlags, CVPixelBufferUnlockBaseAddress, kCVReturnSuccess,
 };
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "macos")]
 pub(crate) mod xcap_backend;
 
 #[cfg(target_os = "linux")]
@@ -39,6 +39,17 @@ pub(crate) mod x11;
 
 #[cfg(target_os = "macos")]
 pub(crate) mod mac;
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum PortalInput {
+    Keycode { code: i32, pressed: bool },
+    Keysym { keysym: i32, pressed: bool },
+    Button { button: i32, pressed: bool },
+    MotionAbsolute { x: f64, y: f64 },
+    MotionRelative { dx: f64, dy: f64 },
+    Scroll { horizontal: bool, steps: i32 },
+}
 
 /// One captured frame or sub-region: BGRA8888, `stride` bytes per row,
 /// `height` rows. `x`/`y` are the top-left origin of this region within the
@@ -398,6 +409,19 @@ pub(crate) trait Capturer {
         false
     }
 
+    /// Whether input can be injected through the capture authorization
+    /// context. Wayland's RemoteDesktop portal requires capture and input to
+    /// share one session; X11 and other platforms keep their native input path.
+    #[cfg(target_os = "linux")]
+    fn supports_portal_input(&self) -> bool {
+        false
+    }
+
+    #[cfg(target_os = "linux")]
+    fn inject_portal_input(&mut self, _input: PortalInput) -> anyhow::Result<()> {
+        anyhow::bail!("capture backend does not provide portal input")
+    }
+
     /// Drive one update step and return zero or more BGRA regions to send.
     ///
     /// - `first` is true only for the very first call on a fresh connection; an
@@ -443,14 +467,13 @@ pub(crate) struct CaptureProbe {
 pub(crate) fn capture_capability_summary() -> String {
     #[cfg(target_os = "linux")]
     {
-        if std::env::var_os("DISPLAY").is_some() {
-            return "Linux: X11/XWayland capture available when DISPLAY is set; \
-                    pure Wayland falls back to xcap portal"
+        if wayland::is_wayland_session() {
+            return "Linux Wayland: RemoteDesktop portal + persistent PipeWire capture; \
+                    screen and input permission are requested together"
                 .into();
         }
-        if wayland::is_wayland_session() {
-            return "Linux Wayland: capture via xcap/portal (user must accept ScreenCast prompt)"
-                .into();
+        if std::env::var_os("DISPLAY").is_some() {
+            return "Linux X11: XShm/XDamage capture with XTest input and XRandR monitoring".into();
         }
         return "Linux: no DISPLAY and not a Wayland session — capture unavailable".into();
     }
@@ -474,7 +497,7 @@ pub(crate) fn capture_capability_summary() -> String {
 /// reason. MUST be called on the thread that will own/drive the capturer, since
 /// backends are not `Send`.
 pub(crate) fn create_capturer(log: &LogEmitter) -> anyhow::Result<Box<dyn Capturer>> {
-    create_capturer_for_display(log, None)
+    create_capturer_for_display(log, None, false)
 }
 
 /// Build a capturer for an explicitly selected display. The selector is used
@@ -482,31 +505,23 @@ pub(crate) fn create_capturer(log: &LogEmitter) -> anyhow::Result<Box<dyn Captur
 pub(crate) fn create_capturer_for_display(
     log: &LogEmitter,
     display_id: Option<&str>,
+    request_input: bool,
 ) -> anyhow::Result<Box<dyn Capturer>> {
     #[cfg(target_os = "linux")]
     {
-        // Try X11 first whenever an X server is reachable. This is authoritative:
-        // on a real Xorg session it captures the desktop directly, and on a
-        // Wayland session with XWayland it still captures (XWayland exposes the
-        // root window). Only when X11 is genuinely unreachable do we fall back to
-        // the Wayland/xcap portal path.
-        match x11::X11Capturer::new(log) {
-            Ok(cap) => return Ok(Box::new(cap)),
-            Err(x11_err) => {
-                if wayland::is_wayland_session() {
-                    log.line(format!(
-                        "X11 capturer unavailable ({x11_err}); trying Wayland/xcap portal fallback"
-                    ));
-                    return wayland::try_new(log);
-                }
-                return Err(x11_err);
-            }
+        let _ = display_id;
+        // XWayland's root only contains X11 surfaces. A reachable DISPLAY must
+        // never override the session type, otherwise native Wayland windows are
+        // silently missing from the shared desktop.
+        if wayland::is_wayland_session() {
+            return wayland::try_new(log, request_input);
         }
+        return Ok(Box::new(x11::X11Capturer::new(log)?));
     }
 
     #[cfg(target_os = "windows")]
     {
-        let _ = log;
+        let _ = (log, request_input);
         anyhow::bail!(
             "Windows screen capture (DXGI/WGC) is not implemented yet — RDP server will \
              serve a placeholder frame. Desktop sharing on Windows is deferred in this branch."
@@ -515,12 +530,13 @@ pub(crate) fn create_capturer_for_display(
 
     #[cfg(target_os = "macos")]
     {
+        let _ = request_input;
         mac::try_new(log, display_id)
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
     {
-        let _ = log;
+        let _ = (log, request_input);
         anyhow::bail!("screen capture is not supported on this platform")
     }
 }

--- a/src-tauri/src/servers/rdp/capture/wayland.rs
+++ b/src-tauri/src/servers/rdp/capture/wayland.rs
@@ -1,30 +1,732 @@
-//! Wayland screen capture for the RDP server.
+//! Wayland screen capture and input through one xdg-desktop-portal session.
 //!
-//! When no usable X11 connection exists but the session is Wayland, we fall
-//! back to [`super::xcap_backend::XcapCapturer`], which uses the xdg-desktop-portal
-//! ScreenCast path (user must accept the compositor permission dialog).
-//!
-//! Input injection remains via enigo's Wayland backend (virtual-keyboard /
-//! remote-desktop protocols as supported by the compositor).
+//! A Wayland compositor does not expose the desktop through XWayland. The RDP
+//! server therefore asks the RemoteDesktop portal for a monitor ScreenCast and,
+//! for interactive sessions, keyboard/pointer devices in the same consent
+//! dialog. Frames arrive through a persistent PipeWire stream instead of one
+//! portal screenshot request per frame.
 
-use super::Capturer;
-use super::xcap_backend::XcapCapturer;
+use std::io::Cursor;
+use std::os::fd::OwnedFd;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
+
+use anyhow::{Context as _, bail};
+use ashpd::desktop::remote_desktop::{Axis as PortalAxis, DeviceType, KeyState, RemoteDesktop};
+use ashpd::desktop::screencast::{CursorMode, Screencast, SourceType};
+use ashpd::desktop::{PersistMode, Session};
+use pipewire::channel;
+use pipewire::context::ContextRc;
+use pipewire::keys::{MEDIA_CATEGORY, MEDIA_ROLE, MEDIA_TYPE};
+use pipewire::main_loop::MainLoopRc;
+use pipewire::properties;
+use pipewire::spa::param::format::FormatProperties;
+use pipewire::spa::param::format_utils;
+use pipewire::spa::param::video::{VideoFormat, VideoInfoRaw};
+use pipewire::spa::param::{ParamType, format::MediaSubtype, format::MediaType};
+use pipewire::spa::pod::{self, Pod, serialize::PodSerializer};
+use pipewire::spa::utils::{Direction, Fraction, Rectangle, SpaTypes};
+use pipewire::stream::{StreamFlags, StreamRc};
+
+use super::{Capturer, Frame, PortalInput};
 use crate::servers::engine::LogEmitter;
 
-/// True when the current session is Wayland (so the X11/XShm backend will only
-/// see XWayland surfaces, not the real desktop — unless XWayland root is enough).
+const FRAME_WAIT: Duration = Duration::from_millis(100);
+const INITIAL_FRAME_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_DIMENSION: u32 = 16_384;
+
+/// The environment is authoritative. `DISPLAY` is commonly present in a real
+/// Wayland session because XWayland is running, so it must not affect routing.
 pub(crate) fn is_wayland_session() -> bool {
-    if std::env::var_os("WAYLAND_DISPLAY").is_some() {
-        return true;
-    }
-    matches!(std::env::var("XDG_SESSION_TYPE").as_deref(), Ok("wayland"))
+    std::env::var_os("WAYLAND_DISPLAY").is_some()
+        || std::env::var("XDG_SESSION_TYPE")
+            .is_ok_and(|value| value.eq_ignore_ascii_case("wayland"))
 }
 
-/// Build a Wayland capturer via xcap/portal.
-pub(crate) fn try_new(log: &LogEmitter) -> anyhow::Result<Box<dyn Capturer>> {
+pub(crate) fn try_new(log: &LogEmitter, request_input: bool) -> anyhow::Result<Box<dyn Capturer>> {
     log.line(
-        "Wayland session: starting xcap ScreenCast capture. Accept the portal \
-         permission dialog if prompted; denial will keep the RDP client on a placeholder.",
+        "Wayland session: requesting one RemoteDesktop portal session for persistent \
+         PipeWire capture and optional keyboard/pointer control",
     );
-    Ok(Box::new(XcapCapturer::new(log)?))
+    Ok(Box::new(WaylandCapturer::new(log, request_input)?))
+}
+
+#[derive(Debug)]
+struct RawFrame {
+    width: u32,
+    height: u32,
+    bgra: Vec<u8>,
+}
+
+struct FrameMailbox {
+    frame: Mutex<Option<RawFrame>>,
+    ready: Condvar,
+    closed: AtomicBool,
+}
+
+impl Default for FrameMailbox {
+    fn default() -> Self {
+        Self {
+            frame: Mutex::new(None),
+            ready: Condvar::new(),
+            closed: AtomicBool::new(false),
+        }
+    }
+}
+
+impl FrameMailbox {
+    fn publish(&self, frame: RawFrame) {
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        if let Ok(mut pending) = self.frame.lock() {
+            if self.closed.load(Ordering::Acquire) {
+                return;
+            }
+            *pending = Some(frame);
+            self.ready.notify_one();
+        }
+    }
+
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.ready.notify_all();
+    }
+
+    fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+
+    fn take_timeout(&self, timeout: Duration) -> anyhow::Result<Option<RawFrame>> {
+        let mut pending = self
+            .frame
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Wayland frame mailbox poisoned"))?;
+        if pending.is_none() {
+            let (guard, _) = self
+                .ready
+                .wait_timeout(pending, timeout)
+                .map_err(|_| anyhow::anyhow!("Wayland frame mailbox poisoned"))?;
+            pending = guard;
+        }
+        Ok(pending.take())
+    }
+}
+
+struct PortalContext {
+    runtime: tokio::runtime::Runtime,
+    remote_desktop: RemoteDesktop<'static>,
+    screencast: Screencast<'static>,
+    session: Session<'static, RemoteDesktop<'static>>,
+    stream_node: u32,
+    logical_size: Option<(u32, u32)>,
+    input_enabled: bool,
+}
+
+impl PortalContext {
+    fn new(request_input: bool) -> anyhow::Result<(Self, OwnedFd)> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("create Wayland portal runtime")?;
+
+        let (
+            remote_desktop,
+            screencast,
+            session,
+            stream_node,
+            logical_size,
+            input_enabled,
+            pipewire_fd,
+        ) = runtime.block_on(async move {
+            let remote_desktop = RemoteDesktop::new().await?;
+            let screencast = Screencast::new().await?;
+            let session = remote_desktop.create_session().await?;
+
+            if request_input {
+                remote_desktop
+                    .select_devices(
+                        &session,
+                        DeviceType::Keyboard | DeviceType::Pointer,
+                        None,
+                        PersistMode::DoNot,
+                    )
+                    .await?
+                    .response()?;
+            }
+            screencast
+                .select_sources(
+                    &session,
+                    CursorMode::Embedded,
+                    SourceType::Monitor.into(),
+                    false,
+                    None,
+                    PersistMode::DoNot,
+                )
+                .await?
+                .response()?;
+
+            let response = remote_desktop.start(&session, None).await?.response()?;
+            let stream = response
+                .streams()
+                .and_then(|streams| streams.first())
+                .ok_or_else(|| anyhow::anyhow!("portal did not return a monitor stream"))?;
+            let logical_size = stream.size().and_then(|(width, height)| {
+                u32::try_from(width).ok().zip(u32::try_from(height).ok())
+            });
+            let input_enabled = request_input
+                && response.devices().contains(DeviceType::Keyboard)
+                && response.devices().contains(DeviceType::Pointer);
+            let stream_node = stream.pipe_wire_node_id();
+            let pipewire_fd = screencast.open_pipe_wire_remote(&session).await?;
+            Ok::<_, anyhow::Error>((
+                remote_desktop,
+                screencast,
+                session,
+                stream_node,
+                logical_size,
+                input_enabled,
+                pipewire_fd,
+            ))
+        })?;
+
+        Ok((
+            Self {
+                runtime,
+                remote_desktop,
+                screencast,
+                session,
+                stream_node,
+                logical_size,
+                input_enabled,
+            },
+            pipewire_fd,
+        ))
+    }
+
+    fn inject(&self, input: PortalInput) -> anyhow::Result<()> {
+        if !self.input_enabled {
+            bail!("Wayland portal did not grant keyboard and pointer control");
+        }
+        self.runtime.block_on(async {
+            match input {
+                PortalInput::Keycode { code, pressed } => {
+                    self.remote_desktop
+                        .notify_keyboard_keycode(&self.session, code, key_state(pressed))
+                        .await?
+                }
+                PortalInput::Keysym { keysym, pressed } => {
+                    self.remote_desktop
+                        .notify_keyboard_keysym(&self.session, keysym, key_state(pressed))
+                        .await?
+                }
+                PortalInput::Button { button, pressed } => {
+                    self.remote_desktop
+                        .notify_pointer_button(&self.session, button, key_state(pressed))
+                        .await?
+                }
+                PortalInput::MotionAbsolute { x, y } => {
+                    self.remote_desktop
+                        .notify_pointer_motion_absolute(&self.session, self.stream_node, x, y)
+                        .await?
+                }
+                PortalInput::MotionRelative { dx, dy } => {
+                    self.remote_desktop
+                        .notify_pointer_motion(&self.session, dx, dy)
+                        .await?
+                }
+                PortalInput::Scroll { horizontal, steps } => {
+                    let axis = if horizontal {
+                        PortalAxis::Horizontal
+                    } else {
+                        PortalAxis::Vertical
+                    };
+                    self.remote_desktop
+                        .notify_pointer_axis_discrete(&self.session, axis, steps)
+                        .await?
+                }
+            }
+            Ok::<_, ashpd::Error>(())
+        })?;
+        Ok(())
+    }
+}
+
+impl Drop for PortalContext {
+    fn drop(&mut self) {
+        let _ = self.runtime.block_on(self.session.close());
+        let _ = &self.screencast;
+    }
+}
+
+fn key_state(pressed: bool) -> KeyState {
+    if pressed {
+        KeyState::Pressed
+    } else {
+        KeyState::Released
+    }
+}
+
+pub(crate) struct WaylandCapturer {
+    portal: PortalContext,
+    mailbox: Arc<FrameMailbox>,
+    stop: channel::Sender<()>,
+    width: u16,
+    height: u16,
+    retained: Option<Frame>,
+}
+
+impl WaylandCapturer {
+    fn new(log: &LogEmitter, request_input: bool) -> anyhow::Result<Self> {
+        let (portal, pipewire_fd) = PortalContext::new(request_input).map_err(|error| {
+            anyhow::anyhow!(
+                "Wayland RemoteDesktop portal authorization failed: {error}. \
+                 Approve the monitor and requested input devices in the compositor dialog."
+            )
+        })?;
+        let mailbox = Arc::new(FrameMailbox::default());
+        let stop = spawn_pipewire_capture(
+            pipewire_fd,
+            portal.stream_node,
+            mailbox.clone(),
+            log.clone(),
+        )?;
+        let initial = mailbox
+            .take_timeout(INITIAL_FRAME_TIMEOUT)?
+            .ok_or_else(|| anyhow::anyhow!("PipeWire produced no frame within 10 seconds"))?;
+        let frame = raw_to_frame(initial)?;
+        let width = frame.width;
+        let height = frame.height;
+        log.line(format!(
+            "Wayland capture ready: {}x{} (RemoteDesktop portal, PipeWire, input={})",
+            width,
+            height,
+            if portal.input_enabled {
+                "granted"
+            } else {
+                "disabled"
+            }
+        ));
+        let mut portal = portal;
+        if portal.logical_size.is_none() {
+            portal.logical_size = Some((u32::from(width), u32::from(height)));
+        }
+        Ok(Self {
+            portal,
+            mailbox,
+            stop,
+            width,
+            height,
+            retained: Some(frame),
+        })
+    }
+}
+
+impl Drop for WaylandCapturer {
+    fn drop(&mut self) {
+        let _ = self.stop.send(());
+    }
+}
+
+impl Capturer for WaylandCapturer {
+    fn desktop_size(&self) -> (u16, u16) {
+        (self.width, self.height)
+    }
+
+    fn capture(&mut self) -> anyhow::Result<Frame> {
+        if let Some(frame) = self.retained.take() {
+            return Ok(frame);
+        }
+        loop {
+            if let Some(raw) = self.mailbox.take_timeout(FRAME_WAIT)? {
+                let frame = raw_to_frame(raw)?;
+                self.width = frame.width;
+                self.height = frame.height;
+                return Ok(frame);
+            }
+            if self.mailbox.is_closed() {
+                bail!("Wayland PipeWire capture stream closed");
+            }
+        }
+    }
+
+    fn poll_frame(&mut self) -> anyhow::Result<Option<Frame>> {
+        if let Some(frame) = self.retained.take() {
+            return Ok(Some(frame));
+        }
+        let Some(raw) = self.mailbox.take_timeout(FRAME_WAIT)? else {
+            if self.mailbox.is_closed() {
+                bail!("Wayland PipeWire capture stream closed");
+            }
+            return Ok(None);
+        };
+        let frame = raw_to_frame(raw)?;
+        self.width = frame.width;
+        self.height = frame.height;
+        Ok(Some(frame))
+    }
+
+    fn is_self_paced(&self) -> bool {
+        true
+    }
+
+    fn needs_frame_deduplication(&self) -> bool {
+        false
+    }
+
+    fn supports_portal_input(&self) -> bool {
+        self.portal.input_enabled
+    }
+
+    fn inject_portal_input(&mut self, input: PortalInput) -> anyhow::Result<()> {
+        let input = match input {
+            PortalInput::MotionAbsolute { x, y } => {
+                let (logical_width, logical_height) = self
+                    .portal
+                    .logical_size
+                    .unwrap_or((u32::from(self.width), u32::from(self.height)));
+                PortalInput::MotionAbsolute {
+                    x: map_absolute_coordinate(x, self.width, logical_width),
+                    y: map_absolute_coordinate(y, self.height, logical_height),
+                }
+            }
+            other => other,
+        };
+        self.portal.inject(input)
+    }
+}
+
+fn map_absolute_coordinate(value: f64, surface_extent: u16, logical_extent: u32) -> f64 {
+    if surface_extent <= 1 || logical_extent == 0 {
+        return 0.0;
+    }
+    let max = f64::from(surface_extent - 1);
+    value.clamp(0.0, max) * f64::from(logical_extent) / f64::from(surface_extent)
+}
+
+fn raw_to_frame(raw: RawFrame) -> anyhow::Result<Frame> {
+    let width = u16::try_from(raw.width).context("Wayland stream width exceeds RDP limits")?;
+    let height = u16::try_from(raw.height).context("Wayland stream height exceeds RDP limits")?;
+    let stride = usize::from(width)
+        .checked_mul(4)
+        .context("Wayland frame stride overflow")?;
+    let expected = stride
+        .checked_mul(usize::from(height))
+        .context("Wayland frame size overflow")?;
+    if width == 0 || height == 0 || raw.bgra.len() != expected {
+        bail!(
+            "invalid Wayland frame geometry {}x{} for {} bytes",
+            width,
+            height,
+            raw.bgra.len()
+        );
+    }
+    Ok(Frame::bgra(raw.bgra, 0, 0, width, height, stride))
+}
+
+#[derive(Default)]
+struct ListenerData {
+    format: VideoInfoRaw,
+}
+
+fn spawn_pipewire_capture(
+    remote_fd: OwnedFd,
+    stream_node: u32,
+    mailbox: Arc<FrameMailbox>,
+    log: LogEmitter,
+) -> anyhow::Result<channel::Sender<()>> {
+    let (stop_tx, stop_rx) = channel::channel();
+    let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("rdp-pipewire".to_string())
+        .spawn(move || {
+            let worker_mailbox = mailbox.clone();
+            let result = run_pipewire(remote_fd, stream_node, worker_mailbox, stop_rx, ready_tx);
+            mailbox.close();
+            if let Err(error) = result {
+                log.line(format!("Wayland PipeWire capture stopped: {error}"));
+                tracing::warn!(%error, "Wayland PipeWire capture stopped");
+            }
+        })
+        .context("start PipeWire capture thread")?;
+    ready_rx
+        .recv_timeout(Duration::from_secs(5))
+        .map_err(|_| anyhow::anyhow!("PipeWire capture initialization timed out"))??;
+    Ok(stop_tx)
+}
+
+fn run_pipewire(
+    remote_fd: OwnedFd,
+    stream_node: u32,
+    mailbox: Arc<FrameMailbox>,
+    stop_rx: channel::Receiver<()>,
+    ready_tx: std::sync::mpsc::SyncSender<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
+    pipewire::init();
+    let main_loop = MainLoopRc::new(None).context("create PipeWire main loop")?;
+    let context = ContextRc::new(&main_loop, None).context("create PipeWire context")?;
+    let core = context
+        .connect_fd_rc(remote_fd, None)
+        .context("connect to portal PipeWire remote")?;
+    let stream = StreamRc::new(
+        core,
+        "Taomni RDP Wayland capture",
+        properties::properties! {
+            *MEDIA_TYPE => "Video",
+            *MEDIA_CATEGORY => "Capture",
+            *MEDIA_ROLE => "Screen",
+        },
+    )
+    .context("create PipeWire stream")?;
+
+    let listener = stream
+        .add_local_listener_with_user_data(ListenerData::default())
+        .param_changed(|_, state, id, param| {
+            let Some(param) = param else { return };
+            if id != ParamType::Format.as_raw() {
+                return;
+            }
+            if let Ok((MediaType::Video, MediaSubtype::Raw)) = format_utils::parse_format(param) {
+                if let Err(error) = state.format.parse(param) {
+                    tracing::warn!(?error, "could not parse Wayland PipeWire video format");
+                }
+            }
+        })
+        .process(move |stream, state| {
+            let Some(mut buffer) = stream.dequeue_buffer() else {
+                return;
+            };
+            let Some(data) = buffer.datas_mut().first_mut() else {
+                return;
+            };
+            let chunk = data.chunk();
+            if chunk
+                .flags()
+                .contains(pipewire::spa::buffer::ChunkFlags::CORRUPTED)
+            {
+                return;
+            }
+            let offset = chunk.offset() as usize;
+            let size = chunk.size() as usize;
+            let stride = chunk.stride();
+            let Some(mapped) = data.data() else {
+                tracing::warn!("Wayland PipeWire offered an unmapped DMA buffer");
+                return;
+            };
+            let dimensions = state.format.size();
+            match copy_pipewire_bgra(
+                mapped,
+                offset,
+                size,
+                stride,
+                dimensions.width,
+                dimensions.height,
+                state.format.format(),
+            ) {
+                Ok(frame) => mailbox.publish(frame),
+                Err(error) => tracing::warn!(%error, "discarding invalid PipeWire frame"),
+            }
+        })
+        .register()
+        .context("register PipeWire listener")?;
+
+    let format = pod::object!(
+        SpaTypes::ObjectParamFormat,
+        ParamType::EnumFormat,
+        pod::property!(FormatProperties::MediaType, Id, MediaType::Video),
+        pod::property!(FormatProperties::MediaSubtype, Id, MediaSubtype::Raw),
+        pod::property!(
+            FormatProperties::VideoFormat,
+            Choice,
+            Enum,
+            Id,
+            VideoFormat::BGRx,
+            VideoFormat::BGRA,
+            VideoFormat::RGBx,
+            VideoFormat::RGBA,
+            VideoFormat::BGR,
+            VideoFormat::RGB
+        ),
+        pod::property!(
+            FormatProperties::VideoSize,
+            Choice,
+            Range,
+            Rectangle,
+            Rectangle {
+                width: 1920,
+                height: 1080
+            },
+            Rectangle {
+                width: 1,
+                height: 1
+            },
+            Rectangle {
+                width: MAX_DIMENSION,
+                height: MAX_DIMENSION
+            }
+        ),
+        pod::property!(
+            FormatProperties::VideoFramerate,
+            Choice,
+            Range,
+            Fraction,
+            Fraction { num: 60, denom: 1 },
+            Fraction { num: 0, denom: 1 },
+            Fraction { num: 60, denom: 1 }
+        )
+    );
+    let bytes = PodSerializer::serialize(Cursor::new(Vec::new()), &pod::Value::Object(format))
+        .map_err(|error| anyhow::anyhow!("serialize PipeWire format: {error}"))?
+        .0
+        .into_inner();
+    let mut params =
+        [Pod::from_bytes(&bytes).ok_or_else(|| anyhow::anyhow!("build PipeWire format pod"))?];
+    stream
+        .connect(
+            Direction::Input,
+            Some(stream_node),
+            StreamFlags::AUTOCONNECT | StreamFlags::MAP_BUFFERS,
+            &mut params,
+        )
+        .context("connect PipeWire stream")?;
+
+    let stop_listener = stop_rx.attach(main_loop.loop_(), {
+        let main_loop = main_loop.clone();
+        move |_| main_loop.quit()
+    });
+    let _ = ready_tx.send(Ok(()));
+    main_loop.run();
+    drop(stop_listener);
+    drop(listener);
+    Ok(())
+}
+
+fn copy_pipewire_bgra(
+    mapped: &[u8],
+    offset: usize,
+    chunk_size: usize,
+    stride: i32,
+    width: u32,
+    height: u32,
+    format: VideoFormat,
+) -> anyhow::Result<RawFrame> {
+    if width == 0 || height == 0 || width > MAX_DIMENSION || height > MAX_DIMENSION {
+        bail!("invalid PipeWire dimensions {width}x{height}");
+    }
+    let bytes_per_pixel = if format == VideoFormat::RGB || format == VideoFormat::BGR {
+        3usize
+    } else if matches!(
+        format,
+        VideoFormat::BGRx | VideoFormat::BGRA | VideoFormat::RGBx | VideoFormat::RGBA
+    ) {
+        4usize
+    } else {
+        bail!("unsupported PipeWire pixel format {format:?}");
+    };
+    let row_bytes = usize::try_from(width)
+        .ok()
+        .and_then(|width| width.checked_mul(bytes_per_pixel))
+        .context("PipeWire row size overflow")?;
+    let source_stride = if stride == 0 {
+        row_bytes
+    } else {
+        usize::try_from(stride.unsigned_abs()).context("PipeWire stride overflow")?
+    };
+    if source_stride < row_bytes {
+        bail!("PipeWire stride {source_stride} is smaller than row size {row_bytes}");
+    }
+    let required = source_stride
+        .checked_mul(usize::try_from(height).unwrap())
+        .context("PipeWire frame size overflow")?;
+    let available = chunk_size.min(mapped.len().saturating_sub(offset));
+    if offset > mapped.len() || available < required {
+        bail!("PipeWire buffer has {available} bytes; expected {required}");
+    }
+    let source = &mapped[offset..offset + required];
+    let pixel_count = usize::try_from(width)
+        .unwrap()
+        .checked_mul(usize::try_from(height).unwrap())
+        .context("PipeWire pixel count overflow")?;
+    let mut bgra = Vec::with_capacity(pixel_count * 4);
+    for output_row in 0..usize::try_from(height).unwrap() {
+        let source_row = if stride < 0 {
+            usize::try_from(height).unwrap() - 1 - output_row
+        } else {
+            output_row
+        };
+        let row = &source[source_row * source_stride..source_row * source_stride + row_bytes];
+        for pixel in row.chunks_exact(bytes_per_pixel) {
+            if matches!(
+                format,
+                VideoFormat::BGRx | VideoFormat::BGRA | VideoFormat::BGR
+            ) {
+                bgra.extend_from_slice(&[pixel[0], pixel[1], pixel[2], 0xff]);
+            } else {
+                bgra.extend_from_slice(&[pixel[2], pixel[1], pixel[0], 0xff]);
+            }
+        }
+    }
+    Ok(RawFrame {
+        width,
+        height,
+        bgra,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_detection_prefers_wayland_even_with_xwayland() {
+        assert!(session_is_wayland(Some("wayland-0"), Some("wayland")));
+        assert!(session_is_wayland(None, Some("WAYLAND")));
+        assert!(!session_is_wayland(None, Some("x11")));
+    }
+
+    fn session_is_wayland(wayland_display: Option<&str>, session_type: Option<&str>) -> bool {
+        wayland_display.is_some()
+            || session_type.is_some_and(|value| value.eq_ignore_ascii_case("wayland"))
+    }
+
+    #[test]
+    fn pipewire_bgrx_honors_stride_and_discards_padding() {
+        let source = [
+            1, 2, 3, 0, 4, 5, 6, 0, 99, 99, 99, 99, 7, 8, 9, 0, 10, 11, 12, 0, 88, 88, 88, 88,
+        ];
+        let frame =
+            copy_pipewire_bgra(&source, 0, source.len(), 12, 2, 2, VideoFormat::BGRx).unwrap();
+        assert_eq!(
+            frame.bgra,
+            vec![1, 2, 3, 255, 4, 5, 6, 255, 7, 8, 9, 255, 10, 11, 12, 255,]
+        );
+    }
+
+    #[test]
+    fn pipewire_rgba_swaps_red_and_blue_and_handles_bottom_up() {
+        let source = [1, 2, 3, 4, 5, 6, 7, 8];
+        let frame =
+            copy_pipewire_bgra(&source, 0, source.len(), -4, 1, 2, VideoFormat::RGBA).unwrap();
+        assert_eq!(frame.bgra, vec![7, 6, 5, 255, 3, 2, 1, 255]);
+    }
+
+    #[test]
+    fn pipewire_rejects_truncated_or_oversized_frames() {
+        assert!(copy_pipewire_bgra(&[0; 4], 0, 4, 8, 2, 1, VideoFormat::BGRx).is_err());
+        assert!(copy_pipewire_bgra(&[], 0, 0, 0, MAX_DIMENSION + 1, 1, VideoFormat::BGRx).is_err());
+    }
+
+    #[test]
+    fn mailbox_close_wakes_waiters_and_reports_closed_stream() {
+        let mailbox = FrameMailbox::default();
+        mailbox.close();
+        assert!(mailbox.is_closed());
+        assert!(
+            mailbox
+                .take_timeout(Duration::from_millis(1))
+                .unwrap()
+                .is_none()
+        );
+    }
 }

--- a/src-tauri/src/servers/rdp/capture/x11.rs
+++ b/src-tauri/src/servers/rdp/capture/x11.rs
@@ -38,6 +38,7 @@ use anyhow::{Context as _, bail};
 use x11rb::connection::{Connection, RequestConnection as _};
 use x11rb::protocol::Event;
 use x11rb::protocol::damage::{self, ConnectionExt as _};
+use x11rb::protocol::randr::{self, ConnectionExt as _};
 use x11rb::protocol::shm::{self, ConnectionExt as _};
 use x11rb::protocol::xfixes::{self, ConnectionExt as _};
 use x11rb::protocol::xproto::{self, ConnectionExt as _, ImageFormat};
@@ -119,6 +120,7 @@ pub(crate) struct X11Capturer {
     /// `Some` when event-driven (XDamage) capture is active; `None` falls back
     /// to fixed-interval full-frame polling driven by the display layer.
     damage: Option<DamageState>,
+    randr: bool,
 }
 
 impl X11Capturer {
@@ -182,6 +184,16 @@ impl X11Capturer {
                 None
             }
         };
+        let randr = match Self::try_init_randr(&conn, root) {
+            Ok(()) => {
+                log.line("X11 capture: XRandR geometry monitoring active".to_string());
+                true
+            }
+            Err(error) => {
+                tracing::warn!(%error, "X11 XRandR monitoring unavailable; geometry is checked during capture");
+                false
+            }
+        };
 
         Ok(Self {
             conn,
@@ -191,6 +203,7 @@ impl X11Capturer {
             depth,
             backend,
             damage,
+            randr,
         })
     }
 
@@ -247,6 +260,31 @@ impl X11Capturer {
         })
     }
 
+    fn try_init_randr(conn: &RustConnection, root: xproto::Window) -> anyhow::Result<()> {
+        if conn
+            .extension_information(randr::X11_EXTENSION_NAME)
+            .context("querying RANDR extension")?
+            .is_none()
+        {
+            bail!("X11 server has no RANDR extension");
+        }
+        conn.randr_query_version(1, 5)
+            .context("RANDR query_version")?
+            .reply()
+            .context("RANDR query_version reply")?;
+        conn.randr_select_input(
+            root,
+            randr::NotifyMask::SCREEN_CHANGE
+                | randr::NotifyMask::CRTC_CHANGE
+                | randr::NotifyMask::OUTPUT_CHANGE
+                | randr::NotifyMask::RESOURCE_CHANGE,
+        )
+        .context("RANDR select_input")?
+        .check()
+        .context("RANDR select_input check")?;
+        Ok(())
+    }
+
     /// Probe MIT-SHM and, if usable, allocate the shared segment. Returns `Err`
     /// (rather than panicking or bailing the whole capturer) so the caller can
     /// fall back to plain `GetImage`.
@@ -282,10 +320,11 @@ impl X11Capturer {
             .checked_mul(usize::from(height))
             .and_then(|p| p.checked_mul(4))
             .context("frame size overflow")?;
+        let len_u32 = u32::try_from(len).context("X11 SHM frame exceeds request size limit")?;
 
         let seg = conn.generate_id().context("generate SHM seg id")?;
         let reply = conn
-            .shm_create_segment(seg, len as u32, false)
+            .shm_create_segment(seg, len_u32, false)
             .context("shm_create_segment")?
             .reply()
             .context("shm_create_segment reply")?;
@@ -437,6 +476,20 @@ impl X11Capturer {
             }
         };
 
+        let expected = usize::from(w)
+            .checked_mul(usize::from(h))
+            .and_then(|pixels| pixels.checked_mul(4))
+            .context("X11 image size overflow")?;
+        if data.len() != expected {
+            bail!(
+                "X11 image returned {} bytes for {}x{} BGRA pixels (expected {})",
+                data.len(),
+                w,
+                h,
+                expected
+            );
+        }
+
         // Depth 24 still arrives as 4 bytes/pixel in Z_PIXMAP on 32-bpp visuals;
         // the unused 4th byte is undefined, so force it opaque for BgrA32.
         if self.depth == 24 {
@@ -451,14 +504,20 @@ impl X11Capturer {
     /// Drain all currently-queued `DamageNotify` events. Returns true if at
     /// least one arrived (we don't trust their coordinates — the precise region
     /// comes from `subtract_into_region`; the event is just the wakeup signal).
-    fn drain_damage_events(&self) -> anyhow::Result<bool> {
-        let mut any = false;
+    fn drain_damage_events(&self) -> anyhow::Result<(bool, bool)> {
+        let mut damage = false;
+        let mut resize = false;
         while let Some(event) = self.conn.poll_for_event().context("poll_for_event")? {
-            if let Event::DamageNotify(_) = event {
-                any = true;
+            match event {
+                Event::DamageNotify(_) => damage = true,
+                Event::RandrScreenChangeNotify(change) if change.root == self.root => {
+                    resize = true;
+                }
+                Event::RandrNotify(_) => resize = true,
+                _ => {}
             }
         }
-        Ok(any)
+        Ok((damage, resize))
     }
 
     /// Atomically consume the accumulated damage into our scratch region and
@@ -495,6 +554,50 @@ impl X11Capturer {
         let _ = self.subtract_into_rects()?;
         Ok(())
     }
+
+    fn refresh_geometry(&mut self) -> anyhow::Result<bool> {
+        let geometry = self
+            .conn
+            .get_geometry(self.root)
+            .context("get root geometry")?
+            .reply()
+            .context("get root geometry reply")?;
+        let new_width = geometry.width;
+        let new_height = geometry.height;
+        if !geometry_changed((self.width, self.height), (new_width, new_height)) {
+            return Ok(false);
+        }
+        if new_width == 0 || new_height == 0 {
+            bail!("X11 root geometry changed to zero size");
+        }
+        if let Backend::Shm(shm) = &self.backend {
+            let _ = self.conn.shm_detach(shm.seg);
+        }
+        self.backend = match Self::try_init_shm(&self.conn, new_width, new_height) {
+            Ok(shm) => Backend::Shm(shm),
+            Err(error) => {
+                tracing::warn!(%error, "X11 SHM reallocation failed after resize; using GetImage");
+                Backend::Plain
+            }
+        };
+        self.width = new_width;
+        self.height = new_height;
+        self.depth = geometry.depth;
+        if self.damage.is_some() {
+            self.clear_damage()?;
+        }
+        tracing::info!(
+            width = new_width,
+            height = new_height,
+            randr = self.randr,
+            "X11 capture geometry changed"
+        );
+        Ok(true)
+    }
+}
+
+fn geometry_changed(old: (u16, u16), new: (u16, u16)) -> bool {
+    old != new
 }
 
 impl Capturer for X11Capturer {
@@ -503,6 +606,9 @@ impl Capturer for X11Capturer {
     }
 
     fn capture(&mut self) -> anyhow::Result<Frame> {
+        if !self.randr {
+            let _ = self.refresh_geometry()?;
+        }
         self.grab_rect(0, 0, self.width, self.height)
     }
 
@@ -510,7 +616,27 @@ impl Capturer for X11Capturer {
         self.damage.is_some()
     }
 
+    fn poll_frame(&mut self) -> anyhow::Result<Option<Frame>> {
+        if self.randr {
+            let (_, resize_event) = self.drain_damage_events()?;
+            if resize_event && self.refresh_geometry()? {
+                return Ok(Some(self.capture()?));
+            }
+        }
+        self.capture().map(Some)
+    }
+
     fn next_updates(&mut self, first: bool) -> anyhow::Result<Vec<Frame>> {
+        if self.randr {
+            let (_, resize_event) = self.drain_damage_events()?;
+            if resize_event && self.refresh_geometry()? {
+                self.clear_damage()?;
+                return Ok(vec![self.capture()?]);
+            }
+        } else if self.refresh_geometry()? {
+            self.clear_damage()?;
+            return Ok(vec![self.capture()?]);
+        }
         // Polling fallback (no DAMAGE): one full frame; the display layer adds
         // its own interval + dedup.
         if self.damage.is_none() {
@@ -538,7 +664,12 @@ impl Capturer for X11Capturer {
         let deadline = Instant::now() + DAMAGE_WAIT_BUDGET;
         loop {
             self.conn.flush().context("flush")?;
-            if self.drain_damage_events()? {
+            let (damage_event, resize_event) = self.drain_damage_events()?;
+            if resize_event && self.refresh_geometry()? {
+                self.clear_damage()?;
+                return Ok(vec![self.capture()?]);
+            }
+            if damage_event {
                 break;
             }
             if Instant::now() >= deadline {
@@ -679,6 +810,7 @@ mod tests {
             depth: screen.root_depth,
             backend: Backend::Plain,
             damage: None,
+            randr: false,
             conn,
         };
         let frame = cap.capture().expect("plain GetImage capture");
@@ -725,6 +857,7 @@ mod tests {
             depth,
             backend,
             damage,
+            randr: false,
         })
     }
 
@@ -838,5 +971,12 @@ mod tests {
         );
         // Union is commutative.
         assert_eq!(a.union(b), b.union(a));
+    }
+
+    #[test]
+    fn geometry_change_detection_is_dimension_only() {
+        assert!(!geometry_changed((1920, 1080), (1920, 1080)));
+        assert!(geometry_changed((1920, 1080), (2560, 1440)));
+        assert!(geometry_changed((2560, 1440), (1920, 1080)));
     }
 }

--- a/src-tauri/src/servers/rdp/display.rs
+++ b/src-tauri/src/servers/rdp/display.rs
@@ -17,6 +17,8 @@ use core::num::{NonZeroU16, NonZeroUsize};
 use std::collections::VecDeque;
 #[cfg(target_os = "macos")]
 use std::sync::atomic::{AtomicU32, Ordering};
+#[cfg(target_os = "linux")]
+use std::sync::mpsc::{Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
 #[cfg(target_os = "macos")]
 use std::time::Duration;
@@ -30,6 +32,8 @@ use tokio::sync::Notify;
 #[cfg(target_os = "macos")]
 use tokio::sync::oneshot;
 
+#[cfg(target_os = "linux")]
+use super::capture::PortalInput;
 use super::capture::{Capturer, Frame, create_capturer_for_display};
 #[cfg(target_os = "macos")]
 use super::gfx::{EncodedFrame, GfxReadiness, GfxSubmit, GfxTransport, H264Encoder};
@@ -44,7 +48,7 @@ pub(crate) struct RdpDisplay {
     /// Desktop size reported to the client. Set from the capture backend when
     /// available, else the fallback size passed in at construction.
     size: DesktopSize,
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "windows")]
     display_id: Option<String>,
     /// macOS capture is warmed before the listener becomes ready and remains
     /// alive across client authentication. This removes ScreenCaptureKit setup
@@ -59,6 +63,13 @@ pub(crate) struct RdpDisplay {
     supports_client_size: bool,
     #[cfg(target_os = "macos")]
     input_surface_size: Arc<AtomicU32>,
+    /// Linux capture is also warmed before the listener starts. For Wayland
+    /// this keeps the portal grant and PipeWire stream alive across RDP login;
+    /// for X11 it avoids opening a second X connection per client.
+    #[cfg(target_os = "linux")]
+    mailbox: Arc<LatestFrameMailbox>,
+    #[cfg(target_os = "linux")]
+    portal_input: Option<std::sync::mpsc::SyncSender<PortalInput>>,
 }
 
 #[cfg(target_os = "macos")]
@@ -75,19 +86,28 @@ impl RdpDisplay {
         log: LogEmitter,
         display_id: Option<String>,
         metrics: RdpMetrics,
+        view_only: bool,
         #[cfg(target_os = "macos")] gfx: GfxTransport,
     ) -> anyhow::Result<Self> {
         #[cfg(target_os = "macos")]
         let (size, mailbox, resize_tx, supports_client_size) =
             start_warmed_macos_capture(log.clone(), display_id.clone(), metrics.clone())?;
 
+        #[cfg(target_os = "linux")]
+        let (size, mailbox, portal_input) = start_warmed_linux_capture(
+            log.clone(),
+            display_id.clone(),
+            metrics.clone(),
+            !view_only,
+        )?;
+
         #[cfg(target_os = "macos")]
         let input_surface_size = Arc::new(AtomicU32::new(pack_desktop_size(size)));
 
         // Other platforms keep their existing per-client capture lifecycle.
         // Probing here keeps `size()` honest for the client.
-        #[cfg(not(target_os = "macos"))]
-        let size = match create_capturer_for_display(&log, display_id.as_deref()) {
+        #[cfg(target_os = "windows")]
+        let size = match create_capturer_for_display(&log, display_id.as_deref(), !view_only) {
             Ok(cap) => {
                 let (w, h) = cap.desktop_size();
                 match (NonZeroU16::new(w), NonZeroU16::new(h)) {
@@ -105,7 +125,7 @@ impl RdpDisplay {
             log,
             metrics,
             size,
-            #[cfg(not(target_os = "macos"))]
+            #[cfg(target_os = "windows")]
             display_id,
             #[cfg(target_os = "macos")]
             mailbox,
@@ -117,6 +137,10 @@ impl RdpDisplay {
             supports_client_size,
             #[cfg(target_os = "macos")]
             input_surface_size,
+            #[cfg(target_os = "linux")]
+            mailbox,
+            #[cfg(target_os = "linux")]
+            portal_input,
         })
     }
 
@@ -133,6 +157,11 @@ impl RdpDisplay {
     #[cfg(target_os = "macos")]
     pub(crate) fn supports_client_size(&self) -> bool {
         self.supports_client_size
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn portal_input(&self) -> Option<std::sync::mpsc::SyncSender<PortalInput>> {
+        self.portal_input.clone()
     }
 }
 
@@ -210,12 +239,23 @@ impl RdpServerDisplay for RdpDisplay {
             self.mailbox.replay_latest_full();
             return Ok(Box::new(DisplayUpdatesImpl::from_warmed_capture(
                 self.mailbox.clone(),
+                self.size,
                 self.metrics.clone(),
                 self.gfx.clone(),
             )));
         }
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
+        {
+            self.mailbox.replay_latest_full();
+            return Ok(Box::new(DisplayUpdatesImpl::from_warmed_linux_capture(
+                self.mailbox.clone(),
+                self.size,
+                self.metrics.clone(),
+            )));
+        }
+
+        #[cfg(target_os = "windows")]
         Ok(Box::new(DisplayUpdatesImpl::with_capture(
             self.log.clone(),
             self.size,
@@ -232,12 +272,21 @@ impl Drop for RdpDisplay {
     }
 }
 
+#[cfg(target_os = "linux")]
+impl Drop for RdpDisplay {
+    fn drop(&mut self) {
+        self.mailbox.close();
+    }
+}
+
 /// Per-client update producer that drains the native capture thread.
 pub(crate) struct DisplayUpdatesImpl {
     mailbox: Arc<LatestFrameMailbox>,
     close_mailbox_on_drop: bool,
     active_damage: VecDeque<Frame>,
     metrics: RdpMetrics,
+    current_size: DesktopSize,
+    deferred_full: Option<Frame>,
     #[cfg(target_os = "macos")]
     gfx: GfxTransport,
     #[cfg(target_os = "macos")]
@@ -406,6 +455,7 @@ impl DisplayUpdatesImpl {
     #[cfg(target_os = "macos")]
     fn from_warmed_capture(
         mailbox: Arc<LatestFrameMailbox>,
+        size: DesktopSize,
         metrics: RdpMetrics,
         gfx: GfxTransport,
     ) -> Self {
@@ -414,8 +464,26 @@ impl DisplayUpdatesImpl {
             close_mailbox_on_drop: false,
             active_damage: VecDeque::new(),
             metrics,
+            current_size: size,
+            deferred_full: None,
             gfx,
             h264: None,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn from_warmed_linux_capture(
+        mailbox: Arc<LatestFrameMailbox>,
+        size: DesktopSize,
+        metrics: RdpMetrics,
+    ) -> Self {
+        Self {
+            mailbox,
+            close_mailbox_on_drop: false,
+            active_damage: VecDeque::new(),
+            metrics,
+            current_size: size,
+            deferred_full: None,
         }
     }
 
@@ -443,6 +511,8 @@ impl DisplayUpdatesImpl {
             close_mailbox_on_drop: true,
             active_damage: VecDeque::new(),
             metrics,
+            current_size: _size,
+            deferred_full: None,
         }
     }
 
@@ -580,6 +650,18 @@ impl RdpServerDisplayUpdates for DisplayUpdatesImpl {
                 self.mailbox.finish_damage();
             }
 
+            if let Some(frame) = self.deferred_full.take() {
+                self.metrics.record_frame_handoff(frame.captured_at);
+                self.metrics.report_if_due();
+                #[cfg(target_os = "macos")]
+                {
+                    if self.try_queue_gfx(&frame) {
+                        continue;
+                    }
+                }
+                return Ok(Self::frame_to_bitmap(frame).map(DisplayUpdate::Bitmap));
+            }
+
             if let Some(frame) = self.active_damage.pop_front() {
                 if self.active_damage.is_empty() {
                     self.mailbox.finish_damage();
@@ -646,6 +728,15 @@ impl RdpServerDisplayUpdates for DisplayUpdatesImpl {
 
             match pending {
                 Some(PendingFrames::Full(frame)) => {
+                    let frame_size = DesktopSize {
+                        width: frame.width,
+                        height: frame.height,
+                    };
+                    if frame_size != self.current_size {
+                        self.current_size = frame_size;
+                        self.deferred_full = Some(frame);
+                        return Ok(Some(DisplayUpdate::Resize(frame_size)));
+                    }
                     self.metrics.record_frame_handoff(frame.captured_at);
                     self.metrics.report_if_due();
                     #[cfg(target_os = "macos")]
@@ -711,7 +802,8 @@ fn start_warmed_macos_capture(
             let worker_mailbox = mailbox.clone();
             move || {
                 let result = (|| {
-                    let mut capturer = create_capturer_for_display(&log, display_id.as_deref())?;
+                    let mut capturer =
+                        create_capturer_for_display(&log, display_id.as_deref(), false)?;
                     let supports_client_size = capturer.supports_output_resize();
 
                     // Both ScreenCaptureKit and its legacy fallback retain the
@@ -767,6 +859,89 @@ fn start_warmed_macos_capture(
     Ok((size, mailbox, resize_tx, supports_client_size))
 }
 
+/// Start one Linux capture owner before the RDP listener accepts clients.
+/// Wayland portal permissions and the PipeWire stream are tied to the portal
+/// session, so creating this backend per client would trigger repeated consent
+/// dialogs and lose the first frame during authentication.
+#[cfg(target_os = "linux")]
+fn start_warmed_linux_capture(
+    log: LogEmitter,
+    display_id: Option<String>,
+    metrics: RdpMetrics,
+    request_input: bool,
+) -> anyhow::Result<(
+    DesktopSize,
+    Arc<LatestFrameMailbox>,
+    Option<SyncSender<PortalInput>>,
+)> {
+    let mailbox = Arc::new(LatestFrameMailbox::new());
+    let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
+    let (portal_tx, portal_rx) = std::sync::mpsc::sync_channel(256);
+
+    std::thread::Builder::new()
+        .name("rdp-capture".to_string())
+        .spawn({
+            let worker_mailbox = mailbox.clone();
+            move || {
+                let result = (|| {
+                    let mut capturer =
+                        create_capturer_for_display(&log, display_id.as_deref(), request_input)?;
+                    let supports_input = request_input && capturer.supports_portal_input();
+                    let input_rx = supports_input.then_some(portal_rx);
+                    let started = std::time::Instant::now();
+                    let mut initial = capturer.capture()?;
+                    let width = NonZeroU16::new(initial.width)
+                        .ok_or_else(|| anyhow::anyhow!("screen capture reported zero width"))?;
+                    let height = NonZeroU16::new(initial.height)
+                        .ok_or_else(|| anyhow::anyhow!("screen capture reported zero height"))?;
+                    metrics.record_capture(started.elapsed(), initial.byte_len());
+                    initial.sequence = 1;
+                    if matches!(worker_mailbox.publish_full(initial), PublishResult::Closed) {
+                        anyhow::bail!("screen capture mailbox closed during warm-up");
+                    }
+                    Ok((
+                        DesktopSize {
+                            width: width.get(),
+                            height: height.get(),
+                        },
+                        capturer,
+                        input_rx,
+                        supports_input,
+                    ))
+                })();
+
+                let (size, capturer, input_rx, supports_input) = match result {
+                    Ok(ready) => ready,
+                    Err(error) => {
+                        let _ = ready_tx.send(Err(error));
+                        return;
+                    }
+                };
+                if ready_tx.send(Ok((size, supports_input))).is_err() {
+                    worker_mailbox.close();
+                    return;
+                }
+                log.line(format!(
+                    "Linux capture pre-warmed for RDP login ({}x{}; portal_input={})",
+                    size.width,
+                    size.height,
+                    if supports_input {
+                        "granted"
+                    } else {
+                        "native/disabled"
+                    }
+                ));
+                drive_capture(log, worker_mailbox, capturer, metrics, input_rx);
+            }
+        })
+        .map_err(|error| anyhow::anyhow!("spawn Linux capture thread: {error}"))?;
+
+    let (size, supports_input) = ready_rx
+        .recv()
+        .map_err(|_| anyhow::anyhow!("Linux capture thread stopped during warm-up"))??;
+    Ok((size, mailbox, supports_input.then_some(portal_tx)))
+}
+
 #[cfg(not(target_os = "macos"))]
 fn capture_loop(
     log: LogEmitter,
@@ -774,7 +949,7 @@ fn capture_loop(
     display_id: Option<String>,
     metrics: RdpMetrics,
 ) {
-    let capturer = match create_capturer_for_display(&log, display_id.as_deref()) {
+    let capturer = match create_capturer_for_display(&log, display_id.as_deref(), false) {
         Ok(c) => c,
         Err(e) => {
             log.line(format!("capture thread: {}", e));
@@ -782,7 +957,7 @@ fn capture_loop(
         }
     };
 
-    drive_capture(log, mailbox, capturer, metrics);
+    drive_capture(log, mailbox, capturer, metrics, None);
 }
 
 fn drive_capture(
@@ -791,6 +966,7 @@ fn drive_capture(
     mut capturer: Box<dyn Capturer>,
     metrics: RdpMetrics,
     #[cfg(target_os = "macos")] resize_rx: Option<std::sync::mpsc::Receiver<CaptureResizeRequest>>,
+    #[cfg(target_os = "linux")] input_rx: Option<Receiver<PortalInput>>,
 ) {
     if capturer.is_event_driven() {
         capture_loop_event_driven(capturer.as_mut(), &mailbox, &metrics);
@@ -801,6 +977,8 @@ fn drive_capture(
             &metrics,
             #[cfg(target_os = "macos")]
             resize_rx.as_ref(),
+            #[cfg(target_os = "linux")]
+            input_rx.as_ref(),
         );
     }
     // Every producer exit must wake consumers. This covers native stream
@@ -898,6 +1076,7 @@ fn capture_loop_polling(
     mailbox: &LatestFrameMailbox,
     metrics: &RdpMetrics,
     #[cfg(target_os = "macos")] resize_rx: Option<&std::sync::mpsc::Receiver<CaptureResizeRequest>>,
+    #[cfg(target_os = "linux")] input_rx: Option<&Receiver<PortalInput>>,
 ) {
     // A backend that caps its own frame rate must not be paced again: the extra
     // sleep would hold back a frame that is already sitting in its mailbox.
@@ -907,7 +1086,20 @@ fn capture_loop_polling(
     let mut last_hash: Option<u64> = None;
     let mut first = true;
     let mut sequence = 0;
+    #[cfg(target_os = "linux")]
+    let mut input_failed = false;
     loop {
+        #[cfg(target_os = "linux")]
+        if let Some(input_rx) = input_rx {
+            while let Ok(input) = input_rx.try_recv() {
+                if !input_failed {
+                    if let Err(error) = capturer.inject_portal_input(input) {
+                        tracing::warn!(%error, "Wayland portal input injection stopped");
+                        input_failed = true;
+                    }
+                }
+            }
+        }
         #[cfg(target_os = "macos")]
         if let Some(resize_rx) = resize_rx {
             while let Ok(request) = resize_rx.try_recv() {
@@ -1034,9 +1226,38 @@ mod tests {
     use super::{LatestFrameMailbox, PendingFrames, PublishResult, capture_loop_polling};
     use crate::servers::rdp::capture::{Capturer, Frame};
     use crate::servers::rdp::metrics::RdpMetrics;
+    use ironrdp::server::{DesktopSize, DisplayUpdate, RdpServerDisplayUpdates};
 
     fn frame(value: u8) -> Frame {
         Frame::bgra(vec![value, 0, 0, 0], 0, 0, 1, 1, 4)
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn resize_precedes_the_first_frame_at_the_new_geometry() {
+        let mailbox = Arc::new(LatestFrameMailbox::new());
+        let metrics = RdpMetrics::silent();
+        let mut updates = super::DisplayUpdatesImpl::from_warmed_linux_capture(
+            mailbox.clone(),
+            DesktopSize {
+                width: 1,
+                height: 1,
+            },
+            metrics,
+        );
+        mailbox.publish_full(Frame::bgra(vec![0; 2 * 2 * 4], 0, 0, 2, 2, 8));
+
+        assert!(matches!(
+            updates.next_update().await.unwrap(),
+            Some(DisplayUpdate::Resize(DesktopSize {
+                width: 2,
+                height: 2
+            }))
+        ));
+        assert!(matches!(
+            updates.next_update().await.unwrap(),
+            Some(DisplayUpdate::Bitmap(bitmap)) if bitmap.width.get() == 2 && bitmap.height.get() == 2
+        ));
     }
 
     /// Capturer that reports idle ticks, mimicking ScreenCaptureKit on a static
@@ -1251,7 +1472,14 @@ mod tests {
             })
             .unwrap();
 
-        capture_loop_polling(&mut capturer, &mailbox, &metrics, Some(&resize_rx));
+        capture_loop_polling(
+            &mut capturer,
+            &mailbox,
+            &metrics,
+            Some(&resize_rx),
+            #[cfg(target_os = "linux")]
+            None,
+        );
 
         assert_eq!(*requested.lock().unwrap(), Some((2, 3)));
         assert_eq!(result_rx.blocking_recv().unwrap().unwrap(), requested_size);
@@ -1283,6 +1511,8 @@ mod tests {
             &metrics,
             #[cfg(target_os = "macos")]
             None,
+            #[cfg(target_os = "linux")]
+            None,
         );
 
         // 24 idle ticks were survived; the loop ended only once the client left.
@@ -1308,6 +1538,8 @@ mod tests {
             &mailbox,
             &metrics,
             #[cfg(target_os = "macos")]
+            None,
+            #[cfg(target_os = "linux")]
             None,
         );
 
@@ -1338,6 +1570,8 @@ mod tests {
             &metrics,
             #[cfg(target_os = "macos")]
             None,
+            #[cfg(target_os = "linux")]
+            None,
         );
         let elapsed = started.elapsed();
 
@@ -1364,6 +1598,8 @@ mod tests {
             &mailbox,
             &metrics,
             #[cfg(target_os = "macos")]
+            None,
+            #[cfg(target_os = "linux")]
             None,
         );
 
@@ -1393,6 +1629,8 @@ mod tests {
             &metrics,
             #[cfg(target_os = "macos")]
             None,
+            #[cfg(target_os = "linux")]
+            None,
         );
 
         let capture_us = metrics.capture_p50_us().expect("one frame was captured");
@@ -1419,6 +1657,8 @@ mod tests {
             &mailbox,
             &metrics,
             #[cfg(target_os = "macos")]
+            None,
+            #[cfg(target_os = "linux")]
             None,
         );
 

--- a/src-tauri/src/servers/rdp/input.rs
+++ b/src-tauri/src/servers/rdp/input.rs
@@ -1,5 +1,6 @@
 //! RDP server input handler: injects client keyboard/mouse events into the
-//! local desktop via `enigo`, with native CoreGraphics pointer events on macOS.
+//! local desktop via `enigo`, the RemoteDesktop portal on Wayland, and native
+//! CoreGraphics pointer events on macOS.
 //!
 //! ## Coordinates
 //! [`MouseEvent::Move { x, y }`] carries coordinates in the advertised RDP
@@ -53,6 +54,8 @@ use objc2_core_graphics::{
 };
 
 use super::ControlGate;
+#[cfg(target_os = "linux")]
+use super::capture::PortalInput;
 use super::metrics::RdpMetrics;
 use crate::servers::engine::LogEmitter;
 
@@ -432,6 +435,7 @@ impl RdpInput {
         view_only: bool,
         control_gate: Option<std::sync::Arc<ControlGate>>,
         metrics: RdpMetrics,
+        #[cfg(target_os = "linux")] portal_tx: Option<mpsc::SyncSender<PortalInput>>,
         #[cfg(target_os = "macos")] mapping: Option<MacInputMapping>,
     ) -> Self {
         let tx = if view_only {
@@ -440,6 +444,8 @@ impl RdpInput {
             Self::spawn_actor(
                 &log,
                 metrics.clone(),
+                #[cfg(target_os = "linux")]
+                portal_tx,
                 #[cfg(target_os = "macos")]
                 mapping,
             )
@@ -462,6 +468,7 @@ impl RdpInput {
     fn spawn_actor(
         log: &LogEmitter,
         metrics: RdpMetrics,
+        #[cfg(target_os = "linux")] portal_tx: Option<mpsc::SyncSender<PortalInput>>,
         #[cfg(target_os = "macos")] mapping: Option<MacInputMapping>,
     ) -> Option<InputQueue> {
         let tx = InputQueue::new();
@@ -479,6 +486,19 @@ impl RdpInput {
                     open_prompt_to_get_permissions: false,
                     ..Settings::default()
                 };
+                #[cfg(target_os = "linux")]
+                let mut enigo = if portal_tx.is_some() {
+                    None
+                } else {
+                    match Enigo::new(&settings) {
+                        Ok(e) => Some(e),
+                        Err(e) => {
+                            let _ = ready_tx.send(Err(e.to_string()));
+                            return;
+                        }
+                    }
+                };
+                #[cfg(not(target_os = "linux"))]
                 let mut enigo = match Enigo::new(&settings) {
                     Ok(e) => e,
                     Err(e) => {
@@ -516,12 +536,34 @@ impl RdpInput {
                         }
                         permission_checked_at = Instant::now();
                     }
-                    if let Err(error) = apply(
+                    #[cfg(target_os = "linux")]
+                    let result = if let Some(portal_tx) = &portal_tx {
+                        input_cmd_to_portal(queued.cmd)
+                            .ok_or_else(|| "unsupported input command for Wayland portal".to_string())
+                            .and_then(|input| {
+                                portal_tx
+                                    .send(input)
+                                    .map_err(|_| "Wayland portal input channel closed".to_string())
+                            })
+                    } else {
+                        match enigo.as_mut() {
+                            Some(enigo) => apply(
+                                enigo,
+                                #[cfg(target_os = "macos")]
+                                &mut mac_mouse,
+                                queued.cmd,
+                            ),
+                            None => Err("input backend was not initialized".to_string()),
+                        }
+                    };
+                    #[cfg(not(target_os = "linux"))]
+                    let result = apply(
                         &mut enigo,
                         #[cfg(target_os = "macos")]
                         &mut mac_mouse,
                         queued.cmd,
-                    ) {
+                    );
+                    if let Err(error) = result {
                         actor_log.line(format!("input injection stopped: {error}"));
                         rx.close();
                         break;
@@ -628,6 +670,62 @@ impl Drop for RdpInput {
             tx.close();
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+fn input_cmd_to_portal(cmd: InputCmd) -> Option<PortalInput> {
+    match cmd {
+        // Enigo's Linux raw key API takes X11 keycodes (evdev + 8), while the
+        // RemoteDesktop portal takes Linux evdev keycodes directly.
+        InputCmd::Raw { code, dir } => Some(PortalInput::Keycode {
+            code: i32::from(code.saturating_sub(8)),
+            pressed: dir == Press,
+        }),
+        InputCmd::Key {
+            key: Key::Unicode(ch),
+            dir,
+        } => Some(PortalInput::Keysym {
+            keysym: unicode_to_keysym(ch),
+            pressed: dir == Press,
+        }),
+        InputCmd::Key { .. } => None,
+        InputCmd::Button { button, dir } => Some(PortalInput::Button {
+            button: match button {
+                Button::Left => 0x110,
+                Button::Right => 0x111,
+                Button::Middle => 0x112,
+                Button::Back => 0x116,
+                Button::Forward => 0x115,
+                _ => return None,
+            },
+            pressed: dir == Press,
+        }),
+        InputCmd::MoveMouse { x, y, coord } => match coord {
+            Coordinate::Abs => Some(PortalInput::MotionAbsolute {
+                x: f64::from(x),
+                y: f64::from(y),
+            }),
+            Coordinate::Rel => Some(PortalInput::MotionRelative {
+                dx: f64::from(x),
+                dy: f64::from(y),
+            }),
+        },
+        InputCmd::Scroll { length, axis } => Some(PortalInput::Scroll {
+            horizontal: axis == Axis::Horizontal,
+            steps: length,
+        }),
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn unicode_to_keysym(ch: char) -> i32 {
+    let codepoint = u32::from(ch);
+    let keysym = if codepoint <= 0xff {
+        codepoint
+    } else {
+        0x0100_0000 | codepoint
+    };
+    i32::try_from(keysym).expect("Unicode keysym fits in a signed 32-bit portal value")
 }
 
 /// Replay one command on the thread-owned input backend. Returning an error

--- a/src-tauri/tests/integration/sockscap_win11_scenarios.rs
+++ b/src-tauri/tests/integration/sockscap_win11_scenarios.rs
@@ -89,6 +89,7 @@ fn make_test_config(mode: ScopeMode, upstream: UpstreamRef) -> SocksCapConfig {
         ],
         default_action: Decision::Proxy,
         restore_on_login: false,
+        block_quic: false,
     };
     cfg.normalize();
     cfg

--- a/src/components/editor/workspace/useWorkspaceGitSnapshots.test.tsx
+++ b/src/components/editor/workspace/useWorkspaceGitSnapshots.test.tsx
@@ -97,9 +97,10 @@ describe("useWorkspaceGitSnapshots", () => {
   });
 
   it("refreshes the matching repository and publishes path changes", async () => {
+    const onError = vi.fn();
     const { result } = renderHook(() => useWorkspaceGitSnapshots({
       roots,
-      onError: vi.fn(),
+      onError,
     }));
     await waitFor(() => expect(result.current.gitSnapshots["/repo"]?.headOid).toBe("head-1"));
 

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1754,7 +1754,7 @@ const dict = {
       rdpInsecure:
         "No security means traffic is unencrypted and, without credentials, anyone who can reach the port gets full control. Use only on an isolated network.",
       rdpCapLinux:
-        "Desktop capture: Linux X11/XWayland is fully supported. On pure Wayland, capture uses the portal (accept the ScreenCast prompt). Input works via enigo.",
+        "Desktop capture: Linux X11 uses MIT-SHM/XDamage with XTest input. Native Wayland uses one RemoteDesktop portal session and a persistent PipeWire stream; accept the screen and keyboard/pointer prompts to enable control.",
       rdpCapMacos:
         "Desktop capture: macOS uses a persistent native display stream. Grant Screen Recording permission and select the display to share.",
       rdpCaptureGranted: "Permission granted",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -1740,7 +1740,7 @@ export const zhCN: DeepPartial<typeof en> = {
       rdpInsecure:
         "无安全模式意味着流量不加密；若未设置凭据，任何能访问该端口的人都可完全控制本机桌面。请仅在隔离网络中使用。",
       rdpCapLinux:
-        "桌面采集：Linux X11/XWayland 已完整支持。纯 Wayland 使用门户截屏（需在弹窗中授权）。键鼠注入通过 enigo。",
+        "桌面采集：Linux X11 使用 MIT-SHM/XDamage 和 XTest 输入。原生 Wayland 使用同一个 RemoteDesktop 门户会话及持久 PipeWire 视频流；请在弹窗中授权屏幕和键鼠设备以启用控制。",
       rdpCapMacos:
         "桌面采集：macOS 使用持久原生显示流。请授予屏幕录制权限，并选择要共享的显示器。",
       rdpCaptureGranted: "权限已授予",


### PR DESCRIPTION
Complete the Linux console-sharing implementation described by the IronRDP platform assessment.

- Prefer native Wayland sessions over XWayland DISPLAY and share one RemoteDesktop Portal session across PipeWire capture and keyboard/pointer injection.
- Add persistent PipeWire streaming, validated pixel-format and stride conversion, logical coordinate mapping, latest-frame delivery, capture warmup, and deterministic stream shutdown.
- Monitor XRandR geometry changes, rebuild MIT-SHM buffers safely, fall back to GetImage when needed, and deliver resize notifications before frames at the new dimensions.
- Bound RDP session and WebSocket output, retaining only the latest complete frame batch while preserving control, clipboard, cursor, and audio traffic.
- Refresh Linux capability copy, QA coverage metadata, the platform assessment, and time-sensitive test fixtures.

Automated verification: cargo check, focused RDP server/client tests, complete Rust lib and integration suites, pnpm build, full Vitest suite, git diff checks, and the F9.7 qa-ui-auto audit. Real GNOME/KDE portal behavior, client interoperability, long-running stability, and measured performance remain documented hardware/manual release gates.