### PR TITLE
feat(rdp): enable Windows display selection in settings UI

### DIFF
--- a/src/components/servers/settings/RdpSettings.test.tsx
+++ b/src/components/servers/settings/RdpSettings.test.tsx
@@ -4,13 +4,14 @@ import type { RdpCaptureProbe, ServerConfig } from "../../../lib/servers";
 import { RdpSettings } from "./RdpSettings";
 
 const mocks = vi.hoisted(() => ({
+  platform: "macos" as "macos" | "windows",
   probe: vi.fn<
     (requestCapture?: boolean, requestControl?: boolean) => Promise<RdpCaptureProbe>
   >(),
 }));
 
 vi.mock("../../../lib/runtime", () => ({
-  getAppPlatform: () => "macos",
+  getAppPlatform: () => mocks.platform,
 }));
 
 vi.mock("../../../lib/servers", () => ({
@@ -29,6 +30,7 @@ const config: ServerConfig = {
 
 describe("RdpSettings macOS permissions", () => {
   beforeEach(() => {
+    mocks.platform = "macos";
     mocks.probe.mockReset();
     mocks.probe.mockResolvedValue({
       permission: "granted",
@@ -47,5 +49,32 @@ describe("RdpSettings macOS permissions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Grant permission…" }));
 
     await waitFor(() => expect(mocks.probe).toHaveBeenCalledWith(false, true));
+  });
+
+  it("reports the Windows capture backend and exposes display selection", async () => {
+    mocks.platform = "windows";
+    mocks.probe.mockResolvedValue({
+      permission: "notRequired",
+      controlPermission: "notRequired",
+      displays: [
+        {
+          id: "1",
+          name: "Primary display",
+          width: 1920,
+          height: 1080,
+          primary: true,
+        },
+      ],
+      summary: "Windows: Windows Graphics Capture with GDI compatibility fallback",
+    });
+
+    render(<RdpSettings config={config} onChange={vi.fn()} />);
+
+    await waitFor(() => expect(mocks.probe).toHaveBeenCalledWith(false, false));
+    expect(screen.getByText(/Windows Graphics Capture \(WGC\)/)).toBeInTheDocument();
+    expect(screen.queryByText(/not implemented/i)).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: /Primary display.*1920×1080/ }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/servers/settings/RdpSettings.tsx
+++ b/src/components/servers/settings/RdpSettings.tsx
@@ -37,6 +37,7 @@ export function RdpSettings({ config, onChange }: Props) {
   const requireControlApproval = config.requireControlApproval !== false;
   const displayId = typeof config.displayId === "string" ? config.displayId : "";
   const platform = getAppPlatform();
+  const supportsDisplaySelection = platform === "macos" || platform === "windows";
   const [captureProbe, setCaptureProbe] = useState<RdpCaptureProbe | null>(null);
   const [captureProbeError, setCaptureProbeError] = useState("");
   const [requestingPermission, setRequestingPermission] = useState<
@@ -69,11 +70,11 @@ export function RdpSettings({ config, onChange }: Props) {
   };
 
   useEffect(() => {
-    if (platform === "macos") void refreshCaptureProbe(false, false);
+    if (supportsDisplaySelection) void refreshCaptureProbe(false, false);
     // Probe when the settings panel is mounted; permission requests remain an
     // explicit user action through the button below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [platform]);
+  }, [supportsDisplaySelection]);
 
   const displayOptions = [
     { value: "", label: t("servers.fields.rdpDisplayPrimary") },
@@ -87,16 +88,18 @@ export function RdpSettings({ config, onChange }: Props) {
 
   return (
     <div className="flex flex-col">
-      <FieldNote tone={platform === "windows" ? "warning" : "info"}>{capabilityNote}</FieldNote>
+      <FieldNote>{capabilityNote}</FieldNote>
+      {supportsDisplaySelection ? (
+        <SelectField
+          label={t("servers.fields.rdpDisplay")}
+          value={displayId}
+          onChange={(value) => onChange({ displayId: value })}
+          options={displayOptions}
+          width={280}
+        />
+      ) : null}
       {platform === "macos" ? (
         <>
-          <SelectField
-            label={t("servers.fields.rdpDisplay")}
-            value={displayId}
-            onChange={(value) => onChange({ displayId: value })}
-            options={displayOptions}
-            width={280}
-          />
           <FormRow label={t("servers.fields.rdpCapturePermission")}>
             <span style={{ color: "var(--taomni-text-muted)" }}>
               {captureProbe?.permission === "granted"
@@ -140,8 +143,10 @@ export function RdpSettings({ config, onChange }: Props) {
               </button>
             </FormRow>
           ) : null}
-          {captureProbeError ? <FieldNote tone="warning">{captureProbeError}</FieldNote> : null}
         </>
+      ) : null}
+      {supportsDisplaySelection && captureProbeError ? (
+        <FieldNote tone="warning">{captureProbeError}</FieldNote>
       ) : null}
       <TextField
         label={t("servers.fields.rdpUsername")}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1764,7 +1764,7 @@ const dict = {
       rdpUnattendedControl:
         "Authenticated clients can control this Mac without a local confirmation prompt.",
       rdpCapWindows:
-        "Desktop capture: Windows DXGI/WGC is not implemented in this build — clients see a placeholder checkerboard. Use Linux/macOS for real desktop sharing, or wait for the Windows backend.",
+        "Desktop capture: Windows uses Windows Graphics Capture (WGC) with a bounded GDI compatibility fallback. Select the display to share; keyboard and pointer input use native SendInput.",
       rdpCapUnknown:
         "Desktop capture support depends on the host OS; check Server output after Start for the capture probe result.",
       sshPortForward:

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -1749,7 +1749,7 @@ export const zhCN: DeepPartial<typeof en> = {
       rdpControlRequired: "键盘和鼠标控制需要此权限",
       rdpUnattendedControl: "通过认证的客户端无需本机确认即可控制这台 Mac。",
       rdpCapWindows:
-        "桌面采集：本构建尚未实现 Windows DXGI/WGC，客户端将看到占位棋盘格画面。真实桌面共享请用 Linux/macOS，或等待 Windows 后端。",
+        "桌面采集：Windows 使用 Windows Graphics Capture（WGC），并提供有界的 GDI 兼容回退。请选择要共享的显示器；键盘和鼠标输入使用原生 SendInput。",
       rdpCapUnknown:
         "桌面采集能力取决于宿主系统；点击 Start 后请查看 Server output 中的 capture 探测结果。",
       sshPortForward:


### PR DESCRIPTION
- Allow display selection in RdpSettings on Windows platform.
- Update Windows capture capability descriptions in en and zh-CN i18n locales to reflect WGC backend and native SendInput support.
- Add Vitest test covering Windows capture backend reporting and display selection UI.