### PR TITLE
perf(code-workspace): optimize editor typing performance, LSP progres…

### DIFF
--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -504,6 +504,8 @@ const LSP_DOCUMENT_SYMBOLS_IDLE_DELAY_MS = 650;
 // keypress into the workspace-wide Zustand object redraws the file tree,
 // panels, and command chrome, so commit an editing burst as one update.
 const EDITOR_TEXT_COMMIT_IDLE_DELAY_MS = 220;
+// Shared empty result so "no diagnostics" is always the same array identity.
+const EMPTY_DISPLAY_DIAGNOSTICS: LspDiagnostic[] = [];
 
 import {
   type LibraryBufferInfo,
@@ -3819,6 +3821,31 @@ export function CodeWorkspaceTab({
       applyInspectionProfile(diagnostic, inspectionProfile, { path })
     ),
     [inspectionProfile],
+  );
+  // The session layer already content-dedupes `lspFiles[key].diagnostics`, so the
+  // source array identity is stable between real diagnostic changes. Mapping it
+  // through the inspection profile on every render would throw that stability
+  // away and defeat CodeMirrorHost's identity-based memo, forcing a full
+  // diagnostics-compartment reconfigure per render. Cache per source array so
+  // the mapped result keeps the same identity too.
+  const displayDiagnosticsCache = useMemo(
+    () => new WeakMap<readonly LspDiagnostic[], { path: string | undefined; result: LspDiagnostic[] }>(),
+    [inspectionProfile],
+  );
+  const displayDiagnosticsFor = useCallback(
+    (source: LspDiagnostic[] | null | undefined, path: string | undefined): LspDiagnostic[] => {
+      if (!source || source.length === 0) return EMPTY_DISPLAY_DIAGNOSTICS;
+      const cached = displayDiagnosticsCache.get(source);
+      if (cached && cached.path === path) return cached.result;
+      const mapped = source.flatMap((diagnostic) => {
+        const display = inspectionTransform(diagnostic, path);
+        return display ? [display] : [];
+      });
+      const result = mapped.length === 0 ? EMPTY_DISPLAY_DIAGNOSTICS : mapped;
+      displayDiagnosticsCache.set(source, { path, result });
+      return result;
+    },
+    [displayDiagnosticsCache, inspectionTransform],
   );
   const activeLspDocumentIsSynced = Boolean(
     activeFile
@@ -9511,10 +9538,10 @@ export function CodeWorkspaceTab({
     };
     const lspDiagnostics = openStates
       .map((file) => {
-        const diagnostics = (lspFiles[file.key]?.diagnostics ?? []).flatMap((diagnostic) => {
-          const display = inspectionTransform(diagnostic, inspectionPathForFileKey(file.key));
-          return display ? [display] : [];
-        });
+        const diagnostics = displayDiagnosticsFor(
+          lspFiles[file.key]?.diagnostics,
+          inspectionPathForFileKey(file.key),
+        );
         if (diagnostics.length === 0) return null;
         return {
           file: toContextFile(file),
@@ -9563,8 +9590,8 @@ export function CodeWorkspaceTab({
     deferredActiveFile,
     deferredOpenFiles,
     dirtyFiles,
+    displayDiagnosticsFor,
     inspectionPathForFileKey,
-    inspectionTransform,
     looseFiles,
     lspFiles,
     openOrder,
@@ -9583,10 +9610,7 @@ export function CodeWorkspaceTab({
     const groupFile = group.activeKey ? openFiles[group.activeKey] ?? null : null;
     const groupLspState = group.activeKey ? lspFiles[group.activeKey] ?? null : null;
     const groupPath = groupFile ? inspectionPathForFileKey(groupFile.key) : undefined;
-    const groupDiagnostics = (groupLspState?.diagnostics ?? []).flatMap((diagnostic) => {
-      const display = inspectionTransform(diagnostic, groupPath);
-      return display ? [display] : [];
-    });
+    const groupDiagnostics = displayDiagnosticsFor(groupLspState?.diagnostics, groupPath);
     const groupCapabilities = groupLspState?.status?.capabilities ?? null;
     const groupMarkdownMode = groupFile && isMarkdownPath(groupFile.languagePath)
       ? markdownModes[groupFile.key] ?? "edit"

--- a/src/components/editor/workspace/CodeMirrorHost.tsx
+++ b/src/components/editor/workspace/CodeMirrorHost.tsx
@@ -229,9 +229,20 @@ const EMPTY_INLAY_HINTS: LspInlayHint[] = [];
 const EMPTY_SEMANTIC_TOKENS: LspSemanticToken[] = [];
 const EMPTY_GIT_CHANGES: GitLineChange[] = [];
 
-/** New empty-array props are common while LSP requests are debounced. */
+/**
+ * New empty-array props are common while LSP requests are debounced, and a
+ * caller that rebuilds a derived array per render would otherwise force a full
+ * compartment reconfigure on every keystroke. Callers should keep identities
+ * stable; the element-wise pass is a cheap backstop for the ones that leak
+ * (these arrays hold tens of entries, not thousands).
+ */
 function sameArrayOrBothEmpty<T>(previous: readonly T[], next: readonly T[]): boolean {
-  return previous === next || (previous.length === 0 && next.length === 0);
+  if (previous === next) return true;
+  if (previous.length !== next.length) return false;
+  for (let index = 0; index < previous.length; index += 1) {
+    if (previous[index] !== next[index]) return false;
+  }
+  return true;
 }
 
 /**

--- a/src/components/editor/workspace/coverageEditorChrome.ts
+++ b/src/components/editor/workspace/coverageEditorChrome.ts
@@ -24,6 +24,37 @@ class CoverageGutterMarker extends GutterMarker {
   }
 }
 
+/** Module-level to keep the extension identity stable across reconfigures. */
+const COVERAGE_THEME = EditorView.theme({
+  ".cm-coverage-gutter": {
+    width: "4px",
+    minWidth: "4px",
+    marginRight: "2px",
+  },
+  ".cm-coverage-gutter .cm-gutterElement": {
+    padding: "0",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  ".cm-coverage-marker": {
+    width: "3px",
+    height: "100%",
+    minHeight: "1.2em",
+    borderRadius: "1px",
+    transition: "background-color 0.15s ease",
+  },
+  ".cm-coverage-marker.cm-coverage-covered": {
+    backgroundColor: "#10b981", // Emerald 500
+  },
+  ".cm-coverage-marker.cm-coverage-partial": {
+    backgroundColor: "#f59e0b", // Amber 500
+  },
+  ".cm-coverage-marker.cm-coverage-uncovered": {
+    backgroundColor: "#ef4444", // Rose 500
+  },
+});
+
 export function createCoverageEditorChrome(
   coverage: FileCoverage | null,
   enabled = true,
@@ -44,35 +75,5 @@ export function createCoverageEditorChrome(
     },
   });
 
-  const coverageTheme = EditorView.theme({
-    ".cm-coverage-gutter": {
-      width: "4px",
-      minWidth: "4px",
-      marginRight: "2px",
-    },
-    ".cm-coverage-gutter .cm-gutterElement": {
-      padding: "0",
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-    },
-    ".cm-coverage-marker": {
-      width: "3px",
-      height: "100%",
-      minHeight: "1.2em",
-      borderRadius: "1px",
-      transition: "background-color 0.15s ease",
-    },
-    ".cm-coverage-marker.cm-coverage-covered": {
-      backgroundColor: "#10b981", // Emerald 500
-    },
-    ".cm-coverage-marker.cm-coverage-partial": {
-      backgroundColor: "#f59e0b", // Amber 500
-    },
-    ".cm-coverage-marker.cm-coverage-uncovered": {
-      backgroundColor: "#ef4444", // Rose 500
-    },
-  });
-
-  return [coverageGutter, coverageTheme];
+  return [coverageGutter, COVERAGE_THEME];
 }

--- a/src/components/editor/workspace/editorPerformance.test.tsx
+++ b/src/components/editor/workspace/editorPerformance.test.tsx
@@ -4,7 +4,7 @@ import { EditorState } from "@codemirror/state";
 import { CompletionContext } from "@codemirror/autocomplete";
 import { createLspCompletionSource } from "./lspCompletion";
 import { CodeMirrorHost } from "./CodeMirrorHost";
-import type { LspCompletionResult, LspDocumentStatus } from "../../../lib/editor/lsp";
+import type { LspCompletionResult, LspDiagnostic, LspDocumentStatus } from "../../../lib/editor/lsp";
 
 function testDocStatus(active = true): LspDocumentStatus {
   return {
@@ -119,5 +119,64 @@ describe("Editor typing and completion performance verification", () => {
     rerender(<CodeMirrorHost {...props} />);
 
     expect(props.onChange).not.toHaveBeenCalled();
+  });
+
+  // The case above passes `diagnostics: []`, which satisfies the both-empty
+  // short-circuit trivially. A real Java buffer almost always has diagnostics,
+  // and a caller that rebuilt the array per render used to force a full
+  // diagnostics-compartment reconfigure on every keystroke: a fresh
+  // EditorView.theme (new StyleModule mount + editor-root class rewrite) plus
+  // three rebuilt gutters.
+  it("does not rebuild diagnostics chrome when re-rendered with an equal non-empty diagnostics array", () => {
+    const diagnostic: LspDiagnostic = {
+      range: { start: { line: 0, character: 13 }, end: { line: 0, character: 17 } },
+      severity: 1,
+      code: null,
+      source: "jdtls",
+      message: "cannot find symbol",
+    };
+    const onLightbulb = vi.fn();
+    const baseProps = {
+      path: "Main.java",
+      doc: "public class Main {}",
+      visible: true,
+      reveal: null,
+      readOnly: false,
+      softWrap: false,
+      onChange: vi.fn(),
+      onSave: vi.fn(),
+      onHover: vi.fn(async () => null),
+      onDefinition: vi.fn(async () => false),
+      onReferences: vi.fn(async () => {}),
+      onLightbulb,
+    };
+
+    const { container, rerender } = render(
+      <CodeMirrorHost {...baseProps} diagnostics={[diagnostic]} />,
+    );
+    const editorRoot = container.querySelector(".cm-editor") as HTMLElement;
+    const themeClasses = editorRoot.className;
+    const lightbulb = container.querySelector('[data-testid="code-workspace-lightbulb"]');
+    expect(lightbulb).toBeTruthy();
+
+    // Fresh array identity per render, identical contents.
+    rerender(<CodeMirrorHost {...baseProps} diagnostics={[diagnostic]} />);
+    rerender(<CodeMirrorHost {...baseProps} diagnostics={[diagnostic]} />);
+    rerender(<CodeMirrorHost {...baseProps} diagnostics={[diagnostic]} />);
+
+    // A reconfigure would mint a new theme class and swap the gutter DOM.
+    expect(editorRoot.className).toBe(themeClasses);
+    expect(container.querySelector('[data-testid="code-workspace-lightbulb"]')).toBe(lightbulb);
+
+    // Genuinely different diagnostics must still reconfigure without minting a
+    // new theme class: an EditorView.theme built per call would re-mount every
+    // stylesheet and rewrite the editor root class each time.
+    rerender(
+      <CodeMirrorHost
+        {...baseProps}
+        diagnostics={[{ ...diagnostic, message: "incompatible types" }]}
+      />,
+    );
+    expect(editorRoot.className).toBe(themeClasses);
   });
 });

--- a/src/components/editor/workspace/gitEditorChrome.ts
+++ b/src/components/editor/workspace/gitEditorChrome.ts
@@ -157,6 +157,40 @@ class InlineBlameWidget extends WidgetType {
   }
 }
 
+/** Module-level to keep the extension identity stable across reconfigures. */
+const GIT_EDITOR_THEME = EditorView.theme({
+  ".cm-git-change-gutter": { width: "5px" },
+  ".cm-git-change-gutter .cm-gutterElement": { padding: "0" },
+  ".cm-git-change-marker": {
+    display: "block",
+    width: "4px",
+    height: "100%",
+    minHeight: "1.2em",
+    border: "none",
+    padding: "0",
+    background: "var(--cm-git-change-color)",
+    cursor: "pointer",
+  },
+  ".cm-git-change-deleted": {
+    height: "0",
+    minHeight: "0",
+    borderTop: "4px solid transparent",
+    borderBottom: "4px solid transparent",
+    borderLeft: "5px solid var(--cm-git-change-color)",
+    background: "transparent",
+  },
+  ".cm-inline-git-blame": {
+    marginLeft: "2.5rem",
+    color: "var(--taomni-code-muted)",
+    opacity: "0.66",
+    fontSize: "0.9em",
+    fontStyle: "italic",
+    whiteSpace: "nowrap",
+    userSelect: "none",
+    pointerEvents: "none",
+  },
+});
+
 export function createGitEditorChrome(
   changes: GitLineChange[],
   blame: GitBlameLine | null,
@@ -185,40 +219,5 @@ export function createGitEditorChrome(
       Decoration.widget({ widget: new InlineBlameWidget(blame), side: 1 }).range(line.to),
     ]);
   });
-  return [
-    gitGutter,
-    blameDecoration,
-    EditorView.theme({
-      ".cm-git-change-gutter": { width: "5px" },
-      ".cm-git-change-gutter .cm-gutterElement": { padding: "0" },
-      ".cm-git-change-marker": {
-        display: "block",
-        width: "4px",
-        height: "100%",
-        minHeight: "1.2em",
-        border: "none",
-        padding: "0",
-        background: "var(--cm-git-change-color)",
-        cursor: "pointer",
-      },
-      ".cm-git-change-deleted": {
-        height: "0",
-        minHeight: "0",
-        borderTop: "4px solid transparent",
-        borderBottom: "4px solid transparent",
-        borderLeft: "5px solid var(--cm-git-change-color)",
-        background: "transparent",
-      },
-      ".cm-inline-git-blame": {
-        marginLeft: "2.5rem",
-        color: "var(--taomni-code-muted)",
-        opacity: "0.66",
-        fontSize: "0.9em",
-        fontStyle: "italic",
-        whiteSpace: "nowrap",
-        userSelect: "none",
-        pointerEvents: "none",
-      },
-    }),
-  ];
+  return [gitGutter, blameDecoration, GIT_EDITOR_THEME];
 }

--- a/src/components/editor/workspace/lspDiagnosticChrome.ts
+++ b/src/components/editor/workspace/lspDiagnosticChrome.ts
@@ -64,13 +64,21 @@ class OverviewMarker extends GutterMarker {
 }
 
 class LightbulbMarker extends GutterMarker {
-  constructor(private readonly onClick: () => void) {
+  constructor(
+    private readonly line: number,
+    private readonly onLightbulb: (line: number) => void,
+  ) {
     super();
   }
 
-  // Always re-create so click handlers stay fresh with latest diagnostics.
-  eq(): boolean {
-    return false;
+  /**
+   * `markers` re-runs on every document change, so returning false here rebuilt
+   * the button DOM on each keystroke. The handler is a per-chrome-instance
+   * reference that callers keep fresh through a ref, so comparing it alongside
+   * the line is enough to reuse the existing element.
+   */
+  eq(other: LightbulbMarker): boolean {
+    return other.line === this.line && other.onLightbulb === this.onLightbulb;
   }
 
   toDOM(): HTMLElement {
@@ -84,7 +92,7 @@ class LightbulbMarker extends GutterMarker {
     el.addEventListener("mousedown", (event) => {
       event.preventDefault();
       event.stopPropagation();
-      this.onClick();
+      this.onLightbulb(this.line);
     });
     return el;
   }
@@ -107,6 +115,46 @@ export function diagnosticClass(severity: number | null): string {
   if (severity === 2) return "cm-lsp-diagnostic-warning";
   return "cm-lsp-diagnostic-info";
 }
+
+/**
+ * Module-level so the extension identity stays stable across compartment
+ * reconfigures. Building it per call would mint a fresh `StyleModule` name on
+ * every keystroke, forcing CodeMirror to re-mount every stylesheet and rewrite
+ * the editor root class (full-subtree style recalc).
+ */
+const LSP_DIAGNOSTIC_THEME = EditorView.theme({
+  ".cm-lsp-diag-gutter": {
+    width: "1.1rem",
+  },
+  ".cm-lsp-diag-gutter-mark": {
+    fontSize: "9px",
+    lineHeight: "1",
+    display: "inline-flex",
+    width: "100%",
+    justifyContent: "center",
+  },
+  ".cm-lsp-lightbulb-gutter": {
+    width: "1.2rem",
+  },
+  ".cm-lsp-lightbulb": {
+    border: "none",
+    background: "transparent",
+    cursor: "pointer",
+    fontSize: "11px",
+    lineHeight: "1",
+    padding: 0,
+    width: "100%",
+  },
+  ".cm-lsp-overview-gutter": {
+    width: "4px",
+  },
+  ".cm-lsp-overview-mark": {
+    width: "3px",
+    height: "4px",
+    margin: "2px auto 0",
+    borderRadius: "1px",
+  },
+});
 
 export function diagnosticDecorations(view: EditorView, diagnostics: LspDiagnostic[]): DecorationSet {
   const ranges = diagnostics.flatMap((diagnostic) => {
@@ -166,11 +214,7 @@ export function createDiagnosticChrome(
       for (const lineNo of linesWithDiagnostics) {
         if (lineNo < 0 || lineNo >= view.state.doc.lines) continue;
         const line = view.state.doc.line(lineNo + 1);
-        builder.add(
-          line.from,
-          line.from,
-          new LightbulbMarker(() => onLightbulb(lineNo)),
-        );
+        builder.add(line.from, line.from, new LightbulbMarker(lineNo, onLightbulb));
       }
       return builder.finish();
     },
@@ -181,38 +225,6 @@ export function createDiagnosticChrome(
     severityGutter,
     lightbulbGutter,
     overviewGutter,
-    EditorView.theme({
-      ".cm-lsp-diag-gutter": {
-        width: "1.1rem",
-      },
-      ".cm-lsp-diag-gutter-mark": {
-        fontSize: "9px",
-        lineHeight: "1",
-        display: "inline-flex",
-        width: "100%",
-        justifyContent: "center",
-      },
-      ".cm-lsp-lightbulb-gutter": {
-        width: "1.2rem",
-      },
-      ".cm-lsp-lightbulb": {
-        border: "none",
-        background: "transparent",
-        cursor: "pointer",
-        fontSize: "11px",
-        lineHeight: "1",
-        padding: 0,
-        width: "100%",
-      },
-      ".cm-lsp-overview-gutter": {
-        width: "4px",
-      },
-      ".cm-lsp-overview-mark": {
-        width: "3px",
-        height: "4px",
-        margin: "2px auto 0",
-        borderRadius: "1px",
-      },
-    }),
+    LSP_DIAGNOSTIC_THEME,
   ];
 }

--- a/src/components/editor/workspace/useWorkspaceLspClientEvents.test.ts
+++ b/src/components/editor/workspace/useWorkspaceLspClientEvents.test.ts
@@ -148,6 +148,51 @@ describe("useWorkspaceLspClientEvents", () => {
     unmount();
   });
 
+  it("swallows validation tasks that begin and end inside one flush window", async () => {
+    const onStatus = vi.fn();
+    let renders = 0;
+    const { result, unmount } = renderHook(() => {
+      renders += 1;
+      return useWorkspaceLspClientEvents({ workspaceId: "workspace-a", visible: true, onStatus });
+    });
+    const rendersBefore = renders;
+
+    const validationCycle = async (token: string, title: string) => {
+      for (const kind of ["begin", "report", "end"] as const) {
+        await emit(LSP_WORK_DONE_PROGRESS_EVENT, {
+          workspaceId: "workspace-a",
+          presetId: "java",
+          serverLabel: "Java",
+          rootUri: "file:///repo",
+          token,
+          kind,
+          title,
+          message: kind === "end" ? "done" : "working",
+          percentage: null,
+          cancellable: false,
+        });
+      }
+    };
+
+    // jdtls emits these per keystroke; each triple used to cost three renders
+    // plus a global status-bar write.
+    await act(async () => {
+      await validationCycle("pub-1", "Publish Diagnostics");
+      await validationCycle("val-1", "Validate documents");
+      await validationCycle("pub-2", "Publish Diagnostics");
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+
+    expect(result.current.progresses).toHaveLength(0);
+    // Nothing ever became visible, so the shared status bar stays untouched and
+    // no state update was published.
+    expect(onStatus).not.toHaveBeenCalled();
+    expect(renders).toBe(rendersBefore);
+    unmount();
+  });
+
   it("surfaces one-way server messages only for the visible workspace", async () => {
     const onStatus = vi.fn();
     const { unmount } = renderHook(() => useWorkspaceLspClientEvents({

--- a/src/components/editor/workspace/useWorkspaceLspClientEvents.ts
+++ b/src/components/editor/workspace/useWorkspaceLspClientEvents.ts
@@ -14,8 +14,49 @@ export const LSP_SHOW_MESSAGE_CANCELLED_EVENT = "lsp://show-message-cancelled";
 export const LSP_SHOW_MESSAGE_EVENT = "lsp://show-message";
 export const LSP_WORK_DONE_PROGRESS_EVENT = "lsp://work-done-progress";
 
+/**
+ * jdtls reports its own "Publish Diagnostics" / "Validate documents" jobs on
+ * every validation cycle, so a single keystroke can produce several
+ * begin/report/end triples. Publishing each one straight into React state
+ * re-renders the whole workspace shell per event and makes the status bar
+ * flicker between task names. Fold them into one trailing update instead: work
+ * that starts and finishes inside the window never reaches the UI at all.
+ */
+const PROGRESS_FLUSH_INTERVAL_MS = 150;
+
 function progressKey(event: Pick<LspWorkDoneProgressEvent, "presetId" | "rootUri" | "token">): string {
   return `${event.presetId}\u0000${event.rootUri}\u0000${typeof event.token}:${String(event.token)}`;
+}
+
+function sameProgress(a: LspWorkDoneProgressEvent, b: LspWorkDoneProgressEvent): boolean {
+  return a.kind === b.kind
+    && a.title === b.title
+    && a.message === b.message
+    && a.percentage === b.percentage
+    && a.cancellable === b.cancellable
+    && progressKey(a) === progressKey(b);
+}
+
+function sameProgressList(
+  previous: readonly LspWorkDoneProgressEvent[],
+  next: readonly LspWorkDoneProgressEvent[],
+): boolean {
+  if (previous === next) return true;
+  if (previous.length !== next.length) return false;
+  return previous.every((entry, index) => sameProgress(entry, next[index]));
+}
+
+function reduceProgress(
+  current: readonly LspWorkDoneProgressEvent[],
+  progress: LspWorkDoneProgressEvent,
+): LspWorkDoneProgressEvent[] {
+  const key = progressKey(progress);
+  if (progress.kind === "end") {
+    return current.filter((entry) => progressKey(entry) !== key);
+  }
+  const previous = current.find((entry) => progressKey(entry) === key);
+  const next = { ...previous, ...progress, title: progress.title ?? previous?.title ?? null };
+  return [...current.filter((entry) => progressKey(entry) !== key), next].slice(-20);
 }
 
 function normalizeMessageRequest(value: unknown): LspShowMessageRequest | null {
@@ -102,16 +143,47 @@ export function useWorkspaceLspClientEvents({
   const onStatusRef = useRef(onStatus);
   visibleRef.current = visible;
   onStatusRef.current = onStatus;
+  // Pending (authoritative) progress list. React state trails it by at most one
+  // flush window so event bursts cost one render instead of one render each.
+  const pendingProgressesRef = useRef<LspWorkDoneProgressEvent[]>([]);
+  const publishedProgressesRef = useRef<LspWorkDoneProgressEvent[]>([]);
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastStatusTextRef = useRef<string | null>(null);
+
+  const flushProgresses = useCallback(() => {
+    flushTimerRef.current = null;
+    if (!mountedRef.current) return;
+    const next = pendingProgressesRef.current;
+    if (sameProgressList(publishedProgressesRef.current, next)) return;
+    publishedProgressesRef.current = next;
+    setProgresses(next);
+  }, []);
+
+  const scheduleProgressFlush = useCallback(() => {
+    if (flushTimerRef.current !== null) return;
+    flushTimerRef.current = setTimeout(flushProgresses, PROGRESS_FLUSH_INTERVAL_MS);
+  }, [flushProgresses]);
 
   useEffect(() => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
+      if (flushTimerRef.current !== null) {
+        clearTimeout(flushTimerRef.current);
+        flushTimerRef.current = null;
+      }
     };
   }, []);
 
   useEffect(() => {
     cancelledMessageIdsRef.current.clear();
+    if (flushTimerRef.current !== null) {
+      clearTimeout(flushTimerRef.current);
+      flushTimerRef.current = null;
+    }
+    pendingProgressesRef.current = [];
+    publishedProgressesRef.current = [];
+    lastStatusTextRef.current = null;
     setMessageRequests([]);
     setProgresses([]);
   }, [workspaceId]);
@@ -144,27 +216,33 @@ export function useWorkspaceLspClientEvents({
           listen<LspShowMessageNotification>(LSP_SHOW_MESSAGE_EVENT, (event) => {
             const payload = event.payload;
             if (!payload || payload.workspaceId !== workspaceId || !visibleRef.current) return;
+            // Another writer took over the status line, so the progress dedupe
+            // key no longer describes what is on screen.
+            lastStatusTextRef.current = null;
             onStatusRef.current(notificationText(payload));
           }),
           listen<LspWorkDoneProgressEvent>(LSP_WORK_DONE_PROGRESS_EVENT, (event) => {
             const progress = normalizeProgress(event.payload);
             if (!progress || progress.workspaceId !== workspaceId) return;
             const key = progressKey(progress);
-            setProgresses((current) => {
-              if (progress.kind === "end") {
-                return current.filter((entry) => progressKey(entry) !== key);
+            // Only tasks that actually surfaced in the UI are worth announcing.
+            // Per-keystroke validations begin and end inside a single flush
+            // window, so they never reach `publishedProgressesRef` and no longer
+            // churn the shared status bar.
+            const wasPublished = publishedProgressesRef.current.some((entry) => progressKey(entry) === key);
+            pendingProgressesRef.current = reduceProgress(pendingProgressesRef.current, progress);
+            scheduleProgressFlush();
+            if (
+              visibleRef.current
+              && wasPublished
+              && progress.kind === "end"
+              && (progress.message || progress.title)
+            ) {
+              const text = `${progress.title ?? "Language server task"}${progress.message ? `: ${progress.message}` : " completed"}`;
+              if (text !== lastStatusTextRef.current) {
+                lastStatusTextRef.current = text;
+                onStatusRef.current(text);
               }
-              const previous = current.find((entry) => progressKey(entry) === key);
-              const next = { ...previous, ...progress, title: progress.title ?? previous?.title ?? null };
-              return [
-                ...current.filter((entry) => progressKey(entry) !== key),
-                next,
-              ].slice(-20);
-            });
-            if (visibleRef.current && progress.kind === "end" && (progress.message || progress.title)) {
-              onStatusRef.current(
-                `${progress.title ?? "Language server task"}${progress.message ? `: ${progress.message}` : " completed"}`,
-              );
             }
           }),
         ]);
@@ -183,7 +261,7 @@ export function useWorkspaceLspClientEvents({
       disposed = true;
       unlisten.forEach((remove) => remove());
     };
-  }, [workspaceId]);
+  }, [scheduleProgressFlush, workspaceId]);
 
   const resolveMessageRequest = useCallback((actionIndex: number | null) => {
     const request = messageRequests[0];
@@ -198,9 +276,13 @@ export function useWorkspaceLspClientEvents({
   }, [messageRequests, workspaceId]);
 
   const cancelProgress = useCallback((progress: LspWorkDoneProgressEvent) => {
-    setProgresses((current) => current.map((entry) => (
+    // User-initiated, so publish straight away rather than waiting for a flush.
+    const disable = (entries: readonly LspWorkDoneProgressEvent[]) => entries.map((entry) => (
       progressKey(entry) === progressKey(progress) ? { ...entry, cancellable: false } : entry
-    )));
+    ));
+    pendingProgressesRef.current = disable(pendingProgressesRef.current);
+    publishedProgressesRef.current = disable(publishedProgressesRef.current);
+    setProgresses(publishedProgressesRef.current);
     void lspCancelWorkDoneProgress(
       progress.workspaceId,
       progress.presetId,

--- a/src/components/statusbar/StatusBar.test.tsx
+++ b/src/components/statusbar/StatusBar.test.tsx
@@ -2,7 +2,6 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { StatusBar } from "./StatusBar";
 import { useAppStore } from "../../stores/appStore";
-import { useSessionStore } from "../../stores/sessionStore";
 import { useCodeWorkspaceStatusStore } from "../../stores/codeWorkspaceStatusStore";
 
 vi.mock("../../lib/i18n", async (importOriginal) => {
@@ -34,8 +33,16 @@ vi.mock("../../lib/appTheme", () => ({
   useAppTheme: () => ({ mode: "dark", resolvedTheme: "dark" }),
 }));
 
+// StatusBar reads the session store through per-field selectors, so the mock has
+// to apply the selector the way zustand does.
+const sessionStoreState: { sessions: unknown[]; selectedSessionId: string | null } = {
+  sessions: [],
+  selectedSessionId: null,
+};
 vi.mock("../../stores/sessionStore", () => ({
-  useSessionStore: vi.fn(() => ({ sessions: [], selectedSessionId: null })),
+  useSessionStore: vi.fn((selector?: (state: unknown) => unknown) => (
+    selector ? selector(sessionStoreState) : sessionStoreState
+  )),
 }));
 
 vi.mock("../../stores/aiStore", () => ({
@@ -200,6 +207,8 @@ describe("StatusBar copyable/truncated text", () => {
       statusMessage: "",
     } as never);
     useCodeWorkspaceStatusStore.setState({ status: null, actions: null });
+    sessionStoreState.sessions = [];
+    sessionStoreState.selectedSessionId = null;
   });
 
   it("shows the full status message as tooltip and copies it on click", async () => {
@@ -223,10 +232,8 @@ describe("StatusBar copyable/truncated text", () => {
 
   it("copies the selected session name on click", async () => {
     const writeText = mockClipboard();
-    vi.mocked(useSessionStore).mockReturnValue({
-      sessions: [{ id: "s1", name: "my-very-long-session-name" } as never],
-      selectedSessionId: "s1",
-    });
+    sessionStoreState.sessions = [{ id: "s1", name: "my-very-long-session-name" }];
+    sessionStoreState.selectedSessionId = "s1";
 
     render(<StatusBar />);
 

--- a/src/components/statusbar/StatusBar.tsx
+++ b/src/components/statusbar/StatusBar.tsx
@@ -137,8 +137,16 @@ function StatusSegment({
 }
 
 export function StatusBar() {
-  const { tabs, activeTabId, xServerEnabled, xServerStatus, statusMessage } = useAppStore();
-  const { sessions, selectedSessionId } = useSessionStore();
+  // Per-field selectors: subscribing to the whole store re-rendered the status
+  // bar on every unrelated app-store mutation, and LSP progress writes
+  // `statusMessage` often enough for that to matter while typing.
+  const tabs = useAppStore((s) => s.tabs);
+  const activeTabId = useAppStore((s) => s.activeTabId);
+  const xServerEnabled = useAppStore((s) => s.xServerEnabled);
+  const xServerStatus = useAppStore((s) => s.xServerStatus);
+  const statusMessage = useAppStore((s) => s.statusMessage);
+  const sessions = useSessionStore((s) => s.sessions);
+  const selectedSessionId = useSessionStore((s) => s.selectedSessionId);
   const workspaceStatus = useCodeWorkspaceStatusStore((s) => s.status);
   const workspaceActions = useCodeWorkspaceStatusStore((s) => s.actions);
   const { mode, resolvedTheme } = useAppTheme();


### PR DESCRIPTION
…s batching, and gutter chrome stability

- Memoize transformed diagnostics in CodeWorkspaceTab using WeakMap cache to preserve array identity across renders.
- Add element-wise equality check in CodeMirrorHost's sameArrayOrBothEmpty to prevent unnecessary compartment reconfigurations.
- Hoist EditorView theme definitions in lspDiagnosticChrome, gitEditorChrome, and coverageEditorChrome to module level to prevent StyleModule remounts.
- Implement proper eq comparison on LightbulbMarker to avoid DOM element recreation on document changes.
- Batch and debounce LSP work-done progress events in useWorkspaceLspClientEvents (150ms window) to fold transient validation cycles and eliminate status bar churn.
- Convert StatusBar store subscriptions to fine-grained per-field selectors to prevent re-renders on unrelated store mutations.
- Add unit tests for diagnostics chrome stability and progress batching behavior.