### PR TITLE
fix(sockscap): recover stale Linux capture during updates

### DIFF
--- a/src-tauri/src/sockscap/mod.rs
+++ b/src-tauri/src/sockscap/mod.rs
@@ -2057,12 +2057,14 @@ pub async fn prepare_for_exit(app: &AppHandle, state: State<'_, AppState>) -> Re
 pub async fn sockscap_prepare_for_update(
     app: AppHandle,
     state: State<'_, AppState>,
+    sudo_password: Option<String>,
 ) -> Result<(), String> {
     let owned_capture = state.sockscap.has_activation_lock();
     let recovery_required = matches!(
         state.sockscap.orch.read().await.status().phase,
         orchestrator::EnginePhase::RecoveryRequired
     );
+    #[cfg(not(target_os = "linux"))]
     if recovery_required {
         return Err(
             "SocksCap network recovery is required before updating; use Recover network first"
@@ -2079,20 +2081,57 @@ pub async fn sockscap_prepare_for_update(
         state.sockscap.install_activation_lock(lock);
     }
 
-    // A dirty journal not owned by this runtime means a previous process left
-    // machine-wide state behind. Do not erase the journal or install an update
-    // over it: the user must run Recover with elevation first.
-    if !owned_capture {
-        if let Ok(dir) = data_dir(&app) {
-            let journal = recovery::journal_path(&dir);
-            if recovery::needs_repair(&journal) {
-                state.sockscap.release_activation_lock();
-                return Err(
-                    "SocksCap recovery is required before updating; use Recover network first"
-                        .into(),
+    let journal_path = data_dir(&app).ok().map(|dir| recovery::journal_path(&dir));
+    let dirty_journal = journal_path.as_deref().is_some_and(recovery::needs_repair);
+
+    // A previous Linux process may have exited after installing nftables and
+    // cgroups but before clearing its journal. The updater already has the old
+    // binary and runtime available, so repair that narrowly-owned state here
+    // instead of sending the user back to the SocksCap panel. Credentials are
+    // accepted only for this call and are zeroized when it returns.
+    #[cfg(target_os = "linux")]
+    if should_recover_stale_capture_for_update(owned_capture, recovery_required, dirty_journal) {
+        let sudo_password = sudo_password.map(Zeroizing::new);
+        let sudo_pw = sudo_password.as_deref().map(|password| password.as_str());
+        if let Err(error) = capture::recover_system(sudo_pw).await {
+            let message = format!("automatic SocksCap recovery before updating failed: {error}");
+            state
+                .sockscap
+                .orch
+                .write()
+                .await
+                .set_recovery_required(&capture::capabilities().capture_backend, message.clone());
+            state.sockscap.release_activation_lock();
+            if sudo_pw.is_none() && linux_recovery_requires_elevation(&error) {
+                return Err(format!("SOCKSCAP_UPDATE_SUDO_REQUIRED: {message}"));
+            }
+            return Err(message);
+        }
+        if let Some(journal) = journal_path.as_deref() {
+            if let Err(error) = recovery::mark_clean_and_clear(journal) {
+                let message = format!(
+                    "SocksCap network recovery succeeded, but its journal could not be cleared before updating: {error}"
                 );
+                state.sockscap.orch.write().await.set_recovery_required(
+                    &capture::capabilities().capture_backend,
+                    message.clone(),
+                );
+                state.sockscap.release_activation_lock();
+                return Err(message);
             }
         }
+        state.sockscap.orch.write().await.force_idle();
+        tracing::info!("sockscap: automatically recovered stale Linux state before update");
+    }
+
+    // Other platforms retain their existing explicit-recovery policy. Their
+    // stale state cannot be safely repaired with a Linux sudo credential.
+    #[cfg(not(target_os = "linux"))]
+    if !owned_capture && dirty_journal {
+        state.sockscap.release_activation_lock();
+        return Err(
+            "SocksCap recovery is required before updating; use Recover network first".into(),
+        );
     }
 
     // 1) Stop capture before the installer or relaunch can terminate the
@@ -2134,6 +2173,24 @@ pub async fn sockscap_prepare_for_update(
     } else {
         Err(errors.join("; "))
     }
+}
+
+#[cfg(target_os = "linux")]
+fn should_recover_stale_capture_for_update(
+    owned_capture: bool,
+    recovery_required: bool,
+    dirty_journal: bool,
+) -> bool {
+    !owned_capture && (recovery_required || dirty_journal)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_recovery_requires_elevation(error: &str) -> bool {
+    let error = error.to_ascii_lowercase();
+    error.contains("cap_net_admin")
+        || error.contains("linux capture requires")
+        || error.contains("linux cgroup cleanup requires root")
+        || error.contains("permission to manage cgroup v2")
 }
 
 /// Poll the bundled privileged files until each is openable for writing (i.e.
@@ -3343,6 +3400,8 @@ mod tests {
         Orchestrator, classify_client, ensure_configuration_unlocked, session_password_ref,
         session_proxy_password, session_ssh_auth, should_block_exit_for_recovery,
     };
+    #[cfg(target_os = "linux")]
+    use super::{linux_recovery_requires_elevation, should_recover_stale_capture_for_update};
     use crate::session::models::{AuthMethod, SessionConfig, SessionType};
     #[cfg(target_os = "macos")]
     use crate::sockscap::recovery::{RecoveryJournal, RecoveryPhase};
@@ -3394,6 +3453,31 @@ mod tests {
         assert!(!should_block_exit_for_recovery(true, false));
         assert!(should_block_exit_for_recovery(true, true));
         assert!(!should_block_exit_for_recovery(false, true));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn stale_linux_capture_is_recovered_during_update_preparation() {
+        assert!(should_recover_stale_capture_for_update(false, true, true));
+        assert!(should_recover_stale_capture_for_update(false, false, true));
+        assert!(!should_recover_stale_capture_for_update(true, true, true));
+        assert!(!should_recover_stale_capture_for_update(
+            false, false, false
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_update_recovery_requests_sudo_only_for_permission_failures() {
+        assert!(linux_recovery_requires_elevation(
+            "query nftables table failed: Operation not permitted. Linux capture requires CAP_NET_ADMIN"
+        ));
+        assert!(linux_recovery_requires_elevation(
+            "Linux cgroup cleanup requires root or delegated cgroup v2 permissions"
+        ));
+        assert!(!linux_recovery_requires_elevation(
+            "an nftables table named taomni_sockscap is not recognized as SocksCap-owned"
+        ));
     }
 
     #[test]

--- a/src/components/UpdateDialog.test.tsx
+++ b/src/components/UpdateDialog.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setLocale } from "../lib/i18n";
+import { useUpdateStore } from "../stores/updateStore";
+import { UpdateDialog } from "./UpdateDialog";
+
+afterEach(cleanup);
+
+describe("UpdateDialog SocksCap recovery authorization", () => {
+  const authorizeInstall = vi.fn(async (_password: string) => undefined);
+  const cancelAuthorization = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setLocale("en");
+    useUpdateStore.setState({
+      status: "authorizing",
+      dialogOpen: true,
+      os: "linux",
+      authorizationBusy: false,
+      authorizationError: null,
+      authorizeInstall,
+      cancelAuthorization,
+    });
+  });
+
+  it("requests sudo in the updater and continues the pending installation", async () => {
+    render(<UpdateDialog />);
+
+    expect(screen.getByTestId("sockscap-root-prompt-dialog")).toHaveTextContent(
+      "remove residual SocksCap nftables and cgroup state",
+    );
+
+    fireEvent.change(screen.getByTestId("sockscap-root-password-input"), {
+      target: { value: "root-secret" },
+    });
+    fireEvent.click(screen.getByTestId("sockscap-root-prompt-submit"));
+
+    await waitFor(() => {
+      expect(authorizeInstall).toHaveBeenCalledWith("root-secret");
+    });
+  });
+
+  it("returns to the update without navigating to SocksCap when authorization is cancelled", () => {
+    render(<UpdateDialog />);
+
+    fireEvent.click(screen.getByTestId("sockscap-root-prompt-cancel"));
+
+    expect(cancelAuthorization).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/UpdateDialog.tsx
+++ b/src/components/UpdateDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
 import { useUpdateStore } from "../stores/updateStore";
 import { useT, type TranslateFn } from "../lib/i18n";
+import { SocksCapRootPrompt } from "./sockscap/SocksCapRootPrompt";
 
 const DANGER = "#e5534b";
 
@@ -26,14 +27,15 @@ export function UpdateDialog() {
   const s = useUpdateStore();
 
   const downloading = s.status === "downloading";
+  const authorizing = s.status === "authorizing";
+  const updating = downloading || authorizing;
   const percent = s.progress?.percent ?? null;
-  const installing = downloading && percent === 100;
+  const installing = updating && percent === 100;
   const canDownload =
     s.status === "available" && s.targetStatus !== "checking" && s.targetStatus !== "unavailable";
-  // A download must run to completion without being dismissed by an accidental
-  // click-away or Escape — only the explicit Cancel button (which calls
-  // closeDialog directly) can hide it. Every other state is freely dismissable.
-  const dismissable = s.status !== "downloading";
+  // Download and authorization must not be dismissed by an accidental
+  // click-away or Escape. Their explicit controls own cancellation.
+  const dismissable = !downloading && !authorizing;
 
   const close = () => {
     if (dismissable) s.closeDialog();
@@ -173,7 +175,7 @@ export function UpdateDialog() {
           </div>
         )}
 
-        {(s.status === "available" || downloading) && (
+        {(s.status === "available" || updating) && (
           <>
             <div className="text-[12px] taomni-mono mb-1" style={{ color: "var(--taomni-text-muted)" }}>
               {t("update.currentVersion", { version: s.currentVersion ?? "" })} →{" "}
@@ -201,7 +203,7 @@ export function UpdateDialog() {
                       <button
                         key={target}
                         type="button"
-                        disabled={downloading}
+                        disabled={updating}
                         onClick={() => void s.setSelectedTarget(target)}
                         className="taomni-btn h-8 px-3 text-[12px]"
                         data-primary={selected ? "true" : undefined}
@@ -232,7 +234,7 @@ export function UpdateDialog() {
               </div>
             )}
 
-            {downloading && (
+            {updating && (
               <div className="mb-3" data-testid="update-progress">
                 <div className="h-2 rounded overflow-hidden" style={{ background: "var(--taomni-card-border)" }}>
                   <div
@@ -312,6 +314,15 @@ export function UpdateDialog() {
           )}
         </div>
       </div>
+      {authorizing && (
+        <SocksCapRootPrompt
+          subtitle={t("update.sockscapRecoveryAuthorization")}
+          onSubmit={(password) => s.authorizeInstall(password)}
+          onCancel={s.cancelAuthorization}
+          error={s.authorizationError}
+          busy={s.authorizationBusy}
+        />
+      )}
     </div>
   );
 }

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -464,6 +464,8 @@ const dict = {
     later: "Later",
     errorTitle: "Update failed",
     retry: "Try again",
+    sockscapRecoveryAuthorization:
+      "Taomni needs sudo authorization to remove residual SocksCap nftables and cgroup state before installing this update.",
   },
   welcome: {
     versionLabel: "Version {version}",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -463,6 +463,8 @@ export const zhCN: DeepPartial<typeof en> = {
     later: "稍后",
     errorTitle: "更新失败",
     retry: "重试",
+    sockscapRecoveryAuthorization:
+      "安装本次更新前，Taomni 需要 sudo 授权以自动清理 SocksCap 残留的 nftables 与 cgroup 状态。",
   },
   welcome: {
     versionLabel: "版本 {version}",

--- a/src/lib/updateService.test.ts
+++ b/src/lib/updateService.test.ts
@@ -28,7 +28,13 @@ vi.mock("./runtime", () => ({
   isTauriRuntime: () => true,
 }));
 
-import { checkForUpdate, downloadAndInstall, relaunchApp } from "./updateService";
+import {
+  checkForUpdate,
+  downloadAndInstall,
+  installDownloadedUpdate,
+  isSocksCapUpgradeAuthorizationRequired,
+  relaunchApp,
+} from "./updateService";
 
 const update = {
   version: "0.4.4",
@@ -58,7 +64,9 @@ describe("updateService.relaunchApp", () => {
   it("gracefully tears down SocksCap before relaunching on Linux", async () => {
     await relaunchApp();
 
-    expect(mocks.invoke).toHaveBeenCalledWith("sockscap_prepare_for_update");
+    expect(mocks.invoke).toHaveBeenCalledWith("sockscap_prepare_for_update", {
+      sudoPassword: undefined,
+    });
     expect(mocks.relaunch).toHaveBeenCalledTimes(1);
     expect(mocks.invoke.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.relaunch.mock.invocationCallOrder[0],
@@ -87,5 +95,25 @@ describe("updateService.relaunchApp", () => {
 
     expect(mocks.download).toHaveBeenCalledTimes(1);
     expect(mocks.install).not.toHaveBeenCalled();
+  });
+
+  it("resumes a downloaded Linux update after automatic recovery gets sudo authorization", async () => {
+    await checkForUpdate();
+    mocks.invoke.mockRejectedValueOnce(
+      "SOCKSCAP_UPDATE_SUDO_REQUIRED: automatic SocksCap recovery failed",
+    );
+
+    const initialInstall = downloadAndInstall(undefined, vi.fn());
+    await expect(initialInstall).rejects.toSatisfy(isSocksCapUpgradeAuthorizationRequired);
+    expect(mocks.download).toHaveBeenCalledTimes(1);
+    expect(mocks.install).not.toHaveBeenCalled();
+
+    await installDownloadedUpdate(undefined, "root-secret");
+
+    expect(mocks.invoke).toHaveBeenLastCalledWith("sockscap_prepare_for_update", {
+      sudoPassword: "root-secret",
+    });
+    expect(mocks.download).toHaveBeenCalledTimes(1);
+    expect(mocks.install).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/updateService.ts
+++ b/src/lib/updateService.ts
@@ -36,6 +36,26 @@ export interface DownloadProgress {
 // One resolved Update per target key (e.g. "darwin-x86_64"). check() resolves
 // to a single platform entry, so we keep them apart and reuse at install time.
 const updateCache = new Map<string, Update>();
+const SOCKSCAP_UPDATE_SUDO_REQUIRED = "SOCKSCAP_UPDATE_SUDO_REQUIRED:";
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function isSocksCapUpgradeAuthorizationRequired(error: unknown): boolean {
+  return errorText(error).includes(SOCKSCAP_UPDATE_SUDO_REQUIRED);
+}
+
+export function isSudoAuthenticationError(error: unknown): boolean {
+  const message = errorText(error).toLowerCase();
+  return (
+    message.includes("incorrect password") ||
+    message.includes("authentication failure") ||
+    message.includes("sudo authentication failed") ||
+    message.includes("sorry, try again") ||
+    message.includes("a password is required")
+  );
+}
 
 function devOsToken(): string {
   switch (getAppPlatform()) {
@@ -124,9 +144,24 @@ export async function checkForUpdate(target?: string): Promise<AvailableUpdate |
  * are still available; macOS disables Redirector interception over IPC. A cleanup failure blocks the
  * transition so the app cannot silently strand network state.
  */
-async function prepareSocksCapForUpgrade(): Promise<void> {
+async function prepareSocksCapForUpgrade(sudoPassword?: string): Promise<void> {
   if (!isTauriRuntime()) return;
-  await invoke("sockscap_prepare_for_update");
+  await invoke("sockscap_prepare_for_update", { sudoPassword });
+}
+
+/**
+ * Install an already-downloaded update after SocksCap cleanup succeeds.
+ * Exported separately so Linux can request sudo authorization and resume the
+ * installation without downloading the package a second time.
+ */
+export async function installDownloadedUpdate(
+  target: string | undefined,
+  sudoPassword?: string,
+): Promise<void> {
+  const update = updateCache.get(target ?? "");
+  if (!update) throw new Error("The downloaded update is no longer available. Download it again.");
+  await prepareSocksCapForUpgrade(sudoPassword);
+  await update.install();
 }
 
 /**
@@ -182,9 +217,7 @@ export async function downloadAndInstall(
   // Stop SocksCap before installation can replace files or a later relaunch can
   // terminate the process with machine-wide capture state still installed.
   onProgress({ downloaded, total, percent: 100 });
-  await prepareSocksCapForUpgrade();
-
-  await update.install();
+  await installDownloadedUpdate(target);
 }
 
 /** Restart into the freshly installed version (confirmation gate #2). */

--- a/src/stores/updateStore.test.ts
+++ b/src/stores/updateStore.test.ts
@@ -6,6 +6,13 @@ vi.mock("../lib/updateService", () => ({
   getUpdaterPlatform: vi.fn(),
   checkForUpdate: vi.fn(),
   downloadAndInstall: vi.fn(),
+  installDownloadedUpdate: vi.fn(),
+  isSocksCapUpgradeAuthorizationRequired: vi.fn((error: unknown) =>
+    String(error).includes("SOCKSCAP_UPDATE_SUDO_REQUIRED:"),
+  ),
+  isSudoAuthenticationError: vi.fn((error: unknown) =>
+    String(error).includes("sudo authentication failed"),
+  ),
   relaunchApp: vi.fn(),
 }));
 
@@ -42,6 +49,8 @@ beforeEach(() => {
     notes: "",
     error: null,
     progress: null,
+    authorizationBusy: false,
+    authorizationError: null,
     os: null,
     nativeTarget: null,
     recommendedTarget: null,
@@ -218,5 +227,47 @@ describe("updateStore.startDownload", () => {
     await get().startDownload();
     expect(get().status).toBe("error");
     expect(get().error).toBe("boom");
+  });
+
+  it("requests sudo authorization and resumes the already-downloaded Linux update", async () => {
+    useUpdateStore.setState({
+      status: "available",
+      os: "linux",
+      selectedTarget: "linux-x86_64",
+      candidates: ["linux-x86_64"],
+    });
+    mocked.downloadAndInstall.mockRejectedValue(
+      new Error("SOCKSCAP_UPDATE_SUDO_REQUIRED: stale capture state"),
+    );
+
+    await get().startDownload();
+
+    expect(get().status).toBe("authorizing");
+    expect(mocked.installDownloadedUpdate).not.toHaveBeenCalled();
+
+    mocked.installDownloadedUpdate.mockResolvedValue(undefined);
+    await get().authorizeInstall("root-secret");
+
+    expect(mocked.installDownloadedUpdate).toHaveBeenCalledWith(undefined, "root-secret");
+    expect(mocked.downloadAndInstall).toHaveBeenCalledTimes(1);
+    expect(get().status).toBe("ready");
+  });
+
+  it("keeps the authorization prompt open after an incorrect sudo password", async () => {
+    useUpdateStore.setState({
+      status: "authorizing",
+      os: "linux",
+      selectedTarget: "linux-x86_64",
+      candidates: ["linux-x86_64"],
+    });
+    mocked.installDownloadedUpdate.mockRejectedValue(
+      new Error("sudo authentication failed: Sorry, try again"),
+    );
+
+    await get().authorizeInstall("incorrect");
+
+    expect(get().status).toBe("authorizing");
+    expect(get().authorizationBusy).toBe(false);
+    expect(get().authorizationError).toBe("Sudo password incorrect or authentication failed. Please try again.");
   });
 });

--- a/src/stores/updateStore.ts
+++ b/src/stores/updateStore.ts
@@ -3,15 +3,20 @@ import {
   getUpdaterPlatform,
   checkForUpdate,
   downloadAndInstall,
+  installDownloadedUpdate,
+  isSocksCapUpgradeAuthorizationRequired,
+  isSudoAuthenticationError,
   relaunchApp,
   type DownloadProgress,
 } from "../lib/updateService";
+import { t as tr } from "../lib/i18n";
 
 export type UpdateStatus =
   | "idle"
   | "checking"
   | "available"
   | "downloading"
+  | "authorizing"
   | "ready"
   | "error"
   | "uptodate";
@@ -30,6 +35,8 @@ interface UpdateState {
   notes: string;
   error: string | null;
   progress: DownloadProgress | null;
+  authorizationBusy: boolean;
+  authorizationError: string | null;
 
   // Package / architecture selection (see claudedocs/auto-update-plan.md).
   os: string | null;
@@ -43,6 +50,8 @@ interface UpdateState {
   check: (opts?: { manual?: boolean }) => Promise<void>;
   setSelectedTarget: (target: string) => Promise<void>;
   startDownload: () => Promise<void>;
+  authorizeInstall: (sudoPassword: string) => Promise<void>;
+  cancelAuthorization: () => void;
   restart: () => Promise<void>;
   openDialog: () => void;
   closeDialog: () => void;
@@ -62,6 +71,8 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
   notes: "",
   error: null,
   progress: null,
+  authorizationBusy: false,
+  authorizationError: null,
   os: null,
   nativeTarget: null,
   recommendedTarget: null,
@@ -158,15 +169,57 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
 
   startDownload: async () => {
     const { selectedTarget, candidates } = get();
-    set({ status: "downloading", error: null, progress: { downloaded: 0, total: null, percent: 0 } });
+    set({
+      status: "downloading",
+      error: null,
+      progress: { downloaded: 0, total: null, percent: 0 },
+      authorizationBusy: false,
+      authorizationError: null,
+    });
     try {
       const downloadTarget = candidates.length > 1 ? (selectedTarget ?? undefined) : undefined;
       await downloadAndInstall(downloadTarget, (p) => set({ progress: p }));
       set({ status: "ready" });
     } catch (e) {
-      set({ status: "error", error: errMsg(e) });
+      if (isSocksCapUpgradeAuthorizationRequired(e)) {
+        set({ status: "authorizing", authorizationError: null });
+      } else {
+        set({ status: "error", error: errMsg(e) });
+      }
     }
   },
+
+  authorizeInstall: async (sudoPassword) => {
+    const { selectedTarget, candidates } = get();
+    const downloadTarget = candidates.length > 1 ? (selectedTarget ?? undefined) : undefined;
+    set({ authorizationBusy: true, authorizationError: null });
+    try {
+      await installDownloadedUpdate(downloadTarget, sudoPassword);
+      set({ status: "ready", authorizationBusy: false, authorizationError: null });
+    } catch (e) {
+      if (isSudoAuthenticationError(e)) {
+        set({
+          status: "authorizing",
+          authorizationBusy: false,
+          authorizationError: tr("sockscap.rootPromptIncorrectPassword"),
+        });
+      } else {
+        set({
+          status: "error",
+          error: errMsg(e),
+          authorizationBusy: false,
+          authorizationError: null,
+        });
+      }
+    }
+  },
+
+  cancelAuthorization: () =>
+    set({
+      status: "available",
+      authorizationBusy: false,
+      authorizationError: null,
+    }),
 
   restart: async () => {
     try {
@@ -179,5 +232,13 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
   openDialog: () => set({ dialogOpen: true }),
   closeDialog: () => set({ dialogOpen: false }),
   reset: () =>
-    set({ status: "idle", error: null, progress: null, dialogOpen: false, targetStatus: "unknown" }),
+    set({
+      status: "idle",
+      error: null,
+      progress: null,
+      authorizationBusy: false,
+      authorizationError: null,
+      dialogOpen: false,
+      targetStatus: "unknown",
+    }),
 }));


### PR DESCRIPTION
Automatically repair residual Linux SocksCap state during updater preparation when a previous process left a dirty recovery journal. Reuse the existing guarded recovery path so only the marked Taomni nftables table and generated empty cgroup trees are eligible for cleanup.

When cleanup requires elevation, surface a stable authorization result to the frontend and request sudo credentials directly from the update dialog. Keep credentials scoped to one IPC call and zeroize them in Rust, then resume installation from the cached downloaded update instead of downloading it again.

Preserve the existing explicit-recovery behavior on non-Linux platforms and continue blocking installation for unmanaged nftables state, journal cleanup failures, or other unsafe recovery errors.

Add Rust policy coverage plus updater service, Zustand flow, and dialog interaction tests for automatic recovery, authorization retry, incorrect passwords, cancellation, and cached-install resumption.

Tests: pnpm exec vitest run src/lib/updateService.test.ts src/stores/updateStore.test.ts src/components/UpdateDialog.test.tsx

Tests: pnpm build

Tests: cargo test --lib stale_linux_capture_is_recovered_during_update_preparation

Tests: cargo test --lib linux_update_recovery_requests_sudo_only_for_permission_failures