### PR TITLE
fix(vnc): support anonymous TLS security negotiation

### DIFF
--- a/qa-ui-auto-tests/feature-list.md
+++ b/qa-ui-auto-tests/feature-list.md
@@ -2042,14 +2042,16 @@ files:
 controls: []   # backend-only — RFB protocol + WebSocket bridge; the canvas surface is owned by F9.6
 -->
 
-- Rust 端 VNC 模块：`src-tauri/src/vnc/{mod,rfb,ws,encodings,clipboard,error,limits,policy,queue}.rs`
+- Rust 端 VNC 模块：`src-tauri/src/vnc/{mod,rfb,tls,ws,encodings,clipboard,error,limits,policy,queue}.rs`
 - Tauri 命令：`vnc_connect / vnc_disconnect / vnc_test_connection / vnc_create_detach_claim / vnc_consume_detach_claim`
 - 本地动态端口 WebSocket relay：VNC server ↔ 前端 Canvas（前端不再直接持有 TCP 套接字）
 
 ### 9.2 RFB 握手与认证 ✅
-- 安全类型：None（仅显式 `allow-none`）、VNC password、RealVNC RA2 / RA2ne（128 / 256 位 AES）
+- 安全类型：None（仅显式 `allow-none`）、VNC password、RFB 18 anonymous TLS + 内层安全协商、RealVNC RA2 / RA2ne（128 / 256 位 AES）
 - RA2 子模式：USER_PASS、PASS-only；公钥位长度合法性校验（1024–8192 bit）
-- `RequireEncryption` 在没有 VeNCrypt/TLS 实现时 fail closed，并返回 `security-policy-unsupported`；RA2 提供加密但不验证服务器证书身份
+- TCP 建连使用独立 15 秒 deadline；RFB 安全协商和认证使用 45 秒 timeout，支持服务端认证限速/延迟，并将超时标记为可重试的 authentication/security 阶段错误
+- Tokio socket 交给同步 RFB 解码器前恢复 blocking mode，避免 `WouldBlock` 被误报为认证超时
+- RFB 18 TLS 使用匿名密码套件，能够加密传输但不验证服务器身份；`RequireEncryption` 继续 fail closed，VeNCrypt/X509 TLS 和证书校验仍未实现
 
 ### 9.3 编码与画面 ✅
 - 解码器：Raw（0）、CopyRect（1）、Hextile（5）、ZRLE（16，单一持久 zlib 流）
@@ -2125,7 +2127,7 @@ controls:
 - VNC tab 常驻挂载，切换标签时连接不主动销毁
 - 已修复 VNC 剪贴板与输入延迟、Windows 11 上的 client→server 文本粘贴
 - view-only 与剪贴板方向（disabled / client→server / server→client / bidirectional）由前后端同时执行；None 默认拒绝
-- 当前不启用 Tight/JPEG、VeNCrypt/TLS，也不发送 RFB SetDesktopSize；窗口变化只调整本地显示
+- 当前不启用 Tight/JPEG、VeNCrypt/X509 TLS，也不发送 RFB SetDesktopSize；RFB 18 anonymous TLS 已支持，但不提供服务器身份验证；窗口变化只调整本地显示
 
 ### 9.7 RDP client（IronRDP 0.17）🟡
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6670,6 +6670,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6677,6 +6686,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -10320,6 +10330,7 @@ dependencies = [
  "objc2-screen-capture-kit",
  "objc2-video-toolbox",
  "openh264",
+ "openssl",
  "oracle",
  "pbkdf2",
  "pipewire",
@@ -10373,6 +10384,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-opengauss",
+ "tokio-openssl",
  "tokio-rustls 0.26.4",
  "tokio-tungstenite",
  "tokio-util 0.7.18",
@@ -11099,6 +11111,17 @@ dependencies = [
  "socket2 0.4.10",
  "tokio",
  "tokio-util 0.6.10",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
+dependencies = [
+ "openssl",
+ "openssl-sys",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -102,6 +102,11 @@ lettre = "0.11.22"
 mail-parser = { version = "0.11.4", features = ["full_encoding"] }
 native-tls = "0.2"
 tokio-native-tls = "0.3"
+# RFB security type 18 uses anonymous TLS, which rustls and the platform
+# native-tls backends intentionally do not offer. OpenSSL is scoped to the VNC
+# transport upgrade and vendored so Windows builds do not require a system SDK.
+openssl = { version = "0.10.81", features = ["vendored"] }
+tokio-openssl = "0.6.5"
 ironrdp = { version = "0.17.0", features = ["core", "connector", "session", "graphics", "input", "cliprdr", "rdpdr", "rdpsnd", "svc", "dvc", "displaycontrol", "server", "acceptor"] }
 ironrdp-tokio = { version = "0.10.0", features = ["reqwest-rustls-ring"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }

--- a/src-tauri/src/vnc/error.rs
+++ b/src-tauri/src/vnc/error.rs
@@ -38,6 +38,12 @@ impl VncError {
             ("dns-failed", VncStage::Dns, true)
         } else if lower.contains("proxy") || lower.contains("jump host") {
             ("network-route-failed", VncStage::Proxy, true)
+        } else if lower.contains("authentication timed out") {
+            ("authentication-timeout", VncStage::Authentication, true)
+        } else if lower.contains("security negotiation timed out") {
+            ("security-timeout", VncStage::Security, true)
+        } else if lower.contains("vnc tls") {
+            ("tls-failed", VncStage::Security, false)
         } else if lower.contains("vencrypt/tls")
             || (lower.contains("security policy") && lower.contains("unavailable"))
         {
@@ -113,5 +119,28 @@ mod tests {
     fn bounds_error_messages() {
         assert!(VncError::classify("x".repeat(3000)).message.len() <= 2051);
         assert!(VncError::classify("中".repeat(1000)).message.len() <= 2051);
+    }
+
+    #[test]
+    fn authentication_timeout_is_retryable_and_stage_specific() {
+        let error = VncError::classify(
+            "VNC authentication timed out while waiting for the security result",
+        );
+        assert_eq!(error.code, "authentication-timeout");
+        assert_eq!(error.stage, VncStage::Authentication);
+        assert!(error.retryable);
+    }
+
+    #[test]
+    fn tls_and_security_timeouts_have_security_stage_errors() {
+        let timeout = VncError::classify("VNC security negotiation timed out");
+        assert_eq!(timeout.code, "security-timeout");
+        assert_eq!(timeout.stage, VncStage::Security);
+        assert!(timeout.retryable);
+
+        let tls = VncError::classify("VNC TLS handshake failed: no shared cipher");
+        assert_eq!(tls.code, "tls-failed");
+        assert_eq!(tls.stage, VncStage::Security);
+        assert!(!tls.retryable);
     }
 }

--- a/src-tauri/src/vnc/mod.rs
+++ b/src-tauri/src/vnc/mod.rs
@@ -5,6 +5,7 @@ pub mod limits;
 pub mod policy;
 pub mod queue;
 pub mod rfb;
+pub mod tls;
 pub mod ws;
 
 use serde::{Deserialize, Serialize};
@@ -283,14 +284,34 @@ pub async fn vnc_test_connection(
             crate::terminal::resolve_jump_credentials(&state, settings)?;
         }
         let policy = security_policy.unwrap_or_default();
-        let transport = dial_vnc_transport(host, port, network).await?;
+        let transport = dial_vnc_transport(host.clone(), port, network).await?;
         let forward_task = transport.network_forward_task;
+        let prepared = match crate::vnc::tls::prepare_rfb_transport(
+            transport.stream,
+            &host,
+            policy,
+            crate::vnc::ws::VNC_AUTH_TIMEOUT,
+        )
+        .await
+        {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                if let Some(task) = forward_task {
+                    task.abort();
+                }
+                return Err(error);
+            }
+        };
+        let tls_task = prepared.tls_task;
         let handshake = tokio::task::spawn_blocking(move || {
-            let mut rfb = crate::vnc::rfb::RfbConnection::from_stream(
-                transport.stream,
-                std::time::Duration::from_secs(15),
+            let mut rfb = crate::vnc::rfb::RfbConnection::from_negotiated_stream(
+                prepared.stream,
+                crate::vnc::ws::VNC_AUTH_TIMEOUT,
                 policy,
                 crate::vnc::limits::DecodeLimits::default(),
+                prepared.proto_minor,
+                prepared.pending_security,
+                prepared.outer_security_type,
             )?;
             let init =
                 rfb.authenticate_with_policy(username.as_deref(), resolved.as_deref(), policy)?;
@@ -301,6 +322,9 @@ pub async fn vnc_test_connection(
         })
         .await;
         if let Some(task) = forward_task {
+            task.abort();
+        }
+        if let Some(task) = tls_task {
             task.abort();
         }
         handshake.map_err(|e| format!("VNC handshake worker failed: {e}"))?

--- a/src-tauri/src/vnc/policy.rs
+++ b/src-tauri/src/vnc/policy.rs
@@ -42,15 +42,18 @@ pub enum VncSecurityType {
     VncAuth,
     Ra2,
     Ra2ne,
+    /// RFB security type 18. It encrypts the transport but does not
+    /// authenticate the server certificate.
+    AnonymousTls,
 }
 
 impl VncSecurityType {
     pub fn encrypted(self) -> bool {
-        matches!(self, Self::Ra2)
+        matches!(self, Self::Ra2 | Self::AnonymousTls)
     }
 
     pub fn authenticated(self) -> bool {
-        !matches!(self, Self::None)
+        !matches!(self, Self::None | Self::AnonymousTls)
     }
 
     pub fn label(self) -> &'static str {
@@ -59,6 +62,7 @@ impl VncSecurityType {
             Self::VncAuth => "VNCAuth",
             Self::Ra2 => "RA2",
             Self::Ra2ne => "RA2ne",
+            Self::AnonymousTls => "TLS (anonymous)",
         }
     }
 }
@@ -101,6 +105,22 @@ impl VncSecurityPolicy {
         Err(SecurityPolicyError("no supported VNC security type".into()))
     }
 
+    /// Choose an outer security type when the caller can upgrade type 18 to
+    /// TLS before handing the decrypted stream to the RFB engine.
+    pub fn choose_outer(self, offered: &[u8]) -> Result<u8, SecurityPolicyError> {
+        const ANONYMOUS_TLS: u8 = 18;
+
+        if matches!(self, Self::RequireEncryption) {
+            return Err(SecurityPolicyError(
+                "encrypted VNC policy requires authenticated TLS; anonymous RFB TLS does not verify server identity".into(),
+            ));
+        }
+        if offered.contains(&ANONYMOUS_TLS) {
+            return Ok(ANONYMOUS_TLS);
+        }
+        self.choose(offered)
+    }
+
     pub fn allows_v33_none(self) -> bool {
         matches!(self, Self::AllowNone)
     }
@@ -112,6 +132,7 @@ pub fn security_type_kind(value: u8) -> Option<VncSecurityType> {
         2 => Some(VncSecurityType::VncAuth),
         5 | 129 => Some(VncSecurityType::Ra2),
         6 | 130 => Some(VncSecurityType::Ra2ne),
+        18 => Some(VncSecurityType::AnonymousTls),
         _ => None,
     }
 }
@@ -139,6 +160,26 @@ mod tests {
             VncSecurityPolicy::PreferEncryption.choose(&[2, 6, 5]),
             Ok(5)
         );
+    }
+
+    #[test]
+    fn anonymous_tls_is_preferred_for_outer_negotiation() {
+        assert_eq!(
+            VncSecurityPolicy::PreferEncryption.choose_outer(&[2, 18]),
+            Ok(18)
+        );
+        assert_eq!(
+            VncSecurityPolicy::LegacyCompatible.choose_outer(&[18, 2]),
+            Ok(18)
+        );
+    }
+
+    #[test]
+    fn require_encryption_rejects_anonymous_tls_identity() {
+        let error = VncSecurityPolicy::RequireEncryption
+            .choose_outer(&[18, 2])
+            .unwrap_err();
+        assert!(error.0.contains("does not verify server identity"));
     }
 
     #[test]

--- a/src-tauri/src/vnc/rfb.rs
+++ b/src-tauri/src/vnc/rfb.rs
@@ -15,6 +15,7 @@ const SEC_TYPE_NONE: u8 = 1;
 const SEC_TYPE_VNC_AUTH: u8 = 2;
 const SEC_TYPE_RA2_128: u8 = 5;
 const SEC_TYPE_RA2NE_128: u8 = 6;
+pub(crate) const SEC_TYPE_ANONYMOUS_TLS: u8 = 18;
 const SEC_TYPE_RA2_256: u8 = 129;
 const SEC_TYPE_RA2NE_256: u8 = 130;
 
@@ -23,6 +24,43 @@ const RA2_SUBTYPE_PASS: u8 = 2;
 const RA2_MIN_KEY_BITS: usize = 1024;
 const RA2_MAX_KEY_BITS: usize = 8192;
 const RA2_AES_FRAME_MAX: usize = 8192;
+
+pub(crate) fn negotiate_protocol_version(
+    server_banner: &[u8; 12],
+) -> Result<([u8; 12], u8), String> {
+    if &server_banner[..4] != b"RFB " || server_banner[11] != b'\n' {
+        return Err(format!(
+            "invalid RFB version: {:?}",
+            String::from_utf8_lossy(server_banner)
+        ));
+    }
+
+    let major: u32 = std::str::from_utf8(&server_banner[4..7])
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(3);
+    let minor: u32 = std::str::from_utf8(&server_banner[8..11])
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(3);
+
+    let (reply, negotiated_minor) = if major > 3 || minor >= 8 {
+        (*b"RFB 003.008\n", 8)
+    } else if minor >= 7 {
+        (*b"RFB 003.007\n", 7)
+    } else {
+        (*b"RFB 003.003\n", 3)
+    };
+    Ok((reply, negotiated_minor))
+}
+
+fn authentication_read_error(action: &str, error: Error) -> String {
+    if matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) {
+        format!("VNC authentication timed out while {action}")
+    } else {
+        format!("VNC authentication failed while {action}: {error}")
+    }
+}
 
 #[derive(Debug)]
 pub struct ServerInit {
@@ -41,12 +79,20 @@ pub struct RfbConnection {
     pub framebuffer: Vec<u8>,
     limits: DecodeLimits,
     security_policy: VncSecurityPolicy,
+    pending_security: Option<PendingSecurity>,
+    outer_security_type: Option<u8>,
     /// Negotiated protocol minor version (3, 7, or 8).
     proto_minor: u8,
     /// Hextile bg/fg carry across tiles per the RFB spec.
     hextile_state: HextileState,
     /// ZRLE uses a single zlib stream for the whole session.
     zrle_decoder: ZrleDecoder,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum PendingSecurity {
+    V33(u32),
+    Selected(u8),
 }
 
 pub struct RfbWriter {
@@ -92,6 +138,47 @@ impl RfbConnection {
         security_policy: VncSecurityPolicy,
         limits: DecodeLimits,
     ) -> Result<Self, String> {
+        let mut conn = Self::new_stream(stream, timeout, limits, security_policy, 8, None, None)?;
+
+        conn.handshake_protocol_version()?;
+        Ok(conn)
+    }
+
+    pub(crate) fn from_negotiated_stream(
+        stream: TcpStream,
+        timeout: Duration,
+        security_policy: VncSecurityPolicy,
+        limits: DecodeLimits,
+        proto_minor: u8,
+        pending_security: Option<PendingSecurity>,
+        outer_security_type: Option<u8>,
+    ) -> Result<Self, String> {
+        Self::new_stream(
+            stream,
+            timeout,
+            limits,
+            security_policy,
+            proto_minor,
+            pending_security,
+            outer_security_type,
+        )
+    }
+
+    fn new_stream(
+        stream: TcpStream,
+        timeout: Duration,
+        limits: DecodeLimits,
+        security_policy: VncSecurityPolicy,
+        proto_minor: u8,
+        pending_security: Option<PendingSecurity>,
+        outer_security_type: Option<u8>,
+    ) -> Result<Self, String> {
+        // Tokio's `TcpStream::into_std` intentionally preserves nonblocking
+        // mode. The RFB decoder is synchronous, so restore blocking semantics
+        // before applying bounded socket timeouts.
+        stream
+            .set_nonblocking(false)
+            .map_err(|e| format!("set blocking mode failed: {}", e))?;
         stream
             .set_read_timeout(Some(timeout))
             .map_err(|e| format!("set read timeout failed: {}", e))?;
@@ -102,7 +189,7 @@ impl RfbConnection {
             .set_nodelay(true)
             .map_err(|e| format!("set_nodelay failed: {}", e))?;
 
-        let mut conn = RfbConnection {
+        Ok(Self {
             stream,
             secure_io: None,
             width: 0,
@@ -112,17 +199,37 @@ impl RfbConnection {
             framebuffer: Vec::new(),
             limits,
             security_policy,
-            proto_minor: 8,
+            pending_security,
+            outer_security_type,
+            proto_minor,
             hextile_state: HextileState::new(),
             zrle_decoder: ZrleDecoder::new(),
-        };
-
-        conn.handshake_protocol_version()?;
-        Ok(conn)
+        })
     }
 
     pub fn protocol_version(&self) -> String {
         format!("3.{}", self.proto_minor)
+    }
+
+    pub fn security_label(&self) -> String {
+        let inner = self
+            .security_type
+            .and_then(crate::vnc::policy::security_type_kind)
+            .map(|kind| kind.label())
+            .unwrap_or("Unknown");
+        if self.outer_security_type == Some(SEC_TYPE_ANONYMOUS_TLS) {
+            format!("TLS (anonymous) + {inner}")
+        } else {
+            inner.to_string()
+        }
+    }
+
+    pub fn encrypted(&self) -> bool {
+        self.outer_security_type == Some(SEC_TYPE_ANONYMOUS_TLS)
+            || self
+                .security_type
+                .and_then(crate::vnc::policy::security_type_kind)
+                .is_some_and(|kind| kind.encrypted())
     }
 
     pub fn shutdown_handle(&self) -> Result<TcpStream, String> {
@@ -138,36 +245,11 @@ impl RfbConnection {
         self.read_exact(&mut buf)
             .map_err(|e| format!("read protocol version: {}", e))?;
 
-        if &buf[..4] != b"RFB " || buf[11] != b'\n' {
-            return Err(format!(
-                "invalid RFB version: {:?}",
-                String::from_utf8_lossy(&buf)
-            ));
-        }
-
-        // Parse "RFB MMM.NNN\n": major = buf[4..7], minor = buf[8..11]
-        let major: u32 = std::str::from_utf8(&buf[4..7])
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(3);
-        let minor: u32 = std::str::from_utf8(&buf[8..11])
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(3);
-
-        // Any major > 3 (e.g. 4.x, 5.x) is a modern server — negotiate 3.8.
-        // Within major 3: use the highest version we support (3.8 > 3.7 > 3.3).
-        let (reply, negotiated_minor) = if major > 3 || minor >= 8 {
-            (b"RFB 003.008\n" as &[u8], 8u8)
-        } else if minor >= 7 {
-            (b"RFB 003.007\n" as &[u8], 7u8)
-        } else {
-            (b"RFB 003.003\n" as &[u8], 3u8)
-        };
+        let (reply, negotiated_minor) = negotiate_protocol_version(&buf)?;
 
         self.proto_minor = negotiated_minor;
 
-        self.write_all(reply)
+        self.write_all(&reply)
             .map_err(|e| format!("write protocol version: {}", e))?;
         self.flush().map_err(|e| format!("flush: {}", e))?;
 
@@ -190,45 +272,29 @@ impl RfbConnection {
         policy: VncSecurityPolicy,
     ) -> Result<ServerInit, String> {
         self.security_policy = policy;
-        // RFB 3.3: server dictates the security type directly as a u32
+        if matches!(self.pending_security, Some(PendingSecurity::V33(_))) {
+            let Some(PendingSecurity::V33(sec_type)) = self.pending_security.take() else {
+                unreachable!();
+            };
+            return self.authenticate_v33_with_policy(password, policy, Some(sec_type));
+        }
+        // RFB 3.3: server dictates the security type directly as a u32.
         if self.proto_minor <= 3 {
-            return self.authenticate_v33_with_policy(password, policy);
+            return self.authenticate_v33_with_policy(password, policy, None);
         }
 
-        // RFB 3.7 / 3.8: server sends a list of security types
-        let mut sec_buf = [0u8; 1];
-        self.read_exact(&mut sec_buf)
-            .map_err(|e| format!("read security types count: {}", e))?;
-
-        let num_types = sec_buf[0] as usize;
-
-        if num_types == 0 {
-            let mut len_buf = [0u8; 4];
-            self.read_exact(&mut len_buf)
-                .map_err(|e| format!("read sec failure len: {}", e))?;
-            let reason_len = u32::from_be_bytes(len_buf) as usize;
-            if reason_len > self.limits.max_reason_bytes {
-                return Err("VNC failure reason exceeds configured limit".into());
-            }
-            let mut reason = vec![0u8; reason_len];
-            self.read_exact(&mut reason)
-                .map_err(|e| format!("read sec failure reason: {}", e))?;
-            return Err(format!(
-                "server rejected connection: {}",
-                String::from_utf8_lossy(&reason)
-            ));
-        }
-
-        let mut types = vec![0u8; num_types];
-        self.read_exact(&mut types)
-            .map_err(|e| format!("read security types: {}", e))?;
-
-        let chosen = self.security_policy.choose(&types).map_err(|e| e.0)?;
+        let (chosen, write_selection) = match self.pending_security.take() {
+            Some(PendingSecurity::Selected(chosen)) => (chosen, false),
+            Some(PendingSecurity::V33(_)) => unreachable!(),
+            None => (self.read_and_choose_security_type()?, true),
+        };
         self.security_type = Some(chosen);
 
-        self.write_all(&[chosen])
-            .map_err(|e| format!("write security type: {}", e))?;
-        self.flush().map_err(|e| format!("flush: {}", e))?;
+        if write_selection {
+            self.write_all(&[chosen])
+                .map_err(|e| format!("write security type: {}", e))?;
+            self.flush().map_err(|e| format!("flush: {}", e))?;
+        }
 
         match chosen {
             SEC_TYPE_NONE => {} // None — no auth
@@ -247,7 +313,7 @@ impl RfbConnection {
         if self.proto_minor >= 8 || chosen != 1 {
             let mut result_buf = [0u8; 4];
             self.read_exact(&mut result_buf)
-                .map_err(|e| format!("read security result: {}", e))?;
+                .map_err(|e| authentication_read_error("waiting for the security result", e))?;
             let result = u32::from_be_bytes(result_buf);
             if result != 0 {
                 // 3.8 sends a reason string; 3.7 does not
@@ -283,16 +349,51 @@ impl RfbConnection {
         self.read_server_init()
     }
 
+    fn read_and_choose_security_type(&mut self) -> Result<u8, String> {
+        let mut sec_buf = [0u8; 1];
+        self.read_exact(&mut sec_buf)
+            .map_err(|e| authentication_read_error("reading the security type count", e))?;
+
+        let num_types = sec_buf[0] as usize;
+        if num_types == 0 {
+            let mut len_buf = [0u8; 4];
+            self.read_exact(&mut len_buf)
+                .map_err(|e| authentication_read_error("reading the rejection reason", e))?;
+            let reason_len = u32::from_be_bytes(len_buf) as usize;
+            if reason_len > self.limits.max_reason_bytes {
+                return Err("VNC failure reason exceeds configured limit".into());
+            }
+            let mut reason = vec![0u8; reason_len];
+            self.read_exact(&mut reason)
+                .map_err(|e| authentication_read_error("reading the rejection reason", e))?;
+            return Err(format!(
+                "server rejected connection: {}",
+                String::from_utf8_lossy(&reason)
+            ));
+        }
+
+        let mut types = vec![0u8; num_types];
+        self.read_exact(&mut types)
+            .map_err(|e| authentication_read_error("reading the security types", e))?;
+        self.security_policy.choose(&types).map_err(|e| e.0)
+    }
+
     /// RFB 3.3 security handshake: server sends a u32 security type, no client choice.
     fn authenticate_v33_with_policy(
         &mut self,
         password: Option<&str>,
         policy: VncSecurityPolicy,
+        pending_security_type: Option<u32>,
     ) -> Result<ServerInit, String> {
-        let mut buf = [0u8; 4];
-        self.read_exact(&mut buf)
-            .map_err(|e| format!("read v3.3 security type: {}", e))?;
-        let sec_type = u32::from_be_bytes(buf);
+        let sec_type = match pending_security_type {
+            Some(value) => value,
+            None => {
+                let mut buf = [0u8; 4];
+                self.read_exact(&mut buf)
+                    .map_err(|e| authentication_read_error("reading the security type", e))?;
+                u32::from_be_bytes(buf)
+            }
+        };
         if sec_type == 1 && !policy.allows_v33_none() {
             return Err(
                 "server offers unauthenticated VNC; enable allow-none explicitly to continue"
@@ -319,7 +420,7 @@ impl RfbConnection {
                 // SecurityResult
                 let mut result_buf = [0u8; 4];
                 self.read_exact(&mut result_buf)
-                    .map_err(|e| format!("read v3.3 security result: {}", e))?;
+                    .map_err(|e| authentication_read_error("waiting for the security result", e))?;
                 let result = u32::from_be_bytes(result_buf);
                 if result != 0 {
                     return Err(format!("authentication failed (result={})", result));
@@ -338,7 +439,7 @@ impl RfbConnection {
     fn vnc_auth_des(&mut self, password: &str) -> Result<(), String> {
         let mut challenge = [0u8; 16];
         self.read_exact(&mut challenge)
-            .map_err(|e| format!("read VNC challenge: {}", e))?;
+            .map_err(|e| authentication_read_error("reading the VNC challenge", e))?;
 
         let response = vnc_des_encrypt(password, &challenge);
 

--- a/src-tauri/src/vnc/tls.rs
+++ b/src-tauri/src/vnc/tls.rs
@@ -1,0 +1,430 @@
+use std::pin::Pin;
+use std::time::Duration;
+
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode, SslVersion};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_openssl::SslStream;
+
+use crate::vnc::limits::DecodeLimits;
+use crate::vnc::policy::VncSecurityPolicy;
+use crate::vnc::rfb::{PendingSecurity, SEC_TYPE_ANONYMOUS_TLS, negotiate_protocol_version};
+
+pub(crate) struct PreparedRfbTransport {
+    pub stream: std::net::TcpStream,
+    pub proto_minor: u8,
+    pub pending_security: Option<PendingSecurity>,
+    pub outer_security_type: Option<u8>,
+    pub tls_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+pub(crate) async fn prepare_rfb_transport(
+    socket: TcpStream,
+    host: &str,
+    policy: VncSecurityPolicy,
+    timeout: Duration,
+) -> Result<PreparedRfbTransport, String> {
+    tokio::time::timeout(timeout, negotiate_outer_security(socket, host, policy))
+        .await
+        .map_err(|_| "VNC security negotiation timed out".to_string())?
+}
+
+async fn negotiate_outer_security(
+    mut socket: TcpStream,
+    host: &str,
+    policy: VncSecurityPolicy,
+) -> Result<PreparedRfbTransport, String> {
+    let mut banner = [0u8; 12];
+    socket
+        .read_exact(&mut banner)
+        .await
+        .map_err(|e| format!("read protocol version: {e}"))?;
+    let (reply, proto_minor) = negotiate_protocol_version(&banner)?;
+    socket
+        .write_all(&reply)
+        .await
+        .map_err(|e| format!("write protocol version: {e}"))?;
+    socket
+        .flush()
+        .await
+        .map_err(|e| format!("flush protocol version: {e}"))?;
+
+    if proto_minor <= 3 {
+        let sec_type = socket
+            .read_u32()
+            .await
+            .map_err(|e| format!("read v3.3 security type: {e}"))?;
+        if sec_type > u8::MAX as u32 {
+            return Err(format!("unsupported v3.3 security type: {sec_type}"));
+        }
+        let chosen = policy.choose_outer(&[sec_type as u8]).map_err(|e| e.0)?;
+        if chosen == SEC_TYPE_ANONYMOUS_TLS {
+            return Err("RFB 3.3 anonymous TLS negotiation is not supported".into());
+        }
+        return plain_transport(socket, proto_minor, Some(PendingSecurity::V33(sec_type)));
+    }
+
+    let num_types = socket
+        .read_u8()
+        .await
+        .map_err(|e| format!("read security types count: {e}"))? as usize;
+    if num_types == 0 {
+        let reason_len = socket
+            .read_u32()
+            .await
+            .map_err(|e| format!("read security rejection length: {e}"))?
+            as usize;
+        if reason_len > DecodeLimits::default().max_reason_bytes {
+            return Err("VNC failure reason exceeds configured limit".into());
+        }
+        let mut reason = vec![0u8; reason_len];
+        socket
+            .read_exact(&mut reason)
+            .await
+            .map_err(|e| format!("read security rejection reason: {e}"))?;
+        return Err(format!(
+            "server rejected connection: {}",
+            String::from_utf8_lossy(&reason)
+        ));
+    }
+
+    let mut types = vec![0u8; num_types];
+    socket
+        .read_exact(&mut types)
+        .await
+        .map_err(|e| format!("read security types: {e}"))?;
+    let chosen = policy.choose_outer(&types).map_err(|e| e.0)?;
+    socket
+        .write_u8(chosen)
+        .await
+        .map_err(|e| format!("write security type: {e}"))?;
+    socket
+        .flush()
+        .await
+        .map_err(|e| format!("flush security type: {e}"))?;
+
+    if chosen == SEC_TYPE_ANONYMOUS_TLS {
+        anonymous_tls_transport(socket, host, proto_minor).await
+    } else {
+        plain_transport(socket, proto_minor, Some(PendingSecurity::Selected(chosen)))
+    }
+}
+
+fn plain_transport(
+    socket: TcpStream,
+    proto_minor: u8,
+    pending_security: Option<PendingSecurity>,
+) -> Result<PreparedRfbTransport, String> {
+    let stream = socket
+        .into_std()
+        .map_err(|e| format!("VNC transport conversion failed: {e}"))?;
+    Ok(PreparedRfbTransport {
+        stream,
+        proto_minor,
+        pending_security,
+        outer_security_type: None,
+        tls_task: None,
+    })
+}
+
+async fn anonymous_tls_transport(
+    socket: TcpStream,
+    host: &str,
+    proto_minor: u8,
+) -> Result<PreparedRfbTransport, String> {
+    let mut builder = SslConnector::builder(SslMethod::tls_client())
+        .map_err(|e| format!("VNC TLS configuration failed: {e}"))?;
+    builder.set_verify(SslVerifyMode::NONE);
+    builder
+        .set_cipher_list("aNULL:@SECLEVEL=0")
+        .map_err(|e| format!("VNC TLS cipher configuration failed: {e}"))?;
+    builder
+        .set_min_proto_version(Some(SslVersion::TLS1))
+        .map_err(|e| format!("VNC TLS minimum version configuration failed: {e}"))?;
+    builder
+        .set_max_proto_version(Some(SslVersion::TLS1_2))
+        .map_err(|e| format!("VNC TLS maximum version configuration failed: {e}"))?;
+
+    let ssl = builder
+        .build()
+        .configure()
+        .and_then(|config| config.into_ssl(host))
+        .map_err(|e| format!("VNC TLS client configuration failed: {e}"))?;
+    let mut tls = SslStream::new(ssl, socket)
+        .map_err(|e| format!("VNC TLS stream initialization failed: {e}"))?;
+    Pin::new(&mut tls)
+        .connect()
+        .await
+        .map_err(|e| format!("VNC TLS handshake failed: {e}"))?;
+
+    // The RFB decoder is synchronous and splits its TCP socket into independent
+    // read/write handles. Keep TLS asynchronous and expose a loopback plaintext
+    // socket so both directions remain full duplex without sharing TLS state.
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| format!("bind VNC TLS bridge: {e}"))?;
+    let local_addr = listener
+        .local_addr()
+        .map_err(|e| format!("read VNC TLS bridge address: {e}"))?;
+    let local_client = TcpStream::connect(local_addr)
+        .await
+        .map_err(|e| format!("connect VNC TLS bridge: {e}"))?;
+    let (mut local_bridge, _) = listener
+        .accept()
+        .await
+        .map_err(|e| format!("accept VNC TLS bridge: {e}"))?;
+
+    let tls_task = tokio::spawn(async move {
+        if let Err(error) = tokio::io::copy_bidirectional(&mut local_bridge, &mut tls).await {
+            tracing::debug!(%error, "VNC TLS bridge stopped");
+        }
+    });
+    let stream = local_client
+        .into_std()
+        .map_err(|e| format!("VNC TLS bridge conversion failed: {e}"))?;
+
+    Ok(PreparedRfbTransport {
+        stream,
+        proto_minor,
+        pending_security: None,
+        outer_security_type: Some(SEC_TYPE_ANONYMOUS_TLS),
+        tls_task: Some(tls_task),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use openssl::dh::Dh;
+    use openssl::ssl::{Ssl, SslAcceptor};
+    use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+    use super::*;
+    use crate::vnc::rfb::RfbConnection;
+
+    async fn write_server_init<S: AsyncWrite + Unpin>(
+        stream: &mut S,
+        width: u16,
+        height: u16,
+        name: &[u8],
+    ) {
+        let mut init = Vec::with_capacity(24 + name.len());
+        init.extend_from_slice(&width.to_be_bytes());
+        init.extend_from_slice(&height.to_be_bytes());
+        init.extend_from_slice(&[32, 24, 0, 1]);
+        init.extend_from_slice(&255u16.to_be_bytes());
+        init.extend_from_slice(&255u16.to_be_bytes());
+        init.extend_from_slice(&255u16.to_be_bytes());
+        init.extend_from_slice(&[0, 8, 16, 0, 0, 0]);
+        init.extend_from_slice(&(name.len() as u32).to_be_bytes());
+        init.extend_from_slice(name);
+        stream.write_all(&init).await.unwrap();
+        stream.flush().await.unwrap();
+    }
+
+    async fn complete_vncauth<S: AsyncRead + AsyncWrite + Unpin>(
+        stream: &mut S,
+        delay: Duration,
+        name: &[u8],
+    ) {
+        stream.write_all(&[1, 2]).await.unwrap();
+        stream.flush().await.unwrap();
+        let mut chosen = [0u8; 1];
+        stream.read_exact(&mut chosen).await.unwrap();
+        assert_eq!(chosen[0], 2);
+        stream.write_all(&[0x5a; 16]).await.unwrap();
+        stream.flush().await.unwrap();
+        let mut response = [0u8; 16];
+        stream.read_exact(&mut response).await.unwrap();
+        assert!(response.iter().any(|byte| *byte != 0));
+        tokio::time::sleep(delay).await;
+        stream.write_all(&0u32.to_be_bytes()).await.unwrap();
+        stream.flush().await.unwrap();
+        let mut client_init = [0u8; 1];
+        stream.read_exact(&mut client_init).await.unwrap();
+        assert_eq!(client_init[0], 1);
+        write_server_init(stream, 1024, 768, name).await;
+    }
+
+    async fn read_version_and_offer_tls(stream: &mut TcpStream) {
+        stream.write_all(b"RFB 003.007\n").await.unwrap();
+        stream.flush().await.unwrap();
+        let mut client_banner = [0u8; 12];
+        stream.read_exact(&mut client_banner).await.unwrap();
+        assert_eq!(&client_banner, b"RFB 003.007\n");
+        stream.write_all(&[2, 18, 2]).await.unwrap();
+        stream.flush().await.unwrap();
+        let mut selected = [0u8; 1];
+        stream.read_exact(&mut selected).await.unwrap();
+        assert_eq!(selected[0], 18);
+    }
+
+    #[tokio::test]
+    async fn delayed_plain_vncauth_succeeds_with_authentication_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            stream.write_all(b"RFB 003.007\n").await.unwrap();
+            stream.flush().await.unwrap();
+            let mut client_banner = [0u8; 12];
+            stream.read_exact(&mut client_banner).await.unwrap();
+            stream.write_all(&[1, 2]).await.unwrap();
+            stream.flush().await.unwrap();
+            let mut selected = [0u8; 1];
+            stream.read_exact(&mut selected).await.unwrap();
+            assert_eq!(selected[0], 2);
+            stream.write_all(&[0x5a; 16]).await.unwrap();
+            stream.flush().await.unwrap();
+            let mut response = [0u8; 16];
+            stream.read_exact(&mut response).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(75)).await;
+            stream.write_all(&0u32.to_be_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+            let mut client_init = [0u8; 1];
+            stream.read_exact(&mut client_init).await.unwrap();
+            write_server_init(&mut stream, 800, 600, b"delayed fixture").await;
+        });
+
+        let socket = TcpStream::connect(address).await.unwrap();
+        let prepared = prepare_rfb_transport(
+            socket,
+            "127.0.0.1",
+            VncSecurityPolicy::LegacyCompatible,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        let started = Instant::now();
+        let init = tokio::task::spawn_blocking(move || {
+            let mut connection = RfbConnection::from_negotiated_stream(
+                prepared.stream,
+                Duration::from_millis(250),
+                VncSecurityPolicy::LegacyCompatible,
+                DecodeLimits::default(),
+                prepared.proto_minor,
+                prepared.pending_security,
+                prepared.outer_security_type,
+            )?;
+            connection.authenticate(None, Some("passw0rd"))
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert!(started.elapsed() >= Duration::from_millis(70));
+        assert_eq!((init.width, init.height), (800, 600));
+        assert_eq!(init.name, "delayed fixture");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn anonymous_tls_wraps_inner_vncauth() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            read_version_and_offer_tls(&mut stream).await;
+
+            let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls_server()).unwrap();
+            builder.set_verify(SslVerifyMode::NONE);
+            builder.set_cipher_list("aNULL:@SECLEVEL=0").unwrap();
+            builder
+                .set_min_proto_version(Some(SslVersion::TLS1_2))
+                .unwrap();
+            builder
+                .set_max_proto_version(Some(SslVersion::TLS1_2))
+                .unwrap();
+            builder.set_tmp_dh(&Dh::get_2048_256().unwrap()).unwrap();
+            let ssl = Ssl::new(builder.build().context()).unwrap();
+            let mut tls = SslStream::new(ssl, stream).unwrap();
+            Pin::new(&mut tls).accept().await.unwrap();
+            complete_vncauth(&mut tls, Duration::ZERO, b"TLS fixture").await;
+        });
+
+        let socket = TcpStream::connect(address).await.unwrap();
+        let prepared = prepare_rfb_transport(
+            socket,
+            "127.0.0.1",
+            VncSecurityPolicy::PreferEncryption,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        assert_eq!(prepared.outer_security_type, Some(18));
+        let tls_task = prepared.tls_task;
+        let result = tokio::task::spawn_blocking(move || {
+            let mut connection = RfbConnection::from_negotiated_stream(
+                prepared.stream,
+                Duration::from_secs(2),
+                VncSecurityPolicy::PreferEncryption,
+                DecodeLimits::default(),
+                prepared.proto_minor,
+                prepared.pending_security,
+                prepared.outer_security_type,
+            )?;
+            let init = connection.authenticate(None, Some("passw0rd"))?;
+            Ok::<_, String>((init, connection.security_label(), connection.encrypted()))
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!((result.0.width, result.0.height), (1024, 768));
+        assert_eq!(result.0.name, "TLS fixture");
+        assert_eq!(result.1, "TLS (anonymous) + VNCAuth");
+        assert!(result.2);
+        if let Some(task) = tls_task {
+            task.abort();
+        }
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore = "requires TAOMNI_VNC_LIVE_HOST and TAOMNI_VNC_LIVE_PASSWORD"]
+    async fn connects_live_vnc_fixture() {
+        let host = std::env::var("TAOMNI_VNC_LIVE_HOST").unwrap();
+        let port = std::env::var("TAOMNI_VNC_LIVE_PORT")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(5900);
+        let username = std::env::var("TAOMNI_VNC_LIVE_USERNAME").ok();
+        let password = std::env::var("TAOMNI_VNC_LIVE_PASSWORD").unwrap();
+        let socket = TcpStream::connect((host.as_str(), port)).await.unwrap();
+        let prepared = prepare_rfb_transport(
+            socket,
+            &host,
+            VncSecurityPolicy::PreferEncryption,
+            Duration::from_secs(45),
+        )
+        .await
+        .unwrap();
+        let tls_task = prepared.tls_task;
+        let result = tokio::task::spawn_blocking(move || {
+            let mut connection = RfbConnection::from_negotiated_stream(
+                prepared.stream,
+                Duration::from_secs(45),
+                VncSecurityPolicy::PreferEncryption,
+                DecodeLimits::default(),
+                prepared.proto_minor,
+                prepared.pending_security,
+                prepared.outer_security_type,
+            )?;
+            let init = connection.authenticate(username.as_deref(), Some(&password))?;
+            Ok::<_, String>((init, connection.security_label(), connection.encrypted()))
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        println!(
+            "connected {}x{} '{}' via {}",
+            result.0.width, result.0.height, result.0.name, result.1
+        );
+        assert!(result.2);
+        if let Some(task) = tls_task {
+            task.abort();
+        }
+    }
+}

--- a/src-tauri/src/vnc/ws.rs
+++ b/src-tauri/src/vnc/ws.rs
@@ -21,7 +21,7 @@ use crate::vnc::clipboard::{
     SUPPORTED_ACTIONS, build_caps_body, build_notify_body, build_provide_body, build_request_body,
 };
 use crate::vnc::encodings::DecodedRect;
-use crate::vnc::policy::{VncClipboardPolicy, VncSecurityPolicy, security_type_kind};
+use crate::vnc::policy::{VncClipboardPolicy, VncSecurityPolicy};
 use crate::vnc::queue::{FrameQueueReceiver, FrameQueueSender, QueuedWsOutgoing};
 use crate::vnc::rfb::{RfbConnection, RfbWriter, ServerMessage};
 
@@ -32,6 +32,7 @@ const WS_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 /// How often the idle watchdog checks the last-seen timestamp.
 const WS_IDLE_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 const VNC_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+pub(crate) const VNC_AUTH_TIMEOUT: Duration = Duration::from_secs(45);
 const VNC_WS_PATH: &str = "/vnc";
 
 // ── Messages for internal channels ──────────────────────────────────
@@ -147,6 +148,7 @@ pub struct VncSession {
     pub ws_token: String,
     pub cancel: CancellationToken,
     pub network_forward_task: Option<tokio::task::JoinHandle<()>>,
+    pub tls_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl Drop for VncSession {
@@ -155,11 +157,14 @@ impl Drop for VncSession {
         if let Some(task) = self.network_forward_task.as_ref() {
             task.abort();
         }
+        if let Some(task) = self.tls_task.as_ref() {
+            task.abort();
+        }
     }
 }
 
 pub(crate) struct VncDialedTransport {
-    pub stream: std::net::TcpStream,
+    pub stream: TcpStream,
     pub network_forward_task: Option<tokio::task::JoinHandle<()>>,
 }
 
@@ -195,11 +200,8 @@ pub(crate) async fn dial_vnc_transport(
                 .await
                 .map_err(|e| format!("VNC TCP connection failed: {e}"))?,
         };
-        let stream = socket
-            .into_std()
-            .map_err(|e| format!("VNC transport conversion failed: {e}"))?;
         Ok(VncDialedTransport {
-            stream,
+            stream: socket,
             network_forward_task: forward_guard.0.take(),
         })
     })
@@ -233,15 +235,25 @@ pub async fn spawn_vnc_relay(
     // through the shared loopback forwarder, allowing the synchronous RA2
     // framing code to keep its tested std::net transport while the upstream
     // network path remains fully asynchronous and cancellable.
-    let transport = dial_vnc_transport(host, port, network).await?;
+    let transport = dial_vnc_transport(host.clone(), port, network).await?;
     let mut network_forward_guard = ForwardTaskGuard(transport.network_forward_task);
-    let std_stream = transport.stream;
+    let prepared = crate::vnc::tls::prepare_rfb_transport(
+        transport.stream,
+        &host,
+        security_policy,
+        VNC_AUTH_TIMEOUT,
+    )
+    .await?;
+    let mut tls_guard = ForwardTaskGuard(prepared.tls_task);
     let (rfb, writer, server_init) = tokio::task::spawn_blocking(move || {
-        let mut rfb = RfbConnection::from_stream(
-            std_stream,
-            Duration::from_secs(15),
+        let mut rfb = RfbConnection::from_negotiated_stream(
+            prepared.stream,
+            VNC_AUTH_TIMEOUT,
             security_policy,
             crate::vnc::limits::DecodeLimits::default(),
+            prepared.proto_minor,
+            prepared.pending_security,
+            prepared.outer_security_type,
         )?;
         let server_init = rfb.authenticate_with_policy(
             username.as_deref(),
@@ -287,17 +299,13 @@ pub async fn spawn_vnc_relay(
 
     // Send connected notification with the actual negotiated security, never
     // just the requested policy.
-    let negotiated = rfb.security_type.and_then(security_type_kind);
     let connected = serde_json::to_string(&WsOutgoingText::Connected {
         width: server_init.width,
         height: server_init.height,
         name: server_init.name.clone(),
         protocol: rfb.protocol_version(),
-        security: negotiated
-            .map(|kind| kind.label())
-            .unwrap_or("Unknown")
-            .to_string(),
-        encrypted: negotiated.is_some_and(|kind| kind.encrypted()),
+        security: rfb.security_label(),
+        encrypted: rfb.encrypted(),
     })
     .unwrap();
     let _ = ws_out_tx.send_critical_control(connected);
@@ -337,6 +345,7 @@ pub async fn spawn_vnc_relay(
         ws_token,
         cancel,
         network_forward_task: network_forward_guard.0.take(),
+        tls_task: tls_guard.0.take(),
     })
 }
 


### PR DESCRIPTION
Restore blocking mode when Tokio TCP streams enter the synchronous RFB decoder so transient WouldBlock errors are not misreported as authentication timeouts.

Add RFB Security Type 18 support with an OpenSSL-backed anonymous TLS transport, then negotiate the inner security type including VNCAuth. Keep strict encryption policy behavior explicit because anonymous TLS cannot verify server identity.

Separate connection and authentication timeout handling, extend security negotiation to 45 seconds, expose retryable stage-specific errors, and report the negotiated TLS plus VNCAuth transport metadata.

Cover delayed VNCAuth and anonymous TLS negotiation with regression tests, update the VNC feature inventory, and verify against the 10.1.0.80 server.