### PR TITLE
fix(backup): make scopeguard dependency cross-platform in Cargo.toml

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -207,6 +207,7 @@ xcap = { version = "0.9.6", optional = true }
 image = { version = "0.25", default-features = false, features = ["png"] }
 tauri-plugin-dialog = "2.7.1"
 sqlparser = "0.62.0"
+scopeguard = "1.2"
 
 [patch.crates-io]
 # libspa 0.9.2 assumes the latest spa_video_info_raw layout even though its
@@ -248,7 +249,6 @@ winreg = "0.55"
 # native frame pool and session. The capture module supplies a bounded native
 # GDI fallback when Graphics Capture is unavailable.
 xcap = { version = "0.9.6", features = ["wgc"] }
-scopeguard = "1.2"
 windows = { version = "0.62", features = [
   "Win32_Foundation",
   "Win32_Graphics_Gdi",


### PR DESCRIPTION
Problem:
When compiling on non-Windows platforms (e.g. Linux / macOS), `cargo check` and builds fail with:
  error[E0433]: cannot find module or crate `scopeguard` in this scope
   --> src/backup/engine.rs:111:26
    |
111 |     let _cleanup_guard = scopeguard::guard(temp_staging_dir.clone(), |dir| {
    |                          ^^^^^^^^^^ use of unresolved module or unlinked crate `scopeguard`

Root Cause:
`scopeguard = "1.2"` was previously declared only under `[target.'cfg(windows)'.dependencies]` in `src-tauri/Cargo.toml`. However, the backup engine (`src/backup/engine.rs`) uses `scopeguard::guard` in platform-agnostic code, causing compilation errors on Linux and macOS.

Solution:
- Move `scopeguard = "1.2"` from `[target.'cfg(windows)'.dependencies]` to the common `[dependencies]` section in `src-tauri/Cargo.toml`.

Verification:
- `cd src-tauri && cargo check`: passed cleanly without scopeguard resolution errors.