### PR TITLE
fix(vnc): reduce cross-platform client mouse latency

### DIFF
--- a/src-tauri/src/vnc/encodings.rs
+++ b/src-tauri/src/vnc/encodings.rs
@@ -27,6 +27,20 @@ pub struct DecodedCursor {
     pub rgba: Vec<u8>,
 }
 
+/// Cursor position delivered by the RFB PointerPos pseudo-encoding (-232).
+/// The encoding uses the rectangle header only; its width and height must be
+/// zero and no payload follows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DecodedPointerPosition {
+    pub x: u16,
+    pub y: u16,
+}
+
+pub const ENCODING_DESKTOP_SIZE: i32 = -223;
+pub const ENCODING_POINTER_POS: i32 = -232;
+pub const ENCODING_RICH_CURSOR: i32 = -239;
+pub const ENCODING_X_CURSOR: i32 = -240;
+
 const MAX_CURSOR_DIMENSION: u16 = 512;
 
 // ── Helpers to read big-endian integers from an `impl Read`. ──
@@ -658,6 +672,91 @@ pub fn read_rich_cursor<R: Read>(
     })
 }
 
+/// Decode the XCursor pseudo-encoding (-240). The payload contains foreground
+/// and background RGB colours, followed by one-bit image and transparency
+/// bitmaps whose rows are padded to whole bytes. A set image bit selects the
+/// foreground colour; a set mask bit makes the pixel visible.
+pub fn read_x_cursor<R: Read>(
+    reader: &mut R,
+    hotspot_x: u16,
+    hotspot_y: u16,
+    width: u16,
+    height: u16,
+) -> Result<DecodedCursor, String> {
+    if width == 0 || height == 0 {
+        return Ok(DecodedCursor {
+            hotspot_x: 0,
+            hotspot_y: 0,
+            width: 0,
+            height: 0,
+            rgba: Vec::new(),
+        });
+    }
+    if width > MAX_CURSOR_DIMENSION || height > MAX_CURSOR_DIMENSION {
+        return Err(format!(
+            "X cursor dimensions {width}x{height} exceed {MAX_CURSOR_DIMENSION}x{MAX_CURSOR_DIMENSION}"
+        ));
+    }
+    if hotspot_x >= width || hotspot_y >= height {
+        return Err(format!(
+            "X cursor hotspot {hotspot_x},{hotspot_y} lies outside {width}x{height}"
+        ));
+    }
+
+    let pixel_count = usize::from(width)
+        .checked_mul(usize::from(height))
+        .ok_or_else(|| "X cursor pixel count overflow".to_string())?;
+    let rgba_bytes = pixel_count
+        .checked_mul(4)
+        .ok_or_else(|| "X cursor RGBA byte count overflow".to_string())?;
+    let bitmap_stride = usize::from(width).div_ceil(8);
+    let bitmap_bytes = bitmap_stride
+        .checked_mul(usize::from(height))
+        .ok_or_else(|| "X cursor bitmap byte count overflow".to_string())?;
+
+    let mut colours = [0u8; 6];
+    reader
+        .read_exact(&mut colours)
+        .map_err(|e| format!("X cursor colours: {e}"))?;
+    let mut bitmap = vec![0u8; bitmap_bytes];
+    reader
+        .read_exact(&mut bitmap)
+        .map_err(|e| format!("X cursor bitmap: {e}"))?;
+    let mut mask = vec![0u8; bitmap_bytes];
+    reader
+        .read_exact(&mut mask)
+        .map_err(|e| format!("X cursor mask: {e}"))?;
+
+    let mut rgba = vec![0u8; rgba_bytes];
+    for row in 0..usize::from(height) {
+        for column in 0..usize::from(width) {
+            let bit = 0x80 >> (column % 8);
+            let bitmap_offset = row * bitmap_stride + column / 8;
+            let colour_offset = if bitmap[bitmap_offset] & bit != 0 {
+                0
+            } else {
+                3
+            };
+            let rgba_offset = (row * usize::from(width) + column) * 4;
+            rgba[rgba_offset..rgba_offset + 3]
+                .copy_from_slice(&colours[colour_offset..colour_offset + 3]);
+            rgba[rgba_offset + 3] = if mask[bitmap_offset] & bit != 0 {
+                255
+            } else {
+                0
+            };
+        }
+    }
+
+    Ok(DecodedCursor {
+        hotspot_x,
+        hotspot_y,
+        width,
+        height,
+        rgba,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -691,6 +790,42 @@ mod tests {
     fn rich_cursor_rejects_invalid_geometry() {
         assert!(read_rich_cursor(&mut Cursor::new(Vec::<u8>::new()), 3, 0, 3, 1).is_err());
         assert!(read_rich_cursor(&mut Cursor::new(Vec::<u8>::new()), 0, 0, 513, 1).is_err());
+    }
+
+    #[test]
+    fn x_cursor_applies_colours_bitmap_mask_and_hotspot() {
+        let mut payload = vec![10, 20, 30, 40, 50, 60];
+        payload.extend_from_slice(&[0b1010_0000, 0b0100_0000]);
+        payload.extend_from_slice(&[0b1100_0000, 0b0110_0000]);
+        let mut reader = Cursor::new(payload);
+        let cursor = read_x_cursor(&mut reader, 2, 1, 3, 2).unwrap();
+
+        assert_eq!((cursor.hotspot_x, cursor.hotspot_y), (2, 1));
+        assert_eq!((cursor.width, cursor.height), (3, 2));
+        assert_eq!(
+            cursor.rgba,
+            vec![
+                10, 20, 30, 255, 40, 50, 60, 255, 10, 20, 30, 0, 40, 50, 60, 0, 10, 20, 30, 255,
+                40, 50, 60, 255,
+            ]
+        );
+        assert_eq!(reader.position() as usize, reader.get_ref().len());
+    }
+
+    #[test]
+    fn x_cursor_rejects_invalid_geometry_and_truncated_payloads() {
+        assert!(read_x_cursor(&mut Cursor::new(Vec::<u8>::new()), 3, 0, 3, 1).is_err());
+        assert!(read_x_cursor(&mut Cursor::new(Vec::<u8>::new()), 0, 0, 513, 1).is_err());
+        assert!(read_x_cursor(&mut Cursor::new(vec![0; 7]), 0, 0, 8, 1).is_err());
+    }
+
+    #[test]
+    fn zero_sized_x_cursor_is_hidden_without_consuming_payload() {
+        let mut reader = Cursor::new(vec![1, 2, 3]);
+        let cursor = read_x_cursor(&mut reader, 12, 34, 0, 10).unwrap();
+        assert_eq!((cursor.width, cursor.height), (0, 0));
+        assert!(cursor.rgba.is_empty());
+        assert_eq!(reader.position(), 0);
     }
 
     #[test]

--- a/src-tauri/src/vnc/rfb.rs
+++ b/src-tauri/src/vnc/rfb.rs
@@ -7,7 +7,10 @@ use crate::vnc::clipboard::{
     ExtendedClipboardMsg, decode_legacy_cut_text, encode_legacy_cut_text,
     parse_extended_body_with_limits,
 };
-use crate::vnc::encodings::{self, DecodedCursor, DecodedRect, HextileState, ZrleDecoder};
+use crate::vnc::encodings::{
+    self, DecodedCursor, DecodedPointerPosition, DecodedRect, ENCODING_DESKTOP_SIZE,
+    ENCODING_POINTER_POS, ENCODING_RICH_CURSOR, ENCODING_X_CURSOR, HextileState, ZrleDecoder,
+};
 use crate::vnc::limits::DecodeLimits;
 use crate::vnc::policy::VncSecurityPolicy;
 
@@ -858,17 +861,22 @@ impl RfbConnection {
 
         let mut decoded: Vec<DecodedRect> = Vec::with_capacity(num_rects);
         let mut cursor = None;
+        let mut pointer_pos = None;
         for _ in 0..num_rects {
             let x = self.read_u16()?;
             let y = self.read_u16()?;
             let w = self.read_u16()?;
             let h = self.read_u16()?;
             let encoding = self.read_i32()?;
-            if encoding == -223 {
+            if encoding == ENCODING_DESKTOP_SIZE {
                 self.limits
                     .framebuffer_bytes(w, h)
                     .map_err(|e| e.to_string())?;
-            } else if encoding != -239 {
+            } else if encoding == ENCODING_POINTER_POS {
+                if w != 0 || h != 0 {
+                    return Err("pointer position encoding must have zero dimensions".into());
+                }
+            } else if encoding != ENCODING_RICH_CURSOR && encoding != ENCODING_X_CURSOR {
                 self.limits
                     .rectangle_bytes(w, h)
                     .map_err(|e| e.to_string())?;
@@ -878,7 +886,11 @@ impl RfbConnection {
             {
                 // DesktopSize is the only rectangle allowed to describe a new
                 // framebuffer geometry; pixel rectangles must stay in bounds.
-                if encoding != -223 && encoding != -239 {
+                if encoding != ENCODING_DESKTOP_SIZE
+                    && encoding != ENCODING_RICH_CURSOR
+                    && encoding != ENCODING_X_CURSOR
+                    && encoding != ENCODING_POINTER_POS
+                {
                     return Err("framebuffer rectangle is outside the negotiated size".into());
                 }
             }
@@ -961,7 +973,7 @@ impl RfbConnection {
                     }
                     decoded.extend(rects);
                 }
-                -223 => {
+                ENCODING_DESKTOP_SIZE => {
                     // DesktopSize pseudo-encoding: no payload, just a resize.
                     let size = self
                         .limits
@@ -971,10 +983,18 @@ impl RfbConnection {
                     self.height = h;
                     self.framebuffer = vec![0u8; size];
                 }
-                -239 => {
+                ENCODING_RICH_CURSOR => {
                     cursor = Some(self.decode_via_reader(|reader| {
                         encodings::read_rich_cursor(reader, x, y, w, h)
                     })?);
+                }
+                ENCODING_X_CURSOR => {
+                    cursor = Some(self.decode_via_reader(|reader| {
+                        encodings::read_x_cursor(reader, x, y, w, h)
+                    })?);
+                }
+                ENCODING_POINTER_POS => {
+                    pointer_pos = Some(DecodedPointerPosition { x, y });
                 }
                 other => {
                     return Err(format!(
@@ -988,6 +1008,7 @@ impl RfbConnection {
         Ok(ServerMessage::FramebufferUpdate {
             rects: decoded,
             cursor,
+            pointer_pos,
         })
     }
 
@@ -1603,6 +1624,7 @@ pub enum ServerMessage {
     FramebufferUpdate {
         rects: Vec<DecodedRect>,
         cursor: Option<DecodedCursor>,
+        pointer_pos: Option<DecodedPointerPosition>,
     },
     SetColourMapEntries,
     Bell,
@@ -1851,5 +1873,137 @@ mod tests {
         );
         connection.enter_runtime_mode().unwrap();
         assert_eq!(connection.stream.read_timeout().unwrap(), None);
+    }
+
+    #[test]
+    fn decodes_pointer_position_pseudo_encoding_without_a_pixel_payload() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut update = Vec::new();
+            update.extend_from_slice(&[0, 0, 0, 1]);
+            update.extend_from_slice(&320u16.to_be_bytes());
+            update.extend_from_slice(&240u16.to_be_bytes());
+            update.extend_from_slice(&0u16.to_be_bytes());
+            update.extend_from_slice(&0u16.to_be_bytes());
+            update.extend_from_slice(&ENCODING_POINTER_POS.to_be_bytes());
+            stream.write_all(&update).unwrap();
+
+            let mut invalid = Vec::new();
+            invalid.extend_from_slice(&[0, 0, 0, 1]);
+            invalid.extend_from_slice(&320u16.to_be_bytes());
+            invalid.extend_from_slice(&240u16.to_be_bytes());
+            invalid.extend_from_slice(&1u16.to_be_bytes());
+            invalid.extend_from_slice(&0u16.to_be_bytes());
+            invalid.extend_from_slice(&ENCODING_POINTER_POS.to_be_bytes());
+            stream.write_all(&invalid).unwrap();
+        });
+
+        let stream = TcpStream::connect(address).unwrap();
+        let mut connection = RfbConnection::new_stream(
+            stream,
+            Duration::from_secs(2),
+            DecodeLimits::default(),
+            VncSecurityPolicy::AllowNone,
+            8,
+            None,
+            None,
+        )
+        .unwrap();
+        connection.width = 800;
+        connection.height = 600;
+        connection.framebuffer = vec![0; 800 * 600 * 4];
+
+        match connection.read_server_message().unwrap() {
+            ServerMessage::FramebufferUpdate {
+                rects,
+                cursor,
+                pointer_pos,
+            } => {
+                assert!(rects.is_empty());
+                assert!(cursor.is_none());
+                assert_eq!(pointer_pos, Some(DecodedPointerPosition { x: 320, y: 240 }));
+            }
+            other => panic!("expected pointer position update, got {other:?}"),
+        }
+        assert!(connection.read_server_message().is_err());
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn decodes_visible_and_hidden_x_cursor_pseudo_encodings() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+
+            let mut visible = Vec::new();
+            visible.extend_from_slice(&[0, 0, 0, 1]);
+            visible.extend_from_slice(&1u16.to_be_bytes());
+            visible.extend_from_slice(&0u16.to_be_bytes());
+            visible.extend_from_slice(&2u16.to_be_bytes());
+            visible.extend_from_slice(&1u16.to_be_bytes());
+            visible.extend_from_slice(&ENCODING_X_CURSOR.to_be_bytes());
+            visible.extend_from_slice(&[1, 2, 3, 4, 5, 6]);
+            visible.extend_from_slice(&[0b1000_0000]);
+            visible.extend_from_slice(&[0b1100_0000]);
+            stream.write_all(&visible).unwrap();
+
+            let mut hidden = Vec::new();
+            hidden.extend_from_slice(&[0, 0, 0, 1]);
+            hidden.extend_from_slice(&0u16.to_be_bytes());
+            hidden.extend_from_slice(&0u16.to_be_bytes());
+            hidden.extend_from_slice(&0u16.to_be_bytes());
+            hidden.extend_from_slice(&0u16.to_be_bytes());
+            hidden.extend_from_slice(&ENCODING_X_CURSOR.to_be_bytes());
+            stream.write_all(&hidden).unwrap();
+        });
+
+        let stream = TcpStream::connect(address).unwrap();
+        let mut connection = RfbConnection::new_stream(
+            stream,
+            Duration::from_secs(2),
+            DecodeLimits::default(),
+            VncSecurityPolicy::AllowNone,
+            8,
+            None,
+            None,
+        )
+        .unwrap();
+        connection.width = 800;
+        connection.height = 600;
+        connection.framebuffer = vec![0; 800 * 600 * 4];
+
+        match connection.read_server_message().unwrap() {
+            ServerMessage::FramebufferUpdate {
+                rects,
+                cursor: Some(cursor),
+                pointer_pos,
+            } => {
+                assert!(rects.is_empty());
+                assert!(pointer_pos.is_none());
+                assert_eq!((cursor.hotspot_x, cursor.hotspot_y), (1, 0));
+                assert_eq!((cursor.width, cursor.height), (2, 1));
+                assert_eq!(cursor.rgba, vec![1, 2, 3, 255, 4, 5, 6, 255]);
+            }
+            other => panic!("expected visible X cursor update, got {other:?}"),
+        }
+
+        match connection.read_server_message().unwrap() {
+            ServerMessage::FramebufferUpdate {
+                rects,
+                cursor: Some(cursor),
+                pointer_pos,
+            } => {
+                assert!(rects.is_empty());
+                assert!(pointer_pos.is_none());
+                assert_eq!((cursor.width, cursor.height), (0, 0));
+                assert!(cursor.rgba.is_empty());
+            }
+            other => panic!("expected hidden X cursor update, got {other:?}"),
+        }
+
+        server.join().unwrap();
     }
 }

--- a/src-tauri/src/vnc/tls.rs
+++ b/src-tauri/src/vnc/tls.rs
@@ -24,6 +24,9 @@ pub(crate) async fn prepare_rfb_transport(
     policy: VncSecurityPolicy,
     timeout: Duration,
 ) -> Result<PreparedRfbTransport, String> {
+    socket
+        .set_nodelay(true)
+        .map_err(|e| format!("configure VNC upstream TCP_NODELAY: {e}"))?;
     tokio::time::timeout(timeout, negotiate_outer_security(socket, host, policy))
         .await
         .map_err(|_| "VNC security negotiation timed out".to_string())?
@@ -173,6 +176,12 @@ async fn anonymous_tls_transport(
         .accept()
         .await
         .map_err(|e| format!("accept VNC TLS bridge: {e}"))?;
+    local_client
+        .set_nodelay(true)
+        .map_err(|e| format!("configure VNC TLS client bridge TCP_NODELAY: {e}"))?;
+    local_bridge
+        .set_nodelay(true)
+        .map_err(|e| format!("configure VNC TLS relay bridge TCP_NODELAY: {e}"))?;
 
     let tls_task = tokio::spawn(async move {
         if let Err(error) = tokio::io::copy_bidirectional(&mut local_bridge, &mut tls).await {
@@ -194,14 +203,17 @@ async fn anonymous_tls_transport(
 
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
+    use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
     use openssl::dh::Dh;
     use openssl::ssl::{Ssl, SslAcceptor};
     use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
     use super::*;
-    use crate::vnc::rfb::RfbConnection;
+    use crate::vnc::encodings::{
+        ENCODING_DESKTOP_SIZE, ENCODING_POINTER_POS, ENCODING_RICH_CURSOR, ENCODING_X_CURSOR,
+    };
+    use crate::vnc::rfb::{RfbConnection, ServerMessage};
 
     async fn write_server_init<S: AsyncWrite + Unpin>(
         stream: &mut S,
@@ -288,6 +300,7 @@ mod tests {
         });
 
         let socket = TcpStream::connect(address).await.unwrap();
+        socket.set_nodelay(false).unwrap();
         let prepared = prepare_rfb_transport(
             socket,
             "127.0.0.1",
@@ -296,6 +309,7 @@ mod tests {
         )
         .await
         .unwrap();
+        assert!(prepared.stream.nodelay().unwrap());
         let started = Instant::now();
         let init = tokio::task::spawn_blocking(move || {
             let mut connection = RfbConnection::from_negotiated_stream(
@@ -412,17 +426,86 @@ mod tests {
                 prepared.outer_security_type,
             )?;
             let init = connection.authenticate(username.as_deref(), Some(&password))?;
-            Ok::<_, String>((init, connection.security_label(), connection.encrypted()))
+            let security = connection.security_label();
+            let encrypted = connection.encrypted();
+            connection.set_pixel_format_rgba()?;
+            connection.set_encodings(&[
+                16,
+                5,
+                1,
+                0,
+                ENCODING_DESKTOP_SIZE,
+                ENCODING_POINTER_POS,
+                ENCODING_X_CURSOR,
+                ENCODING_RICH_CURSOR,
+            ])?;
+            let frame_started = Instant::now();
+            connection.request_update(false)?;
+            let (rect_count, cursor_shape, pointer_pos) = loop {
+                if let ServerMessage::FramebufferUpdate {
+                    rects,
+                    cursor,
+                    pointer_pos,
+                } = connection.read_server_message()?
+                {
+                    break (rects.len(), cursor.is_some(), pointer_pos.is_some());
+                }
+            };
+            let mut writer = connection.take_writer()?;
+            let pointer_started = Instant::now();
+            let probe_seed = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .subsec_nanos();
+            let pointer_x = (probe_seed % u32::from(init.width)) as u16;
+            let pointer_y = (probe_seed.rotate_left(13) % u32::from(init.height)) as u16;
+            writer.send_pointer_event(pointer_x, pointer_y, 0)?;
+            writer.request_update(true)?;
+            let (pointer_rect_count, pointer_cursor, pointer_position) = loop {
+                if let ServerMessage::FramebufferUpdate {
+                    rects,
+                    cursor,
+                    pointer_pos,
+                } = connection.read_server_message()?
+                {
+                    break (rects.len(), cursor.is_some(), pointer_pos);
+                }
+            };
+            Ok::<_, String>((
+                init,
+                security,
+                encrypted,
+                rect_count,
+                cursor_shape,
+                pointer_pos,
+                frame_started.elapsed(),
+                pointer_rect_count,
+                pointer_cursor,
+                pointer_position,
+                pointer_started.elapsed(),
+            ))
         })
         .await
         .unwrap()
         .unwrap();
 
         println!(
-            "connected {}x{} '{}' via {}",
-            result.0.width, result.0.height, result.0.name, result.1
+            "connected {}x{} '{}' via {}; first frame rects={} cursor={} pointer_pos={} in {:?}; pointer update rects={} cursor={} pointer_pos={:?} in {:?}",
+            result.0.width,
+            result.0.height,
+            result.0.name,
+            result.1,
+            result.3,
+            result.4,
+            result.5,
+            result.6,
+            result.7,
+            result.8,
+            result.9,
+            result.10,
         );
         assert!(result.2);
+        assert!(result.3 > 0 || result.4 || result.5);
         if let Some(task) = tls_task {
             task.abort();
         }

--- a/src-tauri/src/vnc/ws.rs
+++ b/src-tauri/src/vnc/ws.rs
@@ -22,7 +22,10 @@ use crate::vnc::clipboard::{
     ENCODING_EXTENDED_CLIPBOARD_LEGACY, ExtendedClipboardMsg, FORMAT_HTML, FORMAT_RTF, FORMAT_TEXT,
     SUPPORTED_ACTIONS, build_caps_body, build_notify_body, build_provide_body, build_request_body,
 };
-use crate::vnc::encodings::{DecodedCursor, DecodedRect};
+use crate::vnc::encodings::{
+    DecodedCursor, DecodedRect, ENCODING_DESKTOP_SIZE, ENCODING_POINTER_POS, ENCODING_RICH_CURSOR,
+    ENCODING_X_CURSOR,
+};
 use crate::vnc::policy::{VncClipboardPolicy, VncSecurityPolicy};
 use crate::vnc::queue::{FrameQueueReceiver, FrameQueueSender, QueuedWsOutgoing};
 use crate::vnc::rfb::{RfbConnection, RfbWriter, ServerMessage};
@@ -152,6 +155,8 @@ enum WsOutgoingText {
         height: u16,
         png_base64: String,
     },
+    #[serde(rename = "pointer_pos")]
+    PointerPos { x: u16, y: u16 },
 }
 
 // ── Public session handle ───────────────────────────────────────────
@@ -280,8 +285,10 @@ pub async fn spawn_vnc_relay(
             5,
             1,
             0,
-            -223,
-            -239,
+            ENCODING_DESKTOP_SIZE,
+            ENCODING_POINTER_POS,
+            ENCODING_X_CURSOR,
+            ENCODING_RICH_CURSOR,
             ENCODING_EXTENDED_CLIPBOARD,
             ENCODING_EXTENDED_CLIPBOARD_LEGACY,
         ])?;
@@ -559,7 +566,11 @@ async fn run_relay(
                 }
             };
             match msg {
-                ServerMessage::FramebufferUpdate { rects, cursor } => {
+                ServerMessage::FramebufferUpdate {
+                    rects,
+                    cursor,
+                    pointer_pos,
+                } => {
                     if (fb_width, fb_height) != published_framebuffer_size {
                         framebuffer_generation = framebuffer_generation.saturating_add(1);
                         published_framebuffer_size = (fb_width, fb_height);
@@ -588,9 +599,17 @@ async fn run_relay(
                                 let _ = ws_out.send_control(json);
                             }
                             Err(error) => {
-                                tracing::warn!(%error, "ignoring invalid VNC RichCursor update");
+                                tracing::warn!(%error, "ignoring invalid VNC cursor update");
                             }
                         }
+                    }
+                    if let Some(pointer_pos) = pointer_pos {
+                        let json = serde_json::to_string(&WsOutgoingText::PointerPos {
+                            x: pointer_pos.x,
+                            y: pointer_pos.y,
+                        })
+                        .unwrap();
+                        let _ = ws_out.send_control(json);
                     }
                     if ws_out.finish_frame().unwrap_or(false) {
                         let _ = rfb_writer_for_read.lock().await.request_update(false);
@@ -1105,6 +1124,9 @@ async fn accept_authorized_ws(
             },
             _ = cancel.cancelled() => return Err("VNC relay cancelled".into()),
         };
+        stream
+            .set_nodelay(true)
+            .map_err(|error| format!("configure VNC WebSocket TCP_NODELAY: {error}"))?;
 
         let protocol = expected_protocol.clone();
         let callback = move |request: &Request, mut response: Response| {
@@ -1221,6 +1243,16 @@ mod tests {
                 .as_str()
                 .unwrap()
                 .starts_with("iVBORw0KGgo")
+        );
+    }
+
+    #[test]
+    fn pointer_position_serializes_as_a_small_control_message() {
+        let json = serde_json::to_string(&WsOutgoingText::PointerPos { x: 123, y: 456 }).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({ "type": "pointer_pos", "x": 123, "y": 456 })
         );
     }
 

--- a/src/components/vnc/VncPanel.test.tsx
+++ b/src/components/vnc/VncPanel.test.tsx
@@ -1,8 +1,34 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ invoke: vi.fn() }));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
 
 import { useVncStore, type VncConnectionState } from "../../stores/vncStore";
 import VncPanel from "./VncPanel";
+
+class MockWebSocket {
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.OPEN;
+  binaryType: BinaryType = "blob";
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  send = vi.fn();
+
+  constructor() {
+    MockWebSocket.instances.push(this);
+  }
+
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED;
+  });
+}
 
 const CONNECTED: VncConnectionState = {
   status: "connected",
@@ -20,16 +46,33 @@ const CONNECTED: VncConnectionState = {
 describe("VncPanel pointer rendering", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "vnc_connect") {
+        return Promise.resolve({
+          session_id: "vnc-session",
+          ws_port: 41000,
+          ws_token: "relay-token",
+          width: 1920,
+          height: 1080,
+          name: "windows-host",
+        });
+      }
+      return Promise.resolve();
+    });
     useVncStore.setState({ connections: {} });
   });
 
   afterEach(() => {
     cleanup();
+    vi.unstubAllGlobals();
+    mocks.invoke.mockReset();
     vi.clearAllTimers();
     vi.useRealTimers();
   });
 
-  it("hides the local WebView cursor over a connected remote desktop", () => {
+  it("hides the local cursor until the server confirms client-side cursor support", () => {
     useVncStore.setState({ connections: { "vnc-tab": CONNECTED } });
 
     render(
@@ -42,5 +85,38 @@ describe("VncPanel pointer rendering", () => {
     );
 
     expect(screen.getByTestId("vnc-canvas")).toHaveStyle({ cursor: "none" });
+  });
+
+  it("uses a local cursor after PointerPos while preserving a later cursor shape", async () => {
+    render(
+      <VncPanel
+        tabId="vnc-tab"
+        host="windows.example.test"
+        port={5900}
+        visible
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    const socket = MockWebSocket.instances[0];
+    expect(socket).toBeDefined();
+
+    act(() => {
+      socket.onmessage?.({
+        data: '{"type":"connected","width":1920,"height":1080,"name":"fixture","protocol":"3.8","security":"VNCAuth","encrypted":false}',
+      } as MessageEvent);
+      socket.onmessage?.({ data: '{"type":"pointer_pos","x":100,"y":200}' } as MessageEvent);
+    });
+    expect(screen.getByTestId("vnc-canvas")).toHaveStyle({ cursor: "default" });
+
+    act(() => {
+      socket.onmessage?.({
+        data: '{"type":"cursor","visible":true,"hotspot_x":0,"hotspot_y":0,"width":1,"height":1,"png_base64":"iVBORw0KGgo="}',
+      } as MessageEvent);
+      socket.onmessage?.({ data: '{"type":"pointer_pos","x":101,"y":201}' } as MessageEvent);
+    });
+    expect(screen.getByTestId("vnc-canvas").style.cursor).toContain("data:image/png;base64,iVBORw0KGgo=");
   });
 });

--- a/src/components/vnc/VncPanel.tsx
+++ b/src/components/vnc/VncPanel.tsx
@@ -16,6 +16,10 @@ import {
   mouseButtonMask,
 } from "../../lib/vnc";
 import type { WsOutgoing } from "../../lib/vnc";
+import {
+  VncPointerScheduler,
+  type VncPointerState,
+} from "../../lib/vncPointerScheduler";
 import { useVncStore } from "../../stores/vncStore";
 import { useAppStore } from "../../stores/appStore";
 import { ExternalLink, Maximize, Maximize2, Minimize, Minimize2, RefreshCw } from "lucide-react";
@@ -71,15 +75,10 @@ type PendingFrame = {
   h: number;
   rgba: Uint8ClampedArray<ArrayBuffer>;
 };
-type PointerState = {
-  x: number;
-  y: number;
-  buttons: number;
-};
 type DelayedPointerDown = {
   pointerId: number;
-  down: PointerState;
-  up: PointerState | null;
+  down: VncPointerState;
+  up: VncPointerState | null;
 };
 
 function modifierKeysymFromKey(key: string): number | null {
@@ -160,9 +159,8 @@ export default function VncPanel({
   const visibleRef = useRef(visible);
   const ackPendingRef = useRef(false);
   const pasteDelayTimerRef = useRef<number | null>(null);
-  const pointerRafRef = useRef<number | null>(null);
-  const pendingPointerRef = useRef<PointerState | null>(null);
-  const lastPointerSentRef = useRef<PointerState | null>(null);
+  const pointerSchedulerRef = useRef<VncPointerScheduler | null>(null);
+  const lastPointerSentRef = useRef<VncPointerState | null>(null);
   const delayedPointerDownRef = useRef<DelayedPointerDown | null>(null);
   const clipboardSyncPromiseRef = useRef<Promise<void> | null>(null);
   const serverClipboardWriteInFlightRef = useRef(0);
@@ -177,6 +175,7 @@ export default function VncPanel({
   // pseudo-encoding. Stored as a ref so input handlers read the latest value
   // without re-binding.
   const extClipboardSupportedRef = useRef<boolean>(false);
+  const cursorShapeReceivedRef = useRef(false);
   const [scaleMode, setScaleMode] = useState<ScaleMode>("fit");
   const [remoteCursorCss, setRemoteCursorCss] = useState("none");
   const allowClipboardSend = clipboardPolicy === "bidirectional" || clipboardPolicy === "client-to-server";
@@ -191,10 +190,12 @@ export default function VncPanel({
     }
   }, []);
 
-  const sendWsBinary = useCallback((data: ArrayBuffer) => {
+  const sendWsBinary = useCallback((data: ArrayBuffer): boolean => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       wsRef.current.send(data);
+      return true;
     }
+    return false;
   }, []);
 
   const requestFullRefresh = useCallback(() => {
@@ -278,6 +279,9 @@ export default function VncPanel({
 
     let cancelled = false;
     suppressReconnectRef.current = false;
+    pointerSchedulerRef.current?.reset();
+    lastPointerSentRef.current = null;
+    cursorShapeReceivedRef.current = false;
     setRemoteCursorCss("none");
     if (reconnectStableTimerRef.current !== null) {
       window.clearTimeout(reconnectStableTimerRef.current);
@@ -447,7 +451,13 @@ export default function VncPanel({
                 );
                 break;
               case "cursor":
+                cursorShapeReceivedRef.current = true;
                 setRemoteCursorCss(vncCursorToCss(msg));
+                break;
+              case "pointer_pos":
+                if (!cursorShapeReceivedRef.current) {
+                  setRemoteCursorCss("default");
+                }
                 break;
             }
           }
@@ -545,15 +555,13 @@ export default function VncPanel({
         pasteDelayTimerRef.current = null;
       }
       ackPendingRef.current = false;
-      if (pointerRafRef.current !== null) {
-        cancelAnimationFrame(pointerRafRef.current);
-        pointerRafRef.current = null;
-      }
-      pendingPointerRef.current = null;
+      pointerSchedulerRef.current?.dispose();
+      pointerSchedulerRef.current = null;
       lastPointerSentRef.current = null;
       delayedPointerDownRef.current = null;
       pasteInFlightRef.current = null;
       extClipboardSupportedRef.current = false;
+      cursorShapeReceivedRef.current = false;
       clipboardSyncPromiseRef.current = null;
       serverClipboardWriteInFlightRef.current = 0;
       lastClipboardSyncCheckAtRef.current = 0;
@@ -835,7 +843,7 @@ export default function VncPanel({
   );
 
   const sendPointerNow = useCallback(
-    (pointer: PointerState) => {
+    (pointer: VncPointerState) => {
       const last = lastPointerSentRef.current;
       if (
         last &&
@@ -845,11 +853,19 @@ export default function VncPanel({
       ) {
         return;
       }
-      lastPointerSentRef.current = pointer;
-      sendWsBinary(encodeWsPointer(pointer.x, pointer.y, pointer.buttons));
+      if (sendWsBinary(encodeWsPointer(pointer.x, pointer.y, pointer.buttons))) {
+        lastPointerSentRef.current = pointer;
+      }
     },
     [sendWsBinary],
   );
+
+  const pointerScheduler = useCallback(() => {
+    if (!pointerSchedulerRef.current) {
+      pointerSchedulerRef.current = new VncPointerScheduler({ send: sendPointerNow });
+    }
+    return pointerSchedulerRef.current;
+  }, [sendPointerNow]);
 
   const handlePointer = useCallback(
     (e: React.PointerEvent<HTMLCanvasElement>) => {
@@ -871,23 +887,13 @@ export default function VncPanel({
       const pointer = { x, y, buttons };
 
       if (e.type === "pointermove") {
-        pendingPointerRef.current = pointer;
-        if (pointerRafRef.current === null) {
-          pointerRafRef.current = requestAnimationFrame(() => {
-            pointerRafRef.current = null;
-            const pending = pendingPointerRef.current;
-            pendingPointerRef.current = null;
-            if (!pending || destroyedRef.current || conn?.status !== "connected") return;
-            sendPointerNow(pending);
-          });
-        }
+        pointerScheduler().move(pointer);
         return;
       }
 
-      pendingPointerRef.current = null;
-      sendPointerNow(pointer);
+      pointerScheduler().sendNow(pointer);
     },
-    [viewOnly, conn?.status, getFbCoords, sendPointerNow, syncLocalClipboardToServer],
+    [viewOnly, conn?.status, getFbCoords, pointerScheduler, syncLocalClipboardToServer],
   );
 
   const handlePointerDown = useCallback(
@@ -909,6 +915,7 @@ export default function VncPanel({
           up: null,
         };
         delayedPointerDownRef.current = delayed;
+        pointerSchedulerRef.current?.cancelPending();
         void (async () => {
           await syncLocalClipboardToServer("button", true);
           await new Promise((resolve) => window.setTimeout(resolve, PASTE_KEY_DELAY_MS));

--- a/src/lib/vnc.test.ts
+++ b/src/lib/vnc.test.ts
@@ -60,6 +60,11 @@ describe("VNC WebSocket protocol", () => {
       type: "desktop_size", width: 2560, height: 1440, generation: 1,
     });
     expect(parseWsMessage('{"type":"desktop_size","width":0,"height":1440,"generation":1}')).toBeNull();
+    expect(parseWsMessage('{"type":"pointer_pos","x":123,"y":456}')).toEqual({
+      type: "pointer_pos", x: 123, y: 456,
+    });
+    expect(parseWsMessage('{"type":"pointer_pos","x":65536,"y":0}')).toBeNull();
+    expect(parseWsMessage('{"type":"pointer_pos","x":1.5,"y":0}')).toBeNull();
     const cursor = parseWsMessage('{"type":"cursor","visible":true,"hotspot_x":1,"hotspot_y":2,"width":16,"height":16,"png_base64":"iVBORw0KGgo="}');
     expect(cursor).toMatchObject({ type: "cursor", visible: true, hotspot_x: 1, hotspot_y: 2 });
     expect(cursor?.type === "cursor" ? vncCursorToCss(cursor) : "").toContain("data:image/png;base64,iVBORw0KGgo=");

--- a/src/lib/vnc.ts
+++ b/src/lib/vnc.ts
@@ -204,6 +204,7 @@ export type WsIncoming =
     }
   | { type: "bell" }
   | { type: "desktop_size"; width: number; height: number; generation: number }
+  | { type: "pointer_pos"; x: number; y: number }
   | { type: "clipboard"; text: string }
   | {
       type: "ext_clipboard";
@@ -243,6 +244,15 @@ export function parseWsMessage(data: string): WsIncoming | null {
         return validFramebufferSize(msg.width, msg.height)
           && Number.isSafeInteger(msg.generation)
           && (msg.generation as number) > 0
+          ? value as WsIncoming
+          : null;
+      case "pointer_pos":
+        return Number.isInteger(msg.x)
+          && Number.isInteger(msg.y)
+          && (msg.x as number) >= 0
+          && (msg.y as number) >= 0
+          && (msg.x as number) <= 0xffff
+          && (msg.y as number) <= 0xffff
           ? value as WsIncoming
           : null;
       case "disconnected":

--- a/src/lib/vncPointerScheduler.test.ts
+++ b/src/lib/vncPointerScheduler.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { VncPointerScheduler, type VncPointerState } from "./vncPointerScheduler";
+
+function createScheduler() {
+  let now = 0;
+  let timer: (() => void) | null = null;
+  let timerDelay: number | null = null;
+  const sent: VncPointerState[] = [];
+  const scheduler = new VncPointerScheduler({
+    send: (pointer) => sent.push(pointer),
+    now: () => now,
+    setTimer: (callback, delay) => {
+      timer = callback;
+      timerDelay = delay;
+      return 1 as unknown as ReturnType<typeof window.setTimeout>;
+    },
+    clearTimer: () => {
+      timer = null;
+      timerDelay = null;
+    },
+  });
+
+  return {
+    scheduler,
+    sent,
+    advance: (ms: number) => {
+      now += ms;
+    },
+    timerDelay: () => timerDelay,
+    runTimer: () => {
+      const callback = timer;
+      timer = null;
+      timerDelay = null;
+      callback?.();
+    },
+  };
+}
+
+describe("VncPointerScheduler", () => {
+  it("sends the leading move immediately and the latest trailing move at 4 ms", () => {
+    const state = createScheduler();
+    state.scheduler.move({ x: 1, y: 2, buttons: 0 });
+    expect(state.sent).toEqual([{ x: 1, y: 2, buttons: 0 }]);
+
+    state.advance(1);
+    state.scheduler.move({ x: 2, y: 3, buttons: 0 });
+    state.advance(1);
+    state.scheduler.move({ x: 4, y: 5, buttons: 0 });
+
+    expect(state.timerDelay()).toBe(3);
+    expect(state.sent).toHaveLength(1);
+    state.advance(2);
+    state.runTimer();
+    expect(state.sent).toEqual([
+      { x: 1, y: 2, buttons: 0 },
+      { x: 4, y: 5, buttons: 0 },
+    ]);
+  });
+
+  it("cancels an older move before sending a button transition", () => {
+    const state = createScheduler();
+    state.scheduler.move({ x: 1, y: 1, buttons: 0 });
+    state.advance(1);
+    state.scheduler.move({ x: 2, y: 2, buttons: 0 });
+    state.scheduler.sendNow({ x: 3, y: 3, buttons: 1 });
+    state.runTimer();
+
+    expect(state.sent).toEqual([
+      { x: 1, y: 1, buttons: 0 },
+      { x: 3, y: 3, buttons: 1 },
+    ]);
+  });
+
+  it("drops pending work on reset and lets the next move lead immediately", () => {
+    const state = createScheduler();
+    state.scheduler.move({ x: 1, y: 1, buttons: 0 });
+    state.advance(1);
+    state.scheduler.move({ x: 2, y: 2, buttons: 0 });
+    state.scheduler.reset();
+    state.scheduler.move({ x: 8, y: 9, buttons: 0 });
+    state.runTimer();
+
+    expect(state.sent).toEqual([
+      { x: 1, y: 1, buttons: 0 },
+      { x: 8, y: 9, buttons: 0 },
+    ]);
+  });
+});

--- a/src/lib/vncPointerScheduler.ts
+++ b/src/lib/vncPointerScheduler.ts
@@ -1,0 +1,89 @@
+export interface VncPointerState {
+  x: number;
+  y: number;
+  buttons: number;
+}
+
+export const VNC_POINTER_MOVE_INTERVAL_MS = 4;
+
+type TimerHandle = ReturnType<typeof window.setTimeout>;
+
+interface VncPointerSchedulerOptions {
+  send: (pointer: VncPointerState) => void;
+  now?: () => number;
+  setTimer?: (callback: () => void, delay: number) => TimerHandle;
+  clearTimer?: (handle: TimerHandle) => void;
+  intervalMs?: number;
+}
+
+/**
+ * Sends the leading pointer move immediately and retains only the newest move
+ * during a short rate-limit window. Button transitions use sendNow() so they
+ * cannot be reordered behind a pending movement.
+ */
+export class VncPointerScheduler {
+  private pending: VncPointerState | null = null;
+  private timer: TimerHandle | null = null;
+  private lastSentAt = Number.NEGATIVE_INFINITY;
+  private readonly send: (pointer: VncPointerState) => void;
+  private readonly now: () => number;
+  private readonly setTimer: (callback: () => void, delay: number) => TimerHandle;
+  private readonly clearTimer: (handle: TimerHandle) => void;
+  private readonly intervalMs: number;
+
+  constructor(options: VncPointerSchedulerOptions) {
+    this.send = options.send;
+    this.now = options.now ?? (() => performance.now());
+    this.setTimer = options.setTimer ?? ((callback, delay) => window.setTimeout(callback, delay));
+    this.clearTimer = options.clearTimer ?? ((handle) => window.clearTimeout(handle));
+    this.intervalMs = Math.max(0, options.intervalMs ?? VNC_POINTER_MOVE_INTERVAL_MS);
+  }
+
+  move(pointer: VncPointerState): void {
+    const now = this.now();
+    const elapsed = now - this.lastSentAt;
+    if (this.timer === null && elapsed >= this.intervalMs) {
+      this.pending = null;
+      this.emit(pointer, now);
+      return;
+    }
+
+    this.pending = pointer;
+    if (this.timer !== null) return;
+
+    const delay = Math.max(0, this.intervalMs - Math.max(0, elapsed));
+    this.timer = this.setTimer(() => {
+      this.timer = null;
+      const pending = this.pending;
+      this.pending = null;
+      if (pending) this.emit(pending, this.now());
+    }, delay);
+  }
+
+  sendNow(pointer: VncPointerState): void {
+    this.cancelPending();
+    this.emit(pointer, this.now());
+  }
+
+  cancelPending(): void {
+    if (this.timer !== null) {
+      this.clearTimer(this.timer);
+      this.timer = null;
+    }
+    this.pending = null;
+  }
+
+  reset(): void {
+    this.cancelPending();
+    this.lastSentAt = Number.NEGATIVE_INFINITY;
+  }
+
+  dispose(): void {
+    this.reset();
+  }
+
+  private emit(pointer: VncPointerState, now: number): void {
+    this.lastSentAt = now;
+    this.send(pointer);
+  }
+}


### PR DESCRIPTION
Move VNC cursor handling to the client-side cursor path by negotiating PointerPos, XCursor, and RichCursor together. Decode XCursor bitmap/color/mask payloads strictly, relay pointer-position control messages, and preserve cursor-shape updates for the frontend.

Replace the pointermove requestAnimationFrame delay with a leading/trailing 4ms scheduler that coalesces only high-frequency moves while sending button transitions immediately. Enable TCP_NODELAY on upstream, TLS bridge, and WebSocket sockets so small pointer packets are not delayed by buffering.

Add protocol, cursor decoder, scheduler, WebSocket, and UI regression coverage. U80 live verification reports zero framebuffer pixel rectangles for a pointer move and a PointerPos response in approximately 23ms.

Validation: cargo test --lib vnc:: (67 passed, 1 ignored); pnpm test (238 files, 2025 tests); pnpm build; git diff --check.