### PR TITLE
fix(backup): make restore confirmation dialog theme-opaque

### DIFF
--- a/src/components/settings/BackupSettingsPanel.test.tsx
+++ b/src/components/settings/BackupSettingsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BackupSettingsPanel } from "./BackupSettingsPanel";
 import { useBackupStore } from "../../stores/backupStore";
@@ -111,6 +111,17 @@ describe("BackupSettingsPanel", () => {
     expect(screen.getByText("2.00 MB")).toBeDefined();
     expect(screen.getByText("Restore")).toBeDefined();
     expect(screen.getByText("Delete")).toBeDefined();
+  });
+
+  it("renders the restore dialog on an opaque theme surface", () => {
+    render(<BackupSettingsPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+
+    const dialog = screen.getByTestId("backup-restore-dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveProperty("style.background", "var(--taomni-bg)");
+    expect(dialog).toHaveProperty("style.borderColor", "var(--taomni-card-border)");
   });
 
   it("renders manual backup controls with Backup Now and Export to... buttons without requiring vault password during creation", () => {

--- a/src/components/settings/BackupSettingsPanel.tsx
+++ b/src/components/settings/BackupSettingsPanel.tsx
@@ -625,53 +625,86 @@ export function BackupSettingsPanel() {
 
       {/* Restore Confirmation Modal */}
       {restoreModalOpen && (
-        <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center p-4">
-          <div className="bg-theme-surface border border-theme-border rounded-xl shadow-2xl max-w-md w-full p-5 space-y-4 text-theme-text">
-            <div className="flex items-center justify-between border-b border-theme-border pb-3">
-              <h3 className="font-semibold text-base flex items-center gap-2">
-                <ShieldCheck className="w-5 h-5 text-accent" />
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="backup-restore-dialog-title"
+            data-testid="backup-restore-dialog"
+            className="w-full max-w-md max-h-[calc(100vh-2rem)] overflow-y-auto rounded-xl border p-5 shadow-2xl space-y-4"
+            style={{
+              background: "var(--taomni-bg)",
+              borderColor: "var(--taomni-card-border)",
+              color: "var(--taomni-text)",
+            }}
+          >
+            <div
+              className="flex items-center justify-between border-b pb-3"
+              style={{ borderColor: "var(--taomni-divider)" }}
+            >
+              <h3 id="backup-restore-dialog-title" className="font-semibold text-base flex items-center gap-2">
+                <ShieldCheck className="w-5 h-5 text-[var(--taomni-accent)]" />
                 {t("backupSettings.restoreModalTitle")}
               </h3>
               <button
                 type="button"
                 onClick={() => setRestoreModalOpen(false)}
-                className="text-theme-muted hover:text-theme-text text-sm"
+                className="text-sm text-[var(--taomni-text-muted)] hover:text-[var(--taomni-text)]"
               >
                 ✕
               </button>
             </div>
 
-            <div className="p-3 bg-amber-500/10 border border-amber-500/30 rounded text-xs text-amber-600 dark:text-amber-400">
+            <div
+              className="rounded border p-3 text-xs"
+              style={{
+                background: "var(--taomni-warning-bg)",
+                borderColor: "var(--taomni-warning-border)",
+                color: "var(--taomni-warning-text)",
+              }}
+            >
               {t("backupSettings.restoreModalWarning")}
             </div>
 
             {inspecting ? (
-              <div className="py-8 flex flex-col items-center justify-center gap-2 text-xs text-theme-muted">
-                <Loader2 className="w-5 h-5 animate-spin text-accent" />
+              <div className="flex flex-col items-center justify-center gap-2 py-8 text-xs text-[var(--taomni-text-muted)]">
+                <Loader2 className="h-5 w-5 animate-spin text-[var(--taomni-accent)]" />
                 {t("backupSettings.inspecting")}
               </div>
             ) : manifest ? (
               <div className="space-y-3 text-xs">
-                <div className="grid grid-cols-2 gap-2 bg-theme-bg/60 p-3 rounded border border-theme-border">
+                <div
+                  className="grid grid-cols-2 gap-2 rounded border p-3"
+                  style={{
+                    background: "var(--taomni-card-bg)",
+                    borderColor: "var(--taomni-card-border)",
+                  }}
+                >
                   <div>
-                    <span className="text-theme-muted">{t("backupSettings.archiveVersion")}:</span>
+                    <span className="text-[var(--taomni-text-muted)]">{t("backupSettings.archiveVersion")}:</span>
                     <div className="font-medium font-mono">{manifest.appVersion}</div>
                   </div>
                   <div>
-                    <span className="text-theme-muted">{t("backupSettings.scopeLabel")}:</span>
+                    <span className="text-[var(--taomni-text-muted)]">{t("backupSettings.scopeLabel")}:</span>
                     <div className="font-medium capitalize">{manifest.backupScope}</div>
                   </div>
                   <div>
-                    <span className="text-theme-muted">{t("backupSettings.archiveDate")}:</span>
+                    <span className="text-[var(--taomni-text-muted)]">{t("backupSettings.archiveDate")}:</span>
                     <div className="font-mono">{new Date(manifest.createdAt).toLocaleString()}</div>
                   </div>
                   <div>
-                    <span className="text-theme-muted">{t("backupSettings.archiveFilesCount")}:</span>
+                    <span className="text-[var(--taomni-text-muted)]">{t("backupSettings.archiveFilesCount")}:</span>
                     <div className="font-mono">{manifest.files.length} 个文件</div>
                   </div>
                 </div>
 
-                <div className="max-h-36 overflow-y-auto space-y-1 p-2 bg-theme-bg/40 rounded border border-theme-border/40 font-mono text-[11px] text-theme-muted">
+                <div
+                  className="max-h-36 overflow-y-auto space-y-1 rounded border p-2 font-mono text-[11px] text-[var(--taomni-text-muted)]"
+                  style={{
+                    background: "var(--taomni-panel-bg)",
+                    borderColor: "var(--taomni-divider)",
+                  }}
+                >
                   {manifest.files.map((f) => (
                     <div key={f.path} className="flex justify-between">
                       <span className="truncate pr-2">{f.path}</span>
@@ -681,9 +714,12 @@ export function BackupSettingsPanel() {
                 </div>
 
                 {vaultState !== "empty" ? (
-                  <div className="space-y-1.5 pt-2 border-t border-theme-border/40">
-                    <label className="text-xs font-medium text-theme-muted flex items-center gap-1.5">
-                      <ShieldCheck className="w-3.5 h-3.5 text-accent" />
+                  <div
+                    className="space-y-1.5 border-t pt-2"
+                    style={{ borderColor: "var(--taomni-divider)" }}
+                  >
+                    <label className="flex items-center gap-1.5 text-xs font-medium text-[var(--taomni-text-muted)]">
+                      <ShieldCheck className="h-3.5 w-3.5 text-[var(--taomni-accent)]" />
                       <span>{t("backupSettings.restoreVaultPasswordLabel")}</span>
                       <span className="text-red-500">*</span>
                     </label>
@@ -695,21 +731,28 @@ export function BackupSettingsPanel() {
                         setInspectError(null);
                       }}
                       placeholder={t("backupSettings.restoreVaultPasswordPh")}
-                      className="w-full px-3 py-1.5 text-xs bg-theme-bg border border-theme-border rounded text-theme-text focus:border-accent outline-none"
+                      className="w-full rounded border px-3 py-1.5 text-xs text-[var(--taomni-text)] outline-none focus:border-[var(--taomni-accent)] placeholder:text-[var(--taomni-text-muted)]"
+                      style={{
+                        background: "var(--taomni-input-bg)",
+                        borderColor: "var(--taomni-input-border)",
+                      }}
                     />
-                    <p className="text-[11px] text-theme-muted">
+                    <p className="text-[11px] text-[var(--taomni-text-muted)]">
                       {t("backupSettings.restoreVaultPasswordHint")}
                     </p>
                   </div>
                 ) : (
-                  <div className="pt-2 border-t border-theme-border/40 text-[11px] text-theme-muted italic">
+                  <div
+                    className="border-t pt-2 text-[11px] italic text-[var(--taomni-text-muted)]"
+                    style={{ borderColor: "var(--taomni-divider)" }}
+                  >
                     {t("backupSettings.vaultEmptyNotice")}
                   </div>
                 )}
 
                 {inspectError && (
                   <div className="text-xs text-red-500 bg-red-500/10 p-2.5 rounded border border-red-500/20 flex items-center gap-2">
-                    <AlertTriangle className="w-4 h-4 flex-shrink-0" />
+                    <AlertTriangle className="h-4 w-4 flex-shrink-0" />
                     <span>{inspectError}</span>
                   </div>
                 )}
@@ -722,7 +765,7 @@ export function BackupSettingsPanel() {
                   </div>
                 )}
                 <div className="space-y-1.5">
-                  <label className="text-xs font-medium text-theme-muted">
+                  <label className="text-xs font-medium text-[var(--taomni-text-muted)]">
                     {t("backupSettings.inputPasswordForDecrypt")}
                   </label>
                   <input
@@ -730,12 +773,20 @@ export function BackupSettingsPanel() {
                     value={restorePassword}
                     onChange={(e) => setRestorePassword(e.target.value)}
                     placeholder="输入解密密码"
-                    className="w-full px-3 py-2 text-xs bg-theme-bg border border-theme-border rounded text-theme-text focus:border-accent outline-none"
+                    className="w-full rounded border px-3 py-2 text-xs text-[var(--taomni-text)] outline-none focus:border-[var(--taomni-accent)] placeholder:text-[var(--taomni-text-muted)]"
+                    style={{
+                      background: "var(--taomni-input-bg)",
+                      borderColor: "var(--taomni-input-border)",
+                    }}
                   />
                   <button
                     type="button"
                     onClick={handleRetryInspectWithPassword}
-                    className="w-full py-1.5 text-xs rounded bg-theme-surface border border-theme-border hover:border-accent text-theme-text mt-2 font-medium"
+                    className="mt-2 w-full rounded border py-1.5 text-xs font-medium text-[var(--taomni-text)] hover:border-[var(--taomni-accent)]"
+                    style={{
+                      background: "var(--taomni-card-bg)",
+                      borderColor: "var(--taomni-input-border)",
+                    }}
                   >
                     解锁并验证备份
                   </button>
@@ -744,18 +795,32 @@ export function BackupSettingsPanel() {
             )}
 
             {restoreStaged && (
-              <div className="p-3 bg-emerald-500/10 border border-emerald-500/30 rounded text-xs text-emerald-500 flex items-center gap-2">
-                <CheckCircle2 className="w-4 h-4 flex-shrink-0" />
+              <div
+                className="flex items-center gap-2 rounded border p-3 text-xs"
+                style={{
+                  background: "var(--taomni-success-bg)",
+                  borderColor: "var(--taomni-success-border)",
+                  color: "var(--taomni-success-text)",
+                }}
+              >
+                <CheckCircle2 className="h-4 w-4 flex-shrink-0" style={{ color: "var(--taomni-success-icon)" }} />
                 <span>{t("backupSettings.restoreStagedSuccess")}</span>
               </div>
             )}
 
-            <div className="flex justify-end gap-2 pt-2 border-t border-theme-border">
+            <div
+              className="flex justify-end gap-2 border-t pt-2"
+              style={{ borderColor: "var(--taomni-divider)" }}
+            >
               <button
                 type="button"
                 disabled={restoring}
                 onClick={() => setRestoreModalOpen(false)}
-                className="px-3 py-1.5 text-xs rounded bg-theme-bg border border-theme-border hover:bg-theme-surface text-theme-text"
+                className="rounded border px-3 py-1.5 text-xs text-[var(--taomni-text)] hover:bg-[var(--taomni-hover)]"
+                style={{
+                  background: "var(--taomni-card-bg)",
+                  borderColor: "var(--taomni-input-border)",
+                }}
               >
                 取消
               </button>
@@ -764,7 +829,7 @@ export function BackupSettingsPanel() {
                   type="button"
                   disabled={restoring || restoreStaged}
                   onClick={handleConfirmRestore}
-                  className="px-4 py-1.5 text-xs rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 font-medium flex items-center gap-1.5"
+                  className="flex items-center gap-1.5 rounded bg-red-600 px-4 py-1.5 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50"
                 >
                   {restoring ? (
                     <>


### PR DESCRIPTION
The backup restore confirmation modal used semantic utility class names that are not defined by the app theme, so its panel and nested controls rendered without reliable backgrounds and exposed the settings page underneath.

Use the established --taomni-* variables for the dialog surface, borders, cards, inputs, warning and success states, text, and accents. Keep the modal within the viewport and add dialog labeling plus a focused regression test for the opaque themed surface.

Validation: pnpm exec vitest run src/components/settings/BackupSettingsPanel.test.tsx; pnpm build; git diff --check.