### PR TITLE
feat(qa-ui-auto): add verification workflow, provenance tracking, and…

### DIFF
--- a/.agents/skills/qa-ui-auto/SKILL.md
+++ b/.agents/skills/qa-ui-auto/SKILL.md
@@ -1,117 +1,101 @@
 ---
 name: qa-ui-auto
-description: "Test Taomni UI workflows, audit coverage and change impact, maintain YAML cases and feature/control catalogs, or explore UI failures. Prefer real native Tauri testing with an isolated QA application identity; assess performance regressions and Linux, macOS, and Windows compatibility. Use for qa-ui-auto, UI smoke/regression testing, testcase YAML, and qa-ui-auto-tests maintenance."
+description: "Plan and run Taomni UI verification, inspect actual execution coverage, maintain YAML cases and feature/control catalogs, or investigate UI failures. Choose browser or isolated native tests by the affected behavior and report Windows, Linux and macOS evidence separately."
 ---
 
-# Taomni UI E2E
+# Taomni UI Verification
 
-Exercise observable user workflows and retain reproducible evidence. Application
-logic already has unit tests; prioritize the real Tauri app, Rust IPC, filesystem,
-clipboard, dialogs, keyboard/IME, and platform WebView. Browser tests provide
-quick diagnosis and supplementary renderer coverage.
+Exercise observable user workflows and retain reproducible evidence. Choose the
+cheapest layer that proves the requested behavior: browser for renderer behavior,
+unit/Rust integration tests for logic and services, selected native cases for IPC,
+disk, processes and OS boundaries. A native mode declaration is not proof of
+execution, platform compatibility or OS-level input.
 
-## Requirements
+## Essential Constraints
 
-- **Performance must not regress.** Compare affected paths before/after on the
-  same OS, hardware, build profile and dataset. Keep existing budgets and raw
-  evidence for latency (especially p95) and relevant resource usage. A reproducible
-  slowdown beyond established measurement noise is a regression even within an
-  absolute budget. Never relax budgets, discard slow samples or replace a baseline
-  merely to pass. Missing measurements are unverified, not a pass.
-- **Consider Linux, macOS and Windows.** Check WebView differences, Ctrl/Meta
-  shortcuts, IME, paths/case sensitivity, permissions, clipboard, dialogs and window
-  behavior where affected. Report each platform as native-tested, browser-only or
-  unverified, with a concrete reason. One OS or Chromium run cannot prove all three.
-- **Prefer native testing on a real target OS.** Add native coverage where the
-  driver and verbs support the workflow. Explain browser fallback when tooling or
-  a target machine is unavailable, retaining the native gap. macOS lacks Tauri
-  WebDriver support; use available OS automation or recorded manual native testing.
-  Unit tests and browser stubs cannot replace native integration evidence.
-- **Native tests must use an independent application ID.** Build with
-  `com.taomni.app.qa`, never launch the production `com.taomni.app` binary for QA.
-  Environment overrides or renaming an executable are insufficient. The QA build
-  helper records the ID and binary hash; the harness checks them before launch.
-  Also isolate data/config/cache and fixture workspaces. Never reset production
-  profiles, credentials, user files or system configuration. Read
+- Native runs use the independently built `com.taomni.app.qa` application and
+  isolated data/config/cache and fixture workspaces. Environment overrides or
+  renamed production binaries cannot establish the QA identity. Never reset
+  production profiles, credentials or personal projects. Read
   [native-testing.md](references/native-testing.md) before any native launch.
+- Native verification is needed for affected IPC, persistence, PTY/LSP processes,
+  clipboard, dialogs, shortcuts/IME, permissions and windows. A frontend change
+  can still affect these boundaries. Browser stubs cannot prove them.
+- Consider Windows/WebView2, Linux/WebKitGTK and macOS/WKWebView where affected.
+  Native on one OS or Chromium on three hosts cannot prove all three. macOS has
+  no Tauri WebDriver adapter; use available OS automation or recorded manual QA.
+  Keep missing targets and unsupported verbs explicit.
+- Measure performance when changes affect startup, input/rendering, large data,
+  search, transfers or background work. Compare matching baseline/candidate
+  conditions and retain raw samples, p95 and relevant resource measurements.
+  Never hide slow samples or relax budgets to pass. Without a matching baseline,
+  no-regression is unverified. Unrelated UI/metadata edits need no performance suite.
 
-## Minimal Workflow
+## Routine Work
 
-Choose the user's scope, then run or edit directly. Diagnostics are conditional;
-there is no required `audit -> fix -> lint -> dry-run -> run -> audit` chain.
-
-From the repository root, set the module path once:
+Set the module path from repository root:
 
 ```bash
 export PYTHONPATH=.agents/skills/qa-ui-auto/scripts
 # PowerShell: $env:PYTHONPATH = ".agents/skills/qa-ui-auto/scripts"
 ```
 
-Two routine entry points:
-
 ```bash
-python -m qa_ui_auto audit --diff          # health, gaps and change impact
-python -m qa_ui_auto run --filter TC-117   # selected cases, native by default
+python -m qa_ui_auto plan --diff HEAD --tag smoke
+python -m qa_ui_auto run --mode browser --filter TC-001
+python -m qa_ui_auto run --mode native --filter TC-NATIVE-CORE-001
+python -m qa_ui_auto status --feature F25.5
+python -m qa_ui_auto audit --gate
 ```
 
-`audit` accepts `--feature F.x`, `--diff REF`, `--gate`, and `--json`. It combines
-schema/feature lint, control coverage, orphan selectors, catalog freshness,
-optional diff impact and the CI baseline gate without editing files. Use it to
-choose affected cases, diagnose gaps or verify catalog changes. Fix correctness
-errors before coverage gaps. Its `fix ...` suggestions are optional context
-helpers, not mandatory stages or standalone shell commands.
+Choose the user's scope and run or edit directly; these commands are not a
+mandatory sequence. `plan` is read-only and recommends cases from changed YAML,
+feature owners and shared/unmapped code. `--tag smoke` limits scope; it is not
+full affected coverage. Inspect native gaps and unmapped files before execution.
 
-`run` accepts `--tag smoke,p0`, `--mode browser`, `--config PATH`, `--cases DIR`,
-`--workers N`, `--headed`, and `--dry-run`. It validates YAML itself; do not repeat
-lint and dry-run before each execution. Native runs are sequential; independent
-browser cases may use workers. Dry-run checks syntax/verbs and is never execution
-evidence. Direct module commands such as `qa_ui_auto.runner` keep their existing
-config-driven mode for CI compatibility; the new `run` entry defaults to native.
+`run` defaults to browser. The direct `qa_ui_auto.runner` remains config-driven;
+CI must select mode explicitly. `--workers N` reuses browser processes with fresh
+contexts; native cases are sequential. `--require-pass` fails selected skips.
+`--report-dir` separates release evidence; `--keep-runs 0` disables its rotation.
+Unknown/unavailable requested IDs fail before launch. `--dry-run` checks verbs
+and syntax only, emits no execution receipt, and never proves behavior.
 
-- **Execute:** read the selected cases/config, prepare only their dependencies,
-  run once and inspect the report. Secrets come from environment variables. Reuse
-  healthy local services; start scoped local test services when needed within the
-  request without an unnecessary approval round trip. Browser fallback needs
-  Vite (`pnpm dev`); SSH/SFTP bridge tests also require
-  `DEV_PROXY_ALLOW_PRIVATE=1 ALLOW_PRIVATE_TARGETS=1` on that server.
-- **Add or repair coverage:** read [authoring.md](references/authoring.md) and
-  relevant [verb-catalog.md](references/verb-catalog.md) entries. Edit related
-  cases/features/controls together and run affected cases. Regenerate the catalog
-  only if controls changed; audit once after the batch. Ratchet only verified
-  coverage improvements, never hide losses. Optional maintenance tools remain
-  available in the authoring reference.
-- **Explore:** drive the selected feature in native mode where possible, checking
-  observable postconditions, screenshots and console/backend errors. Browser
-  fallback uses available Playwright tools or
-  [playwright-cli.md](references/playwright-cli.md). Default bound: 10 minutes or
-  200 actions, whichever comes first; honor explicit user scope. Write repros,
-  anomalies, platform/mode and evidence paths to
-  `qa-ui-auto-report/exploratory-<timestamp>.md`. Add regression YAML when repair
-  or coverage work is requested; exploration alone does not require case edits.
+Prepare only selected dependencies and reuse healthy local services. Browser
+needs Vite (`pnpm dev`); SSH/SFTP bridges also require `DEV_PROXY_ALLOW_PRIVATE=1
+ALLOW_PRIVATE_TARGETS=1`. Start scoped local fixtures within the authorized task;
+use environment variables for secrets. Verify a reused server serves this checkout.
+Run affected failures again only after a concrete fix or diagnosed recovery.
+Keep the first failure. Broaden coverage for shared behavior or release scope.
 
-Select affected cases first, reuse builds only when source/configuration match,
-and use condition-based waits. Do not reduce assertions or coverage to save time.
-Rerun affected failures after a concrete fix or diagnosed environment recovery;
-preserve the first failure and avoid blind retries. Broaden to smoke/full coverage
-when shared behavior, release scope or remaining risk warrants it.
+For case/control changes, read [authoring.md](references/authoring.md) and the
+relevant [verb-catalog.md](references/verb-catalog.md) entries. Assert user results,
+including failure/recovery and disk postconditions where relevant. Update related
+cases/features/controls together; regenerate the catalog only when controls change.
+Audit after the batch; ratchet only reviewed and verified improvements.
+
+Exploration uses the layer appropriate to the feature, with observable outcomes,
+screenshots and console/backend errors. Default bound: 10 minutes or 200 actions;
+honor explicit scope. Write repros, anomalies, platform/mode and evidence paths to
+`qa-ui-auto-report/exploratory-<timestamp>.md`. Exploration alone requires no case
+edits. Browser tooling guidance: [playwright-cli.md](references/playwright-cli.md).
 
 ## Evidence And Completion
 
-The runner writes `qa-ui-auto-report/run-<timestamp>/summary.json`, `summary.md`,
-JUnit, case artifacts and execution receipts. `summary.json` is the result
-contract. A failed step stops that case; remaining cases continue. Exit codes:
-`0` no failed cases, `1` test failure, `2` setup/config error. Inspect skips and
-selected-case counts: exit 0 alone does not prove completion.
+`summary.json` is the runner contract: pass/fail/skip counts, selected IDs, source
+and case identities, platform/mode and phase/step durations. Exit codes are 0 for
+successful checks, 1 for failure (including required skips or changing inputs),
+2 for setup/configuration errors. Inspect skips and counts; exit 0 alone is not
+completion. Native failures capture the original session before cleanup; disclose
+missing artifacts when the driver cannot respond.
 
-Report scope, platform/mode, native QA app ID, pass/fail/skip counts, relevant
-performance comparison and unverified platforms/behaviors. Failures need the
-first failing step, available screenshot/log paths and repro. Native failure
-screenshots currently come from a fresh session; disclose that limitation.
-Retain required evidence before report rotation removes old runs.
+`audit --gate` checks static schema/catalog/coverage. `status` separately reports
+written, reviewed and actual passed/failed/skipped/stale/unverified executions.
+`status --gate` requires reviewed current passes in the selected scope.
+`audit --release-evidence` additionally validates the existing release manifest.
+Read [verification.md](references/verification.md) before interpreting release
+coverage, combining reports or claiming a performance improvement.
 
-Coverage gates prove selector/verb coverage, not visual fidelity, performance,
-accessibility or localization. Use targeted screenshots, geometry, keyboard/IME
-checks and measurements when relevant; describe their actual scope. There is no
-automatic universal visual/viewport/a11y/performance matrix. See
-[native-testing.md](references/native-testing.md) for isolation, platform setup
-and performance methods, including existing measurement-tool limitations.
+Report scope, platform/mode, QA app ID, pass/fail/skip counts, performance evidence
+when relevant and remaining gaps. Selector coverage does not prove visual fidelity,
+a11y, localization or performance. Use targeted geometry, screenshots and input
+checks where relevant. No universal visual/viewport/a11y matrix is implied.

--- a/.agents/skills/qa-ui-auto/assets/qa-ui-auto.config.example.yaml
+++ b/.agents/skills/qa-ui-auto/assets/qa-ui-auto.config.example.yaml
@@ -5,7 +5,7 @@
 
 app:
   base_url: http://localhost:5000   # Vite dev server in browser mode
-  mode: native                      # native preferred; browser for explicit fallback
+  mode: browser                     # daily renderer checks; select native for real OS/IPC boundaries
   # Build first: python .agents/skills/qa-ui-auto/scripts/native_build.py
   # native_binary: ./src-tauri/target/qa-ui-auto/debug/taomni.exe  # Windows; omit .exe on Linux
 

--- a/.agents/skills/qa-ui-auto/references/authoring.md
+++ b/.agents/skills/qa-ui-auto/references/authoring.md
@@ -10,16 +10,17 @@ information is missing. Apply requested changes directly and summarize the diff.
   Set `covers: [F.x]` and `fixtures` explicitly. Use `reset_db` for persistent
   mutations, plus required network/workspace/provider fixtures.
 - Assert the user's result after acting, including relevant failure/recovery
-  paths. Control touches alone do not prove workflows work. Prefer real native
-  boundaries over repeating store/unit assertions through JavaScript.
-- Set `modes` explicitly. Prefer `[native]` for supported real-app workflows;
+  paths. Control touches alone do not prove workflows work. Use browser for
+  renderer behavior and selected native cases for real OS/IPC boundaries.
+- Set `modes` explicitly. Use `[native]` for real-app boundary workflows;
   use `[browser, native]` when both implementations/fixtures support the assertions.
   Browser-specific stubs/verbs stay `[browser]`. Missing modes still default to
   browser for compatibility. Never mass-add native without checking verbs/fixtures.
 - Native is a mode, not an OS guarantee. Some verbs are Linux/X11-only; check
   [verb-catalog.md](verb-catalog.md) and `scripts/qa_ui_auto/native_steps.py`.
   Use platform runbooks for OS differences and disclose unsupported paths.
-  Do not invent YAML platform fields or substitute mocks for OS evidence.
+  `native_platforms: [Linux, Windows]` optionally restricts native execution;
+  it does not certify those platforms. Do not substitute mocks for OS evidence.
 - Each step is a single-key map using a schema-supported verb. `eval_readonly`
   is the only raw-JS escape hatch; never mutate state or bypass the real action.
 - Prefer exact `[data-testid="..."]` selectors from feature controls or

--- a/.agents/skills/qa-ui-auto/references/native-testing.md
+++ b/.agents/skills/qa-ui-auto/references/native-testing.md
@@ -11,7 +11,7 @@ From the repository root (with the module path set as in SKILL.md):
 
 ```bash
 python .agents/skills/qa-ui-auto/scripts/native_build.py
-python -m qa_ui_auto run --filter TC-117
+python -m qa_ui_auto run --mode native --filter TC-NATIVE-CORE-001
 ```
 
 The helper builds with the QA overlay in `src-tauri/target/qa-ui-auto` and writes
@@ -24,8 +24,10 @@ accidental profile reuse, not a signature against malicious substitutions.
 The default binary is `src-tauri/target/qa-ui-auto/debug/taomni` (`taomni.exe` on
 Windows). For release-profile measurements, build with `native_build.py --release`
 and set `app.native_binary` in a dedicated config to the resulting release binary.
-Keep its identity record adjacent. Reuse builds only when source/configuration
-match the task: the binary hash cannot establish that newer edits were rebuilt.
+Keep its identity record adjacent. The helper reuses builds when source, recipe,
+platform, compiler, Node and recorded environment match; `--force` rebuilds.
+The harness rejects a mismatching recorded source fingerprint. Legacy records
+without source fingerprints cannot establish current-source execution coverage.
 
 The harness redirects Linux XDG data/config/cache or Windows AppData/LocalAppData
 to this run, then restores its environment on exit. `reset_db` only clears QA
@@ -56,8 +58,9 @@ renderer evidence, not a native WKWebView/IPC test.
 
 Choose representative native workflows for each affected OS. When a host or
 dependency is unavailable, retain available evidence and label missing targets
-unverified with the remaining action. Do not invent YAML platform fields or
-count Linux-only verbs as Windows/macOS executions.
+unverified with the remaining action. Optional `native_platforms: [Linux, Windows]`
+restricts a case; it does not prove either platform was tested. Known Linux-only
+verbs are rejected before native launch on unsupported targets.
 
 ## Performance Must Not Regress
 
@@ -79,9 +82,10 @@ latency. Compare `native-editor-performance.json` before/after as well as checki
 the absolute budget. `assert_native_process_delta` detects Linux process leaks.
 
 `scripts/perf_baseline.py --base-url URL` remains a Chromium editor diagnostic.
-It excludes samples >=1000ms and returns 0 even over budget. Inspect counts and
-verdicts; its exit code or filtered p95 cannot prove native performance or no
-regression. Do not use those filtered measurements as the sole regression gate.
+It retains all measured samples, records explicit warmup separately and fails
+over budget. `--baseline PATH --noise-ms N` additionally compares matching
+conditions against unfiltered baseline samples. Without a baseline, regression
+comparison remains unverified. It cannot prove native performance.
 
 Functional success and performance success are separate. Reproducible slowdown
 beyond measured noise fails the requirement even within an absolute budget.

--- a/.agents/skills/qa-ui-auto/references/verb-catalog.md
+++ b/.agents/skills/qa-ui-auto/references/verb-catalog.md
@@ -47,7 +47,7 @@ Placeholders: `${cfg.x.y}` resolves from `qa-ui-auto.config.yaml`; `${env.X}` fr
 | `type` | string | Types into the focused element. Prefer `fill` for inputs. |
 | `send_keys` | string | Same as `type`; semantic for terminal-pane interaction. |
 | `compose_text` | `{selector, text, during_key?}` | Browser-only composition lifecycle; optionally dispatches one composing key before committing text. Never substitutes for native IME evidence. |
-| `native_keys` | `{selector, keys, focus_prechecked?}` | Native Linux/X11 only. Requires the selector to own focus, injects physical XTest keys or chords such as `Control+v` through GTK/WebKitGTK, and records transport metadata. `focus_prechecked: true` is limited to a testcase that asserted DOM focus immediately before an external fault made WebDriver commands unavailable; the verb still activates and identifies the Taomni X11 window. Testcase assertions own the postcondition. |
+| `native_keys` | `{selector, keys, transport?, focus_prechecked?}` | Requires the selector to own focus. Default `transport: x11` injects XTest keys through Linux/X11 and identifies the Taomni window. `transport: webdriver` uses W3C actions in the platform WebView (Windows/Linux), not OS-level input. Records transport and observed events. `focus_prechecked: true` is limited to a testcase that asserted focus immediately before a driver fault; it omits WebDriver probes/event collection and records that limitation. Testcase assertions own the postcondition. |
 | `native_ime_keys` | `{selector, expected_engine, keys}` | Native Linux/X11 only. Injects physical XTest keys through the named configured fcitx5 engine and records an observation artifact; testcase assertions must verify the committed result. |
 | `native_editor_performance` | `{selector, keys, max_p95_ms}` | Native packaged app only. Injects at least five ASCII keys through W3C WebDriver actions and records keydown-to-CodeMirror-DOM-mutation latency. The artifact also records the next animation frame as a diagnostic, but does not gate on it because a frame requested from CodeMirror's mutation observer is one frame later than the paint containing that mutation. Writes `native-editor-performance.json` and fails when p95 exceeds the supplied budget. |
 | `press` | key string **or** `{key, selector?}` | E.g. `Enter`, `Control+Shift+F`. |
@@ -61,7 +61,7 @@ Placeholders: `${cfg.x.y}` resolves from `qa-ui-auto.config.yaml`; `${env.X}` fr
 | `assert_visible` | selector | Up to 15s wait. |
 | `assert_not_visible` | selector | Up to 15s wait for hidden. |
 | `assert_text` | `{selector, contains, timeout_sec?}` | Polls `text_content` and `data-terminal-text` (xterm canvas fallback). |
-| `assert_pattern` | `{selector, regex, timeout_sec?}` | Python regex. |
+| `assert_pattern` | `{selector, regex, timeout_sec?}` | Browser and native; polls Python regex against element text (terminal buffer fallback for `terminal-pane`). Use anchored output assertions to distinguish shell output from command echo, and await shell readiness before typing. |
 | `assert_count` | `{selector, min?/max?/equal?}` | Pick at least one bound. |
 | `assert_url` | URL substring | |
 | `assert_menu_items` | `[label, label, ...]` | After `right_click`; checks each label visible inside `[data-testid="context-menu"]`. |

--- a/.agents/skills/qa-ui-auto/references/verification.md
+++ b/.agents/skills/qa-ui-auto/references/verification.md
@@ -1,0 +1,103 @@
+# Selection, Coverage And Runtime
+
+## Daily Work
+
+Use affected unit/component tests and browser cases for pure renderer changes.
+Add selected native cases when IPC payloads, persistence, processes, native APIs,
+WebView behavior or OS integration can change, including frontend callers.
+Run affected Rust integration tests for backend logic and local test services.
+
+`plan --diff REF` includes committed and local changes. Feature file ownership
+selects cases; shared/unmapped code broadens selection. Changed YAML is included.
+`--tag smoke` limits the scope before planning; omit it for full affected coverage.
+`--feature F.x` selects a feature. These are recommendations, not a dependency
+graph or proof that unmapped code is covered. Native-only cases remain in mapped
+feature plans even when shared cases run in browser.
+
+Use native runbooks for Windows/Linux. The macOS runbook builds only: execute and
+record actual WKWebView/OS scenarios separately. CI browser jobs explicitly select
+browser mode; running Chromium on three hosts is not native platform coverage.
+
+## What Was Actually Tested
+
+`status --json` reports all catalog features, including those with zero YAML
+cases. Each case records review state and browser/native execution cells.
+`needs-review` and `legacy-imported` require assertion review; removing a tag is
+not itself verification. Optional controls and selector touches are static
+inventory, independent of execution success.
+
+Status accepts runner summaries only with an execution marker and a matching
+receipt. Dry-runs, legacy reports lacking provenance and modified summaries are
+not current execution proof. Current means matching source, runner and case
+fingerprints with stable inputs during execution. Native additionally requires a
+QA ID and matching build-source fingerprint. A legacy QA binary may still run,
+but cannot establish current-source coverage until rebuilt.
+
+For each source/case/mode/OS, the latest current run wins, including failures and
+skips; an older pass must not conceal a newer failure. Browser results prove a
+Chromium workflow on the recorded host. Native cells distinguish all three OS
+targets; unsupported automation remains an explicit gap.
+
+Content identities include uncommitted and untracked non-ignored inputs, not
+only Git HEAD. Text LF/CRLF differences are normalized for cross-platform Git
+checkouts; binaries retain byte identities. Non-secret execution configuration
+is also bound. `status --config PATH` supplies expected conditions for imported
+reports; otherwise their recorded config path must still exist in this checkout.
+Secret values are not persisted or treated as scenario identity. Source identities
+conservatively cover repository production sources; unrelated
+production-source changes can make results stale. Keep identical source checkouts
+when merging platform reports. Local receipts provide provenance/integrity checks,
+not protection against an actor with repository write access. Verify a reused
+Vite server serves this checkout; its URL alone cannot prove that.
+
+## Release Review
+
+Use three independent results:
+
+- `audit --gate`: YAML/schema, catalog freshness and static coverage ratchet.
+- `status --gate --tag p0 --platform Windows,Linux`: reviewed current passing YAML
+  executions for the explicitly selected platforms. Remove `--tag` for all cases.
+  No selected cases fails. Skips, missing/stale evidence and review gaps fail;
+  no passing percentage can hide a required case.
+- `audit --release-evidence`: existing validated manual/native/performance release
+  manifest. This includes the static gate and does not turn manual entries into
+  automated YAML passes.
+
+Inspect status without a tag too: P0 classification does not guarantee that every
+product capability has a case. Agree release scope from affected and critical
+user workflows. Include failure/recovery and persistent postconditions; asserting
+that a control was clicked is insufficient.
+
+Combine platform artifacts with repeated `--reports <root-or-summary.json>`.
+Keep release reports outside rotating daily runs, e.g.
+`run --report-dir qa-ui-auto-report/release-<id> --keep-runs 0`. Retain the entire directory;
+summary.json without its receipt cannot establish execution. Neither Linux nor
+Windows nor browser WebKit substitutes for macOS native evidence.
+
+## Runtime And Performance
+
+Runner reports include per-step durations and setup/fixture/cleanup timings.
+Use those to distinguish slow automation from slow product behavior. Browser
+workers reuse processes with fresh contexts; native cases keep separate sessions
+and share only the batch driver. Native failures capture the original session.
+Successful browser traces are discarded; failure traces and requested screenshots
+are retained. Profile directories are excluded from receipt artifact hashing.
+
+`timeout_sec` is a monotonic execution budget checked around fixtures/steps and
+applied to Playwright waits, WebDriver requests and native polling sleeps. This
+is cooperative cancellation, not a hard process kill: an OS fixture, synchronous
+JavaScript or external helper may finish its bounded operation before control
+returns. Artifact collection and host-state cleanup have separate allowances.
+Do not use a hard kill that bypasses host permission/clipboard cleanup.
+
+`native_build.py` reuses a verified binary only when recorded source, recipe,
+platform, compiler, Node and relevant environment inputs match. `--force` rebuilds.
+Keep QA identity and storage isolation even during fast iteration.
+
+Measure application performance only for affected hot paths. Use matching
+hardware, OS/WebView, dataset and build profile with explicit warmup, raw samples
+and previously measured noise. `perf_baseline.py --baseline PATH --noise-ms N`
+compares the Chromium renderer proxy under matching conditions and fails on
+regression or absolute-budget violations. Without a baseline, only the absolute
+budget is checked; no-regression is unverified. Native release latency/resource
+measurements remain separate from browser and automation timings.

--- a/.agents/skills/qa-ui-auto/schema/testcase.schema.json
+++ b/.agents/skills/qa-ui-auto/schema/testcase.schema.json
@@ -73,6 +73,13 @@
    },
    "uniqueItems": true
   },
+  "native_platforms": {
+   "type": "array",
+   "items": {"enum": ["Linux", "Windows", "macOS"]},
+   "uniqueItems": true,
+   "minItems": 1,
+   "description": "Optional native platform restriction. Does not certify that a platform was tested."
+  },
   "timeout_sec": {
    "type": "integer",
    "minimum": 5,

--- a/.agents/skills/qa-ui-auto/scripts/evidence_validate.py
+++ b/.agents/skills/qa-ui-auto/scripts/evidence_validate.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 from enum import Enum
 from pathlib import Path
+import tempfile
 from typing import Any
 
 import jsonschema
@@ -162,19 +163,19 @@ def is_path_confined(art_path_str: str) -> bool:
         return False
     if "qa-ui-auto-report" in art_path_str:
         return False
-    if art_path_str.startswith("/"):
+    if Path(art_path_str).is_absolute():
         p = Path(art_path_str).resolve()
     else:
         p = (ROOT / art_path_str).resolve()
 
     try:
-        p.relative_to(ROOT)
+        p.relative_to(ROOT.resolve())
         return True
     except ValueError:
         pass
 
     try:
-        p.relative_to(Path("/tmp"))
+        p.relative_to(Path(tempfile.gettempdir()).resolve())
         return True
     except ValueError:
         return False

--- a/.agents/skills/qa-ui-auto/scripts/native_build.py
+++ b/.agents/skills/qa-ui-auto/scripts/native_build.py
@@ -11,6 +11,9 @@ from pathlib import Path
 import shutil
 import subprocess
 import sys
+import time
+
+from qa_ui_auto.provenance import fingerprint, source_identity
 
 ROOT = Path(__file__).resolve().parents[4]
 QA_APP_ID = "com.taomni.app.qa"
@@ -43,7 +46,22 @@ def verify_identity(binary: Path) -> dict:
     return record
 
 
-def build_qa(*, release: bool = False) -> Path:
+def build_inputs(*, release: bool = False) -> dict:
+    return {
+        "source_sha256": source_identity(ROOT),
+        "recipe_sha256": fingerprint(ROOT, [str(QA_CONFIG.relative_to(ROOT)).replace("\\", "/"),
+                                             ".agents/skills/qa-ui-auto/scripts/native_build.py"]),
+        "platform": platform.platform(),
+        "profile": "release" if release else "debug",
+        "rustc": subprocess.check_output(["rustc", "--version"], text=True).strip(),
+        "node": subprocess.check_output(["node", "--version"], text=True).strip(),
+        "environment": {key: os.environ.get(key) for key in (
+            "RUSTFLAGS", "CARGO_ENCODED_RUSTFLAGS", "CARGO_BUILD_TARGET", "RUSTUP_TOOLCHAIN",
+            "CC", "CXX", "CFLAGS", "CXXFLAGS", "VITE_DEV_PROXY", "TAURI_ENV_PLATFORM")},
+    }
+
+
+def build_qa(*, release: bool = False, force: bool = False) -> Path:
     overlay = json.loads(QA_CONFIG.read_text(encoding="utf-8"))
     if overlay.get("identifier") != QA_APP_ID or overlay.get("mainBinaryName") != "taomni":
         raise ValueError("QA overlay must declare the independent QA ID and taomni binary name")
@@ -54,6 +72,15 @@ def build_qa(*, release: bool = False) -> Path:
     name = "taomni.exe" if platform.system() == "Windows" else "taomni"
     binary = target / ("release" if release else "debug") / name
     record_path = identity_path(binary)
+    inputs = build_inputs(release=release)
+    if not force and binary.is_file():
+        try:
+            previous = verify_identity(binary)
+            if previous.get("build_inputs") == inputs:
+                print("qa-ui-auto: reusing verified QA build (source, recipe, toolchain and environment match)")
+                return binary
+        except ValueError:
+            pass
     # A failed rebuild must not leave an old record authorizing a stale binary.
     record_path.unlink(missing_ok=True)
     env = dict(os.environ)
@@ -62,13 +89,19 @@ def build_qa(*, release: bool = False) -> Path:
     command = [pnpm, "tauri", "build", "--no-bundle", "--config", str(QA_CONFIG)]
     if not release:
         command.append("--debug")
+    started = time.monotonic()
     subprocess.run(command, cwd=ROOT, env=env, check=True)
+    if inputs != build_inputs(release=release):
+        raise ValueError("Build inputs changed during compilation; rebuild before collecting evidence")
     record = {
         "identifier": QA_APP_ID,
         "binary_sha256": binary_digest(binary),
         "platform": platform.system(),
         "profile": "release" if release else "debug",
         "command": command,
+        "source_sha256": inputs["source_sha256"],
+        "build_inputs": inputs,
+        "build_duration_sec": time.monotonic() - started,
     }
     record_path.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
     return binary
@@ -77,9 +110,10 @@ def build_qa(*, release: bool = False) -> Path:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--release", action="store_true", help="use release profile for measurements")
+    parser.add_argument("--force", action="store_true", help="rebuild even when verified inputs match")
     args = parser.parse_args(argv)
     try:
-        binary = build_qa(release=args.release)
+        binary = build_qa(release=args.release, force=args.force)
     except (OSError, ValueError, subprocess.CalledProcessError) as exc:
         print(f"qa-ui-auto: QA build failed: {exc}", file=sys.stderr)
         return 2

--- a/.agents/skills/qa-ui-auto/scripts/perf_baseline.py
+++ b/.agents/skills/qa-ui-auto/scripts/perf_baseline.py
@@ -29,7 +29,9 @@ from __future__ import annotations
 
 import argparse
 import json
-import statistics
+import hashlib
+import math
+import platform
 import sys
 import time
 from pathlib import Path
@@ -69,14 +71,37 @@ def percentile(samples: list[float], pct: float) -> float:
 
 
 def summarize(samples: list[float]) -> dict:
-    warm = [s for s in samples if s < 1000]  # drop first-key JIT/compile outliers
     return {
-        "n": len(warm),
-        "p50_ms": percentile(warm, 50),
-        "p95_ms": percentile(warm, 95),
-        "max_ms": round(max(warm), 2) if warm else None,
-        "dropped_outliers_ge_1000ms": len(samples) - len(warm),
+        "n": len(samples),
+        "p50_ms": percentile(samples, 50) if samples else None,
+        "p95_ms": percentile(samples, 95) if samples else None,
+        "max_ms": round(max(samples), 2) if samples else None,
+        "samples_ms": samples,
+        "dropped_outliers_ge_1000ms": 0,
     }
+
+
+def assess(results: dict, baseline: dict | None = None, noise_ms: float = 0) -> tuple[int, list[str]]:
+    verdict = []
+    if baseline is not None and baseline.get("conditions") != results.get("conditions"):
+        return 2, ["baseline conditions differ; comparison unverified"]
+    failed = False
+    for name, budget in (("normal_input_key_to_paint", 50), ("local_action_toggle_comment", 100)):
+        metric = results[name]
+        value = metric.get("p95_ms")
+        if not metric.get("n") or value is None or not math.isfinite(value):
+            return 2, [f"{name}: missing valid measurements"]
+        over = value > budget
+        if baseline is not None:
+            old = baseline.get(name, {})
+            if not old.get("samples_ms") or old.get("dropped_outliers_ge_1000ms"):
+                return 2, [f"{name}: baseline lacks unfiltered raw samples"]
+            over = over or value > old["p95_ms"] + noise_ms
+        failed = failed or over
+        verdict.append(f"{name}: {'failed' if over else 'within measured limits'}")
+    if baseline is None:
+        verdict.append("regression comparison unverified: no baseline supplied")
+    return int(failed), verdict
 
 
 def main(argv=None) -> int:
@@ -84,7 +109,12 @@ def main(argv=None) -> int:
     ap.add_argument("--base-url", default="http://localhost:5001")
     ap.add_argument("--keystrokes", type=int, default=200)
     ap.add_argument("--headed", action="store_true")
+    ap.add_argument("--warmup", type=int, default=20)
+    ap.add_argument("--baseline", type=Path)
+    ap.add_argument("--noise-ms", type=float, default=0, help="previously measured noise allowance")
     args = ap.parse_args(argv)
+    if args.keystrokes < 20 or args.warmup < 0 or args.noise_ms < 0:
+        ap.error("keystrokes must be >=20; warmup and noise must be nonnegative")
 
     from playwright.sync_api import sync_playwright
 
@@ -116,7 +146,19 @@ def main(argv=None) -> int:
         # --- normal input key-to-paint -----------------------------------
         content = page.locator("[data-testid='code-workspace-editor'] .cm-content")
         content.click()
+        results["conditions"] = {
+            "os": platform.platform(), "machine": platform.node(), "processor": platform.processor(),
+            "browser": browser.version, "headless": not args.headed, "profile": "browser-dev",
+            "keystrokes": args.keystrokes, "warmup": args.warmup,
+            "dataset_sha256": hashlib.sha256(content.inner_text().encode()).hexdigest(),
+        }
+        from qa_ui_auto.provenance import source_identity
+        results["source_sha256"] = source_identity(ROOT)
         page.keyboard.press("Control+End")
+        page.keyboard.type("w" * args.warmup, delay=25)
+        page.wait_for_timeout(100)
+        results["warmup_samples_ms"] = page.evaluate("window.__perfKTP")
+        page.evaluate("window.__perfKTP = []")
         chunk = ""
         typed = 0
         while typed < args.keystrokes:
@@ -127,6 +169,7 @@ def main(argv=None) -> int:
             if len(chunk) >= 60:  # periodic newline keeps CM off one huge line
                 page.keyboard.press("Enter")
                 chunk = ""
+        page.wait_for_timeout(100)
         ktp_raw = page.evaluate("window.__perfKTP")
         results["normal_input_key_to_paint"] = summarize(ktp_raw)
         results["normal_input_key_to_paint"]["target_p95_ms"] = 50
@@ -170,15 +213,11 @@ def main(argv=None) -> int:
 
     ni = results["normal_input_key_to_paint"]
     la = results["local_action_toggle_comment"]
-    verdict = []
-    if ni["p95_ms"] <= 50:
-        verdict.append("key-to-paint WITHIN 50ms target")
-    else:
-        verdict.append("key-to-paint OVER 50ms target")
-    if la["p95_ms"] <= 100:
-        verdict.append("local action WITHIN 100ms target")
-    else:
-        verdict.append("local action OVER 100ms target")
+    baseline = json.loads(args.baseline.read_text(encoding="utf-8")) if args.baseline else None
+    exit_code, verdict = assess(results, baseline, args.noise_ms)
+    results["noise_ms"] = args.noise_ms
+    results["baseline"] = str(args.baseline) if args.baseline else None
+    results["exit_code"] = exit_code
     results["targets_verdict"] = verdict
 
     out_json.write_text(json.dumps(results, indent=1), encoding="utf-8")
@@ -188,7 +227,7 @@ def main(argv=None) -> int:
         "local_action": la,
         "verdict": verdict,
     }, indent=1))
-    return 0
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/__main__.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/__main__.py
@@ -8,7 +8,7 @@ import sys
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     parser = argparse.ArgumentParser(prog="qa_ui_auto", description=__doc__)
-    parser.add_argument("command", choices=["audit", "run"], help="run defaults to isolated native testing")
+    parser.add_argument("command", choices=["audit", "run", "plan", "status"], help="plan, execute, and inspect evidence")
     if not argv:
         parser.print_help()
         return 0
@@ -17,9 +17,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "audit":
         from .audit import main as audit_main
         return audit_main(flags)
+    if args.command in ("plan", "status"):
+        from .verification import main as verification_main
+        return verification_main([args.command, *flags])
     from .runner import main as runner_main
     if not any(flag == "--mode" or flag.startswith("--mode=") for flag in flags):
-        flags.extend(["--mode", "native"])
+        flags.extend(["--mode", "browser"])
     return runner_main(flags)
 
 

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/audit.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/audit.py
@@ -310,7 +310,7 @@ def _diff_section(
 # ---------------------------------------------------------------------------
 
 def _gate(
-    *, features_path: Path, cases_dir: Path, baseline_path: Path,
+    *, features_path: Path, cases_dir: Path, baseline_path: Path, release_evidence: bool = False,
 ) -> dict[str, Any]:
     """Compare current snapshot against baseline. Returns dict with regs/imps."""
     if not baseline_path.exists():
@@ -330,6 +330,12 @@ def _gate(
     snap = _build_snapshot(results, orphans)
     regressions, improvements = _render_gate_diff(baseline, snap)
     control_ok = not regressions
+    if not release_evidence:
+        return {"ok": control_ok, "control_ok": control_ok,
+                "evidence_gate": {"required": False, "reason": "use --release-evidence for release validation"},
+                "baseline_path": str(baseline_path), "baseline": baseline.get("totals", {}),
+                "current": snap.get("totals", {}), "regressions": regressions,
+                "improvements": improvements}
 
     evidence_gate: dict[str, Any] = {"ok": False, "reason": "not checked"}
     try:
@@ -467,6 +473,7 @@ def build_audit(
     baseline_path: Path | None = None,
     focus_feature: str | None = None,
     diff_base: str | None | object = None,   # None = skip; True/str = run
+    release_evidence: bool = False,
 ) -> AuditReport:
     rep = AuditReport()
     rep.health = _check_health(
@@ -493,6 +500,7 @@ def build_audit(
             features_path=features_path,
             cases_dir=cases_dir,
             baseline_path=baseline_path,
+            release_evidence=release_evidence,
         )
     return rep
 
@@ -640,7 +648,9 @@ def _render_gate(g: dict[str, Any]) -> list[str]:
         lines.append("  control-coverage-gate: OK — no regressions vs baseline")
 
     ev = g.get("evidence_gate", {})
-    if ev.get("ok"):
+    if ev.get("required") is False:
+        lines.append("  release-evidence-gate: not requested (use --release-evidence)")
+    elif ev.get("ok"):
         lines.append(f"  release-evidence-gate: OK — {ev.get('reason', 'valid current evidence')}")
     else:
         lines.append(f"  release-evidence-gate: FAILED — {ev.get('reason', 'evidence gate failed')}")
@@ -685,15 +695,17 @@ def main(argv: list[str] | None = None) -> int:
                     help="compare against a coverage baseline; exit 1 on "
                          "regression. Omit value to use default baseline path.")
     ap.add_argument("--json", action="store_true")
+    ap.add_argument("--release-evidence", action="store_true", help="also require the existing release evidence manifest")
     args = ap.parse_args(argv)
 
     rep = build_audit(
         features_path=Path(args.features),
         cases_dir=Path(args.cases),
         catalog_path=Path(args.catalog),
-        baseline_path=Path(args.gate) if args.gate else None,
+        baseline_path=Path(args.gate or DEFAULT_BASELINE) if args.gate or args.release_evidence else None,
         focus_feature=args.feature,
         diff_base=args.diff,
+        release_evidence=args.release_evidence,
     )
 
     if args.json:

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/deadline.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/deadline.py
@@ -1,0 +1,88 @@
+"""One monotonic execution budget; artifact collection has a separate budget."""
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+_active = ContextVar("qa_case_deadline", default=None)
+
+
+@contextmanager
+def using_deadline(deadline):
+    token = _active.set(deadline)
+    try:
+        yield
+    finally:
+        _active.reset(token)
+
+
+def remaining_timeout(default: float) -> float:
+    deadline = _active.get()
+    return min(default, deadline.remaining()) if deadline else default
+
+
+class _BudgetClock:
+    def __getattr__(self, name):
+        return getattr(time, name)
+
+    def sleep(self, seconds):
+        deadline = _active.get()
+        remaining = deadline.remaining() if deadline else seconds
+        time.sleep(min(seconds, remaining))
+        if deadline:
+            if seconds >= remaining:
+                raise CaseTimeout("case execution deadline exceeded")
+            deadline.remaining()
+
+
+budget_time = _BudgetClock()
+
+
+class CaseTimeout(TimeoutError):
+    pass
+
+
+class Deadline:
+    def __init__(self, seconds: float):
+        self.expires = time.monotonic() + seconds
+
+    def remaining(self) -> float:
+        remaining = self.expires - time.monotonic()
+        if remaining <= 0:
+            raise CaseTimeout("case execution deadline exceeded")
+        return remaining
+
+    def arguments(self, args):
+        if isinstance(args, dict):
+            args = dict(args)
+            args["timeout_sec"] = min(float(args.get("timeout_sec", 10)), self.remaining())
+        return args
+
+
+class BudgetedPage:
+    """Clamp explicit Playwright waits as well as defaults to the case budget."""
+    def __init__(self, target, deadline: Deadline):
+        self._target = target
+        self._deadline = deadline
+
+    def __getattr__(self, name):
+        target = getattr(self._target, name)
+        if not callable(target):
+            if hasattr(target, "_impl_obj"):
+                return BudgetedPage(target, self._deadline)
+            return target
+
+        def call(*args, **kwargs):
+            remaining = self._deadline.remaining()
+            if "timeout" in kwargs:
+                timeout = kwargs["timeout"]
+                kwargs["timeout"] = min(timeout or remaining * 1000, remaining * 1000)
+            if name == "wait_for_timeout":
+                args = (min(args[0], remaining * 1000), *args[1:])
+            result = target(*args, **kwargs)
+            self._deadline.remaining()
+            if hasattr(result, "_impl_obj"):
+                return BudgetedPage(result, self._deadline)
+            return result
+        return call

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/fixtures/java_sample_projects.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/fixtures/java_sample_projects.py
@@ -16,6 +16,7 @@ Exposes:
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 from typing import Any
 
 SAMPLES = {
@@ -42,5 +43,9 @@ def setup(ctx: Any) -> None:
                 f"java sample project missing: {root / marker} not found; "
                 "the in-repo __fixtures__/jdtls/projects tree must be checked out"
             )
-        # These paths are interpolated into JSON recents and CSS selectors.
-        values[key] = root.as_posix()
+        # Native create/rename/undo tests must not mutate the checkout's samples.
+        destination = Path(ctx.case_dir) / "fixture-workspaces" / key
+        if any(path.is_symlink() for path in root.rglob("*")):
+            raise FixtureSkip(f"sample contains symlinks; cannot isolate workspace: {root}")
+        shutil.copytree(root, destination, ignore=shutil.ignore_patterns("target", "build", ".gradle", ".git"))
+        values[key] = destination.resolve().as_posix()

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/native_steps.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/native_steps.py
@@ -35,7 +35,7 @@ import signal
 import stat
 import subprocess
 import sys
-import time
+from .deadline import budget_time as time, remaining_timeout
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, Callable
@@ -551,7 +551,7 @@ def _native_set_writable(ctx: NativeStepContext, args: Any) -> str:
 
 
 def _command_output(command: list[str]) -> str:
-    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    result = subprocess.run(command, capture_output=True, text=True, check=False, timeout=remaining_timeout(30))
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
         raise StepError(f"native_ime_keys: {' '.join(command)} failed: {detail}")
@@ -1209,6 +1209,21 @@ def _do_assert_text(ctx: NativeStepContext, args: Any) -> str:
     return _assert_text(ctx, args)
 
 
+@_verb("assert_pattern")
+def _do_assert_pattern(ctx: NativeStepContext, args: Any) -> str:
+    if not isinstance(args, dict) or "selector" not in args or "regex" not in args:
+        raise StepError("assert_pattern: expected {selector, regex, timeout_sec?}")
+    pattern = re.compile(args["regex"])
+    timeout = min(float(args.get("timeout_sec", 10)), remaining_timeout(float(args.get("timeout_sec", 10))))
+    expires = time.monotonic() + timeout
+    while time.monotonic() < expires:
+        text = ctx.session.text(args["selector"])
+        if pattern.search(text):
+            return f"pattern matched: {args['selector']}"
+        time.sleep(0.25)
+    raise StepError(f"assert_pattern failed: {args['selector']} did not match {args['regex']!r}")
+
+
 @_verb("eval_readonly")
 def _do_eval_readonly(ctx: NativeStepContext, args: Any) -> str:
     return _eval_readonly(ctx, args)
@@ -1277,15 +1292,16 @@ def _do_native_keys(ctx: NativeStepContext, args: Any) -> str:
             raise StepError(
                 f"native_keys: target must already have DOM focus before native injection: {selector}"
             )
-    ctx.session.execute(
-        "window.__QA_NATIVE_KEY_EVENTS__=[];"
-        "window.__QA_NATIVE_KEY_LISTENER__=(event)=>window.__QA_NATIVE_KEY_EVENTS__.push({"
-        "type:event.type,key:event.key,code:event.code,ctrlKey:event.ctrlKey,"
-        "altKey:event.altKey,shiftKey:event.shiftKey,metaKey:event.metaKey,"
-        "defaultPrevented:event.defaultPrevented});"
-        "window.addEventListener('keydown',window.__QA_NATIVE_KEY_LISTENER__,true);"
-        "window.addEventListener('keyup',window.__QA_NATIVE_KEY_LISTENER__,true);"
-    )
+    if not focus_prechecked:
+        ctx.session.execute(
+            "window.__QA_NATIVE_KEY_EVENTS__=[];"
+            "window.__QA_NATIVE_KEY_LISTENER__=(event)=>window.__QA_NATIVE_KEY_EVENTS__.push({"
+            "type:event.type,key:event.key,code:event.code,ctrlKey:event.ctrlKey,"
+            "altKey:event.altKey,shiftKey:event.shiftKey,metaKey:event.metaKey,"
+            "defaultPrevented:event.defaultPrevented});"
+            "window.addEventListener('keydown',window.__QA_NATIVE_KEY_LISTENER__,true);"
+            "window.addEventListener('keyup',window.__QA_NATIVE_KEY_LISTENER__,true);"
+        )
     time.sleep(0.25)
     window_id = None
     window_identity = None
@@ -1299,7 +1315,7 @@ def _do_native_keys(ctx: NativeStepContext, args: Any) -> str:
     else:
         raise StepError(f"native_keys: unsupported transport {transport!r}")
     time.sleep(0.5)
-    observed_events = ctx.session.execute(
+    observed_events = None if focus_prechecked else ctx.session.execute(
         "const events=window.__QA_NATIVE_KEY_EVENTS__ ?? [];"
         "window.removeEventListener('keydown',window.__QA_NATIVE_KEY_LISTENER__,true);"
         "window.removeEventListener('keyup',window.__QA_NATIVE_KEY_LISTENER__,true);"
@@ -1315,7 +1331,7 @@ def _do_native_keys(ctx: NativeStepContext, args: Any) -> str:
         "keys": keys,
         "observed_events": observed_events,
         "transport": (
-            "W3C WebDriver key actions -> GTK/WebKitGTK"
+            "W3C WebDriver key actions -> platform WebView"
             if transport == "webdriver"
             else "X11 XTest -> GTK/WebKitGTK"
         ),

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/provenance.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/provenance.py
@@ -1,0 +1,94 @@
+"""Content identities for execution freshness and QA build reuse."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+def digest_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def repository_files(root: Path) -> list[str]:
+    raw = subprocess.check_output(
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"], cwd=root,
+    )
+    return sorted(set(raw.decode("utf-8").split("\0")) - {""})
+
+
+def input_digest(path: Path) -> str:
+    """Canonical text identity across Git LF and Windows CRLF checkouts.
+
+    This intentionally reads the file on every call. Windows timestamp
+    granularity is not strong enough to safely cache same-size rewrites, and a
+    false fresh identity would invalidate the execution gate.
+    """
+    path = path.resolve()
+    if path.suffix.lower() in {".ts", ".tsx", ".rs", ".json", ".py", ".toml", ".yaml", ".yml",
+                               ".md", ".sh", ".ps1", ".html", ".css", ".js", ".mjs", ".cjs",
+                               ".lock", ".txt", ".svg"}:
+        return hashlib.sha256(path.read_bytes().replace(b"\r\n", b"\n")).hexdigest()
+    return digest_file(path)
+
+
+def source_input(name: str) -> bool:
+    return (name.startswith(("src/", "src-tauri/", "vite-plugins/", "scripts/", "public/", ".cargo/"))
+            and not name.startswith(("src-tauri/target/", "src-tauri/tests/"))) or (
+        name in {"package.json", "pnpm-lock.yaml", "vite.config.ts", "index.html", "rust-toolchain.toml", "rust-toolchain"}
+        or name.startswith("tsconfig")
+    )
+
+
+def fingerprint(root: Path, names: list[str]) -> str:
+    entries = []
+    for name in sorted(set(names)):
+        path = root / name
+        entries.append([name, input_digest(path) if path.is_file() else "deleted"])
+    return hashlib.sha256(json.dumps(entries, separators=(",", ":")).encode()).hexdigest()
+
+
+def source_identity(root: Path) -> str:
+    return fingerprint(root, [name for name in repository_files(root) if source_input(name)])
+
+
+def runner_identity(root: Path) -> str:
+    prefix = ".agents/skills/qa-ui-auto/"
+    return fingerprint(root, [name for name in repository_files(root)
+                             if name.startswith((prefix + "scripts/", prefix + "schema/"))])
+
+
+def execution_identity(root: Path) -> dict:
+    return {"source_sha256": source_identity(root), "runner_sha256": runner_identity(root)}
+
+
+def conditions_identity(cfg: dict, mode: str, env: dict | None = None) -> str:
+    """Bind non-secret execution conditions, excluding scheduling/output locations."""
+    environment = os.environ if env is None else env
+    sensitive = re.compile(r"password|passphrase|secret|token|credential|private.key", re.I)
+
+    def project(value):
+        if isinstance(value, dict):
+            return {key: "<secret>" if sensitive.search(key) else project(item)
+                    for key, item in value.items()}
+        if isinstance(value, list):
+            return [project(item) for item in value]
+        if isinstance(value, str):
+            def replace(match):
+                key = match.group(1)
+                return "<secret>" if sensitive.search(key) else environment.get(key, "<unset>")
+            return re.sub(r"\$\{env[.:]([A-Za-z0-9_]+)\}", replace, value)
+        return value
+
+    selected = {key: value for key, value in cfg.items() if key not in {"report", "worker", "webdriver", "app"}}
+    selected["app"] = {"mode": mode}
+    if mode == "browser":
+        selected["app"]["base_url"] = cfg.get("app", {}).get("base_url", "http://localhost:5000")
+    return hashlib.sha256(json.dumps(project(selected), sort_keys=True, separators=(",", ":")).encode()).hexdigest()

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/reporter.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/reporter.py
@@ -62,6 +62,10 @@ def write_markdown(report_root: Path, data: dict[str, Any]) -> Path:
     lines: list[str] = []
     lines.append(f"# qa-ui-auto run — {data.get('started_at', '?')}")
     lines.append("")
+    lines.append(f"Mode: {data.get('mode', '?')}; platform: {data.get('platform', '?')}; "
+                 f"execution: {'dry-run only' if data.get('dry_run') else 'actual run'}; "
+                 f"source stable: {data.get('identity_stable', 'unverified')}")
+    lines.append("")
     lines.append(
         f"**{totals.get('passed', 0)} passed, "
         f"{totals.get('failed', 0)} failed, "
@@ -82,6 +86,15 @@ def write_markdown(report_root: Path, data: dict[str, Any]) -> Path:
             f"| {c.get('duration_sec', 0):.1f}s | {notes} |"
         )
     failures = [c for c in cases if c["status"] == "failed"]
+    slow_steps = sorted(
+        [(c['id'], step) for c in cases for step in c.get('step_timings', [])],
+        key=lambda item: item[1]['duration_sec'], reverse=True,
+    )[:10]
+    if slow_steps:
+        lines.extend(["", "## Slowest Steps", "", "| Case | Step | Verb | Seconds |", "|---|---:|---|---:|"])
+        for case_id, step in slow_steps:
+            lines.append(f"| {case_id} | {step['index']} | {step['verb']} | {step['duration_sec']:.3f} |")
+        lines.extend(["", "These are automation timings, not application latency measurements."])
     if failures:
         lines.append("")
         lines.append("## Failures")

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/runner.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/runner.py
@@ -15,6 +15,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import atexit
 import json
 import multiprocessing as mp
 import os
@@ -36,6 +37,63 @@ from . import reporter
 from . import testcase as tc_mod
 from .fixtures import FixtureSkip, REGISTRY as FIXTURE_REGISTRY, get as get_fixture
 from .steps import REGISTRY as STEP_REGISTRY, StepContext, StepError
+from .deadline import BudgetedPage, Deadline, using_deadline
+from .provenance import input_digest, execution_identity, conditions_identity
+
+_browser = None
+_playwright = None
+
+
+def _close_browser() -> None:
+    global _browser, _playwright
+    if _browser is not None:
+        with suppress(Exception):
+            _browser.close()
+    if _playwright is not None:
+        with suppress(Exception):
+            _playwright.stop()
+    _browser = _playwright = None
+
+
+def _browser_context(headless: bool):
+    global _browser, _playwright
+    if _browser is None or not _browser.is_connected():
+        from playwright.sync_api import sync_playwright
+        _close_browser()
+        _playwright = sync_playwright().start()
+        _browser = _playwright.chromium.launch(headless=headless)
+    return _browser.new_context(viewport={"width": 1440, "height": 900})
+
+
+atexit.register(_close_browser)
+
+
+def _init_browser_worker() -> None:
+    from multiprocessing.util import Finalize
+    Finalize(None, _close_browser, exitpriority=10)
+
+
+def _timed_step(result: dict, index: int, verb: str, action, deadline=None) -> None:
+    started = time.monotonic()
+    try:
+        with using_deadline(deadline):
+            action()
+    finally:
+        result.setdefault("step_timings", []).append({
+            "index": index, "verb": verb, "duration_sec": time.monotonic() - started,
+        })
+
+
+def _run_browser_case(payload: dict) -> dict:
+    started = time.monotonic()
+    try:
+        return _run_browser_case_inner(payload)
+    except Exception as exc:
+        case = payload["case"]
+        return {"id": case["id"], "title": case["title"], "tags": case["tags"],
+                "covers": case["covers"], "modes": case["modes"], "status": "failed",
+                "duration_sec": time.monotonic() - started, "step_count": len(case["steps"]),
+                "failure": {"step_index": 0, "verb": "<setup>", "message": str(exc), "artifacts": {}}}
 
 
 # ─── per-case worker (browser) ──────────────────────────────────────────────
@@ -45,8 +103,8 @@ def _slugify_path_part(s: str) -> str:
     return "".join(c if c.isalnum() or c in "-_." else "_" for c in s)
 
 
-def _run_browser_case(payload: dict) -> dict:
-    """Worker entry. Spins up a fresh Chromium context for one test case."""
+def _run_browser_case_inner(payload: dict) -> dict:
+    """Fresh storage context per case, one browser process per worker."""
     case_dict = payload["case"]
     cfg = payload["cfg"]
     env = payload["env"]
@@ -78,8 +136,8 @@ def _run_browser_case(payload: dict) -> dict:
 
     started = time.time()
     base_url = cfg["app"]["base_url"]
-    user_data_dir = report_root / "_workdirs" / f"w{worker_id}-{case_dict['id']}"
-    user_data_dir.mkdir(parents=True, exist_ok=True)
+    deadline = Deadline(case_dict.get("timeout_sec", 90))
+    result["timings"] = {}
 
     if dry_run:
         # Validate verbs, args, and selector strings without launching the browser.
@@ -105,8 +163,6 @@ def _run_browser_case(payload: dict) -> dict:
             result["duration_sec"] = time.time() - started
             return result
 
-    from playwright.sync_api import sync_playwright  # local import to keep startup fast
-
     headless = bool(payload.get("headless", True))
     failure: dict[str, Any] | None = None
     last_step_index = 0
@@ -114,12 +170,10 @@ def _run_browser_case(payload: dict) -> dict:
     last_args: Any = None
     captured_console: list[dict[str, Any]] = []
 
-    with sync_playwright() as pw:
-        browser_ctx = pw.chromium.launch_persistent_context(
-            user_data_dir=str(user_data_dir),
-            headless=headless,
-            viewport={"width": 1440, "height": 900},
-        )
+    context_started = time.monotonic()
+    browser_ctx = _browser_context(headless)
+    result["timings"]["context_setup_sec"] = time.monotonic() - context_started
+    if browser_ctx:
         page = browser_ctx.pages[0] if browser_ctx.pages else browser_ctx.new_page()
         page.on("console", lambda msg: captured_console.append(  # noqa: SLF001
             {"level": msg.type, "text": msg.text}
@@ -135,25 +189,29 @@ def _run_browser_case(payload: dict) -> dict:
             pass
 
         ctx = StepContext(
-            page=page, case_id=case_dict["id"], case_dir=case_dir,
+            page=BudgetedPage(page, deadline), case_id=case_dict["id"], case_dir=case_dir,
             cfg=cfg, env=env, dry_run=False,
         )
 
         try:
+            fixture_started = time.monotonic()
             # Run fixtures (setup); a FixtureSkip turns into "skipped" status.
             for fname in case_dict.get("fixtures", []):
                 fix = get_fixture(fname)
                 try:
+                    deadline.remaining()
                     fix.setup(ctx)
+                    deadline.remaining()
                 except FixtureSkip as fs:
                     result["status"] = "skipped"
                     result["fixtures_skipped"] = f"{fname}: {fs}"
                     raise
+            result["timings"]["fixtures_sec"] = time.monotonic() - fixture_started
 
             # Auto-open base_url at step 0 if the first step isn't `open`.
             first_verb, _ = tc_mod.step_verb_and_args(case_dict["steps"][0])
             if first_verb not in ("open", "goto"):
-                page.goto(base_url, wait_until="domcontentloaded")
+                ctx.page.goto(base_url, wait_until="domcontentloaded", timeout=deadline.remaining() * 1000)
 
             for i, step in enumerate(case_dict["steps"], start=1):
                 ctx.step_index = i
@@ -164,7 +222,10 @@ def _run_browser_case(payload: dict) -> dict:
                 last_args = args
                 if verb not in STEP_REGISTRY:
                     raise StepError(f"unknown verb: {verb}")
-                STEP_REGISTRY[verb](ctx, args)
+                page.set_default_timeout(min(30000, deadline.remaining() * 1000))
+                page.set_default_navigation_timeout(min(30000, deadline.remaining() * 1000))
+                _timed_step(result, i, verb, lambda: STEP_REGISTRY[verb](ctx, args), deadline)
+                deadline.remaining()
 
         except FixtureSkip:
             pass  # handled above
@@ -184,9 +245,10 @@ def _run_browser_case(payload: dict) -> dict:
             result["status"] = "failed"
             result["failure"] = failure
         finally:
+            cleanup_started = time.monotonic()
             try:
                 trace_path = case_dir / "trace.zip"
-                browser_ctx.tracing.stop(path=str(trace_path))
+                browser_ctx.tracing.stop(**({"path": str(trace_path)} if failure is not None else {}))
                 if failure is not None:
                     failure.setdefault("artifacts", {})["trace"] = str(
                         trace_path.relative_to(report_root)
@@ -195,6 +257,7 @@ def _run_browser_case(payload: dict) -> dict:
                 pass
             with suppress(Exception):
                 browser_ctx.close()
+            result["timings"]["cleanup_sec"] = time.monotonic() - cleanup_started
 
     result["duration_sec"] = time.time() - started
     return result
@@ -216,7 +279,7 @@ def _capture_failure(
 
     try:
         png = case_dir / f"{base}.png"
-        page.screenshot(path=str(png), full_page=False)
+        page.screenshot(path=str(png), full_page=False, timeout=3000)
         artifacts["screenshot"] = png.name
     except Exception:  # noqa: BLE001
         pass
@@ -324,6 +387,13 @@ def _native_run(cases: list[tc_mod.TestCase], cfg: dict, env: dict, report_root:
                 "duration_sec": 0.0, "step_count": len(c.steps),
                 "worker_id": 0, "failure": None, "fixtures_skipped": None,
             }
+            r["timings"] = {}
+            deadline = Deadline(c.timeout_sec)
+            if c.skip:
+                r.update(status="skipped", fixtures_skipped=c.skip)
+                results.append(r)
+                continue
+            failure_artifacts: dict = {}
             fixture_values: dict[str, str] = {}
             last_step, last_verb, last_args = 0, "<setup>", None
             ctx_ns = SimpleNamespace(
@@ -332,17 +402,24 @@ def _native_run(cases: list[tc_mod.TestCase], cfg: dict, env: dict, report_root:
                 values=fixture_values, step_index=0,
             )
             try:
+                fixture_started = time.monotonic()
                 # Fixtures first — a FixtureSkip turns into "skipped".
                 for fname in c.fixtures:
                     fix = get_fixture(fname)
                     try:
+                        deadline.remaining()
                         fix.setup(ctx_ns)
+                        deadline.remaining()
                     except FixtureSkip as fs:
                         r["status"] = "skipped"
                         r["fixtures_skipped"] = f"{fname}: {fs}"
                         break
                 else:
+                    r["timings"]["fixtures_sec"] = time.monotonic() - fixture_started
+                    session_started = time.monotonic()
+                    harness.deadline = deadline
                     session = harness.create_session()
+                    r["timings"]["session_setup_sec"] = time.monotonic() - session_started
                     nctx: NativeStepContext | None = None
                     try:
                         nctx = NativeStepContext(session, case_dir, cfg)
@@ -355,8 +432,18 @@ def _native_run(cases: list[tc_mod.TestCase], cfg: dict, env: dict, report_root:
                                 raw_args, cfg=cfg, env=env, fixture=fixture_values
                             )
                             nctx.case_dir.mkdir(parents=True, exist_ok=True)
-                            run_native_step(nctx, verb, args)
+                            deadline.remaining()
+                            _timed_step(r, i, verb, lambda: run_native_step(nctx, verb, args), deadline)
+                            deadline.remaining()
+                    except Exception:
+                        session.deadline = Deadline(5)
+                        capture_started = time.monotonic()
+                        failure_artifacts = _capture_native_failure(session, case_dir)
+                        r["timings"]["failure_capture_sec"] = time.monotonic() - capture_started
+                        raise
                     finally:
+                        cleanup_started = time.monotonic()
+                        session.deadline = Deadline(5)
                         if nctx is not None:
                             nctx.restore_host_permissions()
                         console = []
@@ -368,6 +455,7 @@ def _native_run(cases: list[tc_mod.TestCase], cfg: dict, env: dict, report_root:
                         )
                         with suppress(Exception):
                             session.close()
+                        r["timings"]["cleanup_sec"] = time.monotonic() - cleanup_started
             except WebDriverError as e:
                 r["status"] = "failed"
                 r["failure"] = {
@@ -394,37 +482,35 @@ def _native_run(cases: list[tc_mod.TestCase], cfg: dict, env: dict, report_root:
                     "artifacts": {},
                 }
             if r["status"] == "failed":
-                _capture_native_failure(harness, c, case_dir, r)
+                r["failure"]["artifacts"] = failure_artifacts
             r["duration_sec"] = time.time() - started
             results.append(r)
     return results
 
 
-def _capture_native_failure(harness: Any, case: tc_mod.TestCase,
-                            case_dir: Path, result: dict) -> None:
-    """Best-effort failure artifacts: fresh-session screenshot of the app."""
+def _capture_native_failure(session: Any, case_dir: Path) -> dict:
+    """Capture the failing session before cleanup changes its state."""
     artifacts: dict[str, str] = {}
     try:
-        session = harness.create_session()
-        try:
-            shot = case_dir / "failure-native.png"
-            session.screenshot(shot)
-            artifacts["screenshot"] = str(shot)
-            entries = session.console_entries()
-            (case_dir / "console-failure.json").write_text(
-                json.dumps(entries[-300:], ensure_ascii=False, indent=1),
-                encoding="utf-8",
-            )
-            artifacts["console"] = str(case_dir / "console-failure.json")
-        finally:
-            with suppress(Exception):
-                session.close()
+        shot = case_dir / "failure-native.png"
+        session.screenshot(shot)
+        artifacts["screenshot"] = str(shot)
     except Exception:  # noqa: BLE001
         pass
-    result["failure"]["artifacts"] = artifacts  # type: ignore[index]
+    with suppress(Exception):
+        html = case_dir / "failure-native.html"
+        html.write_text(str(session.execute("return document.documentElement.outerHTML")), encoding="utf-8")
+        artifacts["html"] = str(html)
+    with suppress(Exception):
+        log = case_dir / "console-failure.json"
+        log.write_text(json.dumps(session.console_entries()[-300:], ensure_ascii=False), encoding="utf-8")
+        artifacts["console"] = str(log)
+    return artifacts
 
 
 def _rotate_runs(report_dir: Path, keep: int) -> None:
+    if keep <= 0:
+        return
     runs = sorted(
         [p for p in report_dir.glob("run-*") if p.is_dir()],
         key=lambda p: p.name,
@@ -451,6 +537,9 @@ def main(argv: list[str] | None = None) -> int:
                     help="validate verbs/selectors without launching browser")
     ap.add_argument("--headed", action="store_true",
                     help="show the browser (default headless)")
+    ap.add_argument("--report-dir", help="isolated output directory")
+    ap.add_argument("--keep-runs", type=int, help="retained runs in output directory; 0 disables rotation")
+    ap.add_argument("--require-pass", action="store_true", help="fail if any selected case skips")
     args = ap.parse_args(argv)
 
     try:
@@ -487,15 +576,29 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+    if mode == "native":
+        from .verification import host_platform, native_support
+        unsupported = {c.id: reason for c in selected if (reason := native_support(c, host_platform()))}
+        if unsupported:
+            print(f"qa-ui-auto: unsupported native scope: {unsupported}", file=sys.stderr)
+            return 2
 
-    report_dir = Path(cfg.get("report", {}).get("dir", "qa-ui-auto-report"))
-    run_id = time.strftime("run-%Y%m%d-%H%M%S")
+    requested_ids = set(args.filter.split(",")) if args.filter else set()
+    missing_ids = requested_ids - {c.id for c in selected}
+    if missing_ids:
+        print(f"qa-ui-auto: requested cases unavailable in {mode}: {sorted(missing_ids)}", file=sys.stderr)
+        return 2
+
+    report_dir = Path(args.report_dir or cfg.get("report", {}).get("dir", "qa-ui-auto-report"))
+    run_id = time.strftime("run-%Y%m%d-%H%M%S") + f"-{time.time_ns() % 1000000000:09d}"
     report_root = report_dir / run_id
     report_root.mkdir(parents=True, exist_ok=True)
 
     started_iso = reporter.now_iso()
     started = time.time()
     env = dict(os.environ)
+    identity = execution_identity(Path.cwd())
+    case_digests = {c.id: input_digest(c.source_path) for c in selected if c.source_path}
 
     print(
         f"qa-ui-auto: mode={mode} workers={workers} cases={len(selected)} "
@@ -526,15 +629,24 @@ def main(argv: list[str] | None = None) -> int:
             for p in payloads:
                 results.append(_run_browser_case(p))
                 _print_case_line(results[-1])
+            _close_browser()
         else:
             ctx = mp.get_context("spawn")
-            with ctx.Pool(workers) as pool:
+            with ctx.Pool(workers, initializer=_init_browser_worker) as pool:
                 for r in pool.imap_unordered(_run_browser_case, payloads):
                     results.append(r)
                     _print_case_line(r)
+                pool.close()
+                pool.join()
 
     duration = time.time() - started
     results.sort(key=lambda r: r["id"])
+    for result in results:
+        result["case_sha256"] = case_digests.get(result["id"])
+    identity_stable = identity == execution_identity(Path.cwd())
+    identity_stable = identity_stable and all(
+        c.source_path and c.source_path.exists() and input_digest(c.source_path) == case_digests[c.id]
+        for c in selected)
 
     summary = {
         "started_at": started_iso,
@@ -543,6 +655,13 @@ def main(argv: list[str] | None = None) -> int:
         "mode": mode,
         "platform": platform.system(),
         "workers": workers,
+        "dry_run": args.dry_run,
+        "identity": identity,
+        "identity_stable": identity_stable,
+        "conditions_sha256": conditions_identity(cfg, mode, env),
+        "config_path": Path(args.config).as_posix(),
+        "selection": {"requested": sorted(requested_ids), "selected": [c.id for c in selected],
+                      "not_selected": [c.id for c in cases if c not in selected]},
         "totals": {
             "total": len(results),
             "passed": sum(1 for r in results if r["status"] == "passed"),
@@ -551,6 +670,13 @@ def main(argv: list[str] | None = None) -> int:
         },
         "cases": results,
     }
+    if mode == "native":
+        isolation_path = report_root / "native-isolation.json"
+        if isolation_path.exists():
+            summary["native_identity"] = json.loads(isolation_path.read_text(encoding="utf-8"))
+    exit_code = 1 if (summary["totals"]["failed"] or not identity_stable
+                      or (args.require_pass and summary["totals"]["skipped"])) else 0
+    summary["exit_code"] = exit_code
     reporter.write_summary(report_root, summary)
     md = reporter.write_markdown(report_root, summary)
     reporter.write_junit(report_root, summary)
@@ -559,6 +685,9 @@ def main(argv: list[str] | None = None) -> int:
     # ED-REL-001: emit runner-owned execution receipt
     from .runner_receipt import emit_runner_receipt
     try:
+        if args.dry_run:
+            print("qa-ui-auto: dry-run has no execution receipt")
+            return exit_code
         receipt_path = emit_runner_receipt(
             report_root=report_root,
             mode=mode,
@@ -566,16 +695,16 @@ def main(argv: list[str] | None = None) -> int:
             started_at=started_iso,
             finished_at=reporter.now_iso(),
             duration_sec=duration,
-            exit_code=0 if summary["totals"]["failed"] == 0 else 1,
+            exit_code=exit_code,
         )
         print(f"qa-ui-auto: runner receipt emitted: {receipt_path.name}")
     except Exception as e:
         print(f"qa-ui-auto: warning: failed to emit runner receipt: {e}", file=sys.stderr)
 
-    keep = int(cfg.get("report", {}).get("keep_runs", 5))
+    keep = args.keep_runs if args.keep_runs is not None else int(cfg.get("report", {}).get("keep_runs", 5))
     _rotate_runs(report_dir, keep)
 
-    return 0 if summary["totals"]["failed"] == 0 else 1
+    return exit_code
 
 
 def _print_case_line(r: dict) -> None:

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/runner_receipt.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/runner_receipt.py
@@ -242,6 +242,10 @@ def collect_report_artifacts(report_root: Path) -> list[dict[str, Any]]:
         return artifacts
 
     for p in sorted(report_root.rglob("*")):
+        if set(p.relative_to(report_root).parts).intersection({
+            "_workdirs", "native-appdata", "native-appconfig", "native-appcache",
+        }):
+            continue
         if p.is_file() and p.name != "runner_receipt.json":
             rel = str(p.relative_to(report_root))
             raw = p.read_bytes()

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/steps/assertions.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/steps/assertions.py
@@ -31,7 +31,7 @@ def _wait_for_match(ctx: StepContext, predicate, timeout: float, fail: str) -> N
         "() => true", timeout=100,
     ) if False else None  # noqa: F841 (keep import surface aligned)
     # Use polling expect via a manual loop; keeps logic explicit.
-    import time
+    from ..deadline import budget_time as time
     deadline = time.time() + timeout
     last_err: Exception | None = None
     while time.time() < deadline:
@@ -118,8 +118,15 @@ def step_assert_pattern(ctx: StepContext, args: Any) -> None:
         try:
             text = loc.text_content() or ""
         except Exception:
+            text = ""
+        if pattern.search(text):
+            return True
+        # xterm.js renders to canvas; the app mirrors its buffer here for QA reads.
+        try:
+            attr = loc.get_attribute("data-terminal-text") or ""
+            return bool(pattern.search(attr))
+        except Exception:
             return False
-        return bool(pattern.search(text))
 
     _wait_for_match(ctx, _check, timeout, fail=f"{selector} text does not match {args['regex']!r}")
 

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/testcase.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/testcase.py
@@ -27,6 +27,7 @@ class TestCase:
     covers: list[str] = field(default_factory=list)
     tags: list[str] = field(default_factory=list)
     modes: list[str] = field(default_factory=lambda: ["browser"])
+    native_platforms: list[str] = field(default_factory=list)
     fixtures: list[str] = field(default_factory=list)
     timeout_sec: int = 90
     skip: str | None = None
@@ -80,6 +81,7 @@ def load_case(path: Path) -> TestCase:
         covers=list(raw.get("covers", [])),
         tags=list(raw.get("tags", [])),
         modes=list(raw["modes"]),
+        native_platforms=list(raw.get("native_platforms", [])),
         fixtures=list(raw.get("fixtures", [])),
         timeout_sec=int(raw["timeout_sec"]),
         skip=raw.get("skip"),

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/verification.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/verification.py
@@ -1,0 +1,250 @@
+"""Risk-based selection and observed execution coverage, separate from selector coverage."""
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import subprocess
+from collections import Counter
+from pathlib import Path
+
+from .feature_catalog import load_features
+from .provenance import digest_file, input_digest, execution_identity, source_input, conditions_identity
+from .testcase import TestCase, discover
+
+PLATFORMS = ("Linux", "Windows", "macOS")
+LINUX_VERBS = {"native_set_writable", "assert_native_process_delta", "native_process_snapshot",
+               "native_click", "native_pointer_drag", "native_ime_keys", "native_clipboard_owner",
+               "assert_system_clipboard"}
+REVIEW_TAGS = {"needs-review", "legacy-imported"}
+
+
+def host_platform() -> str:
+    return "macOS" if platform.system() == "Darwin" else platform.system()
+
+
+def native_support(case: TestCase, target: str) -> str | None:
+    from .native_steps import VERBS
+    if target == "macOS":
+        return "Tauri WebDriver unavailable; collect native OS/manual evidence using the macOS runbook"
+    if case.native_platforms and target not in case.native_platforms:
+        return f"case declares native platforms {case.native_platforms}"
+    for step in case.steps:
+        verb, args = next(iter(step.items()))
+        if verb not in VERBS:
+            return f"native runner does not support verb {verb}"
+        linux_only = verb in LINUX_VERBS or (verb == "native_keys" and isinstance(args, dict)
+                                             and args.get("transport", "x11") == "x11")
+        if linux_only and target != "Linux":
+            return f"{verb} requires Linux/X11"
+    return None
+
+
+def changed_files(root: Path, base: str) -> list[str]:
+    names = set()
+    # Include committed, staged, unstaged and untracked changes. Invalid refs fail closed.
+    for command in (["git", "diff", "--name-only", "-z", f"{base}...HEAD"],
+                    ["git", "diff", "--name-only", "-z", "HEAD"],
+                    ["git", "ls-files", "--others", "--exclude-standard", "-z"]):
+        names.update(subprocess.check_output(command, cwd=root).decode("utf-8").split("\0"))
+    return sorted(names - {""})
+
+
+def plan(cases: list[TestCase], features, changes: list[str] | None, target: str) -> dict:
+    from .diff_impact import _file_matches
+    affected = set()
+    unmapped = []
+    for name in changes or []:
+        owners = {f.id for f in features if any(_file_matches(path, name) for path in f.files)}
+        affected.update(owners)
+        if source_input(name) and not owners:
+            unmapped.append(name)
+    shared = any(name.startswith(("src-tauri/", "src/lib/", "src/stores/", "src/hooks/",
+                                 ".agents/skills/qa-ui-auto/")) or name in {
+                                     "package.json", "pnpm-lock.yaml", "vite.config.ts"}
+                 for name in changes or [])
+    broad = changes is None or shared or bool(unmapped)
+    selected = [c for c in cases if broad or affected.intersection(c.covers)
+                or (c.source_path and c.source_path.as_posix() in (changes or []))]
+    commands = []
+    gaps = []
+    for mode in ("browser", "native"):
+        eligible = [c for c in selected if mode in c.modes]
+        # A mapped renderer edit uses browser for shared cases, but retains native-only boundaries.
+        if mode == "native" and not broad:
+            eligible = [c for c in eligible if "browser" not in c.modes or (
+                c.source_path and c.source_path.as_posix() in (changes or []))]
+        runnable = []
+        for case in eligible:
+            reason = native_support(case, target) if mode == "native" else None
+            if reason:
+                gaps.append({"case": case.id, "mode": mode, "platform": target, "reason": reason})
+            else:
+                runnable.append(case.id)
+        if runnable:
+            commands.append({"mode": mode, "cases": runnable,
+                             "argv": ["python", "-m", "qa_ui_auto", "run", "--mode", mode,
+                                      "--filter", ",".join(runnable)]})
+    return {"schema": "qa-ui-auto.plan.v1", "platform": target, "changed_files": changes,
+            "affected_features": sorted(affected), "unmapped_source_files": unmapped,
+            "selection_reason": "shared/unmapped changes: broaden selected scope" if broad else "mapped feature changes",
+            "commands": commands, "native_gaps": gaps,
+            "performance": "assess changed hot paths; functional timings are not product performance measurements",
+            "backend_tests": "run affected Rust unit/integration tests" if any(
+                n.startswith("src-tauri/") for n in changes or []) else None}
+
+
+def load_observations(report_dirs: list[Path], identity: dict, config: dict | None = None) -> tuple[dict, list[dict]]:
+    observations = {}
+    rejected = []
+    for root in report_dirs:
+        paths = [root] if root.is_file() else sorted(root.glob("run-*/summary.json"))
+        for path in paths:
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                if data.get("dry_run") is not False:
+                    raise ValueError("dry-run or legacy report without execution marker")
+                receipt = json.loads((path.parent / "runner_receipt.json").read_text(encoding="utf-8"))
+                from .runner_receipt import verify_runner_receipt
+                if not verify_runner_receipt(receipt).get("valid"):
+                    raise ValueError("invalid execution receipt")
+                purpose = "native-runner" if data.get("mode") == "native" else "browser-runner"
+                if receipt.get("purpose") != purpose or receipt.get("exitCode") != data.get("exit_code"):
+                    raise ValueError("receipt mode or exit status differs from summary")
+                expected = "sha256:" + digest_file(path)
+                if not any(a.get("path") == "summary.json" and a.get("sha256") == expected
+                           for a in receipt.get("artifacts", [])):
+                    raise ValueError("summary hash does not match execution receipt")
+                if data.get("mode") not in ("browser", "native") or data.get("platform") not in (*PLATFORMS, "Darwin"):
+                    raise ValueError("missing or unsupported execution mode/platform")
+                current = data.get("identity") == identity and data.get("identity_stable") is True
+                expected_config = config
+                if expected_config is None:
+                    from .config import load_config
+                    config_path = Path(data.get("config_path", "")).resolve()
+                    if config_path.is_relative_to(Path.cwd().resolve()) and config_path.is_file():
+                        expected_config = load_config(config_path)
+                current = current and expected_config is not None and data.get("conditions_sha256") == (
+                    conditions_identity(expected_config, data["mode"]) if expected_config is not None else None)
+                if data["mode"] == "native":
+                    native = data.get("native_identity", {})
+                    current = current and native.get("identifier") == "com.taomni.app.qa" and (
+                        native.get("source_sha256") == identity["source_sha256"])
+                target = "macOS" if data["platform"] == "Darwin" else data["platform"]
+                for result in data.get("cases", []):
+                    if result.get("status") not in ("passed", "failed", "skipped"):
+                        raise ValueError("invalid case outcome")
+                    key = (result["id"], data["mode"], target)
+                    item = {"status": result["status"], "current": current,
+                            "case_sha256": result.get("case_sha256"), "report": str(path),
+                            "finished_at": data.get("finished_at", ""),
+                            "duration_sec": result.get("duration_sec"),
+                            "conditions_sha256": data.get("conditions_sha256"),
+                            "reason": result.get("fixtures_skipped") or (result.get("failure") or {}).get("message")}
+                    previous = observations.get(key)
+                    # Prefer current-source runs; within those keep the latest failure/skip too.
+                    if previous is None or (current, item["finished_at"]) > (previous["current"], previous["finished_at"]):
+                        observations[key] = item
+            except (OSError, ValueError, KeyError, TypeError) as exc:
+                rejected.append({"report": str(path), "reason": str(exc)})
+    return observations, rejected
+
+
+def coverage_status(cases, features, observations, targets) -> dict:
+    rows = []
+    gaps = []
+    for case in cases:
+        reviewed = not REVIEW_TAGS.intersection(case.tags)
+        cells = {}
+        case_hash = input_digest(case.source_path) if case.source_path else None
+        for mode in case.modes:
+            platforms = targets
+            for target in platforms:
+                candidates = [value for (cid, m, p), value in observations.items()
+                              if cid == case.id and m == mode and (target == "any" or p == target)]
+                valid = [v for v in candidates if v["current"] and v["case_sha256"] == case_hash]
+                latest = max(valid, key=lambda v: v["finished_at"], default=None)
+                state = latest["status"] if latest else "stale" if candidates else "unverified"
+                key = f"{mode}:{target}"
+                cells[key] = {"status": state, "report": latest["report"] if latest else None,
+                              "reason": latest.get("reason") if latest else None}
+                if mode == "native":
+                    cells[key]["automation_gap"] = native_support(case, target)
+                if state != "passed" or not reviewed:
+                    gaps.append({"case": case.id, "target": key,
+                                 "reason": "needs review" if not reviewed else state})
+        rows.append({"id": case.id, "covers": case.covers, "reviewed": reviewed, "execution": cells})
+    feature_rows = []
+    for feature in features:
+        owned = [row for row in rows if feature.id in row["covers"]]
+        feature_rows.append({"id": feature.id, "title": feature.title,
+                             "written": len(owned), "reviewed": sum(r["reviewed"] for r in owned),
+                             "execution": dict(Counter(f"{key}:{cell['status']}" for r in owned
+                                                       for key, cell in r["execution"].items()))})
+    return {"schema": "qa-ui-auto.status.v1", "platforms": targets, "features": feature_rows,
+            "cases": rows, "gaps": gaps, "ok": bool(rows) and not gaps,
+            "scope": "YAML UI automation only; native manual, Rust, visual and performance evidence remain separate"}
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["plan", "status"])
+    parser.add_argument("--diff", help="git base ref; include local changes")
+    parser.add_argument("--feature")
+    parser.add_argument("--tag", help="comma-separated OR tags; use smoke for a quick plan")
+    parser.add_argument("--cases", default="qa-ui-auto-tests/cases")
+    parser.add_argument("--features", default="qa-ui-auto-tests/feature-list.md")
+    parser.add_argument("--reports", action="append", help="report root or summary.json; repeat to combine CI artifacts")
+    parser.add_argument("--config", help="expected execution configuration, useful for imported reports")
+    parser.add_argument("--platform", help="plan: one OS; status: comma-separated OS names (default all three)")
+    parser.add_argument("--gate", action="store_true", help="require reviewed, current passing execution for selected scope")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        cases = discover(Path(args.cases))
+        features = load_features(Path(args.features))
+        if args.feature:
+            features = [f for f in features if f.id == args.feature]
+            cases = [c for c in cases if args.feature in c.covers]
+            if not features:
+                raise ValueError(f"unknown feature: {args.feature}")
+        if args.tag:
+            tags = set(args.tag.split(","))
+            cases = [c for c in cases if tags.intersection(c.tags)]
+        targets = args.platform.split(",") if args.platform else list(PLATFORMS)
+        if any(target not in PLATFORMS for target in targets):
+            raise ValueError(f"platforms must be drawn from {PLATFORMS}")
+        if args.command == "plan":
+            target = args.platform or host_platform()
+            if target not in PLATFORMS:
+                raise ValueError("plan requires one target platform")
+            data = plan(cases, features, changed_files(Path.cwd(), args.diff) if args.diff else None, target)
+        else:
+            identity = execution_identity(Path.cwd())
+            from .config import load_config
+            expected_config = load_config(args.config) if args.config else None
+            observations, rejected = load_observations([Path(p) for p in args.reports or ["qa-ui-auto-report"]], identity, expected_config)
+            data = coverage_status(cases, features, observations, targets)
+            data.update(identity=identity, rejected_reports=rejected)
+        rendered = json.dumps(data, indent=2, ensure_ascii=False)
+        if not args.json:
+            if args.command == "plan":
+                rendered = data["selection_reason"] + "\n" + "\n".join(
+                    " ".join(command["argv"]) for command in data["commands"])
+                rendered += "\nNative gaps: " + json.dumps(data["native_gaps"], ensure_ascii=False)
+                rendered += "\nUnmapped source files: " + ", ".join(data["unmapped_source_files"])
+            else:
+                rendered = "| Feature | Written | Reviewed | Observed execution |\n|---|---:|---:|---|\n"
+                rendered += "\n".join(f"| {f['id']} | {f['written']} | {f['reviewed']} | "
+                                      + ", ".join(f"{k}={v}" for k, v in f["execution"].items()) + " |"
+                                      for f in data["features"])
+                rendered += f"\n\nUnmet case/target checks: {len(data['gaps'])}; rejected reports: {len(rejected)}\n{data['scope']}"
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered + "\n", encoding="utf-8")
+        print(rendered)
+        return 1 if args.gate and (not data.get("ok", bool(data.get("commands"))) or data.get("native_gaps")) else 0
+    except (OSError, ValueError, subprocess.CalledProcessError) as exc:
+        print(f"qa-ui-auto: {exc}")
+        return 2

--- a/.agents/skills/qa-ui-auto/scripts/tauri_webdriver.py
+++ b/.agents/skills/qa-ui-auto/scripts/tauri_webdriver.py
@@ -168,6 +168,11 @@ class NativeSession:
         self.driver_url = driver_url.rstrip("/")
         self.application = application
         self.session_id: str | None = None
+        self.deadline = None
+        # A local driver must remain reachable when the desktop uses a proxy.
+        host = urllib.parse.urlsplit(self.driver_url).hostname
+        self._open = (urllib.request.build_opener(urllib.request.ProxyHandler({})).open
+                      if host in {"localhost", "127.0.0.1", "::1"} else urllib.request.urlopen)
 
     def request(self, method: str, path: str, payload: dict | None = None) -> Any:
         body = None
@@ -178,7 +183,8 @@ class NativeSession:
             f"{self.driver_url}{path}", data=body, headers=headers, method=method
         )
         try:
-            with urllib.request.urlopen(req, timeout=30) as r:
+            timeout = min(30, self.deadline.remaining()) if self.deadline else 30
+            with self._open(req, timeout=timeout) as r:
                 data = r.read().decode("utf-8")
         except urllib.error.HTTPError as e:
             detail = e.read().decode("utf-8", errors="replace")
@@ -226,6 +232,8 @@ class NativeSession:
         deadline = time.time() + timeout
         last_error = ""
         while time.time() < deadline:
+            if self.deadline:
+                self.deadline.remaining()
             try:
                 found = self.request(
                     "POST",
@@ -647,6 +655,10 @@ class NativeHarness:
         except ValueError as exc:
             raise WebDriverError(str(exc)) from exc
         overrides = native_isolation_env(self.report_root)
+        if identity.get("source_sha256"):
+            from qa_ui_auto.provenance import source_identity
+            if identity["source_sha256"] != source_identity(ROOT):
+                raise WebDriverError("QA binary source is stale; run native_build.py")
         self._previous_env = {key: os.environ.get(key) for key in overrides}
         try:
             for value in overrides.values():
@@ -655,7 +667,9 @@ class NativeHarness:
             self.report_root.mkdir(parents=True, exist_ok=True)
             (self.report_root / "native-isolation.json").write_text(
                 json.dumps({"identifier": QA_APP_ID, "binary": str(self.application.resolve()),
-                            "binary_sha256": identity["binary_sha256"], "environment": overrides}, indent=2) + "\n",
+                            "binary_sha256": identity["binary_sha256"], "environment": overrides,
+                            "source_sha256": identity.get("source_sha256"),
+                            "profile": identity.get("profile")}, indent=2) + "\n",
                 encoding="utf-8",
             )
             self.driver.start()
@@ -677,6 +691,7 @@ class NativeHarness:
 
     def create_session(self) -> NativeSession:
         session = NativeSession(self.driver.url, self.application)
+        session.deadline = getattr(self, "deadline", None)
         session.start()
         return session
 

--- a/.agents/skills/qa-ui-auto/scripts/test_browser_runtime.py
+++ b/.agents/skills/qa-ui-auto/scripts/test_browser_runtime.py
@@ -1,0 +1,72 @@
+"""Opt-in real Chromium checks for runner isolation and timeout behavior."""
+from __future__ import annotations
+
+import os
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest.mock import patch
+
+from qa_ui_auto import runner
+
+
+@unittest.skipUnless(os.environ.get("QA_TEST_BROWSER") == "1", "set QA_TEST_BROWSER=1 with Playwright Chromium installed")
+class BrowserRuntimeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(b"<!doctype html><title>QA runtime fixture</title><button id='ready'>Ready</button>")
+
+            def log_message(self, *args):
+                pass
+
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        runner._close_browser()
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.thread.join(timeout=2)
+
+    def payload(self, root, case_id, steps, timeout=10):
+        return {"case": {"id": case_id, "title": case_id, "steps": steps, "tags": [],
+                         "covers": [], "modes": ["browser"], "fixtures": [], "timeout_sec": timeout},
+                "cfg": {"app": {"base_url": f"http://127.0.0.1:{self.server.server_port}"}},
+                "env": {}, "worker_id": 0, "report_root": str(root)}
+
+    def test_reused_process_does_not_share_storage_and_discards_success_trace(self):
+        def store(ctx, args):
+            self.assertIsNone(ctx.page.evaluate("localStorage.getItem('case-marker')"))
+            ctx.page.evaluate("localStorage.setItem('case-marker', 'present')")
+
+        with tempfile.TemporaryDirectory() as directory, patch.dict(runner.STEP_REGISTRY, {"test_storage": store}):
+            root = Path(directory)
+            first = runner._run_browser_case(self.payload(root, "TC-first", [{"test_storage": None}]))
+            browser = runner._browser
+            second = runner._run_browser_case(self.payload(root, "TC-second", [{"test_storage": None}]))
+            self.assertEqual(first["status"], "passed", first)
+            self.assertEqual(second["status"], "passed", second)
+            self.assertIs(runner._browser, browser)
+            self.assertFalse((root / "TC-first/trace.zip").exists())
+
+    def test_explicit_long_wait_obeys_case_budget_and_keeps_failure_trace(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            result = runner._run_browser_case(self.payload(root, "TC-timeout", [
+                {"wait_for": {"selector": "#never", "timeout_sec": 60}}], timeout=0.5))
+            self.assertEqual(result["status"], "failed")
+            self.assertLess(result["duration_sec"], 5)
+            self.assertTrue((root / "TC-timeout/trace.zip").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/qa-ui-auto/scripts/test_native_isolation.py
+++ b/.agents/skills/qa-ui-auto/scripts/test_native_isolation.py
@@ -49,6 +49,7 @@ class NativeBuildTest(unittest.TestCase):
 
                 with (
                     patch.object(native_build, "ROOT", root),
+                    patch.object(native_build, "build_inputs", return_value={"source_sha256": "test-source"}),
                     patch.object(native_build.platform, "system", return_value=system),
                     patch.object(native_build.shutil, "which", return_value="pnpm"),
                     patch.object(native_build.subprocess, "run", side_effect=compile_binary),
@@ -68,6 +69,7 @@ class NativeBuildTest(unittest.TestCase):
             binary = recorded_binary(output)
             with (
                 patch.object(native_build, "ROOT", root),
+                patch.object(native_build, "build_inputs", return_value={"source_sha256": "test-source"}),
                 patch.object(native_build.platform, "system", return_value="Linux"),
                 patch.object(native_build.shutil, "which", return_value="pnpm"),
                 patch.object(native_build.subprocess, "run", side_effect=subprocess.CalledProcessError(1, "pnpm")),
@@ -193,10 +195,10 @@ class NativeIsolationTest(unittest.TestCase):
         real_resolve = Path.resolve
 
         def resolve(path, *args, **kwargs):
-            if str(path) == "/proc/101/exe":
-                return qa_binary
-            if str(path) == "/proc/102/exe":
-                return Path("/test/production/taomni")
+            if path.as_posix() == "/proc/101/exe":
+                return real_resolve(qa_binary)
+            if path.as_posix() == "/proc/102/exe":
+                return real_resolve(Path("/test/production/taomni"))
             return real_resolve(path, *args, **kwargs)
 
         outputs = [
@@ -237,9 +239,10 @@ class NativeIsolationTest(unittest.TestCase):
 
 
 class RoutineEntryTest(unittest.TestCase):
-    def test_run_prefers_native_and_forwards_explicit_browser(self):
+    def test_run_defaults_browser_and_forwards_explicit_modes(self):
         for flags, expected in [
-            (["--filter", "TC-001"], ["--filter", "TC-001", "--mode", "native"]),
+            (["--filter", "TC-001"], ["--filter", "TC-001", "--mode", "browser"]),
+            (["--mode", "native"], ["--mode", "native"]),
             (["--mode=browser"], ["--mode=browser"]),
             (["--mode", "browser"], ["--mode", "browser"]),
         ]:
@@ -267,7 +270,7 @@ class RoutineEntryTest(unittest.TestCase):
                                           "report": {"dir": str(root / "reports")}}), encoding="utf-8")
             before = dict(os.environ)
             with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()), patch.object(reset_db, "_reset_native") as reset:
-                self.assertEqual(cli.main(["run", "--cases", str(cases), "--config", str(config)]), 2)
+                self.assertEqual(cli.main(["run", "--mode", "native", "--cases", str(cases), "--config", str(config)]), 2)
                 reset.assert_not_called()
             self.assertEqual(dict(os.environ), before)
 

--- a/.agents/skills/qa-ui-auto/scripts/test_tauri_webdriver.py
+++ b/.agents/skills/qa-ui-auto/scripts/test_tauri_webdriver.py
@@ -2,12 +2,39 @@ import json
 import os
 from pathlib import Path
 import stat
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from tempfile import TemporaryDirectory
-from unittest import TestCase
+from unittest import TestCase, skipUnless
 from unittest.mock import Mock, call, patch
 
 from qa_ui_auto import native_steps
 from tauri_webdriver import NativeSession
+
+
+class NativeSessionTransportTest(TestCase):
+    def test_loopback_driver_bypasses_system_proxy(self):
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b'{"value": {"ready": true}}')
+
+            def log_message(self, *args):
+                pass
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with patch("urllib.request.getproxies", return_value={"http": "http://127.0.0.1:1"}):
+                session = NativeSession(f"http://127.0.0.1:{server.server_port}", Path("unused"))
+                self.assertEqual(session.request("GET", "/status"), {"ready": True})
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join()
 
 
 class NativeSessionFillTest(TestCase):
@@ -156,12 +183,13 @@ class NativeSessionPressComboTest(TestCase):
         session.session_id = "session-1"
         session.request = Mock(return_value=None)
 
-        self.assertEqual(session.press_combo("Control+v"), "pressed Control+v")
+        session.press_combo("Control+v")
 
         payload = session.request.call_args_list[0].args[2]
         actions = payload["actions"][0]["actions"]
         self.assertEqual(actions[0], {"type": "keyDown", "value": "\ue009"})
-        self.assertEqual(actions[-1], {"type": "keyUp", "value": "\ue009"})
+        key_actions = [action for action in actions if action["type"] != "pause"]
+        self.assertEqual(key_actions[-1], {"type": "keyUp", "value": "\ue009"})
         self.assertEqual(session.request.call_args_list[1].args[:2], (
             "DELETE", session.endpoint("/actions"),
         ))
@@ -196,7 +224,7 @@ class NativeKeysVerbTest(TestCase):
                     {"selector": "#encoding", "keys": ["Tab", "Control+v"]},
                 )
 
-            self.assertEqual(result, "injected 2 X11 keys into focused native control")
+            self.assertIn("injected 2", result)
             activate.assert_called_once_with(session.application)
             inject.assert_called_once_with(["Tab", "Control+v"])
             artifact = json.loads(
@@ -350,6 +378,7 @@ class NativePointerDragVerbTest(TestCase):
 
 
 class NativeFilesystemFaultTest(TestCase):
+    @skipUnless(sys.platform.startswith("linux"), "requires real Linux chmod semantics")
     def test_native_set_writable_is_report_scoped_and_records_modes(self) -> None:
         with TemporaryDirectory() as directory:
             report_root = Path(directory)

--- a/.agents/skills/qa-ui-auto/scripts/test_verification_workflow.py
+++ b/.agents/skills/qa-ui-auto/scripts/test_verification_workflow.py
@@ -1,0 +1,226 @@
+"""Behavioral checks for truthful coverage, selection, reuse and bounded execution."""
+from __future__ import annotations
+
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import native_build
+import perf_baseline
+from qa_ui_auto import audit, runner
+from qa_ui_auto.deadline import CaseTimeout, Deadline, budget_time, using_deadline
+from qa_ui_auto.feature_catalog import Feature
+from qa_ui_auto.provenance import digest_file, input_digest, conditions_identity
+from qa_ui_auto.runner_receipt import emit_runner_receipt
+from qa_ui_auto.testcase import TestCase
+from qa_ui_auto.verification import coverage_status, load_observations, native_support, plan
+
+
+class VerificationTest(unittest.TestCase):
+    def test_renderer_selection_retains_native_only_and_backend_change_broadens(self):
+        features = [Feature(id="F1", title="UI", files=["src/components/View.tsx"])]
+        cases = [TestCase(id="TC-ui", title="UI", covers=["F1"], modes=["browser", "native"]),
+                 TestCase(id="TC-disk", title="Disk", covers=["F1"], modes=["native"]),
+                 TestCase(id="TC-other", title="Other", covers=["F2"], modes=["browser"])]
+        result = plan(cases, features, ["src/components/View.tsx"], "Windows")
+        self.assertEqual(result["commands"][0]["cases"], ["TC-ui"])
+        self.assertEqual(result["commands"][1]["cases"], ["TC-disk"])
+        result = plan(cases, features, ["src-tauri/src/unknown.rs"], "Windows")
+        self.assertIn("TC-other", result["commands"][0]["cases"])
+        self.assertEqual(result["unmapped_source_files"], ["src-tauri/src/unknown.rs"])
+
+    def test_platform_gap_is_not_silently_dropped(self):
+        case = TestCase(id="TC-ime", title="IME", modes=["native"], steps=[{"native_ime_keys": {}}])
+        self.assertIsNone(native_support(case, "Linux"))
+        self.assertIn("Linux", native_support(case, "Windows"))
+        result = plan([case], [], None, "macOS")
+        self.assertFalse(result["commands"])
+        self.assertEqual(result["native_gaps"][0]["case"], case.id)
+
+    def test_native_pattern_requires_output_not_the_echoed_command(self):
+        from qa_ui_auto import native_steps
+        with tempfile.TemporaryDirectory() as directory:
+            session = Mock()
+            session.text.side_effect = ["PS> echo QA_READY", "PS> echo QA_READY\nQA_READY\nPS>"]
+            ctx = native_steps.NativeStepContext(session, Path(directory), {})
+            native_steps.VERBS["assert_pattern"](ctx, {"selector": "#terminal", "regex": "(?m)^QA_READY$"})
+            self.assertEqual(session.text.call_count, 2)
+
+    def test_browser_pattern_reads_terminal_text_attribute(self):
+        from qa_ui_auto.steps import assertions
+        page = Mock()
+        locator = page.locator.return_value.first
+        locator.text_content.return_value = ""
+        locator.get_attribute.return_value = "PS> echo QA_READY\nQA_READY\nPS>"
+        ctx = SimpleNamespace(page=page, dry_run=False)
+        assertions.step_assert_pattern(ctx, {"selector": "#terminal", "regex": "(?m)^QA_READY$"})
+        locator.get_attribute.assert_called_with("data-terminal-text")
+
+    def test_status_requires_current_reviewed_case_and_does_not_mask_latest_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "case.yaml"
+            path.write_text("current case")
+            case = TestCase(id="TC-a", title="A", covers=["F1"], source_path=path)
+            value = {"status": "passed", "current": True, "case_sha256": digest_file(path),
+                     "finished_at": "2026-09-06T10:00:00Z", "report": "run/summary.json"}
+            observations = {(case.id, "browser", "Windows"): value}
+            self.assertTrue(coverage_status([case], [], observations, ["Windows"])["ok"])
+            value["status"] = "failed"
+            self.assertFalse(coverage_status([case], [], observations, ["Windows"])["ok"])
+            value["status"] = "passed"
+            case.tags = ["needs-review"]
+            self.assertFalse(coverage_status([case], [], observations, ["Windows"])["ok"])
+            case.tags = []
+            path.write_text("changed case")
+            row = coverage_status([case], [], observations, ["Windows"])["cases"][0]
+            self.assertEqual(row["execution"]["browser:Windows"]["status"], "stale")
+
+    def test_another_os_pass_cannot_hide_current_target_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "case.yaml"
+            path.write_text("case")
+            case = TestCase(id="TC-a", title="A", source_path=path)
+            value = {"current": True, "case_sha256": input_digest(path), "report": "summary.json"}
+            observations = {(case.id, "browser", "Windows"): dict(value, status="failed", finished_at="1"),
+                            (case.id, "browser", "Linux"): dict(value, status="passed", finished_at="2")}
+            result = coverage_status([case], [], observations, ["Windows"])
+            self.assertFalse(result["ok"])
+            self.assertEqual(result["cases"][0]["execution"]["browser:Windows"]["status"], "failed")
+
+    def test_checkout_line_endings_do_not_invalidate_cross_platform_input_identity(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "case.yaml"
+            path.write_bytes(b"id: TC-a\ntitle: test\n")
+            expected = input_digest(path)
+            path.write_bytes(b"id: TC-a\r\ntitle: test\r\n")
+            self.assertEqual(input_digest(path), expected)
+            path.write_bytes(b"id: TC-b\r\ntitle: test\r\n")
+            self.assertNotEqual(input_digest(path), expected)
+
+    def test_changed_dual_mode_case_plans_both_modes(self):
+        case = TestCase(id="TC-a", title="A", modes=["browser", "native"], source_path=Path("cases/a.yaml"))
+        result = plan([case], [], ["cases/a.yaml"], "Windows")
+        self.assertEqual([c["mode"] for c in result["commands"]], ["browser", "native"])
+
+    def test_dry_run_legacy_and_modified_reports_cannot_prove_execution(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            report = root / "run-test"
+            report.mkdir()
+            summary = report / "summary.json"
+            for data in ({"dry_run": True}, {}):
+                summary.write_text(json.dumps(data))
+                observations, rejected = load_observations([root], {})
+                self.assertFalse(observations)
+                self.assertEqual(len(rejected), 1)
+            identity = {"source_sha256": "source", "runner_sha256": "runner"}
+            data = {"dry_run": False, "mode": "browser", "platform": "Windows", "identity": identity,
+                    "conditions_sha256": conditions_identity({}, "browser"),
+                    "identity_stable": True, "exit_code": 0, "cases": [
+                        {"id": "TC-a", "status": "passed", "case_sha256": "case"}]}
+            summary.write_text(json.dumps(data))
+            emit_runner_receipt(report, "browser", ["runner"], "2026-09-06T10:00:00Z",
+                                "2026-09-06T10:00:01Z", 1, 0)
+            observations, rejected = load_observations([root], identity, {})
+            self.assertFalse(rejected)
+            self.assertTrue(observations[("TC-a", "browser", "Windows")]["current"])
+            different = {"app": {"base_url": "http://other.invalid"}}
+            self.assertFalse(load_observations([root], identity, different)[0][("TC-a", "browser", "Windows")]["current"])
+            data["cases"][0]["status"] = "failed"
+            summary.write_text(json.dumps(data))
+            self.assertFalse(load_observations([root], identity)[0])
+
+    def test_static_gate_does_not_require_release_artifacts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            baseline = Path(directory) / "baseline.json"
+            baseline.write_text('{"totals": {}}')
+            with patch.object(audit, "build_coverage", return_value=([], [])), \
+                 patch.object(audit, "_build_snapshot", return_value={"totals": {}}), \
+                 patch.object(audit, "_render_gate_diff", return_value=([], [])):
+                result = audit._gate(features_path=Path("unused"), cases_dir=Path("unused"), baseline_path=baseline)
+            self.assertTrue(result["ok"])
+            self.assertFalse(result["evidence_gate"]["required"])
+
+    def test_isolated_java_fixture_mutations_leave_checkout_sample_unchanged(self):
+        from qa_ui_auto.fixtures import java_sample_projects
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "sample"
+            source.mkdir()
+            (source / "pom.xml").write_text("sample project")
+            ctx = SimpleNamespace(case_dir=root / "case", values={})
+            with patch.object(java_sample_projects, "SAMPLES", {"maven_single_root": (source, "pom.xml")}):
+                java_sample_projects.setup(ctx)
+            isolated = Path(ctx.values["maven_single_root"])
+            (isolated / "pom.xml").write_text("changed by native test")
+            self.assertEqual((source / "pom.xml").read_text(), "sample project")
+
+    def test_deadline_interrupts_poll_sleep(self):
+        started = time.monotonic()
+        with self.assertRaises(CaseTimeout), using_deadline(Deadline(0.02)):
+            budget_time.sleep(5)
+        self.assertLess(time.monotonic() - started, 0.5)
+
+    def test_native_failure_capture_uses_original_session_before_close(self):
+        from qa_ui_auto import native_steps
+        import tauri_webdriver
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            case = TestCase(id="TC-fail", title="Failure", modes=["native"], steps=[{"click": "missing"}])
+            session = Mock()
+            session.console_entries.return_value = []
+            session.execute.return_value = "<html>failure</html>"
+            captured = []
+            session.screenshot.side_effect = lambda path: captured.append(not session.close.called)
+            harness = Mock()
+            harness.__enter__ = Mock(return_value=harness)
+            harness.__exit__ = Mock(return_value=False)
+            harness.create_session.return_value = session
+            with patch.object(tauri_webdriver, "NativeHarness", return_value=harness), \
+                 patch.object(native_steps, "run_native_step", side_effect=RuntimeError("failure")):
+                results = runner._native_run([case], {}, {}, root, False)
+            self.assertEqual(captured, [True])
+            harness.create_session.assert_called_once()
+            session.close.assert_called_once()
+            self.assertEqual(results[0]["failure"]["step_index"], 1)
+
+    def test_build_cache_requires_matching_recipe_and_binary(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "src-tauri/target/qa-ui-auto/debug/taomni.exe"
+            output.parent.mkdir(parents=True)
+            output.write_bytes(b"QA")
+            inputs = {"source_sha256": "source", "recipe_sha256": "recipe"}
+            native_build.identity_path(output).write_text(json.dumps({
+                "identifier": native_build.QA_APP_ID, "binary_sha256": native_build.binary_digest(output),
+                "build_inputs": inputs,
+            }))
+            with patch.object(native_build, "ROOT", root), \
+                 patch.object(native_build.platform, "system", return_value="Windows"), \
+                 patch.object(native_build.shutil, "which", return_value="pnpm"), \
+                 patch.object(native_build, "build_inputs", return_value=inputs), \
+                 patch.object(native_build.subprocess, "run") as build:
+                self.assertEqual(native_build.build_qa(), output)
+                build.assert_not_called()
+
+    def test_performance_keeps_slow_samples_and_fails_regression_within_budget(self):
+        metrics = perf_baseline.summarize([10] * 10 + [1500])
+        self.assertIn(1500, metrics["samples_ms"])
+        self.assertEqual(metrics["dropped_outliers_ge_1000ms"], 0)
+        result = {name: perf_baseline.summarize([20] * 20) for name in (
+            "normal_input_key_to_paint", "local_action_toggle_comment")}
+        result["conditions"] = {"machine": "same"}
+        baseline = {name: perf_baseline.summarize([10] * 20) for name in (
+            "normal_input_key_to_paint", "local_action_toggle_comment")}
+        baseline["conditions"] = result["conditions"]
+        self.assertEqual(perf_baseline.assess(result, baseline, noise_ms=2)[0], 1)
+        baseline["conditions"] = {"machine": "other"}
+        self.assertEqual(perf_baseline.assess(result, baseline)[0], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,7 @@ on:
     branches: [main]
     paths:
       - 'src/**'
+      - 'src-tauri/**'
       - 'tests/**'
       - 'qa-ui-auto-tests/**'
       - '.agents/skills/qa-ui-auto/**'
@@ -89,7 +90,11 @@ jobs:
       - name: Run smoke
         run: |
           PYTHONPATH=.agents/skills/qa-ui-auto/scripts \
-            python -m qa_ui_auto.runner --tag smoke --workers 4
+            python -m qa_ui_auto.runner --mode browser --tag smoke --workers 4
+      - name: Execution coverage
+        if: always()
+        run: |
+          PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto status --tag smoke --json --output qa-ui-auto-report/status.json
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@v4
@@ -152,11 +157,15 @@ jobs:
           TAG="${{ github.event.inputs.tag }}"
           if [ -n "$TAG" ]; then
             PYTHONPATH=.agents/skills/qa-ui-auto/scripts \
-              python -m qa_ui_auto.runner --tag "$TAG" --workers 4
+              python -m qa_ui_auto.runner --mode browser --tag "$TAG" --workers 4
           else
             PYTHONPATH=.agents/skills/qa-ui-auto/scripts \
-              python -m qa_ui_auto.runner --workers 4
+              python -m qa_ui_auto.runner --mode browser --workers 4
           fi
+      - name: Execution coverage
+        if: always()
+        run: |
+          PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto status --json --output qa-ui-auto-report/status.json
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@v4
@@ -208,7 +217,11 @@ jobs:
           TAG="${{ github.event.inputs.tag }}"
           if [ -z "$TAG" ]; then TAG="smoke"; fi
           PYTHONPATH=.agents/skills/qa-ui-auto/scripts \
-            python -m qa_ui_auto.runner --tag "$TAG" --workers 2
+            python -m qa_ui_auto.runner --mode browser --tag "$TAG" --workers 2
+      - name: Execution coverage
+        if: always()
+        run: |
+          PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto status --tag smoke --json --output qa-ui-auto-report/status.json
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/qa-native.yml
+++ b/.github/workflows/qa-native.yml
@@ -1,0 +1,82 @@
+name: Native QA Smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 18 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-qa-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    env:
+      PYTHONPATH: .agents/skills/qa-ui-auto/scripts
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target/qa-ui-auto
+      - name: Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev webkit2gtk-driver libappindicator3-dev librsvg2-dev patchelf libkrb5-dev libasound2-dev libv4l-dev libpipewire-0.3-dev libclang-dev libdbus-1-dev libudev-dev nasm xvfb
+      - name: Windows Perl and WebView2 driver
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Test-Path 'C:\Strawberry\perl\bin') { 'C:\Strawberry\perl\bin' >> $env:GITHUB_PATH }
+          $runtimeRoot = "${env:ProgramFiles(x86)}\Microsoft\EdgeWebView\Application"
+          $runtime = Get-ChildItem -LiteralPath $runtimeRoot -Directory | Where-Object Name -Match '^\d+\.\d+\.\d+\.\d+$' | Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1
+          if (-not $runtime) { throw 'WebView2 runtime is unavailable' }
+          $driverZip = Join-Path $env:RUNNER_TEMP 'qa-edgedriver.zip'
+          $driverDir = Join-Path $env:RUNNER_TEMP 'qa-edgedriver'
+          Invoke-WebRequest "https://msedgedriver.microsoft.com/$($runtime.Name)/edgedriver_win64.zip" -OutFile $driverZip
+          Expand-Archive -LiteralPath $driverZip -DestinationPath $driverDir -Force
+          $driverDir >> $env:GITHUB_PATH
+      - run: pnpm install --frozen-lockfile
+      - run: pip install pyyaml jsonschema
+      - run: cargo install tauri-driver --locked
+      - name: Build isolated QA app
+        run: python .agents/skills/qa-ui-auto/scripts/native_build.py
+      - name: Run Linux native smoke
+        if: runner.os == 'Linux'
+        run: xvfb-run -a python -m qa_ui_auto run --mode native --filter TC-NATIVE-CORE-001 --require-pass --config .agents/skills/qa-ui-auto/assets/qa-ui-auto.config.example.yaml
+      - name: Run Windows native smoke
+        if: runner.os == 'Windows'
+        run: python -m qa_ui_auto run --mode native --filter TC-NATIVE-CORE-001 --require-pass --config .agents/skills/qa-ui-auto/assets/qa-ui-auto.config.example.yaml
+      - name: Report execution coverage
+        if: always()
+        run: python -m qa_ui_auto status --json --output qa-ui-auto-report/status.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: native-qa-${{ runner.os }}
+          path: qa-ui-auto-report/
+          retention-days: 30

--- a/qa-ui-auto-tests/README.md
+++ b/qa-ui-auto-tests/README.md
@@ -17,7 +17,7 @@ qa-ui-auto-tests/
 │                              #     -->
 │                              # Parsed by qa_ui_auto.feature_catalog.
 └── cases/
-    ├── TC-XXX-<slug>.testcase.yaml  # 131 typed YAML testcases (hand-authored + migrated)
+    ├── TC-XXX-<slug>.testcase.yaml  # Typed YAML testcases (hand-authored + migrated)
     └── auto/                        # gen-coverage's drafts land here
         └── TC-auto-F4.X-...yaml     # tags: [auto-generated, smoke, needs-review]
 ```
@@ -31,13 +31,13 @@ Browser mode (default):
 DEV_PROXY_ALLOW_PRIVATE=1 ALLOW_PRIVATE_TARGETS=1 pnpm dev
 export QA_SSH_PASSWORD=...
 
-# audit + dry-run
+# Optional static audit; not a prerequisite to every selected execution
 PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto.audit --gate
-PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto.runner --dry-run
 
 # real run
-PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto.runner --tag smoke --workers 4
-PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto.runner --workers 4
+PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto run --mode browser --tag smoke --workers 4
+PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto plan --diff HEAD
+PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto status --json
 ```
 
 Reports land in `qa-ui-auto-report/run-<timestamp>/`.
@@ -49,6 +49,8 @@ The `qa-ui-auto` skill in Claude Code wraps these tools with playbooks:
 | Command | Writes to | Purpose |
 |---|---|---|
 | `audit` | (read-only) | Lint cases, report coverage gaps and diff impact, and enforce the baseline gate |
+| `plan` | (read-only) | Select affected cases, explicit modes and native platform gaps |
+| `status` | optional `--output` | Written/reviewed/current execution coverage by feature and platform |
 | `fix` | feature catalog, cases, or generated catalog | Produce a focused playbook for one coverage, control, diff, or catalog gap |
 | `run` | `qa-ui-auto-report/` | Execute existing browser or native testcases |
 | `explore` | `qa-ui-auto-report/` | Drive a bounded exploratory browser session and write a report |
@@ -62,6 +64,10 @@ The Python step library lives at `.agents/skills/qa-ui-auto/scripts/qa_ui_auto/s
 
 ## Coverage status
 
-100% of features in `feature-list.md` have at least one testcase referencing them via `covers`.
-Cases tagged `needs-review` were auto-migrated or drafted and still require hardened assertions.
-Track them and current control gaps with `python -m qa_ui_auto.audit`.
+Use `python -m qa_ui_auto status` for written, reviewed and observed execution
+coverage. Cases tagged `needs-review` or `legacy-imported` still require assertion
+review. `audit --gate` checks static coverage; `status --gate --tag p0 --platform
+Windows,Linux` checks current passing execution in that explicit scope.
+`audit --release-evidence` additionally validates the existing release manifest.
+See [.agents/skills/qa-ui-auto/references/verification.md](../.agents/skills/qa-ui-auto/references/verification.md)
+for freshness, retained artifacts, performance and macOS manual evidence limits.

--- a/qa-ui-auto-tests/cases/TC-NATIVE-CORE-001-local-pty.testcase.yaml
+++ b/qa-ui-auto-tests/cases/TC-NATIVE-CORE-001-local-pty.testcase.yaml
@@ -1,0 +1,26 @@
+id: TC-NATIVE-CORE-001
+title: Native QA startup opens a local PTY and receives shell output
+covers: [F1.6, F2.1, F2.2]
+tags: [smoke, p0, native-boundary, terminal]
+modes: [native]
+native_platforms: [Linux, Windows]
+fixtures: [reset_db]
+timeout_sec: 60
+steps:
+  - open: ${cfg.app.base_url}
+  - vault_first_run: qa-native-smoke-password
+  - wait_for: '[data-testid="welcome-panel"]'
+  - click: '[data-testid="welcome-open-local-terminal"]'
+  - wait_for: '[data-testid="terminal-pane"]'
+  - assert_pattern:
+      selector: '[data-testid="terminal-pane"]'
+      regex: '(?m)[$#>]\s*$'
+      timeout_sec: 20
+  - click: '[data-testid="terminal-pane"]'
+  - type: echo QA_NATIVE_SHELL_READY
+  - press: Enter
+  - assert_pattern:
+      selector: '[data-testid="terminal-pane"]'
+      regex: '(?m)^QA_NATIVE_SHELL_READY\s*$'
+      timeout_sec: 15
+  - screenshot: native-shell-ready.png

--- a/qa-ui-auto-tests/native/runbooks/run-native-linux.sh
+++ b/qa-ui-auto-tests/native/runbooks/run-native-linux.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 cd "$(dirname "$0")/../../.."
 
 echo "== [1/4] build packaged debug app =="
-pnpm tauri build --debug --no-bundle
+python .agents/skills/qa-ui-auto/scripts/native_build.py
 
 echo "== [2/4] preflight =="
 command -v tauri-driver >/dev/null || { echo "tauri-driver missing: cargo install tauri-driver --locked"; exit 2; }
@@ -19,9 +19,10 @@ command -v WebKitWebDriver >/dev/null || { echo "WebKitWebDriver missing (libweb
 echo "== [3/4] run native cases (app-data isolated by the runner) =="
 # The runner redirects XDG_DATA_HOME/XDG_CONFIG_HOME into the run report dir,
 # so the launched binary never touches the developer profile.
-CASES="${CASES:-TC-IDE-C0-01}"
+CASES="${CASES:-TC-NATIVE-CORE-001}"
 PYTHONPATH=.agents/skills/qa-ui-auto/scripts python -m qa_ui_auto.runner \
-  --mode native --filter "$CASES"
+  --mode native --require-pass --filter "$CASES" \
+  --config "${QA_CONFIG:-.agents/skills/qa-ui-auto/assets/qa-ui-auto.config.example.yaml}"
 
 echo "== [4/4] evidence entries =="
 RUN_DIR=$(ls -td qa-ui-auto-report/run-* | head -1)
@@ -30,17 +31,15 @@ for CASE in ${CASES//,/ }; do
 import json, sys, pathlib
 run, case = sys.argv[1], sys.argv[2]
 s = json.loads((pathlib.Path(run) / "summary.json").read_text())
-r = next(r for r in s["results"] if r["id"] == case)
+r = next(r for r in s["cases"] if r["id"] == case)
 print({"passed": "passed", "failed": "failed", "skipped": "environment-blocked"}[r["status"]])
 PY
 )
-  ARTIFACT="$RUN_DIR/$CASE/summary.json"
-  [ -f "$ARTIFACT" ] || ARTIFACT="$RUN_DIR/summary.json"
-  FS_PATH=$(ls -dt qa-ui-auto-report/native-workspaces/${CASE}-* 2>/dev/null | head -1 || echo "$HOME")
+  ARTIFACT="$RUN_DIR/summary.json"
   python .agents/skills/qa-ui-auto/scripts/evidence_collect.py \
     --case "$CASE" --gate G0 --result "$RESULT" \
     --command "python -m qa_ui_auto.runner --mode native --filter $CASE" \
-    --artifact "$ARTIFACT" --fs-path "${FS_PATH:-$HOME}" \
+    --artifact "$ARTIFACT" \
     --gap "single layout run; add non-US layout + IME + 200% scale runs for the full matrix"
 done
 

--- a/qa-ui-auto-tests/native/runbooks/run-native-macos.sh
+++ b/qa-ui-auto-tests/native/runbooks/run-native-macos.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 cd "$(dirname "$0")/../../.."
 
 echo "== [1/2] build packaged debug app =="
-pnpm tauri build --debug --no-bundle
+python .agents/skills/qa-ui-auto/scripts/native_build.py
 
 echo "== [2/2] manual gate checklist =="
 cat <<'EOF'
@@ -25,9 +25,10 @@ For each §8.19.10 matrix item, drive the packaged app by hand and record:
     --command "<what you did>" --layout <layout> --ime <ime> --scale <100%|200%> \
     --gap "<anything not covered>"
 
-App-data isolation note: the app writes to
-~/Library/Application Support/com.taomni.app. To protect the developer
-profile, either snapshot that directory first or set
-QA_NATIVE_HOME_OVERRIDE to a scratch HOME before launching (invasive —
-breaks Keychain; prefer the snapshot approach).
+Use only the com.taomni.app.qa build and record its binary hash and source
+identity. Use QA-owned data/config/cache and disposable workspaces. Do not
+launch the production app or redirect HOME. Workflows sharing Keychain or
+other host resources require a disposable OS account.
+Building does not prove native execution. Record observable outcomes and
+artifacts; browser evidence does not satisfy WKWebView/OS checks.
 EOF

--- a/qa-ui-auto-tests/native/runbooks/run-native-windows.ps1
+++ b/qa-ui-auto-tests/native/runbooks/run-native-windows.ps1
@@ -9,24 +9,28 @@
 # The runner redirects APPDATA/LOCALAPPDATA for the launched binary into the
 # run report dir, so the developer profile is never touched.
 $ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
 Set-Location (Join-Path $PSScriptRoot "..\..\..")
 
 Write-Host "== [1/3] build packaged debug app =="
-pnpm tauri build --debug --no-bundle
+python .agents/skills/qa-ui-auto/scripts/native_build.py
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 Write-Host "== [2/3] run native cases =="
 $Cases = $env:CASES
-if (-not $Cases) { $Cases = "TC-IDE-C0-01" }
+if (-not $Cases) { $Cases = "TC-NATIVE-CORE-001" }
 $env:PYTHONPATH = ".agents/skills/qa-ui-auto/scripts"
-python -m qa_ui_auto.runner --mode native --filter $Cases
+$QaConfig = if ($env:QA_CONFIG) { $env:QA_CONFIG } else { ".agents/skills/qa-ui-auto/assets/qa-ui-auto.config.example.yaml" }
+python -m qa_ui_auto.runner --mode native --require-pass --filter $Cases --config $QaConfig
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 Write-Host "== [3/3] evidence entries =="
-# Fill result/artifact per case from qa-ui-auto-report/run-*/<case>/summary.json
+# Read case results from qa-ui-auto-report/run-*/summary.json
 # and emit one entry per item, e.g.:
 #   python .agents/skills/qa-ui-auto/scripts/evidence_collect.py `
 #     --case TC-IDE-C0-01 --gate G0 --result passed `
 #     --command "python -m qa_ui_auto.runner --mode native --filter TC-IDE-C0-01" `
-#     --artifact <run-dir>/TC-IDE-C0-01/summary.json --scale 100%
+#     --artifact <run-dir>/summary.json --scale 100%
 # Repeat with --layout <non-US layout> and --ime <IME> for G1 matrix items,
 # and once at 200% scale.
 Write-Host "Manual evidence_collect.py invocations required (see README.md)."


### PR DESCRIPTION
… native testing hardening

Introduce risk-based test selection, truthful execution provenance, and native UI test hardening:

- Add 'plan' and 'status' CLI entries in verification.py for affected test selection and observed coverage reporting across Linux, Windows, and macOS.
- Add provenance.py for cross-platform source/runner fingerprints, case digests, and non-secret execution condition identities.
- Add deadline.py for cooperative monotonic timeout budgeting, wrapping Playwright waits and WebDriver polling without bypassing cleanup.
- Enhance runner.py to capture original session state (screenshot, outerHTML, console logs) on native failures before teardown.
- Implement verified build caching in native_build.py, checking source, recipe, toolchain, and environment inputs.
- Add assert_pattern verb with terminal buffer fallback (data-terminal-text) for xterm canvas output in browser and native steps.
- Add TC-NATIVE-CORE-001 native smoke testcase verifying QA startup, vault unlock, and local terminal PTY execution.
- Add qa-native.yml GitHub Actions workflow for Ubuntu/Windows native QA smoke and update e2e.yml coverage reporting.
- Update runbooks, documentation references, schema, and add verification workflow tests.