### PR TITLE
feat(mail): support Markdown clipboard paste

### DIFF
--- a/src/components/mail/RichMailEditor.test.tsx
+++ b/src/components/mail/RichMailEditor.test.tsx
@@ -185,6 +185,58 @@ describe("RichMailEditor", () => {
     });
   });
 
+  it("opens a full editing context menu with Markdown and plain-text paste", () => {
+    render(<RichMailEditor html="<p>Hello</p>" onChange={vi.fn()} />);
+
+    fireEvent.contextMenu(screen.getByTestId("mail-compose-editor"));
+
+    expect(screen.getByTestId("mail-compose-context-undo")).toBeInTheDocument();
+    expect(screen.getByTestId("mail-compose-context-copy")).toBeInTheDocument();
+    expect(screen.getByTestId("mail-compose-context-paste")).toBeInTheDocument();
+    expect(screen.getByTestId("mail-compose-paste-plain-text")).toBeInTheDocument();
+    expect(screen.getByTestId("mail-compose-paste-markdown")).toBeInTheDocument();
+    expect(screen.getByTestId("mail-compose-context-select-all")).toBeInTheDocument();
+  });
+
+  it("pastes clipboard text as Markdown from the context menu", async () => {
+    const execCommand = vi.fn();
+    Object.defineProperty(document, "execCommand", { configurable: true, value: execCommand });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { readText: vi.fn(async () => "# Heading\n\n**bold**") },
+    });
+    const onChange = vi.fn();
+    const onRichFormatUsed = vi.fn();
+    render(<RichMailEditor html="<p>Hello</p>" onChange={onChange} onRichFormatUsed={onRichFormatUsed} />);
+
+    fireEvent.contextMenu(screen.getByTestId("mail-compose-editor"));
+    fireEvent.click(screen.getByTestId("mail-compose-paste-markdown"));
+
+    await waitFor(() => {
+      expect(execCommand).toHaveBeenCalledWith("insertHTML", false, expect.stringContaining("<h1>Heading</h1>"));
+    });
+    expect(onRichFormatUsed).toHaveBeenCalledTimes(1);
+  });
+
+  it("pastes clipboard text as plain text without marking rich format", async () => {
+    const execCommand = vi.fn();
+    Object.defineProperty(document, "execCommand", { configurable: true, value: execCommand });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { readText: vi.fn(async () => "<not html>\nnext") },
+    });
+    const onRichFormatUsed = vi.fn();
+    render(<RichMailEditor html="<p>Hello</p>" onChange={vi.fn()} onRichFormatUsed={onRichFormatUsed} />);
+
+    fireEvent.contextMenu(screen.getByTestId("mail-compose-editor"));
+    fireEvent.click(screen.getByTestId("mail-compose-paste-plain-text"));
+
+    await waitFor(() => {
+      expect(execCommand).toHaveBeenCalledWith("insertHTML", false, "&lt;not html&gt;<br>next");
+    });
+    expect(onRichFormatUsed).not.toHaveBeenCalled();
+  });
+
   it("does not call native image paste when plain text is present", async () => {
     const execCommand = vi.fn();
     Object.defineProperty(document, "execCommand", {

--- a/src/components/mail/RichMailEditor.tsx
+++ b/src/components/mail/RichMailEditor.tsx
@@ -27,7 +27,9 @@ import {
   Smile,
   Underline,
 } from "lucide-react";
-import { mailHtmlToPlainText, sanitizeMailComposeHtml } from "../../lib/mailHtml";
+import { markdownToMailHtml, mailHtmlToPlainText, sanitizeMailComposeHtml } from "../../lib/mailHtml";
+import { readClipboardImageFiles, readMultiFormat, readText } from "../../lib/clipboard";
+import { useT } from "../../lib/i18n";
 import { isOsFileDrag, preventDefaultForOsFileDrag } from "../../lib/osFileDrop";
 import { useContextMenu, type MenuItem } from "../ContextMenu";
 
@@ -99,9 +101,11 @@ export function RichMailEditor({
   dragActive = false,
 }: RichMailEditorProps) {
   const editorRef = useRef<HTMLDivElement>(null);
+  const selectionRef = useRef<Range | null>(null);
   const [color, setColor] = useState("#1f2937");
   const [localDrag, setLocalDrag] = useState(false);
   const editorMenu = useContextMenu();
+  const t = useT();
 
   useEffect(() => {
     const editor = editorRef.current;
@@ -121,20 +125,75 @@ export function RichMailEditor({
     editorRef.current?.focus();
   };
 
+  const isRangeInEditor = (range: Range | null): range is Range => {
+    const editor = editorRef.current;
+    return !!editor && !!range && editor.contains(range.commonAncestorContainer);
+  };
+
+  const saveSelection = () => {
+    const selection = window.getSelection();
+    if (selection?.rangeCount && isRangeInEditor(selection.getRangeAt(0))) {
+      selectionRef.current = selection.getRangeAt(0).cloneRange();
+    }
+  };
+
+  const restoreSelection = () => {
+    const range = selectionRef.current;
+    if (!isRangeInEditor(range)) return;
+    const selection = window.getSelection();
+    if (!selection) return;
+    selection.removeAllRanges();
+    selection.addRange(range);
+  };
+
+  const focusAndRestoreSelection = () => {
+    focusEditor();
+    restoreSelection();
+  };
+
   const exec = (command: string, value?: string, rich = true) => {
     if (disabled) return;
-    focusEditor();
+    focusAndRestoreSelection();
     document.execCommand(command, false, value);
+    saveSelection();
     if (rich) onRichFormatUsed?.();
     emitChange();
   };
 
   const insertHtml = (value: string, rich = true) => {
-    if (disabled) return;
-    focusEditor();
+    if (disabled || !value) return;
+    focusAndRestoreSelection();
     document.execCommand("insertHTML", false, value);
+    saveSelection();
     if (rich) onRichFormatUsed?.();
     emitChange();
+  };
+
+  const pasteClipboard = async (mode: "normal" | "plain" | "markdown") => {
+    if (disabled) return;
+    if (mode === "plain" || mode === "markdown") {
+      const text = await readText();
+      if (!text.trim()) return;
+      insertHtml(mode === "markdown" ? markdownToMailHtml(text) : plainTextFragment(text), mode === "markdown");
+      return;
+    }
+    const data = await readMultiFormat();
+    const imageFiles = await readClipboardImageFiles();
+    if (onPasteImages && imageFiles.length > 0) {
+      const snippets = await onPasteImages(imageFiles);
+      for (const snippet of snippets) insertHtml(snippet, true);
+      return;
+    }
+    if (onPasteImages && !data.html?.trim() && !data.text.trim()) {
+      const snippets = await onPasteImages([]);
+      for (const snippet of snippets) insertHtml(snippet, true);
+      return;
+    }
+    if (data.html?.trim()) {
+      insertHtml(sanitizeMailComposeHtml(data.html), true);
+    } else if (data.text) {
+      insertHtml(plainTextFragment(data.text), false);
+    }
   };
 
   const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {
@@ -143,9 +202,6 @@ export function RichMailEditor({
     const pastedHtml = event.clipboardData?.getData("text/html") ?? "";
     const pastedText = event.clipboardData?.getData("text/plain") ?? "";
     const imageFiles = clipboardImageFiles(event.clipboardData);
-    // Linux WebKitGTK often omits image/* from the paste event even when the
-    // OS clipboard holds a screenshot. When there is no text/html payload,
-    // let the parent try native clipboard image read.
     const maybeNativeImageOnly =
       !!onPasteImages && imageFiles.length === 0 && !pastedHtml.trim() && !pastedText.trim();
 
@@ -158,7 +214,7 @@ export function RichMailEditor({
             if (snippet) insertHtml(snippet, true);
           }
         } catch {
-          // Parent surfaces errors via compose status/error.
+          // Parent surfaces errors via compose status/compose error.
         }
       })();
       return;
@@ -167,9 +223,9 @@ export function RichMailEditor({
     event.preventDefault();
     if (pastedHtml) {
       insertHtml(sanitizeMailComposeHtml(pastedHtml), true);
-      return;
+    } else if (pastedText) {
+      insertHtml(plainTextFragment(pastedText), false);
     }
-    if (pastedText) insertHtml(escapeHtml(pastedText).replace(/\r?\n/g, "<br>"), false);
   };
 
   const handleDragOver = (event: ReactDragEvent<HTMLDivElement>) => {
@@ -258,6 +314,28 @@ export function RichMailEditor({
     testId: `mail-compose-emoji-${emoji.id}`,
     onClick: () => insertHtml(emoji.value, false),
   }));
+
+  const editingMenuItems = (): MenuItem[] => [
+    { label: t("contextMenu.undo"), testId: "mail-compose-context-undo", shortcut: shortcut("Z"), onClick: () => exec("undo", undefined, false) },
+    { label: t("contextMenu.redo"), testId: "mail-compose-context-redo", shortcut: shortcut("Y"), onClick: () => exec("redo", undefined, false) },
+    { label: "", separator: true },
+    { label: t("contextMenu.cut"), testId: "mail-compose-context-cut", shortcut: shortcut("X"), onClick: () => exec("cut", undefined, false) },
+    { label: t("contextMenu.copy"), testId: "mail-compose-context-copy", shortcut: shortcut("C"), onClick: () => exec("copy", undefined, false) },
+    { label: t("contextMenu.paste"), testId: "mail-compose-context-paste", shortcut: shortcut("V"), onClick: () => void pasteClipboard("normal") },
+    { label: t("contextMenu.pasteAsPlainText"), testId: "mail-compose-paste-plain-text", onClick: () => void pasteClipboard("plain") },
+    { label: t("contextMenu.pasteAsMarkdown"), testId: "mail-compose-paste-markdown", onClick: () => void pasteClipboard("markdown") },
+    { label: "", separator: true },
+    { label: t("contextMenu.selectAll"), testId: "mail-compose-context-select-all", shortcut: shortcut("A"), onClick: () => exec("selectAll", undefined, false) },
+  ];
+
+  const handleEditorContextMenu = (event: ReactMouseEvent<HTMLDivElement>) => {
+    if (disabled) return;
+    const selection = window.getSelection();
+    const hasSelectedText = !!selection && selection.rangeCount > 0 && !selection.isCollapsed && isRangeInEditor(selection.getRangeAt(0));
+    if (!hasSelectedText) placeCaretAtPoint(event.clientX, event.clientY);
+    saveSelection();
+    editorMenu.show(event, editingMenuItems());
+  };
 
   const insertMenuItems = (): MenuItem[] => [
     {
@@ -396,8 +474,12 @@ export function RichMailEditor({
           role="textbox"
           aria-label="Message body"
           data-testid="mail-compose-editor"
-          onInput={emitChange}
+          onInput={() => {
+            saveSelection();
+            emitChange();
+          }}
           onPaste={handlePaste}
+          onContextMenu={handleEditorContextMenu}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
@@ -496,6 +578,37 @@ function hasFilePayload(data: DataTransfer | null): boolean {
   if (!data) return false;
   if ((data.files?.length ?? 0) > 0) return true;
   return Array.from(data.types ?? []).some((type) => type === "Files" || type === "text/uri-list");
+}
+
+function placeCaretAtPoint(x: number, y: number): void {
+  const doc = document as Document & {
+    caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null;
+    caretRangeFromPoint?: (x: number, y: number) => Range | null;
+  };
+  const selection = window.getSelection();
+  if (!selection) return;
+  const position = doc.caretPositionFromPoint?.(x, y);
+  if (position) {
+    const range = document.createRange();
+    range.setStart(position.offsetNode, position.offset);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    return;
+  }
+  const range = doc.caretRangeFromPoint?.(x, y);
+  if (range) {
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+}
+
+function plainTextFragment(value: string): string {
+  return escapeHtml(value).replace(/\r\n?|\n/g, "<br>");
+}
+
+function shortcut(key: string): string {
+  return `${navigator.platform.toLowerCase().includes("mac") ? "Cmd" : "Ctrl"}+${key}`;
 }
 
 function escapeHtml(value: string): string {

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -2513,9 +2513,13 @@ const dict = {
     sessionsDrawer: "Show sessions drawer",
   },
   contextMenu: {
+    undo: "Undo",
+    redo: "Redo",
     cut: "Cut",
     copy: "Copy",
     paste: "Paste",
+    pasteAsPlainText: "Paste as Plain Text",
+    pasteAsMarkdown: "Paste as Markdown",
     selectAll: "Select all",
     inspect: "Inspect",
   },

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -2498,9 +2498,13 @@ export const zhCN: DeepPartial<typeof en> = {
     sessionsDrawer: "显示会话面板",
   },
   contextMenu: {
+    undo: "撤销",
+    redo: "重做",
     cut: "剪切",
     copy: "复制",
     paste: "粘贴",
+    pasteAsPlainText: "粘贴为纯文本",
+    pasteAsMarkdown: "粘贴为 Markdown",
     selectAll: "全选",
     inspect: "检查元素",
   },

--- a/src/lib/mailHtml.test.ts
+++ b/src/lib/mailHtml.test.ts
@@ -4,6 +4,7 @@ import {
   buildMailReaderSrcDoc,
   buildReplyHtml,
   hasRichMailFormatting,
+  markdownToMailHtml,
   isRemoteMailImageSrc,
   mailHtmlHasRemoteImages,
   mailHtmlToPlainText,
@@ -125,6 +126,39 @@ describe("mailHtml", () => {
     expect(forSend).toContain("src=\"cid:logo-1@inline.local\"");
     expect(forSend).not.toContain("data:image");
     expect(forSend).not.toContain("data-taomni-cid");
+  });
+
+  it("renders Markdown as sanitized portable mail HTML", () => {
+    const html = markdownToMailHtml([
+      "# Hello",
+      "",
+      "A **bold** item and [safe link](https://example.com).",
+      "",
+      "| A | B |",
+      "| --- | --- |",
+      "| 1 | 2 |",
+      "",
+      "```ts",
+      "const answer = 42;",
+      "```",
+      "",
+      "<script>alert(1)</script>",
+      "[bad](javascript:alert(1))",
+    ].join("\n"));
+
+    expect(html).toContain("<h1>Hello</h1>");
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<table");
+    expect(html).toContain("<pre");
+    expect(html).toContain("const answer = 42;");
+    expect(html).toContain('target="_blank"');
+    expect(html).not.toContain("<script");
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain("border-collapse");
+  });
+
+  it("normalizes bare carriage returns in plain text", () => {
+    expect(markdownToMailHtml("one\rtwo")).toContain("one<br>two");
   });
 
   it("round-trips plain text through mail HTML and extracts readable text from lists and paragraphs", () => {

--- a/src/lib/mailHtml.ts
+++ b/src/lib/mailHtml.ts
@@ -1,3 +1,4 @@
+import { Marked } from "marked";
 import DOMPurify, { type Config as DomPurifyConfig } from "dompurify";
 
 const MAIL_ALLOWED_TAGS = [
@@ -15,6 +16,11 @@ const MAIL_ALLOWED_ATTR = [
   "rowspan", "rules", "scope", "size", "span", "src", "style", "summary",
   "target", "title", "type", "valign", "width",
 ];
+
+const MAIL_MARKDOWN = new Marked({
+  gfm: true,
+  breaks: true,
+});
 
 const MAIL_PURIFY_CONFIG: DomPurifyConfig = {
   ALLOWED_TAGS: MAIL_ALLOWED_TAGS,
@@ -837,6 +843,52 @@ export function sanitizeMailComposeHtml(html: string): string {
   installMailPurifyHooks();
   const sanitized = DOMPurify.sanitize(html, MAIL_PURIFY_CONFIG) as unknown as string;
   return sanitized.trim() || "<p><br></p>";
+}
+
+/**
+ * Convert Markdown clipboard text to portable, email-safe HTML.
+ *
+ * This deliberately uses a mail-specific renderer rather than the chat
+ * renderer: compose HTML must survive outside Taomni and use the mail
+ * sanitizer/style policy as its final security boundary.
+ */
+export function markdownToMailHtml(markdown: string): string {
+  const source = markdown.replace(/\r\n?/g, "\n");
+  if (!source.trim()) return "<p><br></p>";
+  const rendered = MAIL_MARKDOWN.parse(source) as string;
+  const styled = addMailMarkdownStyles(rendered);
+  return sanitizeMailComposeHtml(styled);
+}
+
+function addMailMarkdownStyles(html: string): string {
+  if (typeof DOMParser === "undefined") return html;
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  doc.querySelectorAll("blockquote").forEach((node) => {
+    appendNodeStyle(node, "border-left: 2px solid #729fcf; margin: 0.6em 0; padding-left: 0.85em; color: #333333;");
+  });
+  doc.querySelectorAll("pre").forEach((node) => {
+    appendNodeStyle(node, "margin: 0.6em 0; padding: 0.65em 0.8em; overflow: auto; background: #f4f4f5; color: #1f2937; white-space: pre-wrap; word-break: break-word;");
+  });
+  doc.querySelectorAll("pre code").forEach((node) => {
+    appendNodeStyle(node, "font-family: ui-monospace, Consolas, monospace; font-size: 0.92em;");
+  });
+  doc.querySelectorAll("code:not(pre code)").forEach((node) => {
+    appendNodeStyle(node, "font-family: ui-monospace, Consolas, monospace; font-size: 0.92em; background: #f4f4f5; padding: 0.05em 0.35em;");
+  });
+  doc.querySelectorAll("table").forEach((node) => {
+    appendNodeStyle(node, "border-collapse: collapse; border-spacing: 0; max-width: 100%;");
+  });
+  doc.querySelectorAll("th, td").forEach((node) => {
+    appendNodeStyle(node, "border: 1px solid #d4d4d8; padding: 0.25em 0.5em; vertical-align: top; text-align: left;");
+  });
+  doc.querySelectorAll("th").forEach((node) => appendNodeStyle(node, "background: #f4f4f5; font-weight: 600;"));
+  doc.querySelectorAll("hr").forEach((node) => appendNodeStyle(node, "margin: 1em 0; border: none; border-top: 1px solid #d4d4d8;"));
+  return doc.body.innerHTML;
+}
+
+function appendNodeStyle(node: Element, style: string): void {
+  const existing = node.getAttribute("style")?.trim();
+  node.setAttribute("style", existing ? `${existing}; ${style}` : style);
 }
 
 /** Build a compose-time inline image that previews via data URL and sends as cid: */


### PR DESCRIPTION
Add a full custom context menu to the rich mail compose editor so the editor can expose Markdown paste alongside plain-text paste without losing standard editing commands.

- preserve undo, redo, cut, copy, paste, and select-all actions
- preserve the compose caret and selection while menus and async clipboard reads take focus
- reuse shared clipboard readers for normal, plain-text, and Markdown paste
- add GFM Markdown conversion with mail-specific sanitization and portable inline styles for headings, quotes, code, tables, and separators
- keep plain-text and rich-format draft bodies synchronized through the existing editor change pipeline
- localize the new context-menu labels in English and Simplified Chinese
- cover Markdown rendering, sanitization, line-ending normalization, menu actions, escaping, and rich-format behavior with focused tests