### PR TITLE
fix(remote): stabilize VNC focus recovery and RDP frame rendering

### DIFF
--- a/src-tauri/src/rdp/session.rs
+++ b/src-tauri/src/rdp/session.rs
@@ -79,15 +79,16 @@ struct SessionOutputState {
     building_frame: Vec<Vec<u8>>,
     building_bytes: usize,
     drop_building_frame: bool,
-    latest_frame: Option<Vec<Vec<u8>>>,
+    pending_frame: Vec<Vec<u8>>,
+    pending_frame_bytes: usize,
     closed: bool,
 }
 
-/// Bounded output relay. Display updates are assembled into a complete frame
-/// batch and replaced by the newest batch; status, cursor, audio and clipboard
-/// messages stay in a bounded reliable queue. A producer only blocks when the
-/// reliable queue is full, so a slow browser cannot accumulate unbounded pixel
-/// memory or make frame age grow without limit.
+/// Bounded output relay. RDP graphics updates are incremental dirty rectangles,
+/// so pending batches must be appended in order rather than replaced by the
+/// newest batch. Replacing one batch leaves untouched canvas regions stale or
+/// black. Status, cursor, audio and clipboard messages use a separate bounded
+/// reliable queue.
 struct SessionOutputQueue {
     state: Mutex<SessionOutputState>,
     wake: Notify,
@@ -111,7 +112,8 @@ impl SessionOutputQueue {
                 building_frame: Vec::new(),
                 building_bytes: 0,
                 drop_building_frame: false,
-                latest_frame: None,
+                pending_frame: Vec::new(),
+                pending_frame_bytes: 0,
                 closed: false,
             }),
             wake: Notify::new(),
@@ -140,8 +142,24 @@ impl SessionOutputQueue {
             }
             SessionOutput::Channel { tag, .. } if tag == channel::FRAME_END => {
                 if !state.drop_building_frame && !state.building_frame.is_empty() {
+                    while state
+                        .pending_frame_bytes
+                        .saturating_add(state.building_bytes)
+                        > MAX_FRAME_BATCH_BYTES
+                        && !state.closed
+                    {
+                        state = self
+                            .space
+                            .wait(state)
+                            .map_err(|_| "rdp output queue poisoned".to_string())?;
+                    }
+                    if state.closed {
+                        return Err("rdp output queue closed".to_string());
+                    }
+                    let combined_bytes = state.pending_frame_bytes + state.building_bytes;
                     let batch = std::mem::take(&mut state.building_frame);
-                    state.latest_frame = Some(batch);
+                    state.pending_frame.extend(batch);
+                    state.pending_frame_bytes = combined_bytes;
                 } else {
                     state.building_frame.clear();
                 }
@@ -178,7 +196,9 @@ impl SessionOutputQueue {
                     self.space.notify_one();
                     return Some(QueuedSessionOutput::Control(output));
                 }
-                if let Some(frame) = state.latest_frame.take() {
+                if !state.pending_frame.is_empty() {
+                    let frame = std::mem::take(&mut state.pending_frame);
+                    state.pending_frame_bytes = 0;
                     self.space.notify_one();
                     return Some(QueuedSessionOutput::FrameBatch(frame));
                 }
@@ -194,7 +214,8 @@ impl SessionOutputQueue {
         if let Ok(mut state) = self.state.lock() {
             state.closed = true;
             state.control.clear();
-            state.latest_frame = None;
+            state.pending_frame.clear();
+            state.pending_frame_bytes = 0;
             state.building_frame.clear();
         }
         self.space.notify_all();
@@ -2687,7 +2708,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn slow_output_consumer_gets_only_the_latest_frame_batch() {
+    async fn slow_output_consumer_keeps_incremental_frame_batches_in_order() {
         let (mut handle, out_tx, _ctrl_rx) = RdpSessionHandle::new();
         for value in [1_u8, 2_u8] {
             let _ = out_tx.send(SessionOutput::Channel {
@@ -2699,6 +2720,10 @@ mod tests {
                 payload: Vec::new(),
             });
         }
+        assert!(matches!(
+            handle.next_outgoing().await,
+            Some(SessionOutput::Channel { tag: channel::FRAME, payload }) if payload == vec![1]
+        ));
         assert!(matches!(
             handle.next_outgoing().await,
             Some(SessionOutput::Channel { tag: channel::FRAME, payload }) if payload == vec![2]

--- a/src-tauri/src/rdp/ws.rs
+++ b/src-tauri/src/rdp/ws.rs
@@ -51,7 +51,8 @@ use crate::rdp::transport::open_transport;
 use crate::terminal::network::NetworkSettings;
 
 const WS_ACCEPT_TIMEOUT: Duration = Duration::from_secs(30);
-const WS_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+const WS_PING_INTERVAL: Duration = Duration::from_secs(15);
+const WS_IDLE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const WS_IDLE_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Wire-protocol channel tags for the binary WS frames.
@@ -130,7 +131,8 @@ struct WsOutgoingState {
     building_frame: Vec<Vec<u8>>,
     building_bytes: usize,
     drop_building_frame: bool,
-    latest_frame: Option<Vec<Vec<u8>>>,
+    pending_frame: Vec<Vec<u8>>,
+    pending_frame_bytes: usize,
     closed: bool,
 }
 
@@ -156,7 +158,8 @@ impl WsOutgoingQueue {
                 building_frame: Vec::new(),
                 building_bytes: 0,
                 drop_building_frame: false,
-                latest_frame: None,
+                pending_frame: Vec::new(),
+                pending_frame_bytes: 0,
                 closed: false,
             }),
             wake: Notify::new(),
@@ -192,7 +195,24 @@ impl WsOutgoingQueue {
             }
             WsOutgoing::Frame(bytes) if bytes.first() == Some(&channel::FRAME_END) => {
                 if !state.drop_building_frame && !state.building_frame.is_empty() {
-                    state.latest_frame = Some(std::mem::take(&mut state.building_frame));
+                    while state
+                        .pending_frame_bytes
+                        .saturating_add(state.building_bytes)
+                        > MAX_WS_FRAME_BATCH_BYTES
+                        && !state.closed
+                    {
+                        state = self
+                            .space
+                            .wait(state)
+                            .map_err(|_| "RDP WebSocket output queue poisoned".to_string())?;
+                    }
+                    if state.closed {
+                        return Err("RDP WebSocket output queue closed".to_string());
+                    }
+                    let combined_bytes = state.pending_frame_bytes + state.building_bytes;
+                    let batch = std::mem::take(&mut state.building_frame);
+                    state.pending_frame.extend(batch);
+                    state.pending_frame_bytes = combined_bytes;
                 } else {
                     state.building_frame.clear();
                 }
@@ -229,7 +249,9 @@ impl WsOutgoingQueue {
                     self.space.notify_one();
                     return Some(QueuedWsOutgoing::Control(output));
                 }
-                if let Some(frame) = state.latest_frame.take() {
+                if !state.pending_frame.is_empty() {
+                    let frame = std::mem::take(&mut state.pending_frame);
+                    state.pending_frame_bytes = 0;
                     self.space.notify_one();
                     return Some(QueuedWsOutgoing::FrameBatch(frame));
                 }
@@ -245,7 +267,8 @@ impl WsOutgoingQueue {
         if let Ok(mut state) = self.state.lock() {
             state.closed = true;
             state.control.clear();
-            state.latest_frame = None;
+            state.pending_frame.clear();
+            state.pending_frame_bytes = 0;
             state.building_frame.clear();
         }
         self.space.notify_all();
@@ -412,13 +435,30 @@ async fn run_relay(
 
     // Pump outgoing → WS sink.
     let ws_write = tokio::spawn(async move {
-        while let Some(out) = ws_out_rx.recv().await {
-            let msg = match out {
-                WsOutgoing::Frame(b) => Message::Binary(b.into()),
-                WsOutgoing::Text(t) => Message::Text(t.into()),
-            };
-            if ws_sink.send(msg).await.is_err() {
-                break;
+        let mut ping = tokio::time::interval(WS_PING_INTERVAL);
+        ping.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ping.tick().await;
+        loop {
+            tokio::select! {
+                output = ws_out_rx.recv() => {
+                    let Some(out) = output else { break; };
+                    let msg = match out {
+                        WsOutgoing::Frame(b) => Message::Binary(b.into()),
+                        WsOutgoing::Text(t) => Message::Text(t.into()),
+                    };
+                    if ws_sink.send(msg).await.is_err() {
+                        break;
+                    }
+                }
+                _ = ping.tick() => {
+                    if ws_sink
+                        .send(Message::Ping(Vec::new().into()))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
             }
         }
     });
@@ -722,12 +762,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn websocket_output_replaces_stale_frame_batches() {
+    async fn websocket_output_keeps_incremental_frame_batches_in_order() {
         let (sender, mut receiver) = WsOutgoingQueue::new();
         let _ = sender.send(WsOutgoing::Frame(vec![channel::FRAME, 1]));
         let _ = sender.send(WsOutgoing::Frame(vec![channel::FRAME_END]));
         let _ = sender.send(WsOutgoing::Frame(vec![channel::FRAME, 2]));
         let _ = sender.send(WsOutgoing::Frame(vec![channel::FRAME_END]));
+        assert!(matches!(
+            receiver.recv().await,
+            Some(WsOutgoing::Frame(bytes)) if bytes == vec![channel::FRAME, 1]
+        ));
         assert!(matches!(
             receiver.recv().await,
             Some(WsOutgoing::Frame(bytes)) if bytes == vec![channel::FRAME, 2]

--- a/src-tauri/src/vnc/encodings.rs
+++ b/src-tauri/src/vnc/encodings.rs
@@ -18,6 +18,17 @@ pub enum DecodedRect {
     },
 }
 
+#[derive(Debug)]
+pub struct DecodedCursor {
+    pub hotspot_x: u16,
+    pub hotspot_y: u16,
+    pub width: u16,
+    pub height: u16,
+    pub rgba: Vec<u8>,
+}
+
+const MAX_CURSOR_DIMENSION: u16 = 512;
+
 // ── Helpers to read big-endian integers from an `impl Read`. ──
 
 fn read_u8<R: Read>(r: &mut R) -> std::io::Result<u8> {
@@ -582,6 +593,71 @@ fn read_zrle_run_length(buf: &[u8], pos: &mut usize) -> Result<usize, String> {
     }
 }
 
+/// Decode the RichCursor pseudo-encoding (-239). Pixel bytes use the 32-bit
+/// RGBA format negotiated for normal rectangles, followed by a one-bit alpha
+/// mask whose rows are padded to whole bytes.
+pub fn read_rich_cursor<R: Read>(
+    reader: &mut R,
+    hotspot_x: u16,
+    hotspot_y: u16,
+    width: u16,
+    height: u16,
+) -> Result<DecodedCursor, String> {
+    if width == 0 || height == 0 {
+        return Ok(DecodedCursor {
+            hotspot_x: 0,
+            hotspot_y: 0,
+            width: 0,
+            height: 0,
+            rgba: Vec::new(),
+        });
+    }
+    if width > MAX_CURSOR_DIMENSION || height > MAX_CURSOR_DIMENSION {
+        return Err(format!(
+            "rich cursor dimensions {width}x{height} exceed {MAX_CURSOR_DIMENSION}x{MAX_CURSOR_DIMENSION}"
+        ));
+    }
+    if hotspot_x >= width || hotspot_y >= height {
+        return Err(format!(
+            "rich cursor hotspot {hotspot_x},{hotspot_y} lies outside {width}x{height}"
+        ));
+    }
+
+    let pixel_bytes = usize::from(width)
+        .checked_mul(usize::from(height))
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or_else(|| "rich cursor pixel byte count overflow".to_string())?;
+    let mask_stride = usize::from(width).div_ceil(8);
+    let mask_bytes = mask_stride
+        .checked_mul(usize::from(height))
+        .ok_or_else(|| "rich cursor mask byte count overflow".to_string())?;
+
+    let mut rgba = vec![0u8; pixel_bytes];
+    reader
+        .read_exact(&mut rgba)
+        .map_err(|e| format!("rich cursor pixels: {e}"))?;
+    let mut mask = vec![0u8; mask_bytes];
+    reader
+        .read_exact(&mut mask)
+        .map_err(|e| format!("rich cursor mask: {e}"))?;
+
+    for row in 0..usize::from(height) {
+        for column in 0..usize::from(width) {
+            let mask_byte = mask[row * mask_stride + column / 8];
+            let visible = mask_byte & (0x80 >> (column % 8)) != 0;
+            rgba[(row * usize::from(width) + column) * 4 + 3] = if visible { 255 } else { 0 };
+        }
+    }
+
+    Ok(DecodedCursor {
+        hotspot_x,
+        hotspot_y,
+        width,
+        height,
+        rgba,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -595,6 +671,26 @@ mod tests {
         let rect = read_raw(&mut cur, 0, 0, 2, 1).unwrap();
         let DecodedRect::Pixels { rgba, .. } = rect;
         assert_eq!(rgba, vec![10, 20, 30, 255, 40, 50, 60, 255]);
+    }
+
+    #[test]
+    fn rich_cursor_applies_bitmask_alpha_and_hotspot() {
+        let mut payload = vec![10, 20, 30, 0, 40, 50, 60, 0, 70, 80, 90, 0];
+        payload.push(0b1010_0000);
+        let mut reader = Cursor::new(payload);
+        let cursor = read_rich_cursor(&mut reader, 1, 0, 3, 1).unwrap();
+        assert_eq!((cursor.hotspot_x, cursor.hotspot_y), (1, 0));
+        assert_eq!((cursor.width, cursor.height), (3, 1));
+        assert_eq!(
+            cursor.rgba,
+            vec![10, 20, 30, 255, 40, 50, 60, 0, 70, 80, 90, 255]
+        );
+    }
+
+    #[test]
+    fn rich_cursor_rejects_invalid_geometry() {
+        assert!(read_rich_cursor(&mut Cursor::new(Vec::<u8>::new()), 3, 0, 3, 1).is_err());
+        assert!(read_rich_cursor(&mut Cursor::new(Vec::<u8>::new()), 0, 0, 513, 1).is_err());
     }
 
     #[test]

--- a/src-tauri/src/vnc/rfb.rs
+++ b/src-tauri/src/vnc/rfb.rs
@@ -7,7 +7,7 @@ use crate::vnc::clipboard::{
     ExtendedClipboardMsg, decode_legacy_cut_text, encode_legacy_cut_text,
     parse_extended_body_with_limits,
 };
-use crate::vnc::encodings::{self, DecodedRect, HextileState, ZrleDecoder};
+use crate::vnc::encodings::{self, DecodedCursor, DecodedRect, HextileState, ZrleDecoder};
 use crate::vnc::limits::DecodeLimits;
 use crate::vnc::policy::VncSecurityPolicy;
 
@@ -747,6 +747,18 @@ impl RfbConnection {
         Ok(())
     }
 
+    /// Authentication uses a bounded read timeout so an unresponsive peer
+    /// cannot hold a connection attempt forever. Once the RFB session is
+    /// established, however, a server may legitimately stay silent while no
+    /// pixels change or while the viewer is hidden. Runtime cancellation closes
+    /// the socket explicitly, so remove the handshake timeout before entering
+    /// the long-lived read loop.
+    pub fn enter_runtime_mode(&self) -> Result<(), String> {
+        self.stream
+            .set_read_timeout(None)
+            .map_err(|e| format!("clear VNC runtime read timeout failed: {e}"))
+    }
+
     /// Split out an independent writer so input events can be sent while the
     /// reader is blocked waiting for the next server message.
     pub fn take_writer(&mut self) -> Result<RfbWriter, String> {
@@ -845,6 +857,7 @@ impl RfbConnection {
         }
 
         let mut decoded: Vec<DecodedRect> = Vec::with_capacity(num_rects);
+        let mut cursor = None;
         for _ in 0..num_rects {
             let x = self.read_u16()?;
             let y = self.read_u16()?;
@@ -855,7 +868,7 @@ impl RfbConnection {
                 self.limits
                     .framebuffer_bytes(w, h)
                     .map_err(|e| e.to_string())?;
-            } else {
+            } else if encoding != -239 {
                 self.limits
                     .rectangle_bytes(w, h)
                     .map_err(|e| e.to_string())?;
@@ -865,7 +878,7 @@ impl RfbConnection {
             {
                 // DesktopSize is the only rectangle allowed to describe a new
                 // framebuffer geometry; pixel rectangles must stay in bounds.
-                if encoding != -223 {
+                if encoding != -223 && encoding != -239 {
                     return Err("framebuffer rectangle is outside the negotiated size".into());
                 }
             }
@@ -958,6 +971,11 @@ impl RfbConnection {
                     self.height = h;
                     self.framebuffer = vec![0u8; size];
                 }
+                -239 => {
+                    cursor = Some(self.decode_via_reader(|reader| {
+                        encodings::read_rich_cursor(reader, x, y, w, h)
+                    })?);
+                }
                 other => {
                     return Err(format!(
                         "unsupported encoding {} — client did not request this",
@@ -967,7 +985,10 @@ impl RfbConnection {
             }
         }
 
-        Ok(ServerMessage::FramebufferUpdate { rects: decoded })
+        Ok(ServerMessage::FramebufferUpdate {
+            rects: decoded,
+            cursor,
+        })
     }
 
     /// Run a decoder closure over a temporary `impl Read` view of the stream.
@@ -1579,10 +1600,15 @@ fn increment_le(counter: &mut [u8; 16]) {
 
 #[derive(Debug)]
 pub enum ServerMessage {
-    FramebufferUpdate { rects: Vec<DecodedRect> },
+    FramebufferUpdate {
+        rects: Vec<DecodedRect>,
+        cursor: Option<DecodedCursor>,
+    },
     SetColourMapEntries,
     Bell,
-    ServerCutText { text: String },
+    ServerCutText {
+        text: String,
+    },
     ExtendedClipboard(ExtendedClipboardMsg),
 }
 
@@ -1801,5 +1827,29 @@ mod tests {
         .unwrap();
         assert!(connection.read_server_message().is_err());
         server.join().unwrap();
+    }
+
+    #[test]
+    fn runtime_mode_clears_the_handshake_read_timeout() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let client = TcpStream::connect(address).unwrap();
+        let (_server, _) = listener.accept().unwrap();
+        let connection = RfbConnection::new_stream(
+            client,
+            Duration::from_secs(2),
+            DecodeLimits::default(),
+            VncSecurityPolicy::AllowNone,
+            8,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            connection.stream.read_timeout().unwrap(),
+            Some(Duration::from_secs(2))
+        );
+        connection.enter_runtime_mode().unwrap();
+        assert_eq!(connection.stream.read_timeout().unwrap(), None);
     }
 }

--- a/src-tauri/src/vnc/ws.rs
+++ b/src-tauri/src/vnc/ws.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use futures::{SinkExt, StreamExt};
+use image::{ColorType, ImageEncoder};
 use serde::{Deserialize, Serialize};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Mutex as AsyncMutex;
@@ -20,15 +22,18 @@ use crate::vnc::clipboard::{
     ENCODING_EXTENDED_CLIPBOARD_LEGACY, ExtendedClipboardMsg, FORMAT_HTML, FORMAT_RTF, FORMAT_TEXT,
     SUPPORTED_ACTIONS, build_caps_body, build_notify_body, build_provide_body, build_request_body,
 };
-use crate::vnc::encodings::DecodedRect;
+use crate::vnc::encodings::{DecodedCursor, DecodedRect};
 use crate::vnc::policy::{VncClipboardPolicy, VncSecurityPolicy};
 use crate::vnc::queue::{FrameQueueReceiver, FrameQueueSender, QueuedWsOutgoing};
 use crate::vnc::rfb::{RfbConnection, RfbWriter, ServerMessage};
 
 /// Deadline for the frontend to complete its WebSocket upgrade after we bind.
 const WS_ACCEPT_TIMEOUT: Duration = Duration::from_secs(30);
-/// Maximum time without a ping from the frontend before we tear down.
-const WS_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Native WebSocket ping cadence. Browser engines answer these at the network
+/// layer even when background-tab JavaScript timers are throttled.
+const WS_PING_INTERVAL: Duration = Duration::from_secs(15);
+/// Backstop for a WebView that has stopped servicing the socket entirely.
+const WS_IDLE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 /// How often the idle watchdog checks the last-seen timestamp.
 const WS_IDLE_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 const VNC_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
@@ -138,6 +143,15 @@ enum WsOutgoingText {
     /// ClientCutText channel is Latin-1 only and would mojibake CJK.
     #[serde(rename = "ext_clipboard_support")]
     ExtClipboardSupport { available: bool },
+    #[serde(rename = "cursor")]
+    Cursor {
+        visible: bool,
+        hotspot_x: u16,
+        hotspot_y: u16,
+        width: u16,
+        height: u16,
+        png_base64: String,
+    },
 }
 
 // ── Public session handle ───────────────────────────────────────────
@@ -267,10 +281,12 @@ pub async fn spawn_vnc_relay(
             1,
             0,
             -223,
+            -239,
             ENCODING_EXTENDED_CLIPBOARD,
             ENCODING_EXTENDED_CLIPBOARD_LEGACY,
         ])?;
         rfb.request_update(false)?;
+        rfb.enter_runtime_mode()?;
         let writer = rfb.take_writer()?;
         Ok::<_, String>((rfb, writer, server_init))
     })
@@ -381,26 +397,43 @@ async fn run_relay(
 
     // Task: pump outgoing messages → WS sink
     let mut ws_write = tokio::spawn(async move {
-        while let Some(out) = ws_out_rx.recv().await {
-            match out {
-                QueuedWsOutgoing::Control(json) => {
-                    if ws_sink.send(Message::Text(json.into())).await.is_err() {
-                        break;
-                    }
-                }
-                QueuedWsOutgoing::Frame(rects) => {
-                    let mut failed = false;
-                    for data in rects {
-                        if ws_sink.send(Message::Binary(data.into())).await.is_err() {
-                            failed = true;
-                            break;
+        let mut ping = tokio::time::interval(WS_PING_INTERVAL);
+        ping.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ping.tick().await;
+        loop {
+            tokio::select! {
+                output = ws_out_rx.recv() => {
+                    let Some(out) = output else { break; };
+                    match out {
+                        QueuedWsOutgoing::Control(json) => {
+                            if ws_sink.send(Message::Text(json.into())).await.is_err() {
+                                break;
+                            }
+                        }
+                        QueuedWsOutgoing::Frame(rects) => {
+                            let mut failed = false;
+                            for data in rects {
+                                if ws_sink.send(Message::Binary(data.into())).await.is_err() {
+                                    failed = true;
+                                    break;
+                                }
+                            }
+                            if failed
+                                || ws_sink
+                                    .send(Message::Binary(Vec::new().into()))
+                                    .await
+                                    .is_err()
+                            {
+                                break;
+                            }
                         }
                     }
-                    if failed
-                        || ws_sink
-                            .send(Message::Binary(Vec::new().into()))
-                            .await
-                            .is_err()
+                }
+                _ = ping.tick() => {
+                    if ws_sink
+                        .send(Message::Ping(Vec::new().into()))
+                        .await
+                        .is_err()
                     {
                         break;
                     }
@@ -526,7 +559,7 @@ async fn run_relay(
                 }
             };
             match msg {
-                ServerMessage::FramebufferUpdate { rects } => {
+                ServerMessage::FramebufferUpdate { rects, cursor } => {
                     if (fb_width, fb_height) != published_framebuffer_size {
                         framebuffer_generation = framebuffer_generation.saturating_add(1);
                         published_framebuffer_size = (fb_width, fb_height);
@@ -548,6 +581,16 @@ async fn run_relay(
                         frame.extend_from_slice(&make_frame_header(x, y, w, h));
                         frame.extend_from_slice(&rgba);
                         let _ = ws_out.push_rect(frame);
+                    }
+                    if let Some(cursor) = cursor {
+                        match serialize_cursor(cursor) {
+                            Ok(json) => {
+                                let _ = ws_out.send_control(json);
+                            }
+                            Err(error) => {
+                                tracing::warn!(%error, "ignoring invalid VNC RichCursor update");
+                            }
+                        }
                     }
                     if ws_out.finish_frame().unwrap_or(false) {
                         let _ = rfb_writer_for_read.lock().await.request_update(false);
@@ -753,8 +796,7 @@ async fn run_relay(
     }
 
     cancel.cancel();
-    // Closing the underlying socket interrupts any blocking read immediately;
-    // the read timeout remains a backstop for broken platform shutdowns.
+    // Closing the underlying socket interrupts the blocking runtime read.
     let _ = shutdown_stream.shutdown(std::net::Shutdown::Both);
     rfb_reader.abort();
     ws_write.abort();
@@ -903,6 +945,39 @@ fn can_send_notify(caps: ServerClipboardCaps) -> bool {
 
 fn can_send_provide(caps: ServerClipboardCaps) -> bool {
     caps.actions == 0 || caps.actions & ACTION_PROVIDE != 0
+}
+
+fn serialize_cursor(cursor: DecodedCursor) -> Result<String, String> {
+    if cursor.width == 0 || cursor.height == 0 {
+        return serde_json::to_string(&WsOutgoingText::Cursor {
+            visible: false,
+            hotspot_x: 0,
+            hotspot_y: 0,
+            width: 0,
+            height: 0,
+            png_base64: String::new(),
+        })
+        .map_err(|e| format!("serialize hidden VNC cursor: {e}"));
+    }
+
+    let mut png = Vec::new();
+    image::codecs::png::PngEncoder::new(&mut png)
+        .write_image(
+            &cursor.rgba,
+            u32::from(cursor.width),
+            u32::from(cursor.height),
+            ColorType::Rgba8.into(),
+        )
+        .map_err(|e| format!("encode VNC cursor PNG: {e}"))?;
+    serde_json::to_string(&WsOutgoingText::Cursor {
+        visible: true,
+        hotspot_x: cursor.hotspot_x,
+        hotspot_y: cursor.hotspot_y,
+        width: cursor.width,
+        height: cursor.height,
+        png_base64: BASE64_STANDARD.encode(png),
+    })
+    .map_err(|e| format!("serialize VNC cursor: {e}"))
 }
 
 fn parse_binary_control(bytes: &[u8]) -> Option<VncControl> {
@@ -1125,6 +1200,28 @@ mod tests {
         assert!(matches!(parse_binary_control(&[0]), Some(VncControl::Ack)));
         assert!(parse_binary_control(&[1]).is_none());
         assert!(parse_binary_control(&[3, 0]).is_none());
+    }
+
+    #[test]
+    fn rich_cursor_serializes_as_a_bounded_png_message() {
+        let json = serialize_cursor(DecodedCursor {
+            hotspot_x: 0,
+            hotspot_y: 0,
+            width: 1,
+            height: 1,
+            rgba: vec![0x12, 0x34, 0x56, 0xff],
+        })
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["type"], "cursor");
+        assert_eq!(value["visible"], true);
+        assert_eq!(value["width"], 1);
+        assert!(
+            value["png_base64"]
+                .as_str()
+                .unwrap()
+                .starts_with("iVBORw0KGgo")
+        );
     }
 
     #[test]

--- a/src/components/rdp/RdpPanel.tsx
+++ b/src/components/rdp/RdpPanel.tsx
@@ -27,12 +27,15 @@ import {
   OUT_AUDIO,
   OUT_CURSOR,
   OUT_FRAME,
+  OUT_FRAME_END,
   parseAudioFrame,
   parseFrameTile,
   parseRdpCursorFrame,
   parseRdpWsText,
   rdpConnect,
   rdpDisconnect,
+  RdpFrameBatchBuffer,
+  type RdpFrameTile,
   rdpCursorToCss,
   rdpTrustCertificate,
   wheelDeltaToRotationUnits,
@@ -123,6 +126,7 @@ export default function RdpPanel({
   const visibleRef = useRef(visible);
   const suppressNextPasteKeyUpRef = useRef(false);
   const pressedScancodesRef = useRef(new Set<number>());
+  const frameBatchRef = useRef(new RdpFrameBatchBuffer());
   const composingRef = useRef(false);
   const initRef = useRef({ host, port, username, password, options, networkSettingsJson });
   const [scaleMode, setScaleMode] = useState<ScaleMode>("fit");
@@ -265,6 +269,7 @@ export default function RdpPanel({
     destroyedRef.current = false;
     lastResizeRequestRef.current = null;
     retryAllowedRef.current = true;
+    frameBatchRef.current.reset();
     setRemoteCursorCss("default");
     store.initConnection(tabId);
 
@@ -309,7 +314,15 @@ export default function RdpPanel({
             const tag = dv.getUint8(0);
             if (tag === OUT_FRAME) {
               const tile = parseFrameTile(event.data);
-              if (tile) drawTile(canvasRef.current, tile);
+              const canvas = canvasRef.current;
+              frameBatchRef.current.push(tile, canvas?.width ?? 0, canvas?.height ?? 0);
+            } else if (tag === OUT_FRAME_END) {
+              const batch = frameBatchRef.current.finish();
+              if (batch.refreshRequired) {
+                sendBinary(encodeRefresh());
+                return;
+              }
+              drawTileBatch(canvasRef.current, batch.tiles);
               if (visibleRef.current) sendBinary(encodeAck());
             } else if (tag === OUT_AUDIO) {
               playAudioFrame(parseAudioFrame(event.data));
@@ -325,6 +338,7 @@ export default function RdpPanel({
                 connectedAtRef.current = Date.now();
                 retryAllowedRef.current = true;
                 store.setConnected(tabId, msg.width, msg.height, msg.protocol, msg.server_name);
+                frameBatchRef.current.reset();
                 resizeCanvas(canvasRef.current, msg.width, msg.height);
                 window.setTimeout(() => requestViewportResize(false), 0);
                 // Nudge the server to repaint the whole desktop shortly after
@@ -486,6 +500,7 @@ export default function RdpPanel({
       }
       closeAudio();
       releaseRemoteInput();
+      frameBatchRef.current.reset();
       const sid = sessionIdRef.current;
       sessionIdRef.current = null;
       if (sid) rdpDisconnect(sid).catch(() => {});
@@ -1037,4 +1052,11 @@ function drawTile(
       : (new Uint8ClampedArray(tile.rgba.buffer, tile.rgba.byteOffset, expected) as Uint8ClampedArray<ArrayBuffer>);
   const img = new ImageData(slice, tile.w, tile.h);
   ctx.putImageData(img, tile.x, tile.y);
+}
+
+function drawTileBatch(
+  canvas: HTMLCanvasElement | null,
+  tiles: RdpFrameTile[],
+) {
+  for (const tile of tiles) drawTile(canvas, tile);
 }

--- a/src/components/vnc/VncPanel.tsx
+++ b/src/components/vnc/VncPanel.tsx
@@ -10,6 +10,7 @@ import {
   parseWsMessage,
   parseFrameHeader,
   parseVncError,
+  vncCursorToCss,
   keyEventToKeysym,
   mapClientToFramebuffer,
   mouseButtonMask,
@@ -177,6 +178,7 @@ export default function VncPanel({
   // without re-binding.
   const extClipboardSupportedRef = useRef<boolean>(false);
   const [scaleMode, setScaleMode] = useState<ScaleMode>("fit");
+  const [remoteCursorCss, setRemoteCursorCss] = useState("none");
   const allowClipboardSend = clipboardPolicy === "bidirectional" || clipboardPolicy === "client-to-server";
   const allowClipboardReceive = clipboardPolicy === "bidirectional" || clipboardPolicy === "server-to-client";
 
@@ -276,6 +278,7 @@ export default function VncPanel({
 
     let cancelled = false;
     suppressReconnectRef.current = false;
+    setRemoteCursorCss("none");
     if (reconnectStableTimerRef.current !== null) {
       window.clearTimeout(reconnectStableTimerRef.current);
       reconnectStableTimerRef.current = null;
@@ -443,6 +446,9 @@ export default function VncPanel({
                   `[vnc.clip] server ExtendedClipboard support: ${msg.available}`,
                 );
                 break;
+              case "cursor":
+                setRemoteCursorCss(vncCursorToCss(msg));
+                break;
             }
           }
         };
@@ -552,6 +558,7 @@ export default function VncPanel({
       serverClipboardWriteInFlightRef.current = 0;
       lastClipboardSyncCheckAtRef.current = 0;
       lastSyncedLocalClipboardTextRef.current = null;
+      setRemoteCursorCss("none");
       const sid = sessionIdRef.current;
       if (sid) {
         vncDisconnect(sid).catch(() => {});
@@ -966,12 +973,12 @@ export default function VncPanel({
           width: "100%",
           height: "100%",
           objectFit: "contain",
-          cursor: conn?.status === "connected" ? "none" : "default",
+          cursor: conn?.status === "connected" ? remoteCursorCss : "default",
         }
       : {
           width: conn?.width ?? 0,
           height: conn?.height ?? 0,
-          cursor: conn?.status === "connected" ? "none" : "default",
+          cursor: conn?.status === "connected" ? remoteCursorCss : "default",
           maxWidth: "none",
           maxHeight: "none",
         };

--- a/src/lib/rdp.test.ts
+++ b/src/lib/rdp.test.ts
@@ -27,6 +27,7 @@ import {
   parseFrameTile,
   parseRdpCursorFrame,
   parseRdpWsText,
+  RdpFrameBatchBuffer,
   RDP_CURSOR_BITMAP,
   RDP_CURSOR_DEFAULT,
   RDP_CURSOR_HIDDEN,
@@ -173,6 +174,39 @@ describe("rdp WS frame parser", () => {
   it("returns null when frame is too short", () => {
     const buf = new Uint8Array([OUT_FRAME, 0, 0]);
     expect(parseFrameTile(buf.buffer)).toBeNull();
+  });
+
+  it("keeps incremental tiles in order until the frame boundary", () => {
+    const batch = new RdpFrameBatchBuffer();
+    const first = {
+      tag: OUT_FRAME,
+      x: 0,
+      y: 0,
+      w: 1,
+      h: 1,
+      rgba: new Uint8ClampedArray([1, 2, 3, 255]),
+    };
+    const second = {
+      ...first,
+      x: 1,
+      rgba: new Uint8ClampedArray([4, 5, 6, 255]),
+    };
+    batch.push(first, 2, 1);
+    batch.push(second, 2, 1);
+    expect(batch.finish()).toEqual({ tiles: [first, second], refreshRequired: false });
+  });
+
+  it("rejects a corrupt tile batch and requests a full refresh", () => {
+    const batch = new RdpFrameBatchBuffer();
+    batch.push({
+      tag: OUT_FRAME,
+      x: 0,
+      y: 0,
+      w: 2,
+      h: 1,
+      rgba: new Uint8ClampedArray([1, 2, 3, 255]),
+    }, 2, 1);
+    expect(batch.finish()).toEqual({ tiles: [], refreshRequired: true });
   });
 });
 

--- a/src/lib/rdp.ts
+++ b/src/lib/rdp.ts
@@ -288,6 +288,54 @@ export interface RdpFrameTile {
   rgba: Uint8ClampedArray<ArrayBuffer>;
 }
 
+const MAX_PENDING_RDP_FRAME_TILES = 8192;
+const MAX_PENDING_RDP_FRAME_BYTES = 128 * 1024 * 1024;
+
+export class RdpFrameBatchBuffer {
+  private tiles: RdpFrameTile[] = [];
+  private bytes = 0;
+  private rejected = false;
+
+  push(tile: RdpFrameTile | null, framebufferWidth: number, framebufferHeight: number): void {
+    if (this.rejected) return;
+    const expectedBytes = tile ? tile.w * tile.h * 4 : 0;
+    const valid = tile
+      && tile.w > 0
+      && tile.h > 0
+      && tile.rgba.byteLength === expectedBytes
+      && tile.x + tile.w <= framebufferWidth
+      && tile.y + tile.h <= framebufferHeight;
+    const nextBytes = this.bytes + expectedBytes;
+    if (
+      !valid
+      || this.tiles.length >= MAX_PENDING_RDP_FRAME_TILES
+      || nextBytes > MAX_PENDING_RDP_FRAME_BYTES
+    ) {
+      this.tiles = [];
+      this.bytes = 0;
+      this.rejected = true;
+      return;
+    }
+    this.tiles.push(tile);
+    this.bytes = nextBytes;
+  }
+
+  finish(): { tiles: RdpFrameTile[]; refreshRequired: boolean } {
+    const result = {
+      tiles: this.rejected ? [] : this.tiles,
+      refreshRequired: this.rejected,
+    };
+    this.reset();
+    return result;
+  }
+
+  reset(): void {
+    this.tiles = [];
+    this.bytes = 0;
+    this.rejected = false;
+  }
+}
+
 export interface RdpAudioFrame {
   tag: number;
   sampleRate: number;

--- a/src/lib/vnc.test.ts
+++ b/src/lib/vnc.test.ts
@@ -19,6 +19,7 @@ import {
   vncConnect,
   vncConsumeDetachClaim,
   vncCreateDetachClaim,
+  vncCursorToCss,
   vncTestConnection,
 } from "./vnc";
 
@@ -59,6 +60,11 @@ describe("VNC WebSocket protocol", () => {
       type: "desktop_size", width: 2560, height: 1440, generation: 1,
     });
     expect(parseWsMessage('{"type":"desktop_size","width":0,"height":1440,"generation":1}')).toBeNull();
+    const cursor = parseWsMessage('{"type":"cursor","visible":true,"hotspot_x":1,"hotspot_y":2,"width":16,"height":16,"png_base64":"iVBORw0KGgo="}');
+    expect(cursor).toMatchObject({ type: "cursor", visible: true, hotspot_x: 1, hotspot_y: 2 });
+    expect(cursor?.type === "cursor" ? vncCursorToCss(cursor) : "").toContain("data:image/png;base64,iVBORw0KGgo=");
+    expect(parseWsMessage('{"type":"cursor","visible":true,"hotspot_x":16,"hotspot_y":0,"width":16,"height":16,"png_base64":"iVBORw0KGgo="}')).toBeNull();
+    expect(parseWsMessage('{"type":"cursor","visible":false,"hotspot_x":0,"hotspot_y":0,"width":0,"height":0,"png_base64":""}')).toMatchObject({ type: "cursor", visible: false });
   });
 
   it("validates binary frame geometry and exact payload length", () => {

--- a/src/lib/vnc.ts
+++ b/src/lib/vnc.ts
@@ -23,6 +23,8 @@ const MAX_FRAMEBUFFER_BYTES = 256 * 1024 * 1024;
 const MAX_RELAY_TEXT_CHARS = 64 * 1024 * 1024;
 const MAX_CLIPBOARD_FORMAT_CHARS = 16 * 1024 * 1024;
 const MAX_CLIPBOARD_TOTAL_CHARS = 32 * 1024 * 1024;
+const MAX_CURSOR_DIMENSION = 512;
+const MAX_CURSOR_BASE64_CHARS = 2 * 1024 * 1024;
 
 function isVncStage(value: unknown): value is VncStructuredError["stage"] {
   return typeof value === "string" && VNC_STAGES.has(value as VncStructuredError["stage"]);
@@ -209,7 +211,16 @@ export type WsIncoming =
       html?: string;
       rtf?: string;
     }
-  | { type: "ext_clipboard_support"; available: boolean };
+  | { type: "ext_clipboard_support"; available: boolean }
+  | {
+      type: "cursor";
+      visible: boolean;
+      hotspot_x: number;
+      hotspot_y: number;
+      width: number;
+      height: number;
+      png_base64: string;
+    };
 
 /** Parse and minimally validate an incoming WS text message. */
 export function parseWsMessage(data: string): WsIncoming | null {
@@ -253,12 +264,44 @@ export function parseWsMessage(data: string): WsIncoming | null {
           : null;
       case "ext_clipboard_support":
         return typeof msg.available === "boolean" ? value as WsIncoming : null;
+      case "cursor": {
+        if (typeof msg.visible !== "boolean") return null;
+        if (msg.visible === false) {
+          return msg.hotspot_x === 0 && msg.hotspot_y === 0
+            && msg.width === 0 && msg.height === 0 && msg.png_base64 === ""
+            ? value as WsIncoming
+            : null;
+        }
+        const validGeometry = Number.isInteger(msg.hotspot_x)
+          && Number.isInteger(msg.hotspot_y)
+          && Number.isInteger(msg.width)
+          && Number.isInteger(msg.height)
+          && (msg.width as number) > 0
+          && (msg.height as number) > 0
+          && (msg.width as number) <= MAX_CURSOR_DIMENSION
+          && (msg.height as number) <= MAX_CURSOR_DIMENSION
+          && (msg.hotspot_x as number) >= 0
+          && (msg.hotspot_y as number) >= 0
+          && (msg.hotspot_x as number) < (msg.width as number)
+          && (msg.hotspot_y as number) < (msg.height as number);
+        const validPng = typeof msg.png_base64 === "string"
+          && msg.png_base64.length > 0
+          && msg.png_base64.length <= MAX_CURSOR_BASE64_CHARS
+          && msg.png_base64.startsWith("iVBORw0KGgo")
+          && /^[A-Za-z0-9+/]*={0,2}$/.test(msg.png_base64);
+        return validGeometry && validPng ? value as WsIncoming : null;
+      }
       default:
         return null;
     }
   } catch {
     return null;
   }
+}
+
+export function vncCursorToCss(cursor: Extract<WsIncoming, { type: "cursor" }>): string {
+  if (!cursor.visible) return "none";
+  return `url("data:image/png;base64,${cursor.png_base64}") ${cursor.hotspot_x} ${cursor.hotspot_y}, default`;
 }
 
 export function encodeWsAck(): ArrayBuffer {


### PR DESCRIPTION
VNC sessions now clear the authentication-only socket read timeout after the RFB session is initialized, preventing an idle remote server from being treated as a failed connection when a tab loses focus. Add native WebSocket pings and extend the idle watchdog backstop so background WebView timer throttling no longer causes premature disconnects.

Negotiate and decode the RichCursor pseudo-encoding, serialize cursor shapes as bounded PNG messages, and apply them as local CSS cursors. This keeps pointer feedback responsive without waiting for remote framebuffer updates.

Preserve RDP incremental dirty-rectangle batches in order across both output queues with bounded backpressure instead of replacing pending batches. Buffer RDP tiles in the frontend until FRAME_END, then render them in one task and request a full refresh for invalid or oversized batches. Add focused queue, cursor, timeout, and frame-batching coverage.

Validated with focused VNC/RDP frontend tests (51 passed), cargo test --lib vnc:: (61 passed, 1 ignored), cargo test --lib rdp:: (220 passed, 7 ignored), pnpm build, and git diff --check.