### PR TITLE
feat(window): add stable drag handle and responsive titlebar actions

### DIFF
--- a/.agents/skills/qa-ui-auto/references/testid-catalog.md
+++ b/.agents/skills/qa-ui-auto/references/testid-catalog.md
@@ -645,6 +645,8 @@
 - `[data-testid="app-titlebar"]` — display — F1.3.titlebar
 - `[data-testid="titlebar-tray"]` — display — F1.3.tray
 - `[data-testid="control-bar"]` — display — F1.3.control-bar
+- `[data-testid="window-drag-handle"]` — display — F1.3.window-drag-handle
+- `[data-testid="titlebar-actions-more"]` — interactive [optional] — F1.3.titlebar-actions-more
 - `[data-testid="theme-cycle"]` — interactive — F1.3.theme-cycle
 - `[data-testid="tab-split-view"]` — interactive — F1.3.split-view
 - `[data-testid="tab-multiexec-toggle"]` — interactive — F1.3.multiexec-toggle

--- a/qa-ui-auto-tests/cases/TC-100-titlebar-window-controls.testcase.yaml
+++ b/qa-ui-auto-tests/cases/TC-100-titlebar-window-controls.testcase.yaml
@@ -1,11 +1,11 @@
 id: TC-100
 title: Custom title bar renders window controls and tray
 description: |
-  Smoke test for F1.3 (custom title bar). Verifies the app-titlebar, the
-  three window controls (minimize/maximize/close), and the tray (theme cycle
-  + compact toggle) are all mounted at startup. Window-min/max/close are
-  asserted as display-only — clicking them would tear down the test
-  window. The theme-cycle button is clicked once to confirm the
+  Smoke test for F1.3 (custom title bar). Verifies the unified control bar, the
+  dedicated window drag handle, the three window controls
+  (minimize/maximize/close), and the normal-width tray are mounted at startup.
+  Window-min/max/close are asserted as display-only — clicking them would tear
+  down the test window. The theme-cycle button is clicked once to confirm the
   interactive contract.
 covers: [F1.3]
 tags: [smoke, p1, main, window]
@@ -14,7 +14,8 @@ fixtures: [reset_db]
 timeout_sec: 30
 steps:
   - open: ${cfg.app.base_url}
-  - wait_for: '[data-testid="app-titlebar"]'
+  - wait_for: '[data-testid="control-bar"]'
+  - assert_visible: '[data-testid="window-drag-handle"]'
   - assert_visible: '[data-testid="window-controls"]'
   - assert_visible: '[data-testid="window-min"]'
   - assert_visible: '[data-testid="window-max"]'

--- a/qa-ui-auto-tests/feature-list.md
+++ b/qa-ui-auto-tests/feature-list.md
@@ -54,6 +54,8 @@ status: done
 area: main/window
 components: [AppTitleBar, WindowControls, WindowResizeHandles, TitleBarTrayControls]
 files:
+  - src/components/tabbar/ControlBar.tsx
+  - src/components/window/WindowDragHandle.tsx
   - src/components/window/AppTitleBar.tsx
   - src/components/window/WindowControls.tsx
   - src/components/window/TitleBarTrayControls.tsx
@@ -67,6 +69,13 @@ controls:
   - id: control-bar
     selector: '[data-testid="control-bar"]'
     kind: display
+  - id: window-drag-handle
+    selector: '[data-testid="window-drag-handle"]'
+    kind: display    # dedicated native window-move target; presence is asserted in browser mode
+  - id: titlebar-actions-more
+    selector: '[data-testid="titlebar-actions-more"]'
+    kind: interactive
+    optional: true   # compact overflow control appears below the narrow-window breakpoint
   - id: theme-cycle
     selector: '[data-testid="theme-cycle"]'
     kind: interactive
@@ -96,7 +105,8 @@ controls:
 -->
 
 - 取消原生 decorations，前端自绘 `AppTitleBar` + `WindowControls`（最小化 / 最大化 / 关闭）
-- 标题栏托盘 `TitleBarTrayControls`：分组排列 — Voice (PTT) | View (主题循环 + 紧凑模式) | Terminal (Split + MultiExec) | Language (locale 切换)
+- 标题栏左侧固定 `WindowDragHandle`（48px）作为可识别的窗口移动锚点；Tab 数量不会挤掉该区域
+- 标题栏托盘 `TitleBarTrayControls`：常规宽度分组排列 — Voice (PTT) | View (主题循环) | Terminal (Split + MultiExec) | Language (locale 切换)；窄窗口收进 `More window actions`
 - `WindowResizeHandles` 在无 decorations 模式下提供 8 向窗口缩放（North/South/East/West/四个角）
 - 主菜单 / Sessions / View / Tunneling / Settings / Help / Exit 入口接入
 

--- a/src/components/tabbar/ControlBar.test.tsx
+++ b/src/components/tabbar/ControlBar.test.tsx
@@ -3,14 +3,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ControlBar } from "./ControlBar";
 import type { AppCommand } from "../menubar/commands";
 
+const windowMocks = vi.hoisted(() => ({
+  startDragging: vi.fn(async () => undefined),
+  toggleMaximize: vi.fn(async () => undefined),
+}));
 const tabBarMocks = vi.hoisted(() => ({ props: [] as Array<{ detailsRevealExternal?: boolean }> }));
 const openTabsMocks = vi.hoisted(() => ({ props: [] as Array<{ onDetachActiveTab?: () => void }> }));
 
 vi.mock("@tauri-apps/api/window", () => ({
-  getCurrentWindow: () => ({
-    startDragging: vi.fn(async () => undefined),
-    toggleMaximize: vi.fn(async () => undefined),
-  }),
+  getCurrentWindow: () => windowMocks,
 }));
 
 vi.mock("../../lib/runtime", () => ({
@@ -143,6 +144,20 @@ describe("ControlBar settings button", () => {
     expect(tabBarMocks.props.at(-1)?.detailsRevealExternal).toBe(true);
     fireEvent.mouseLeave(button);
     expect(tabBarMocks.props.at(-1)?.detailsRevealExternal).toBe(false);
+  });
+
+  it("keeps a dedicated drag handle and preserves the maximize gesture", () => {
+    renderControlBar(vi.fn());
+    const handle = screen.getByTestId("window-drag-handle");
+
+    fireEvent.mouseDown(handle, { button: 0, detail: 1 });
+    expect(windowMocks.startDragging).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseDown(handle, { button: 0, detail: 2 });
+    expect(windowMocks.toggleMaximize).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseDown(screen.getByTestId("app-main-menu"), { button: 0, detail: 1 });
+    expect(windowMocks.startDragging).toHaveBeenCalledTimes(1);
   });
 
   it("forwards the active detach action into the More menu", () => {

--- a/src/components/tabbar/ControlBar.tsx
+++ b/src/components/tabbar/ControlBar.tsx
@@ -33,6 +33,7 @@ import { TabBar } from "./TabBar";
 import { OpenTabsMenu } from "./OpenTabsMenu";
 import { useContextMenu, type MenuItem } from "../ContextMenu";
 import { WindowControls } from "../window/WindowControls";
+import { WindowDragHandle } from "../window/WindowDragHandle";
 import { TitleBarTrayControls } from "../window/TitleBarTrayControls";
 import { CaptureIndicators } from "../capture/CaptureIndicators";
 import { useSessionImportExport } from "../menubar/useSessionImportExport";
@@ -232,6 +233,7 @@ export function ControlBar({
           <BarButton testId="app-main-menu" title={t("compactTitleBar.mainMenu")} icon={<Menu className="w-4 h-4" />} onClick={openMainMenu} />
         )}
       </div>
+      <WindowDragHandle />
       <div className="min-w-0 flex-1 self-stretch">
         <TabBar
           onStartLocalTerminal={onStartLocalTerminal}
@@ -253,7 +255,7 @@ export function ControlBar({
         aria-label={t("tabs.detailsShortcutHint", { shortcut: IS_MAC ? "Cmd+Shift+H" : "Ctrl+Shift+H" })}
         title={t("tabs.detailsShortcutHint", { shortcut: IS_MAC ? "Cmd+Shift+H" : "Ctrl+Shift+H" })}
         data-active={detailsRevealHovered || undefined}
-        className="relative h-6 w-7 shrink-0 inline-flex items-center justify-center rounded hover:bg-[var(--taomni-hover)] data-[active=true]:bg-[var(--taomni-selected)]"
+        className="taomni-tab-details-button relative h-6 w-7 shrink-0 inline-flex items-center justify-center rounded hover:bg-[var(--taomni-hover)] data-[active=true]:bg-[var(--taomni-selected)]"
         onMouseEnter={() => setDetailsRevealHovered(true)}
         onMouseLeave={() => setDetailsRevealHovered(false)}
         onFocus={() => setDetailsRevealHovered(true)}
@@ -265,10 +267,7 @@ export function ControlBar({
       {/* Open-tabs `⋯` overflow — also hosts the Screenshot actions. Sits at the
           right end of the tab-action group. */}
       <TabMore onDetachActiveTab={onDetachActiveTab} />
-      <div
-        className={IS_MAC ? "w-3 self-stretch shrink-0" : "w-6 self-stretch shrink-0"}
-        data-window-drag
-      />
+      <div className={IS_MAC ? "w-2 self-stretch shrink-0" : "w-3 self-stretch shrink-0"} />
       {/* Divider between the tab-related buttons and the main-window controls. */}
       <div aria-hidden="true" className="taomni-control-divider self-stretch shrink-0" />
       <TitleBarTrayControls />

--- a/src/components/window/TitleBarTrayControls.test.tsx
+++ b/src/components/window/TitleBarTrayControls.test.tsx
@@ -1,0 +1,98 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TitleBarTrayControls } from "./TitleBarTrayControls";
+
+const mocks = vi.hoisted(() => ({
+  theme: {
+    mode: "dark" as const,
+    resolvedTheme: "dark" as const,
+    setMode: vi.fn(),
+  },
+  app: {
+    terminalSplitActive: false,
+    multiExecActive: false,
+    toggleTerminalSplit: vi.fn(),
+    toggleMultiExec: vi.fn(),
+  },
+}));
+
+vi.mock("../../lib/appTheme", () => ({
+  useAppTheme: () => mocks.theme,
+}));
+
+vi.mock("../../stores/appStore", () => ({
+  useAppStore: (selector: (state: typeof mocks.app) => unknown) => selector(mocks.app),
+}));
+
+vi.mock("../../stores/aiStore", () => ({
+  useAiStore: (selector: (state: { config: { fully_disabled: boolean } }) => unknown) =>
+    selector({ config: { fully_disabled: true } }),
+}));
+
+vi.mock("../../lib/i18n/labels", () => ({
+  useAppThemeI18nLabel: () => (mode: string) => mode,
+}));
+
+vi.mock("./PttButton", () => ({
+  PttButton: () => <button type="button" data-testid="ptt-button" />,
+}));
+
+vi.mock("./LanguageSwitcher", () => ({
+  LanguageSwitcher: () => <button type="button" data-testid="language-switcher" />,
+}));
+
+describe("TitleBarTrayControls responsive layout", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+      writable: true,
+    });
+    mocks.theme.mode = "dark";
+    mocks.theme.resolvedTheme = "dark";
+    mocks.app.terminalSplitActive = false;
+    mocks.app.multiExecActive = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("keeps the full tray at normal widths", () => {
+    render(<TitleBarTrayControls />);
+
+    expect(screen.getByTestId("titlebar-tray")).toBeInTheDocument();
+    expect(screen.queryByTestId("titlebar-actions-more")).not.toBeInTheDocument();
+  });
+
+  it("moves tray actions into one compact menu at narrow widths", () => {
+    window.innerWidth = 800;
+    render(<TitleBarTrayControls />);
+
+    expect(screen.queryByTestId("titlebar-tray")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("titlebar-actions-more"));
+
+    expect(screen.getByTestId("titlebar-actions-menu")).toBeInTheDocument();
+    expect(screen.getByTestId("tab-split-view")).toBeInTheDocument();
+    expect(screen.getByTestId("tab-multiexec-toggle")).toBeInTheDocument();
+    expect(screen.getByTestId("theme-cycle")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("tab-split-view"));
+    expect(mocks.app.toggleTerminalSplit).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("titlebar-actions-menu")).not.toBeInTheDocument();
+  });
+
+  it("switches layout when the window crosses the breakpoint", async () => {
+    render(<TitleBarTrayControls />);
+    expect(screen.getByTestId("titlebar-tray")).toBeInTheDocument();
+
+    window.innerWidth = 800;
+    fireEvent(window, new Event("resize"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("titlebar-actions-more")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("titlebar-tray")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/window/TitleBarTrayControls.tsx
+++ b/src/components/window/TitleBarTrayControls.tsx
@@ -1,11 +1,16 @@
-import { Monitor, Moon, Sun, SplitSquareVertical, Users } from "lucide-react";
+import { createPortal } from "react-dom";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Monitor, Moon, MoreHorizontal, Sun, SplitSquareVertical, Users } from "lucide-react";
 import { useAppTheme, type AppThemeMode } from "../../lib/appTheme";
 import { useAppStore } from "../../stores/appStore";
 import { useAiStore } from "../../stores/aiStore";
 import { useT } from "../../lib/i18n";
 import { useAppThemeI18nLabel } from "../../lib/i18n/labels";
+import { useViewportSize } from "../../hooks/useViewportSize";
 import { PttButton } from "./PttButton";
 import { LanguageSwitcher } from "./LanguageSwitcher";
+
+const COMPACT_TITLEBAR_BREAKPOINT = 960;
 
 const THEME_MODES: Array<{ mode: AppThemeMode; icon: React.ReactNode }> = [
   { mode: "light", icon: <Sun className="w-[16px] h-[16px]" /> },
@@ -29,8 +34,29 @@ export function TitleBarTrayControls() {
 
   const splitTitle = terminalSplitActive ? t("titlebar.disableSplit") : t("titlebar.enableSplit");
   const multiExecTitle = multiExecActive ? t("titlebar.disableMultiExec") : t("titlebar.enableMultiExec");
+  const themeTitle = t("titlebar.cycleTheme", {
+    mode: themeLabel(mode),
+    resolved: resolvedTheme,
+    next: themeLabel(next.mode),
+  });
+  const { width } = useViewportSize();
+  const trayProps: TrayProps = {
+    terminalSplitActive,
+    multiExecActive,
+    toggleTerminalSplit,
+    toggleMultiExec,
+    aiFullyDisabled,
+    splitTitle,
+    multiExecTitle,
+    themeTitle,
+    themeAriaLabel: t("titlebar.cycleThemeAria"),
+    currentThemeIcon: current.icon,
+    onCycleTheme: () => setMode(next.mode),
+  };
 
-  return (
+  return width <= COMPACT_TITLEBAR_BREAKPOINT
+    ? <CompactTitleBarTray {...trayProps} />
+    : (
     <div className="taomni-titlebar-tray flex items-stretch self-stretch shrink-0" data-testid="titlebar-tray">
       {/* Terminal layout group */}
       <div className="taomni-titlebar-tray-group flex items-stretch self-stretch">
@@ -71,11 +97,7 @@ export function TitleBarTrayControls() {
         <LanguageSwitcher />
         <TrayButton
           testId="theme-cycle"
-          title={t("titlebar.cycleTheme", {
-            mode: themeLabel(mode),
-            resolved: resolvedTheme,
-            next: themeLabel(next.mode),
-          })}
+          title={themeTitle}
           ariaLabel={t("titlebar.cycleThemeAria")}
           onClick={() => setMode(next.mode)}
         >
@@ -83,6 +105,194 @@ export function TitleBarTrayControls() {
         </TrayButton>
       </div>
     </div>
+    );
+}
+
+interface TrayProps {
+  terminalSplitActive: boolean;
+  multiExecActive: boolean;
+  toggleTerminalSplit: () => void;
+  toggleMultiExec: () => void;
+  aiFullyDisabled: boolean;
+  splitTitle: string;
+  multiExecTitle: string;
+  themeTitle: string;
+  themeAriaLabel: string;
+  currentThemeIcon: React.ReactNode;
+  onCycleTheme: () => void;
+}
+
+function CompactTitleBarTray({
+  terminalSplitActive,
+  multiExecActive,
+  toggleTerminalSplit,
+  toggleMultiExec,
+  aiFullyDisabled,
+  splitTitle,
+  multiExecTitle,
+  themeTitle,
+  themeAriaLabel,
+  currentThemeIcon,
+  onCycleTheme,
+}: TrayProps) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState({ top: 0, right: 4 });
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    const update = () => {
+      const rect = anchorRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      setPosition({
+        top: rect.bottom + 4,
+        right: Math.max(4, window.innerWidth - rect.right),
+      });
+    };
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (
+        anchorRef.current?.contains(target) ||
+        menuRef.current?.contains(target) ||
+        target?.closest("[data-taomni-context-menu]")
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen(false);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      window.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [open]);
+
+  const run = (action: () => void) => {
+    action();
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <div ref={anchorRef} className="taomni-titlebar-actions-overflow relative flex items-stretch self-stretch shrink-0">
+        <button
+          type="button"
+          data-testid="titlebar-actions-more"
+          title={t("titlebar.moreActions")}
+          aria-label={t("titlebar.moreActions")}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          className="taomni-titlebar-tray-btn h-full w-9 inline-flex items-center justify-center hover:bg-[var(--taomni-hover)]"
+          style={{ color: "var(--taomni-text)" }}
+          onClick={() => setOpen((visible) => !visible)}
+        >
+          <MoreHorizontal className="w-4 h-4" />
+        </button>
+      </div>
+      {open && typeof document !== "undefined" && createPortal(
+        <div
+          ref={menuRef}
+          data-testid="titlebar-actions-menu"
+          data-taomni-context-menu=""
+          role="menu"
+          className="taomni-titlebar-actions-menu fixed z-[9999] min-w-[236px] rounded shadow-lg border py-1 text-[12px]"
+          style={{
+            top: position.top,
+            right: position.right,
+            background: "var(--taomni-panel-bg)",
+            borderColor: "var(--taomni-divider)",
+            color: "var(--taomni-text)",
+          }}
+        >
+          <CompactActionButton
+            testId="tab-split-view"
+            title={splitTitle}
+            active={terminalSplitActive}
+            icon={<SplitSquareVertical className="w-4 h-4" />}
+            onClick={() => run(toggleTerminalSplit)}
+          />
+          <CompactActionButton
+            testId="tab-multiexec-toggle"
+            title={multiExecTitle}
+            active={multiExecActive}
+            icon={<Users className="w-4 h-4" />}
+            onClick={() => run(toggleMultiExec)}
+          />
+          {!aiFullyDisabled && (
+            <div className="flex items-center justify-between gap-3 px-3 py-1">
+              <span className="truncate">{t("ptt.holdToSpeak")}</span>
+              <PttButton />
+            </div>
+          )}
+          <div className="h-px mx-2 my-1" style={{ background: "var(--taomni-divider)" }} />
+          <div className="flex items-center justify-between gap-3 px-3 py-1">
+            <span className="truncate">{t("language.label")}</span>
+            <LanguageSwitcher />
+          </div>
+          <CompactActionButton
+            testId="theme-cycle"
+            title={themeTitle}
+            active={false}
+            icon={currentThemeIcon}
+            onClick={() => run(onCycleTheme)}
+            ariaLabel={themeAriaLabel}
+          />
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}
+
+function CompactActionButton({
+  testId,
+  title,
+  icon,
+  active,
+  onClick,
+  ariaLabel,
+}: {
+  testId: string;
+  title: string;
+  icon: React.ReactNode;
+  active: boolean;
+  onClick: () => void;
+  ariaLabel?: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      data-testid={testId}
+      title={title}
+      aria-label={ariaLabel ?? title}
+      data-active={active || undefined}
+      className="w-full min-h-7 px-3 py-1 text-left flex items-center gap-2 hover:bg-[var(--taomni-hover)] data-[active=true]:bg-[var(--taomni-selected)]"
+      onClick={onClick}
+    >
+      <span className="w-4 shrink-0 inline-flex items-center justify-center">{icon}</span>
+      <span className="truncate">{title}</span>
+    </button>
   );
 }
 

--- a/src/components/window/WindowDragHandle.tsx
+++ b/src/components/window/WindowDragHandle.tsx
@@ -1,0 +1,24 @@
+import { GripHorizontal } from "lucide-react";
+import { useT } from "../../lib/i18n";
+
+/**
+ * A fixed, visible drag target for the borderless main window. Keeping this
+ * separate from the tab strip means tab count cannot consume the only useful
+ * window-move affordance.
+ */
+export function WindowDragHandle() {
+  const t = useT();
+  const label = t("window.drag");
+
+  return (
+    <div
+      data-testid="window-drag-handle"
+      data-window-drag
+      title={label}
+      aria-label={label}
+      className="taomni-window-drag-handle h-full shrink-0 inline-flex items-center justify-center"
+    >
+      <GripHorizontal aria-hidden="true" className="w-4 h-4" />
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -824,6 +824,45 @@ select.taomni-input:not(.appearance-none):not([multiple]) {
   max-width: min(220px, 28vw);
 }
 
+/* Keep a visible, stable window-move target outside the scrollable tab strip. */
+.taomni-window-drag-handle {
+  width: 48px;
+  color: var(--taomni-text-muted);
+  cursor: grab;
+  border-left: 1px solid color-mix(in srgb, var(--taomni-divider) 55%, transparent);
+  border-right: 1px solid color-mix(in srgb, var(--taomni-divider) 55%, transparent);
+  transition: var(--taomni-transition);
+}
+.taomni-window-drag-handle:hover {
+  color: var(--taomni-text);
+  background: var(--taomni-hover);
+}
+.taomni-window-drag-handle:active {
+  cursor: grabbing;
+}
+
+/* The full tray is useful at normal widths; at the app's narrow-window range
+   its controls are available from the compact overflow menu instead. */
+.taomni-titlebar-actions-overflow {
+  display: none;
+}
+.taomni-titlebar-actions-menu {
+  max-height: calc(100vh - 12px);
+  overflow-y: auto;
+}
+
+@media (max-width: 960px) {
+  .taomni-titlebar-tray {
+    display: none;
+  }
+  .taomni-titlebar-actions-overflow {
+    display: flex;
+  }
+  .taomni-tab-details-button {
+    display: none;
+  }
+}
+
 /* Tab-action slot buttons (the ex-floating toolbar, now docked in the control
    bar / detached window bar) blend into the chrome; add the hover affordance
    their inline styles can't express. */

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -98,6 +98,7 @@ const dict = {
     minimize: "Minimize",
     maximize: "Maximize",
     close: "Close",
+    drag: "Drag window",
   },
   dbObjects: {
     copy: "Copy",
@@ -234,6 +235,7 @@ const dict = {
     disableSplit: "Disable terminal split view",
     enableMultiExec: "Enable MultiExec",
     disableMultiExec: "Disable MultiExec",
+    moreActions: "More window actions",
   },
   theme: {
     light: "Light",

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -97,6 +97,7 @@ export const zhCN: DeepPartial<typeof en> = {
     minimize: "最小化",
     maximize: "最大化",
     close: "关闭",
+    drag: "拖动窗口",
   },
   dbObjects: {
     copy: "复制",
@@ -233,6 +234,7 @@ export const zhCN: DeepPartial<typeof en> = {
     disableSplit: "关闭终端分屏视图",
     enableMultiExec: "启用多终端同步执行",
     disableMultiExec: "关闭多终端同步执行",
+    moreActions: "更多窗口操作",
   },
   theme: {
     light: "浅色",


### PR DESCRIPTION
Problem:
- The scrollable tab strip and titlebar actions consumed the practical window-drag area when the window was narrow and many tabs were open.

Implementation:
- Add a fixed 48px WindowDragHandle immediately after the app menu and before the tab strip.
- Route drag and double-click maximize gestures through the existing ControlBar window handler.
- Collapse split view, MultiExec, PTT, language, and theme actions into a portal-based More menu at widths <= 960px.
- Keep minimize, maximize, close, and active-tab contextual actions reachable at narrow widths.
- Add responsive styling and localized English and Simplified Chinese labels.
- Add unit coverage for drag/maximize behavior and wide/narrow tray rendering.
- Update the F1.3 feature controls, generated testid catalog, and TC-100 selector to cover the unified control bar and drag handle.

Verification:
- pnpm build
- pnpm exec vitest run src/components/tabbar/ControlBar.test.tsx --pool=threads --maxWorkers=1 --no-file-parallelism --reporter=verbose
- pnpm exec vitest run src/components/window/TitleBarTrayControls.test.tsx --pool=threads --maxWorkers=1 --no-file-parallelism --reporter=verbose
- PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto.audit --feature F1.3
- PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto.gen_testid_catalog --check
- Browser smoke checked 1280px and 800px layouts with zero console errors
- git diff --check