### PR TITLE
fix(sftp): prevent terminal paste uploads from replaying

### DIFF
--- a/src/components/filebrowser/FileBrowser.tsx
+++ b/src/components/filebrowser/FileBrowser.tsx
@@ -138,6 +138,11 @@ export function FileBrowser(props: FileBrowserProps) {
   const requestedCwdVersionRef = useRef(props.cwdHintVersion ?? 0);
   const terminalSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const handledUploadRequestRef = useRef<number | null>(null);
+  const onPendingUploadRequestHandledRef = useRef(props.onPendingUploadRequestHandled);
+
+  useEffect(() => {
+    onPendingUploadRequestHandledRef.current = props.onPendingUploadRequestHandled;
+  }, [props.onPendingUploadRequestHandled]);
 
   const clearTerminalSyncTimeout = useCallback(() => {
     if (!terminalSyncTimeoutRef.current) return;
@@ -605,6 +610,12 @@ export function FileBrowser(props: FileBrowserProps) {
 
     handledUploadRequestRef.current = request.id;
     let cancelled = false;
+    let finished = false;
+    const finishRequest = () => {
+      if (finished) return;
+      finished = true;
+      onPendingUploadRequestHandledRef.current?.(request.id);
+    };
 
     void (async () => {
       const currentRemotePath = useSftpStore.getState().sessions[props.sessionId]?.remote.path ?? "/";
@@ -634,18 +645,18 @@ export function FileBrowser(props: FileBrowserProps) {
         }
       }
 
-      if (!cancelled) {
-        props.onPendingUploadRequestHandled?.(request.id);
-      }
+      finishRequest();
     })();
 
     return () => {
       cancelled = true;
+      // The request is one-shot. Closing the sidebar discards paths that have
+      // not started yet so remounting cannot enqueue the same batch again.
+      finishRequest();
     };
   }, [
     controller.upload,
     navigate,
-    props.onPendingUploadRequestHandled,
     props.pendingUploadRequest,
     props.sessionId,
     session?.attached,

--- a/src/components/filebrowser/FileToolbarWiring.test.tsx
+++ b/src/components/filebrowser/FileToolbarWiring.test.tsx
@@ -565,6 +565,48 @@ describe("FileBrowser → FilePanel toolbar wiring", () => {
     expect(useSftpStore.getState().sessions[SESSION_ID].local.path).toBe("/home/me");
   });
 
+  it("discards a consumed terminal upload request when the SFTP browser closes", async () => {
+    seedSession();
+    let finishUpload: (() => void) | undefined;
+    controllerMocks.upload.mockImplementationOnce(
+      () => new Promise<undefined>((resolve) => {
+        finishUpload = () => resolve(undefined);
+      }),
+    );
+    const onHandled = vi.fn();
+    const { unmount } = render(
+      <FileBrowser
+        sessionId={SESSION_ID}
+        host="example.com"
+        port={22}
+        username="user"
+        authMethod="password"
+        authData={null}
+        pendingUploadRequest={{
+          id: 8,
+          paths: ["/home/me/drop.png"],
+          remoteDir: "/work",
+        }}
+        onPendingUploadRequestHandled={onHandled}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(controllerMocks.upload).toHaveBeenCalledTimes(1);
+    });
+    expect(onHandled).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(onHandled).toHaveBeenCalledTimes(1);
+    expect(onHandled).toHaveBeenCalledWith(8);
+
+    await act(async () => {
+      finishUpload?.();
+    });
+    expect(onHandled).toHaveBeenCalledTimes(1);
+  });
+
   it("wires the local-pane Upload toolbar button to controller.upload", async () => {
     const user = userEvent.setup();
     seedSession();


### PR DESCRIPTION
Treat pending terminal-to-SFTP upload requests as one-shot work across the FileBrowser lifecycle.

Keep the latest handled callback in a ref so parent rerenders do not restart the upload effect. Finalize each request exactly once on normal completion or effect cleanup; closing the attached sidebar now discards paths that have not started and removes the parent pending request before a remount can enqueue the batch again.

Add a regression test that holds an upload promise open, unmounts the browser, and verifies the pending request is acknowledged once without a second completion callback.

Fixes #530.