### PR TITLE
fix(code-workspace): transfer focus to context menu on open to isolat…

### DIFF
--- a/src/components/ContextMenu.test.tsx
+++ b/src/components/ContextMenu.test.tsx
@@ -141,6 +141,12 @@ describe("ContextMenu", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("takes focus when opened so editor navigation keys are not targeted at the editor", () => {
+    render(<ContextMenu items={[{ label: "Inspect" }]} x={10} y={10} onClose={vi.fn()} />);
+
+    expect(screen.getByTestId("context-menu")).toHaveFocus();
+  });
+
   it("closes on Escape key press", () => {
     const onClose = vi.fn();
     render(<ContextMenu items={[{ label: "Action" }]} x={10} y={10} onClose={onClose} />);

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -97,6 +97,13 @@ export const MenuSurface = forwardRef<HTMLDivElement, {
     else if (forwardedRef) forwardedRef.current = node;
   }, [forwardedRef]);
 
+  // Context menus are opened from the editor (for example with Alt+Enter).
+  // Move focus into the menu so navigation keys are owned by the menu rather
+  // than also being interpreted by the editor as cursor movement.
+  useEffect(() => {
+    innerRef.current?.focus();
+  }, []);
+
   // Keyboard navigation
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -170,6 +177,7 @@ export const MenuSurface = forwardRef<HTMLDivElement, {
   return (
     <div
       ref={setRef}
+      tabIndex={-1}
       data-testid="context-menu"
       data-taomni-context-menu=""
       className="min-w-[220px] py-1 rounded shadow-lg border text-[12px] outline-none"


### PR DESCRIPTION
…e keyboard navigation

When context menus are triggered from the editor (such as Alt+Enter quick fixes or context actions), focus previously remained in the editor, allowing keyboard navigation events (such as ArrowUp/ArrowDown) to be captured by the editor and move the cursor.

- Set tabIndex={-1} on the MenuSurface container to make it programmatically focusable.
- Trigger focus() on the menu container upon mounting so menu keyboard navigation is isolated from the editor.
- Add unit test in ContextMenu.test.tsx verifying that the context menu container acquires focus upon opening.