### PR TITLE
fix(mail): repair compose editor selection caching, editing shortcuts…

### DIFF
--- a/qa-ui-auto-tests/feature-list.md
+++ b/qa-ui-auto-tests/feature-list.md
@@ -4444,7 +4444,7 @@ controls:
   - id: link
     selector: '[data-testid="mail-compose-link"]'
     kind: interactive
-    optional: true       # opens a URL prompt; covered by component tests to avoid prompt timing in smoke
+    optional: true       # opens the text-input-dialog for the URL; covered by component tests to avoid dialog timing in smoke
   - id: insert-menu
     selector: '[data-testid="mail-compose-insert-menu"]'
     kind: interactive
@@ -4458,7 +4458,7 @@ controls:
   - id: insert-table
     selector: '[data-testid="mail-compose-insert-table"]'
     kind: interactive
-    optional: true       # opens a table-size prompt; covered by component tests
+    optional: true       # opens the text-input-dialog for the size; covered by component tests
   - id: emoji
     selector: '[data-testid="mail-compose-emoji"]'
     kind: interactive

--- a/src/components/mail/RichMailEditor.test.tsx
+++ b/src/components/mail/RichMailEditor.test.tsx
@@ -270,4 +270,143 @@ describe("RichMailEditor", () => {
     });
     expect(onPasteImages).not.toHaveBeenCalled();
   });
+
+  it("keeps toolbar buttons from stealing focus from the editor", () => {
+    render(<RichMailEditor html="<p>Hello</p>" onChange={vi.fn()} />);
+
+    const event = fireEvent.mouseDown(screen.getByTestId("mail-compose-bold"));
+
+    expect(event).toBe(false);
+  });
+
+  it("applies editing shortcuts while the editor holds the selection even without focus", () => {
+    const execCommand = vi.fn();
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(<RichMailEditor html="<p>Hello</p>" onChange={vi.fn()} />);
+
+    const editor = screen.getByTestId("mail-compose-editor");
+    // jsdom has no layout engine; pretend the editor is rendered.
+    vi.spyOn(editor, "getClientRects").mockReturnValue([{ width: 100 }] as unknown as DOMRectList);
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    // Focus deliberately left on body — the pre-fix behavior dropped these.
+    fireEvent.keyDown(window, { ctrlKey: true, key: "z" });
+    fireEvent.keyDown(window, { ctrlKey: true, shiftKey: true, key: "z" });
+    fireEvent.keyDown(window, { ctrlKey: true, key: "b" });
+    fireEvent.keyDown(window, { ctrlKey: true, key: "i" });
+    fireEvent.keyDown(window, { ctrlKey: true, key: "u" });
+
+    expect(execCommand).toHaveBeenNthCalledWith(1, "undo", false, undefined);
+    expect(execCommand).toHaveBeenNthCalledWith(2, "redo", false, undefined);
+    expect(execCommand).toHaveBeenNthCalledWith(3, "bold", false, undefined);
+    expect(execCommand).toHaveBeenNthCalledWith(4, "italic", false, undefined);
+    expect(execCommand).toHaveBeenNthCalledWith(5, "underline", false, undefined);
+  });
+
+  it("ignores editing shortcuts while the editor is hidden (inactive keep-alive tab)", () => {
+    const execCommand = vi.fn();
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(<RichMailEditor html="<p>Hello</p>" onChange={vi.fn()} />);
+
+    const editor = screen.getByTestId("mail-compose-editor");
+    // Hidden keep-alive tab: no layout boxes. jsdom matches this by default.
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    fireEvent.keyDown(window, { ctrlKey: true, key: "z" });
+    fireEvent.keyDown(window, { ctrlKey: true, key: "b" });
+
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("leaves editing shortcuts alone when another editable field has focus", () => {
+    const execCommand = vi.fn();
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(
+      <div>
+        <input data-testid="other-field" />
+        <RichMailEditor html="<p>Hello</p>" onChange={vi.fn()} />
+      </div>,
+    );
+
+    const editor = screen.getByTestId("mail-compose-editor");
+    vi.spyOn(editor, "getClientRects").mockReturnValue([{ width: 100 }] as unknown as DOMRectList);
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    screen.getByTestId("other-field").focus();
+    fireEvent.keyDown(window, { ctrlKey: true, key: "z" });
+
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("opens the in-app link dialog and applies createLink with the typed URL", async () => {
+    const execCommand = vi.fn();
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(<RichMailEditor html="<p>Hello</p>" onChange={vi.fn()} />);
+
+    // The editor must own the caret for createLink to be reachable.
+    screen.getByTestId("mail-compose-editor").focus();
+
+    fireEvent.click(screen.getByTestId("mail-compose-link"));
+    const dialogInput = await screen.findByTestId("text-input-dialog-input");
+    fireEvent.change(dialogInput, { target: { value: "https://example.com" } });
+    fireEvent.click(screen.getByTestId("text-input-dialog-confirm"));
+
+    await waitFor(() => {
+      expect(execCommand).toHaveBeenCalledWith("createLink", false, "https://example.com");
+    });
+  });
+
+  it("opens the table dialog and inserts a table from the size prompt", async () => {
+    const execCommand = vi.fn();
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(<RichMailEditor html="<p>Hello</p>" onChange={vi.fn()} />);
+    screen.getByTestId("mail-compose-editor").focus();
+
+    fireEvent.click(screen.getByTestId("mail-compose-insert-menu"));
+    fireEvent.click(await screen.findByTestId("mail-compose-insert-table"));
+    const dialogInput = await screen.findByTestId("text-input-dialog-input");
+    expect(dialogInput).toHaveValue("2x2");
+    fireEvent.change(dialogInput, { target: { value: "3x2" } });
+    fireEvent.click(screen.getByTestId("text-input-dialog-confirm"));
+
+    await waitFor(() => {
+      expect(execCommand).toHaveBeenCalledWith(
+        "insertHTML",
+        false,
+        expect.stringContaining("<table"),
+      );
+    });
+  });
 });

--- a/src/components/mail/RichMailEditor.tsx
+++ b/src/components/mail/RichMailEditor.tsx
@@ -32,6 +32,7 @@ import { readClipboardImageFiles, readMultiFormat, readText } from "../../lib/cl
 import { useT } from "../../lib/i18n";
 import { isOsFileDrag, preventDefaultForOsFileDrag } from "../../lib/osFileDrop";
 import { useContextMenu, type MenuItem } from "../ContextMenu";
+import { useTextInputDialog } from "../sidebar/ConfirmDialog";
 
 interface RichMailEditorProps {
   html: string;
@@ -71,22 +72,22 @@ const SIZE_OPTIONS = [
 ];
 
 const EMOJI_OPTIONS = [
-  { id: "smile", label: "微笑", value: "🙂" },
-  { id: "frown", label: "皱眉", value: "🙁" },
-  { id: "wink", label: "眨眼", value: "😉" },
-  { id: "tongue", label: "吐舌", value: "😛" },
-  { id: "laugh", label: "大笑", value: "😂" },
-  { id: "blush", label: "窘迫", value: "😳" },
-  { id: "unsure", label: "迟疑", value: "😕" },
-  { id: "surprise", label: "惊讶", value: "😮" },
-  { id: "kiss", label: "亲吻", value: "😘" },
-  { id: "shout", label: "大叫", value: "😱" },
-  { id: "cool", label: "酷", value: "😎" },
-  { id: "money", label: "爱财", value: "🤑" },
-  { id: "sealed", label: "失言", value: "😶" },
-  { id: "innocent", label: "无辜", value: "😇" },
-  { id: "cry", label: "哭泣", value: "😭" },
-  { id: "silent", label: "缄默", value: "🤐" },
+  { id: "smile", value: "🙂" },
+  { id: "frown", value: "🙁" },
+  { id: "wink", value: "😉" },
+  { id: "tongue", value: "😛" },
+  { id: "laugh", value: "😂" },
+  { id: "blush", value: "😳" },
+  { id: "unsure", value: "😕" },
+  { id: "surprise", value: "😮" },
+  { id: "kiss", value: "😘" },
+  { id: "shout", value: "😱" },
+  { id: "cool", value: "😎" },
+  { id: "money", value: "🤑" },
+  { id: "sealed", value: "😶" },
+  { id: "innocent", value: "😇" },
+  { id: "cry", value: "😭" },
+  { id: "silent", value: "🤐" },
 ];
 
 export function RichMailEditor({
@@ -105,6 +106,7 @@ export function RichMailEditor({
   const [color, setColor] = useState("#1f2937");
   const [localDrag, setLocalDrag] = useState(false);
   const editorMenu = useContextMenu();
+  const textInputDialog = useTextInputDialog();
   const t = useT();
 
   useEffect(() => {
@@ -113,6 +115,25 @@ export function RichMailEditor({
     const next = html || "<p><br></p>";
     if (editor.innerHTML !== next) editor.innerHTML = next;
   }, [html]);
+
+  // Keep the cached range in sync with the live selection. Select-all and
+  // mouse drags never fire an input event, so without this the toolbar would
+  // "restore" a stale collapsed caret over the user's real selection and apply
+  // formatting to nothing. Only ranges inside the editor are cached; when the
+  // selection moves elsewhere (e.g. into a prompt dialog's input) the last
+  // editor caret is kept so toolbar actions still land where the user left off.
+  useEffect(() => {
+    const onSelectionChange = () => {
+      const editor = editorRef.current;
+      if (!editor) return;
+      const selection = window.getSelection();
+      if (selection?.rangeCount && isRangeInEditor(selection.getRangeAt(0))) {
+        selectionRef.current = selection.getRangeAt(0).cloneRange();
+      }
+    };
+    document.addEventListener("selectionchange", onSelectionChange);
+    return () => document.removeEventListener("selectionchange", onSelectionChange);
+  }, []);
 
   const emitChange = () => {
     const editor = editorRef.current;
@@ -168,6 +189,70 @@ export function RichMailEditor({
     if (rich) onRichFormatUsed?.();
     emitChange();
   };
+
+  // Own the standard editing shortcuts. The webview only applies Ctrl+Z /
+  // Ctrl+B / … to the currently focused editable, and focus drifts out of a
+  // contentEditable easily (popup menu clicks, dialog drags), which made those
+  // keys dead while the context-menu commands kept working. Apply them
+  // whenever the editor owns the caret — focused, or holding the live
+  // selection — and stay out of the way when another editable has focus.
+  const shortcutCommandsRef = useRef<{ disabled: boolean; exec: typeof exec }>({ disabled, exec });
+  useEffect(() => {
+    shortcutCommandsRef.current = { disabled, exec };
+  });
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.isComposing) return;
+      const primary = event.ctrlKey || event.metaKey;
+      if (!primary || event.altKey) return;
+      const { current: commands } = shortcutCommandsRef;
+      if (commands.disabled) return;
+      const editor = editorRef.current;
+      if (!editor || editor.getClientRects().length === 0) return;
+
+      const active = document.activeElement as HTMLElement | null;
+      if (
+        active
+        && active !== editor
+        && active.closest?.('input, textarea, select, [contenteditable="true"], [contenteditable=""]')
+      ) {
+        return;
+      }
+
+      const selection = window.getSelection();
+      const selectionInEditor =
+        !!selection?.rangeCount && editor.contains(selection.getRangeAt(0).commonAncestorContainer);
+      if (active !== editor && !selectionInEditor) return;
+
+      const key = event.key.toLowerCase();
+      let command: string | null = null;
+      let rich = false;
+      if (key === "z") {
+        command = event.shiftKey ? "redo" : "undo";
+      } else if (key === "y" && !event.shiftKey) {
+        command = "redo";
+      } else if (key === "b" && !event.shiftKey) {
+        command = "bold";
+        rich = true;
+      } else if (key === "i" && !event.shiftKey) {
+        command = "italic";
+        rich = true;
+      } else if (key === "u" && !event.shiftKey) {
+        command = "underline";
+        rich = true;
+      } else if (key === "a" && !event.shiftKey) {
+        command = "selectAll";
+      }
+      if (!command) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      commands.exec(command, undefined, rich);
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   const pasteClipboard = async (mode: "normal" | "plain" | "markdown") => {
     if (disabled) return;
@@ -273,14 +358,25 @@ export function RichMailEditor({
     })();
   };
 
-  const handleLink = () => {
-    const href = window.prompt("Link URL");
+  // window.prompt is silently ignored by Tauri's webviews (see ConfirmDialog),
+  // so link / anchor / table insertion route through the in-app text dialog.
+  // While the dialog is open the editor keeps its cached caret via the
+  // selectionchange guard above, so the command lands at the right spot.
+  const handleLink = async () => {
+    const href = await textInputDialog.promptText({
+      title: "Insert link",
+      label: "Link URL",
+      placeholder: "https://example.com",
+    });
     if (!href?.trim()) return;
     exec("createLink", href.trim());
   };
 
-  const handleAnchor = () => {
-    const name = window.prompt("Anchor name");
+  const handleAnchor = async () => {
+    const name = await textInputDialog.promptText({
+      title: "Insert anchor",
+      label: "Anchor name",
+    });
     const cleaned = name?.trim().replace(/\s+/g, "-");
     if (!cleaned) return;
     insertHtml(`<a name="${escapeHtml(cleaned)}"></a>`, true);
@@ -292,8 +388,12 @@ export function RichMailEditor({
     insertHtml(imageHtml, true);
   };
 
-  const handleTable = () => {
-    const raw = window.prompt("Table size (columns x rows)", "2x2");
+  const handleTable = async () => {
+    const raw = await textInputDialog.promptText({
+      title: "Insert table",
+      label: "Table size (columns x rows)",
+      initialValue: "2x2",
+    });
     if (!raw) return;
     const match = /^\s*(\d{1,2})\s*[x*,]\s*(\d{1,2})\s*$/i.exec(raw);
     const cols = Math.max(1, Math.min(12, Number(match?.[1] ?? 2)));
@@ -310,14 +410,14 @@ export function RichMailEditor({
   };
 
   const emojiMenuItems = (): MenuItem[] => EMOJI_OPTIONS.map((emoji) => ({
-    label: `${emoji.value} ${emoji.label}`,
+    label: emoji.value,
     testId: `mail-compose-emoji-${emoji.id}`,
     onClick: () => insertHtml(emoji.value, false),
   }));
 
   const editingMenuItems = (): MenuItem[] => [
     { label: t("contextMenu.undo"), testId: "mail-compose-context-undo", shortcut: shortcut("Z"), onClick: () => exec("undo", undefined, false) },
-    { label: t("contextMenu.redo"), testId: "mail-compose-context-redo", shortcut: shortcut("Y"), onClick: () => exec("redo", undefined, false) },
+    { label: t("contextMenu.redo"), testId: "mail-compose-context-redo", shortcut: redoShortcut(), onClick: () => exec("redo", undefined, false) },
     { label: "", separator: true },
     { label: t("contextMenu.cut"), testId: "mail-compose-context-cut", shortcut: shortcut("X"), onClick: () => exec("cut", undefined, false) },
     { label: t("contextMenu.copy"), testId: "mail-compose-context-copy", shortcut: shortcut("C"), onClick: () => exec("copy", undefined, false) },
@@ -339,35 +439,35 @@ export function RichMailEditor({
 
   const insertMenuItems = (): MenuItem[] => [
     {
-      label: "链接",
+      label: "Link",
       testId: "mail-compose-insert-link",
       icon: <LinkIcon className="w-3.5 h-3.5" />,
-      onClick: handleLink,
+      onClick: () => void handleLink(),
     },
     {
-      label: "锚标",
+      label: "Anchor",
       testId: "mail-compose-insert-anchor",
       icon: <Anchor className="w-3.5 h-3.5" />,
-      onClick: handleAnchor,
+      onClick: () => void handleAnchor(),
     },
     {
-      label: "图像",
+      label: "Image",
       testId: "mail-compose-insert-image",
       icon: <ImageIcon className="w-3.5 h-3.5" />,
       disabled: !onInlineImage,
       onClick: () => void handleInlineImage(),
     },
     {
-      label: "水平线",
+      label: "Horizontal rule",
       testId: "mail-compose-insert-hr",
       icon: <Minus className="w-3.5 h-3.5" />,
       onClick: () => insertHtml("<hr>", true),
     },
     {
-      label: "表格",
+      label: "Table",
       testId: "mail-compose-insert-table",
       icon: <Table2 className="w-3.5 h-3.5" />,
-      onClick: handleTable,
+      onClick: () => void handleTable(),
     },
   ];
 
@@ -444,7 +544,7 @@ export function RichMailEditor({
         <ToolbarButton label="Align left" testId="mail-compose-align-left" disabled={disabled} onClick={() => exec("justifyLeft")}><AlignLeft className="w-3.5 h-3.5" /></ToolbarButton>
         <ToolbarButton label="Align center" testId="mail-compose-align-center" disabled={disabled} onClick={() => exec("justifyCenter")}><AlignCenter className="w-3.5 h-3.5" /></ToolbarButton>
         <ToolbarButton label="Align right" testId="mail-compose-align-right" disabled={disabled} onClick={() => exec("justifyRight")}><AlignRight className="w-3.5 h-3.5" /></ToolbarButton>
-        <ToolbarButton label="Insert link" testId="mail-compose-link" disabled={disabled} onClick={handleLink}><LinkIcon className="w-3.5 h-3.5" /></ToolbarButton>
+        <ToolbarButton label="Insert link" testId="mail-compose-link" disabled={disabled} onClick={() => void handleLink()}><LinkIcon className="w-3.5 h-3.5" /></ToolbarButton>
         <MenuButton label="Insert" testId="mail-compose-insert-menu" disabled={disabled} onClick={(event) => showMenu(event, insertMenuItems())}>
           <ImageIcon className="w-3.5 h-3.5" />
         </MenuButton>
@@ -465,6 +565,7 @@ export function RichMailEditor({
         )}
       </div>
       {editorMenu.render}
+      {textInputDialog.render}
       <div className="relative flex-1 min-h-[240px] flex flex-col">
         <div
           ref={editorRef}
@@ -518,6 +619,10 @@ function ToolbarButton({
       title={label}
       data-testid={testId}
       disabled={disabled}
+      // Keep focus (and the live selection) in the editor when a toolbar
+      // button is clicked — otherwise the caret/selection is lost to the
+      // button and the command applies to nothing.
+      onMouseDown={(event) => event.preventDefault()}
       onClick={onClick}
     >
       {children}
@@ -546,6 +651,8 @@ function MenuButton({
       title={label}
       data-testid={testId}
       disabled={disabled}
+      // Same as ToolbarButton: don't steal focus from the editor.
+      onMouseDown={(event) => event.preventDefault()}
       onClick={onClick}
     >
       {children}
@@ -609,6 +716,10 @@ function plainTextFragment(value: string): string {
 
 function shortcut(key: string): string {
   return `${navigator.platform.toLowerCase().includes("mac") ? "Cmd" : "Ctrl"}+${key}`;
+}
+
+function redoShortcut(): string {
+  return navigator.platform.toLowerCase().includes("mac") ? "Cmd+Shift+Z" : "Ctrl+Y";
 }
 
 function escapeHtml(value: string): string {


### PR DESCRIPTION
…, and insert dialogs

The rich mail compose editor (contentEditable + document.execCommand) had three classes of defects that made formatting and undo unreliable in daily use, plus several insert actions that were completely dead in the desktop app. All were verified against the running app (browser mode) before and after the fix.

Root causes and fixes:

1. Toolbar formatting silently did nothing (bold/italic/underline/...). The cached selection range was only refreshed on input events, so Ctrl+A select-all and mouse-drag selections never reached the cache. Clicking a toolbar button then "restored" a stale collapsed caret over the user's real selection, and execCommand applied formatting to an empty caret with no visible result. Fix: keep the cache in sync via a document selectionchange listener that only stores ranges inside the editor; when focus/selection moves elsewhere the last editor caret is retained so toolbar actions still land where the user left off.

2. Keyboard shortcuts (Ctrl+Z first reported) stopped working while the context-menu Undo kept working. Native editing shortcuts only apply to the currently focused editable, and focus drifts out of a contentEditable easily: picking an item from the Insert/Emoji popup unmounts the menu, dragging the compose dialog drops focus on body. The context menu worked because exec() refocuses the editor first. Fix: the component now owns the standard shortcuts (Ctrl/Cmd+Z, Ctrl+Shift+Z / Ctrl+Y redo, Ctrl+B/I/U, Ctrl+A) whenever the editor is focused or holds the live selection, applying them through exec() so they share one code path with the toolbar. The handler yields when any other input/textarea/contenteditable has focus, skips composition events, and checks getClientRects so keep-alive hidden mail tabs (rendered with display:none in MainLayout) never intercept keys meant for another tab. Ctrl+A is scoped to select-all-in-editor instead of select-all-in-document once focus has drifted.

3. Insert link / anchor / table were unusable in the desktop app. They prompted via window.prompt, which Tauri webviews silently ignore (returns null; see the note in sidebar/ConfirmDialog.tsx). Fix: route all three through useTextInputDialog, rendered inside the editor shell. While a dialog is open the selectionchange guard preserves the editor caret, so createLink/insertHTML land at the right spot after confirm.

4. Small interaction fixes in the same surface:
   - toolbar buttons no longer steal focus from the editor on mousedown, keeping the live selection intact while clicking Bold mid-edit;
   - Emoji menu items dropped their hardcoded Chinese labels (the only text was already the emoji itself); Insert menu labels are English, matching the rest of MailClientTab's hardcoded strings;
   - context-menu Redo shortcut hint now matches convention per platform (Ctrl+Y on Windows/Linux, Cmd+Shift+Z on macOS).

Tests: six regression tests added covering shortcut takeover without focus, yield-to-other-fields behavior, hidden-editor suppression (jsdom has no layout engine, so getClientRects is mocked), mousedown focus preservation, and the link/table dialog flows. Full suite passes (320 files / 2816 tests), tsc -b clean.

Also updates qa-ui-auto-tests/feature-list.md notes: link and table controls now open the in-app text-input-dialog rather than a prompt.