### PR TITLE
feat(code-workspace): add IDEA 2026.2 parity audit backlog and capabi…

### DIFF
--- a/.agents/skills/code-workspace-idea-task/SKILL.md
+++ b/.agents/skills/code-workspace-idea-task/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: code-workspace-idea-task
-description: Claim and deliver exactly one small Taomni Code Workspace editor task from the active IntelliJ IDEA parity backlog. Use when an agent should select or receive a claimable ED-* card, implement or finish its evidence, verify every acceptance ID, and update the shared board. Do not use the historical design document as a queue or for unrelated Code Workspace work.
+description: Claim and deliver one small Taomni Code Workspace IDEA parity task, or author its backlog and linked specifications when explicitly requested. Verify acceptance and current evidence against production code. Do not use the historical design document as a queue or for unrelated Code Workspace work.
 ---
 
 # Code Workspace IDEA Task
 
-Deliver one `ED-*` task from `claudedocs/code-workspace-idea-parity-backlog.md`. A historical green task, exported model, fixture-only path, screenshot, or unrun check is not current completion evidence.
+Deliver one `ED-*` task from the caller-selected backlog. The current new-work board is `claudedocs/code-workspace-idea-parity-backlog-2026-09-audit.md`; use the earlier `claudedocs/code-workspace-idea-parity-backlog.md` only when the caller selects that board or its task. Pass the selected path through `--doc` on every task-board command; the script's legacy default does not select the new board. A historical green task, exported model, fixture-only path, screenshot, or unrun check is not current completion evidence.
+
+When explicitly asked to create/review a backlog or its designs, use [references/backlog-authoring.md](references/backlog-authoring.md). This is document authoring, not a request to claim or implement a product card. The one-claimed-task lifecycle below applies to execution.
 
 ## Read The Contract
 
@@ -13,7 +15,7 @@ Before claiming:
 
 1. Read the repository `AGENTS.md`.
 2. Read backlog sections 1-3, the selected card, and its dependency cards.
-3. Read `claudedocs/code-workspace-idea-specs/shared-contracts.md` and the selected card's linked spec section, including the capability design above it.
+3. Read `claudedocs/code-workspace-idea-specs/shared-contracts.md` and the selected card's linked spec section, including the capability design above it and its shared comparison contract. The selected board defines its own build-gate owner and platform scope.
 4. Read [references/task-lifecycle.md](references/task-lifecycle.md) before using the task-board script.
 
 Read `claudedocs/code-workspace-ide-design.md` only when a card's `legacy` links or an implementation question needs historical detail. Its old queues are archives, never claim sources.
@@ -38,7 +40,9 @@ If current code already satisfies the card, do not reimplement it; verify the pr
 
 For behavior changes, add a focused regression test that fails for the intended reason on the claimed baseline. Pure ADR, audit, catalog, or evidence tasks may use a deterministic failing check instead. Follow local patterns and avoid broad rewrites, especially in `CodeWorkspaceTab.tsx`.
 
-Always run focused checks. For TypeScript contracts, production wiring, or UI changes run the scoped gate — `python .agents/skills/code-workspace-idea-task/scripts/typecheck_scope.py --path <each path this card owns>` — and run repo-wide `pnpm build` only for the cards that still hold the `build` kind (ED-GATE-003, ED-GATE-001, ED-QA-001). Run relevant Rust tests for Rust/IPC changes. Use the repository `qa-ui-auto` skill when the task changes UI controls, user workflows, testcase YAML, feature ownership, or observation/evidence surfaces. Run native/provider/performance/accessibility/IDEA layers only in qualifying environments; record unavailable layers without fabricating substitutes.
+Always run focused checks. For TypeScript contracts, production wiring, or UI changes run the scoped gate: `python .agents/skills/code-workspace-idea-task/scripts/typecheck_scope.py --path <each path this card owns>`. Run repo-wide `pnpm build` for cards holding the `build` kind in the selected board; feature cards own scoped typecheck. Run relevant Rust tests for Rust/IPC changes.
+
+Use the repository `qa-ui-auto` skill for UI workflows, testcase/catalog changes, or evidence surfaces. Follow its current entrypoints and references: select `run --mode browser` or `native` explicitly, read `summary.json` with its matching receipt and source/case/runner identities, and inspect selected/pass/fail/skip counts. `audit --gate` is static coverage; `status --gate` is reviewed current execution in an explicitly selected scope/platform; `audit --release-evidence` validates the existing release manifest. Dry-run and exit 0 alone prove no behavior. Read native-testing before native launches, authoring/verb-catalog before case edits, and verification before interpreting coverage/performance. Manual IDEA/macOS evidence stays separate from runner-generated passes. Run native/provider/performance/accessibility/IDEA layers only in qualifying environments; record unavailable layers without fabricating substitutes.
 
 Before updating the board, review the final diff and re-check every acceptance ID against the actual production path. Preserve failed checks before successful reruns in chronological evidence.
 

--- a/.agents/skills/code-workspace-idea-task/references/backlog-authoring.md
+++ b/.agents/skills/code-workspace-idea-task/references/backlog-authoring.md
@@ -1,0 +1,50 @@
+# Backlog And Specification Authoring
+
+Use this mode only when the caller asks to create/review task cards or designs.
+Do not claim product work to write a plan. Do not change historical ownership,
+status, or completion evidence unless the caller requests that change.
+
+## Deliver The Linked Contract
+
+- Keep backlog sections 1-3 for board selection/rules, spec index and delivery gates.
+  Cards contain discovery metadata and a spec link; put implementation contracts
+  in the linked capability document.
+- Each card has one small production outcome, explicit file/symbol ownership,
+  dependencies within this board, and a real spec section with
+  `<a id="ed-example-001"></a>`.
+- Use that card's own full acceptance IDs, for example `ED-EXAMPLE-001-A1`.
+  Do not borrow another card's acceptance or anchor to satisfy validation.
+- A spec contains current code facts, proposed changes, UI-to-effect ownership,
+  typed failure/cancel/stale/unknown effects, undo/recovery, exact fixture/action,
+  focused tests, native platform plan, evidence kinds and completion ceiling.
+- Distinguish a confirmed code defect from an IDEA behavior that still requires
+  observation. Reference current production callers, not only exported helpers.
+  Missing evidence is not automatically a code bug. Earlier failed checks followed
+  by a final pass are valid history; unrun non-required layers are not automatic
+  reasons to reopen a card.
+- Record real IDEA version/build and same-fixture observations only after execution.
+  Documents and synthetic fixtures are not real comparison evidence.
+- New tasks may use `prior_completion: {"kind":"new-task","completed":false}`
+  to satisfy the current board format without inventing completion history.
+  Set audit date/HEAD and a factual finding; omit owner/claimed_at/baseline/evidence
+  on new ready cards. Metadata belongs immediately after the task heading.
+- Required evidence in metadata and spec must agree. A behavior card owns scoped
+  typecheck; assign repository build to an explicit integration card. Cross-platform
+  plans and the current-platform completion requirement must be unambiguous.
+- Reuse qa-ui-auto's current runners and evidence contracts. Proposed collectors,
+  cases or schema files must be marked as new and assigned to a task; don't print
+  unimplemented commands as if they already run.
+
+## Handoff Check
+
+Run both commands with the exact selected board path:
+
+```bash
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc claudedocs/code-workspace-idea-parity-backlog-2026-09-audit.md validate
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc claudedocs/code-workspace-idea-parity-backlog-2026-09-audit.md list --claimable
+```
+
+Also review spec links, owner/test paths, every acceptance-to-verification mapping
+and shared-file dependency conflicts. Successful board validation checks metadata
+and anchors, not product implementation or IDEA parity. Do not mark planned work
+done. Report the backlog/spec links, actual validation and remaining runtime gaps.

--- a/.agents/skills/code-workspace-idea-task/references/task-lifecycle.md
+++ b/.agents/skills/code-workspace-idea-task/references/task-lifecycle.md
@@ -1,15 +1,22 @@
 # Task Lifecycle
 
-Use these commands from the repository root. The script locks and atomically rewrites only the selected task metadata.
+Use these commands from the repository root. Select the caller's board once and pass it to every command. The script locks and atomically rewrites only the selected task metadata.
+
+```bash
+task_board_doc=claudedocs/code-workspace-idea-parity-backlog-2026-09-audit.md
+# For a caller-selected earlier board, assign its path instead.
+```
+
+The discovery example uses ED-AUDIT-001 on the new board. Terminal-state examples illustrate different cards; replace each ID with your actually claimed card and never update an unclaimed example card. PowerShell users should pass the literal board path through --doc. Never mix a claim on one board with an update on another.
 
 ## 1. Discover And Inspect
 
 Record current HEAD and `git status --short`, then validate the board:
 
 ```bash
-python .agents/skills/code-workspace-idea-task/scripts/task_board.py validate
-python .agents/skills/code-workspace-idea-task/scripts/task_board.py list --claimable
-python .agents/skills/code-workspace-idea-task/scripts/task_board.py show ED-CLIP-001
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc "$task_board_doc" validate
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc "$task_board_doc" list --claimable
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc "$task_board_doc" show ED-AUDIT-001
 ```
 
 If the caller supplied an ID, inspect that card and reject it when `claimable` is false. Otherwise choose the first highest-priority claimable card that does not overlap files currently being edited. `implemented` is claimable because it still needs a named audit/evidence gap closed.
@@ -19,9 +26,9 @@ Use the owner supplied by the harness or caller. Otherwise create a stable label
 ## 2. Claim Before Production Edits
 
 ```bash
-python .agents/skills/code-workspace-idea-task/scripts/task_board.py claim ED-CLIP-001 \
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc "$task_board_doc" claim ED-AUDIT-001 \
   --owner <owner>
-python .agents/skills/code-workspace-idea-task/scripts/task_board.py update ED-CLIP-001 \
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc "$task_board_doc" update ED-AUDIT-001 \
   --owner <owner> \
   --status in_progress
 ```
@@ -46,7 +53,7 @@ Create evidence using [evidence-policy.md](evidence-policy.md). Prefer `--eviden
 Complete:
 
 ```bash
-python .agents/skills/code-workspace-idea-task/scripts/task_board.py update ED-CLIP-001 \
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc "$task_board_doc" update ED-AUDIT-001 \
   --owner <owner> \
   --status done \
   --evidence-file <evidence.json>
@@ -55,7 +62,7 @@ python .agents/skills/code-workspace-idea-task/scripts/task_board.py update ED-C
 Production complete but required evidence remains:
 
 ```bash
-python .agents/skills/code-workspace-idea-task/scripts/task_board.py update ED-CLIP-001 \
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc "$task_board_doc" update ED-AUDIT-010 \
   --owner <owner> \
   --status implemented \
   --evidence-file <evidence.json> \
@@ -65,7 +72,7 @@ python .agents/skills/code-workspace-idea-task/scripts/task_board.py update ED-C
 Material contract conflict:
 
 ```bash
-python .agents/skills/code-workspace-idea-task/scripts/task_board.py update ED-CLIP-001 \
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc "$task_board_doc" update ED-AUDIT-010 \
   --owner <owner> \
   --status review_required \
   --evidence-file <evidence.json> \
@@ -75,7 +82,7 @@ python .agents/skills/code-workspace-idea-task/scripts/task_board.py update ED-C
 External blocker:
 
 ```bash
-python .agents/skills/code-workspace-idea-task/scripts/task_board.py update ED-PROJECT-002 \
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc "$task_board_doc" update ED-AUDIT-007 \
   --owner <owner> \
   --status blocked \
   --note "Maven fixture cannot resolve offline; resume with the configured repository mirror"
@@ -86,7 +93,7 @@ python .agents/skills/code-workspace-idea-task/scripts/task_board.py update ED-P
 Always finish with:
 
 ```bash
-python .agents/skills/code-workspace-idea-task/scripts/task_board.py validate
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc "$task_board_doc" validate
 git diff --check
 git status --short
 ```
@@ -98,7 +105,7 @@ Only commit when the caller or loop explicitly authorizes it. Inspect the diff, 
 Use a conventional message containing the task ID, for example:
 
 ```text
-fix(code-workspace): complete ED-CLIP-001 lease ownership
+feat(code-workspace): add ED-AUDIT-001 comparison validator
 ```
 
 Do not use broad staging in a dirty worktree. Do not amend, rewrite, or include other owners' changes. Report the resulting commit hash and any task-owned files intentionally left uncommitted.

--- a/claudedocs/code-workspace-idea-parity-backlog-2026-09-audit.md
+++ b/claudedocs/code-workspace-idea-parity-backlog-2026-09-audit.md
@@ -1,0 +1,113 @@
+# Code Workspace IntelliJ IDEA 2026.2 对齐任务板
+
+## 1. 任务规则
+
+本文件管理任务、依赖和规格索引；实施要求以卡片指向的 spec 为准。一次领取一张卡，完成该卡的生产效果及必要证据。所有卡均为待实现或待核验，不能把本文件理解为功能已经完成。
+
+使用 `code-workspace-idea-task`，每次调用任务板脚本都显式指定本文件：
+
+```bash
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc claudedocs/code-workspace-idea-parity-backlog-2026-09-audit.md validate
+python .agents/skills/code-workspace-idea-task/scripts/task_board.py --doc claudedocs/code-workspace-idea-parity-backlog-2026-09-audit.md list --claimable
+```
+
+领取、更新命令见技能的 task-lifecycle。依赖未完成的 ready 卡不能领取；已存在实现时先核验，仅修复当前代码与本卡验收之间的差距。不得修改旧卡状态来代替完成本卡。
+
+## 2. 详细规格索引
+
+| 规格 | 内容 |
+|---|---|
+| [共享合同](./code-workspace-idea-specs/shared-contracts.md) | 状态、owner、事务与证据语义 |
+| [IDEA 对比契约](./code-workspace-idea-specs/idea-2026-comparison.md) | 版本、fixture、动作记录、数据接口、平台手册、校验设施 |
+| [编辑与输入](./code-workspace-idea-specs/idea-2026-editing.md) | Virtual Space、分屏、剪贴板、IME |
+| [语义操作](./code-workspace-idea-specs/idea-2026-semantic.md) | 替换、completion、intention、导航、rearrange、cleanup |
+| [保存与恢复](./code-workspace-idea-specs/idea-2026-transactions.md) | 保存竞争、重构 postcondition 与恢复 |
+| [性能与门禁](./code-workspace-idea-specs/idea-2026-performance.md) | 输入热路径、多标签恢复、发布能力矩阵 |
+
+## 3. 交付标准
+
+每卡拥有独立的 `ED-AUDIT-xxx-A1/A2/A3`。本轮原生验证要求当前执行平台；Windows、Linux、macOS 分别记实测或未验证，不能推广单端结论。没有 IDEA 2026.2 实测时，所需 `idea-comparison` 层保持未运行，不能编造行为或通过证据。
+
+`ED-AUDIT-001` 交付对比校验设施，其余行为卡负责各自真实样本与实现。共享 `CodeWorkspaceTab.tsx` 只按具体 handler/owner 修改；同时领取者必须协调重叠范围。`ED-AUDIT-006` 独家持有本板全仓 build 汇总，功能卡运行自己的 scoped typecheck，不得为绿灯排除自己造成的错误。
+
+## 4. 任务卡
+
+### ED-AUDIT-001 IDEA 对比记录契约与校验器
+<!-- ide-task {"id":"ED-AUDIT-001","status":"ready","priority":"P0","size":"M","depends_on":[],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-comparison.md#ed-audit-001","acceptance":["ED-AUDIT-001-A1","ED-AUDIT-001-A2","ED-AUDIT-001-A3"],"required_evidence":["document","unit"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"新增对比数据校验设施；现有 QA receipt 只证明 Taomni 执行，不能生成 IDEA 观测。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-comparison.md#ed-audit-001)。
+
+### ED-AUDIT-002 Virtual Space 插入与撤销对齐
+<!-- ide-task {"id":"ED-AUDIT-002","status":"ready","priority":"P1","size":"M","depends_on":["ED-AUDIT-001"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-editing.md#ed-audit-002","acceptance":["ED-AUDIT-002-A1","ED-AUDIT-002-A2","ED-AUDIT-002-A3"],"required_evidence":["code-audit","unit","typecheck","browser","native","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"workspaceVirtualSpace 已有独立 overflow state；逐动作 IDEA 语义需要实测确认。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-editing.md#ed-audit-002)。
+
+### ED-AUDIT-003 文件替换范围与冲突对齐
+<!-- ide-task {"id":"ED-AUDIT-003","status":"ready","priority":"P1","size":"M","depends_on":["ED-AUDIT-001"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-semantic.md#ed-audit-003","acceptance":["ED-AUDIT-003-A1","ED-AUDIT-003-A2","ED-AUDIT-003-A3"],"required_evidence":["code-audit","unit","typecheck","browser","native","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"已有 find scope / replace model；需核对 preview 到文件写入的一致范围。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-semantic.md#ed-audit-003)。
+
+### ED-AUDIT-004 保存中的输入竞争与最终字节对齐
+<!-- ide-task {"id":"ED-AUDIT-004","status":"ready","priority":"P1","size":"M","depends_on":["ED-AUDIT-001"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-transactions.md#ed-audit-004","acceptance":["ED-AUDIT-004-A1","ED-AUDIT-004-A2","ED-AUDIT-004-A3"],"required_evidence":["code-audit","unit","typecheck","browser","native","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"SaveCommitResult 已区分 committed/unknown 和 dirty writeback；本卡核对真实保存动作。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-transactions.md#ed-audit-004)。
+
+### ED-AUDIT-005 输入延迟实测与热路径优化
+<!-- ide-task {"id":"ED-AUDIT-005","status":"ready","priority":"P1","size":"M","depends_on":["ED-AUDIT-001"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-performance.md#ed-audit-005","acceptance":["ED-AUDIT-005-A1","ED-AUDIT-005-A2","ED-AUDIT-005-A3"],"required_evidence":["code-audit","unit","typecheck","performance","native","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"必须测生产 CodeMirrorHost 输入链；字符串/rope 微基准不能证明编辑器延迟。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-performance.md#ed-audit-005)。
+
+### ED-AUDIT-006 当前源码门禁与能力发布矩阵
+<!-- ide-task {"id":"ED-AUDIT-006","status":"ready","priority":"P2","size":"S","depends_on":["ED-AUDIT-002","ED-AUDIT-003","ED-AUDIT-004","ED-AUDIT-005","ED-AUDIT-007","ED-AUDIT-008","ED-AUDIT-009","ED-AUDIT-010","ED-AUDIT-011","ED-AUDIT-012","ED-AUDIT-013","ED-AUDIT-014","ED-AUDIT-015","ED-AUDIT-016"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-performance.md#ed-audit-006","acceptance":["ED-AUDIT-006-A1","ED-AUDIT-006-A2","ED-AUDIT-006-A3"],"required_evidence":["code-audit","build","qa-lint","document"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"汇总本任务板能力及当前 source/case/runner identity，不复用过期 PASS。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-performance.md#ed-audit-006)。
+
+### ED-AUDIT-007 Completion 接受与单次撤销对齐
+<!-- ide-task {"id":"ED-AUDIT-007","status":"ready","priority":"P1","size":"M","depends_on":["ED-AUDIT-001"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-semantic.md#ed-audit-007","acceptance":["ED-AUDIT-007-A1","ED-AUDIT-007-A2","ED-AUDIT-007-A3"],"required_evidence":["code-audit","unit","typecheck","browser","native","provider","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"生产 commitLspCompletion 已处理 edit/snippet；需真实 provider 与 IDEA 对比接受边界。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-semantic.md#ed-audit-007)。
+
+### ED-AUDIT-008 Intention 预览提交与失败对齐
+<!-- ide-task {"id":"ED-AUDIT-008","status":"ready","priority":"P1","size":"M","depends_on":["ED-AUDIT-001"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-semantic.md#ed-audit-008","acceptance":["ED-AUDIT-008-A1","ED-AUDIT-008-A2","ED-AUDIT-008-A3"],"required_evidence":["code-audit","unit","typecheck","browser","native","provider","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"runCodeAction 已调用 canonical applyPlan；对比 apply/command failure 与 history。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-semantic.md#ed-audit-008)。
+
+### ED-AUDIT-009 同文档分屏与关闭重开对齐
+<!-- ide-task {"id":"ED-AUDIT-009","status":"ready","priority":"P1","size":"M","depends_on":["ED-AUDIT-001"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-editing.md#ed-audit-009","acceptance":["ED-AUDIT-009-A1","ED-AUDIT-009-A2","ED-AUDIT-009-A3"],"required_evidence":["code-audit","unit","typecheck","browser","native","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"已有 document transaction owner、tab policy；核对 shared history 与独立视图状态。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-editing.md#ed-audit-009)。
+
+### ED-AUDIT-010 系统剪贴板多光标粘贴对齐
+<!-- ide-task {"id":"ED-AUDIT-010","status":"ready","priority":"P1","size":"M","depends_on":["ED-AUDIT-001"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-editing.md#ed-audit-010","acceptance":["ED-AUDIT-010-A1","ED-AUDIT-010-A2","ED-AUDIT-010-A3"],"required_evidence":["code-audit","unit","typecheck","browser","native","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"clipboard session 已区分 permission 与 systemEffect；需验证 OS 与内存 fallback 边界。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-editing.md#ed-audit-010)。
+
+### ED-AUDIT-011 IME 输入期间的命令与焦点隔离
+<!-- ide-task {"id":"ED-AUDIT-011","status":"ready","priority":"P1","size":"M","depends_on":["ED-AUDIT-001"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-editing.md#ed-audit-011","acceptance":["ED-AUDIT-011-A1","ED-AUDIT-011-A2","ED-AUDIT-011-A3"],"required_evidence":["code-audit","unit","typecheck","native","accessibility","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"CodeMirrorHost 有 composing guards；全局 action 层及真实输入法仍需逐端验证。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-editing.md#ed-audit-011)。
+
+### ED-AUDIT-012 语义结果跳转与返回历史对齐
+<!-- ide-task {"id":"ED-AUDIT-012","status":"ready","priority":"P1","size":"M","depends_on":["ED-AUDIT-001"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-semantic.md#ed-audit-012","acceptance":["ED-AUDIT-012-A1","ED-AUDIT-012-A2","ED-AUDIT-012-A3"],"required_evidence":["code-audit","unit","typecheck","browser","native","provider","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"已有 navigation history 与 usage scope；本卡只核对语义结果到 reveal/back 的用户链路。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-semantic.md#ed-audit-012)。
+
+### ED-AUDIT-013 多标签恢复的可交互时机优化
+<!-- ide-task {"id":"ED-AUDIT-013","status":"ready","priority":"P1","size":"M","depends_on":["ED-AUDIT-001","ED-AUDIT-009"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-performance.md#ed-audit-013","acceptance":["ED-AUDIT-013-A1","ED-AUDIT-013-A2","ED-AUDIT-013-A3"],"required_evidence":["code-audit","unit","typecheck","performance","native","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"planWorkspaceRestore 已有 active/background 两阶段和有界队列；需测 active-ready 真实边界。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-performance.md#ed-audit-013)。
+
+### ED-AUDIT-014 Refactor postcondition 失败阻断与恢复入口
+<!-- ide-task {"id":"ED-AUDIT-014","status":"ready","priority":"P0","size":"M","depends_on":["ED-AUDIT-001"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-transactions.md#ed-audit-014","acceptance":["ED-AUDIT-014-A1","ED-AUDIT-014-A2","ED-AUDIT-014-A3"],"required_evidence":["code-audit","unit","typecheck","browser","native","provider","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"当前 post-hash mismatch 仅 console.warn 后继续记录 committed/history；journal 写在 mutation 后且 replay 无生产调用。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-transactions.md#ed-audit-014)。
+
+### ED-AUDIT-015 Rearrange 支持分支接入实际事务
+<!-- ide-task {"id":"ED-AUDIT-015","status":"ready","priority":"P0","size":"M","depends_on":["ED-AUDIT-001","ED-AUDIT-008"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-semantic.md#ed-audit-015","acceptance":["ED-AUDIT-015-A1","ED-AUDIT-015-A2","ED-AUDIT-015-A3"],"required_evidence":["code-audit","unit","typecheck","browser","native","provider","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"workspace.rearrangeCode 的 execute 分支只更新状态；buildRearrangePlan 无生产调用。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-semantic.md#ed-audit-015)。
+
+### ED-AUDIT-016 Cleanup 支持分支接入实际事务
+<!-- ide-task {"id":"ED-AUDIT-016","status":"ready","priority":"P0","size":"M","depends_on":["ED-AUDIT-001","ED-AUDIT-008","ED-AUDIT-015"],"spec":"claudedocs/code-workspace-idea-specs/idea-2026-semantic.md#ed-audit-016","acceptance":["ED-AUDIT-016-A1","ED-AUDIT-016-A2","ED-AUDIT-016-A3"],"required_evidence":["code-audit","unit","typecheck","browser","native","provider","idea-comparison"],"audit":{"date":"2026-09-07","head":"6cda8077b17218ad72cff09ae693a3e55f6ffce5","finding":"workspace.codeCleanup 的 execute 分支只更新状态；buildCleanupPlan 无生产调用。"},"prior_completion":{"kind":"new-task","completed":false}} -->
+
+[设计、代码职责、验收与验证](./code-workspace-idea-specs/idea-2026-semantic.md#ed-audit-016)。

--- a/claudedocs/code-workspace-idea-specs/idea-2026-comparison.md
+++ b/claudedocs/code-workspace-idea-specs/idea-2026-comparison.md
@@ -1,0 +1,110 @@
+# IDEA 2026.2 行为对比与交付契约
+
+## 1. 设计边界
+
+配合 [共享合同](./shared-contracts.md) 与 [任务板](../code-workspace-idea-parity-backlog-2026-09-audit.md) 使用。后续能力规格继承本文件。规格状态为可开展实现和采样，所有实际运行证据初始为未执行。当前代码定位基于 `6cda8077b17218ad72cff09ae693a3e55f6ffce5`，接手时必须重查 production caller。
+
+目标是实现可观察编辑行为的一致性，不复制 IDEA 的 PSI、专有索引或排序引擎。每个工作包先在 IDEA 2026.2.x 实测本卡动作，再映射到 Taomni owner 和验收；不能用其他版本或当前官网文本代替该版本实测。本设计没有声称已经运行 IDEA。
+
+### DEC-01 复用 QA 设施
+
+采用现有 qa-ui-auto runner、summary、receipt、status 和 feature catalog，只新增独立对比记录及校验命令，不另建动作 DSL、签名系统或通用自动化框架。理由：现有工具已管理 Taomni 的隔离、命令、真实执行与来源身份；IDEA 端用可重复手工步骤或已有 OS 自动化即可采集。此为沿用工程设施的局部设计决定。
+
+### DEC-02 对齐策略
+
+先比较结果集合、字节/文本、caret/selection、焦点、history、失败和恢复。排序、推荐策略和 provider 能力须单独记录。被测方法应调用真实 UI 入口；直接写 store 或伪造 provider response 只可用于回归测试，不能作为真实行为对比证据。IDEA 没有对应的 Taomni 内部失败状态时记为 Taomni 安全扩展，仅对比用户可见结果，不虚构 IDEA IPC 语义。
+
+### DEC-03 门禁与状态
+
+历史失败后同类当前检查通过是合法历史，不是缺陷。非必需层的 unrun 不自动否定 done；反之，必需层缺失或最终失败不能记 done。本板 build 汇总归 ED-AUDIT-006；不继承共享合同中旧板的 gate ID 列表。维持三端代码兼容，当前平台 native 达标可以关闭单卡，但不能声明三端已实测。已知兼容性错误必须解决。
+
+## 2. 对比记录接口（拟新增）
+
+ED-AUDIT-001 负责在 `claudedocs/code-workspace-idea-specs/idea-comparison.schema.json` 定义 JSON Schema，在 `.agents/skills/code-workspace-idea-task/scripts/compare_idea.py` 实现标准库 CLI 校验。schema 文档与 CLI 规则保持一致；已有解析工具可复用，不引入新的平台 driver。
+
+每个文件含以下字段。实际采样文件写入被忽略的 `qa-ui-auto-report/idea-comparison/<task>/<run>/`，入库文档只记录脱敏结论、hash、执行步骤及可获取原始产物的位置。
+
+| 字段 | 类型 / 要求 |
+|---|---|
+| schemaVersion, taskId, acceptance | `1`、本卡 ID、该卡完整验收 ID 数组 |
+| scenarioId, fixture | 场景 ID；fixture 包含相对文件路径与 SHA-256、初始内容来源、根目录别名、初始 dirty/磁盘状态 |
+| settings | keymap 名称与 action 绑定、editor/formatter 参数、语言、JDK、项目导入/indexing 就绪条件、locale、相关插件 |
+| steps | 有序对象：stepId、actionName、实际 key/chord 或菜单路径、输入值、前置状态、需观察字段；不是可直接执行的新 DSL |
+| idea | version=2026.2.x、完整 build number、edition、OS、采样时间、operator 或自动化工具、设置快照、原始产物列表、逐步骤 observations |
+| taomni | HEAD 加源码内容身份、QA build identity、OS/WebView、provider ID/version、mode、summary/receipt 路径与 hash、逐步骤 observations |
+| observations | stepId、status、documents（相对路径、文本/字节 hash、dirty）、caret/selection、focus target、结果项或范围、history/undo、错误/恢复事实 |
+| deltas | field、idea value、taomni value、分类、linkedAcceptance、解释及处置；不得只写“相同” |
+| verdict, ceiling | `matched / different / incomparable / unverified`；能力、fixture、provider、平台、通过层级 |
+| artifacts | 相对路径、SHA-256、类型、获取方式；原始文件缺失不能充当可重验 passing 证据 |
+
+路径采用 fixture 根的相对路径；只规范化 OS 路径分隔符和预先声明的运行目录别名。文本、BOM、EOL、字节 hash、结果顺序、耗时不得规范化掉。比较文本 offset 统一为 UTF-16，视觉列单独保存 grapheme/tabSize 与像素观测。两端 provider 不同是事实，不能伪称同一 provider；源码、JDK、动作和就绪前提才是可比条件。
+
+`matched` 要求规定字段全部可比且无未解释差异。`different` 记录真实差距；`incomparable` 用于版本/fixture/动作/平台前提不匹配；缺一端运行是 `unverified`。validator 不凭合法 JSON 签发运行证明。
+
+## 3. 每卡执行流程
+
+1. 读本文件和所选能力章节，核对列出的 owner/caller；把每个 A ID 映射到一个完整生产路径。
+2. 在独立 fixture 工程运行 IDEA 2026.2.x；从 Help/About 记录完整 build，记录 keymap/action 和 settings；等待项目索引完成。每个正常/撤销动作至少重复一次。没有此版本就明确留下缺口。
+3. 用相同初始内容在独立 Taomni QA workspace 重置并执行同动作。通过文件读取、可见 selection/focus、结果列表及撤销后文本采集事实。仅在单测注入 timeout/stale 等受控故障；native 异常只使用隔离 fixture。
+4. 给 confirmed delta 添加失败回归，修改具体 owner，复跑该回归与相邻行为。已经满足的代码不重复实现；存在功能差距时不能只交付对比报告。
+5. 运行本卡 evidence kinds；原始失败保留在重跑通过之前。每个 A ID 在 evidence checks 中有真实通过覆盖，任何未解决的实质行为差距都阻止 done。
+
+产品 UI 沿用现有命令、弹窗和反馈，不在本设计增加布局或技术栈。恢复等行为复用现有确认/预览流程。涉及 materially 不同的 provider 能力或不可逆恢复选择时记录 review_required，写具体选择，不能自行弱化卡片目标。
+
+## 4. QA 命令与平台手册
+
+仓库根目录，先设置 `PYTHONPATH=.agents/skills/qa-ui-auto/scripts`（PowerShell 用 `$env:PYTHONPATH`）。以下为现存入口，filter 和 feature 使用各卡列出的实际 ID；新增 case 在创建并注册之前不能执行。
+
+```bash
+python -m qa_ui_auto plan --diff HEAD
+python -m qa_ui_auto run --mode browser --filter TC-IDE-C4-02 --require-pass
+python -m qa_ui_auto status --feature F25.5 --json
+python -m qa_ui_auto audit --gate
+python .agents/skills/code-workspace-idea-task/scripts/typecheck_scope.py --path src/components/editor/workspace/workspaceDocumentTransactionOwner.ts
+```
+
+typecheck 的所有实际改动 owner/source/test 路径均用重复 `--path` 加入；上面是单路径示例，不是该卡的完整 scope。`pnpm exec vitest run <本卡已有测试文件>` 运行 focused tests；变更 Rust 时从 src-tauri 运行聚焦 `cargo test --lib <实际模块名>`，macOS 先遵守 AGENTS 的 krb5 stage。
+
+| 平台 | 准备与实际执行 | 必须记录的限制 |
+|---|---|---|
+| Linux | 阅读 qa-ui-auto native-testing；native_build.py 独立编译 QA；tauri-driver + WebKitWebDriver，真实桌面或 Xvfb，菜单/编辑及真实文件断言 | Xvfb 不等价实际 IME/compositor/物理键盘或硬件延迟；这些动作在实际桌面补测 |
+| Windows | 同一 QA source build，tauri-driver 与匹配的 WebView2/msedgedriver；执行 Ctrl/Alt、剪贴板、锁定文件、盘符路径动作 | 保存原有 host clipboard 并在 finally 恢复；不能套用 Linux 权限 fixture |
+| macOS | 独立 QA bundle，核实 CFBundleIdentifier=com.taomni.app.qa，独立用户/QA profile，使用 OS 自动化或逐步手工执行 | 无 Tauri WebDriver；禁止用 Chromium/WebKit browser 报告补成 native 自动化 pass |
+
+native build/run 命令与隔离详见 `.agents/skills/qa-ui-auto/references/native-testing.md`，执行前必读。禁止改名生产 binary 充当 QA。新测试工作区只包含本卡 fixture；关闭本轮应用和 provider，恢复 clipboard、只读属性和环境，保留失败原始产物。
+
+每个行为卡复用本卡具体 case，补漏项时按 authoring.md/verb-catalog.md 选择真实 verb 并维护 covers/controls/feature。case 编写不是 passed evidence。F25.5 为 editor shell、F25.3 为 appearance/actions；语义归属按现有 case 的 covers 核对，不能把全部新 case 硬塞进一个 feature。
+
+发布验证区分：
+- `audit --gate`：schema/catalog/static coverage；
+- `status --gate --feature <已登记feature> --platform <当前平台>`：该选择范围的 reviewed/current executions；检查实际 selected/pass/fail/skip，不夸大到全产品；
+- `audit --release-evidence`：现有 release manifest 校验。手工 IDEA/native 数据不能伪装为 runner summary。
+共同遵守 qa-ui-auto verification.md：当前身份含未提交源码和 runner/case fingerprints；只记录 HEAD 不充分。
+
+## 5. IDEA 资料定位与实测场景
+
+官方主题只提供操作定位，不代表 2026.2 已实测：
+[编辑](https://www.jetbrains.com/help/idea/using-code-editor.html)、
+[多光标](https://www.jetbrains.com/help/idea/multicursor.html)、
+[标签](https://www.jetbrains.com/help/idea/editor-tabs.html)、
+[补全](https://www.jetbrains.com/help/idea/auto-completing-code.html)、
+[Intention](https://www.jetbrains.com/help/idea/intention-actions.html)、
+[导航](https://www.jetbrains.com/help/idea/navigating-through-the-source-code.html)、
+[用法](https://www.jetbrains.com/help/idea/find-highlight-usages.html)、
+[格式与重排](https://www.jetbrains.com/help/idea/reformat-and-rearrange-code.html)。
+执行时保存使用的文档版本/访问时间与 IDEA build；用实测校准本卡期望，不能推断私有引擎内部行为。
+
+<a id="ed-audit-001"></a>
+## ED-AUDIT-001 IDEA 对比记录契约与校验器
+
+**目标/owner：** 实现本文件第 2 节接口及 CLI，让行为卡可以复用相同记录格式。范围只限 schema、`compare_idea.py`、同目录拟新增 `test_compare_idea.py` 和本文件运行手册；不改 Taomni QA runner 签名/identity 或任何产品功能。
+
+**实施：** CLI 接受 `--record <json>`，按 schema 与类型校验；默认报告四态 verdict，格式错误 exit 2；`--require-match` 对 different/incomparable/unverified exit 1，只有 matched exit 0。对 duplicate step、缺失观测、无 artifacts、fixture/build mismatch fail closed。允许 Taomni 专有负路径记录，但不能纳入 IDEA matched 分母。对未运行层保留显式理由。不加载/执行记录中的代码或动作。
+
+**验收与验证：**
+- **ED-AUDIT-001-A1：** 所有字段、四态结果、CLI exit code 与只允许的 normalization 被独立单测验证；原始文本/EOL/顺序差異不能被吞掉。证据 unit。
+- **ED-AUDIT-001-A2：** 有效、版本不匹配、缺一端记录、篡改 artifact、重复 step、unverified 假 pass 六种 fixture 都产生确定结果；fixture 明确标为 synthetic validator tests，不能出现在 runtime passing matrix。证据 unit。
+- **ED-AUDIT-001-A3：** 手册含命令、IDEA 人工采样表、三端 native 步骤及与 runner summary/receipt 的链接规则；另一张行为卡仅填写记录即可运行校验，不需要新增 DSL 或修改 verifier。证据 document。
+
+实现后执行 `python -m unittest discover -s .agents/skills/code-workspace-idea-task/scripts -p 'test_compare_idea.py'`；真实 sample 由后续卡采集，本卡不以 schema 测试声称 IDEA parity。必需证据：document、unit。
+

--- a/claudedocs/code-workspace-idea-specs/idea-2026-editing.md
+++ b/claudedocs/code-workspace-idea-specs/idea-2026-editing.md
@@ -1,0 +1,127 @@
+# 编辑、视图与输入详细设计
+
+必读 [IDEA 对比与平台契约](./idea-2026-comparison.md) 和 [共享合同](./shared-contracts.md)。本文件只规定现有 editor surfaces 的行为，不新增界面布局。以下测试路径未加目录者均相对 `src/components/editor/workspace/`；新增对象显式标注。所有验证待执行。
+
+<a id="ed-audit-002"></a>
+## ED-AUDIT-002 Virtual Space 插入与撤销对齐
+
+### 用户目标与代码现状
+
+光标越过行尾只改变视图状态，实际插入才产生 padding，并由一次 undo 恢复。
+
+代码事实：workspaceVirtualSpace.ts 用 virtualSpaceOverflowField 和 EditorVirtualSpacePolicy 保存虚拟坐标，默认 afterLineEnd/atFileBottom 均关闭；CodeMirrorHost.tsx 消费该扩展。这证明有实现，不证明 IDEA 的所有移动/输入行为已对齐。
+
+### 实施范围与状态
+
+Owner：src/components/editor/workspace/workspaceVirtualSpace.ts、workspaceEditorCommands.ts、CodeMirrorHost.tsx 及相邻测试；CodeWorkspaceTab.tsx 仅相应 command context 绑定。
+
+复用 overflow field 与 document transaction owner。冻结发起 view/document revision；根据 grapheme 和 tabSize 保存视觉列，实际 document offset 仍合法。各 leaf 的 overflow 独立；insert/paste/padding 合为一个 transaction，移动不产生文本或 undo 项。IME composing 时交回输入法。不得为了测试引入绕过 production dispatch 的 setter。
+
+仅修改上述职责；出现别的功能差距单独记录。依赖：ED-AUDIT-001。每个操作都遵守共享 failure/cancel/stale/effect 契约，不用其他 owner 的成功测试代替本卡行为。
+
+### IDEA 同场景步骤
+
+UTF-8 文件三行：包含 tab 的长行、短行、空行，另含组合字符和 emoji。两端启用 after-line-end，关闭 at-file-bottom；从长行末向下、向右越过短行，输入 X，Undo/Redo；再分别开启 bottom policy 重复；两 split 交替操作。记录视觉列、UTF-16 offset、padding 数和 undo 后字节；记录 IDEA 实际设置名称与值。
+
+### 验收与验证
+
+- **ED-AUDIT-002-A1：** 两端同设置完成越界移动和插入，所有规定 caret/selection 与文本字段可比较；生产入口复现确认差距并实现修复，已经一致则给出当前证据。
+- **ED-AUDIT-002-A2：** 不插入时文本/hash/history 不变；一次 undo 恢复插入前文本及虚拟 caret，redo 重放；readonly、revision stale、失焦和 composition 均不错误填空格。
+- **ED-AUDIT-002-A3：** 改动 owner scoped typecheck、focused/mounted 回归、当前端 native 及本场景 IDEA 对比全部通过，其他两端记录未验证和动作清单。
+
+验证 V-002：workspaceVirtualSpace.test.ts、workspaceEditorCommands.test.ts、workspaceDocumentTransactionOwner.test.ts；扩展 TC-IDE-C8-01 与 TC-IDE-C8-02。回归必须断言真实 editor 文本和 selection，不只检查 overflow 数组。 先运行对应 `pnpm exec vitest run <上述测试>`；QA/native/IDEA 执行方式见共享对比契约。逐项将 A1 主流程、A2 负路径与恢复、A3 交付门禁映射到 evidence checks；有实际变更时保留 baseline failing regression。
+
+必需证据：`code-audit`、`unit`、`typecheck`、`browser`、`native`、`idea-comparison`。当前平台 native 与 IDEA 缺失不能关闭 done；代码已齐但证据缺失为 implemented。
+
+<a id="ed-audit-009"></a>
+## ED-AUDIT-009 同文档分屏与关闭重开对齐
+
+### 用户目标与代码现状
+
+同文件分屏共享文本和撤销序列，caret/scroll/fold 独立，关闭重开不丢失 dirty 内容。
+
+代码事实：workspaceDocumentTransactionOwner.ts 与 workspaceTabPolicy.ts 已存在；EditorGroup.tsx/CodeWorkspaceTab.tsx 是视图挂载与 tab 生命周期入口。是否与 IDEA 2026.2 默认 preview/pinned/reopen 行为一致仍需实测。
+
+### 实施范围与状态
+
+Owner：src/components/editor/workspace/workspaceDocumentTransactionOwner.ts、workspaceTabPolicy.ts、EditorGroup.tsx、workspaceLayoutPersistence.ts；CodeWorkspaceTab.tsx 仅 close/reopen/split/document routing handlers。
+
+一个 canonical document key 对应一个 transaction owner；订阅以 view lease 释放，关闭其中一 leaf 不销毁另一 leaf 的 document/history。复用现有 persisted layout，旧 snapshot 缺字段采用现有默认值，不另建同类 store。重开恢复 URI/encoding/EOL/dirty 与视图 snapshot；关闭最后 dirty view 使用现有保存/放弃/取消流程。
+
+仅修改上述职责；出现别的功能差距单独记录。依赖：ED-AUDIT-001。每个操作都遵守共享 failure/cancel/stale/effect 契约，不用其他 owner 的成功测试代替本卡行为。
+
+### IDEA 同场景步骤
+
+两端同一文件 split，左侧输入 abc，右侧输入 def，再分别 Undo；调整两边 caret/scroll/fold，pin/preview 后关闭一侧、重开，关闭最后 dirty view 并取消，再保存后重开。所有步骤记录文档版本、内容、焦点和 leaf 状态，IDEA keymap actionName 与实际键位分列。
+
+### 验收与验证
+
+- **ED-AUDIT-009-A1：** 两个真实 leaf 的编辑和 undo/redo 只进入同一逻辑历史，内容实时一致；独立 caret/scroll/fold 不被另一 leaf 输入覆盖，与 IDEA 同动作对比有结果。
+- **ED-AUDIT-009-A2：** 关闭非最后 leaf 不丢文本/history；最后 dirty view 的取消零效果，保存失败不关闭；reopen 不复活错误 workspace 或改变编码。
+- **ED-AUDIT-009-A3：** focused/mounted 生命周期测试、当前端 native（含重启读取 snapshot）、scoped typecheck 与 IDEA 对比通过；兼容旧 snapshot 的测试和两端未运行项保留。
+
+验证 V-009：workspaceDocumentTransactionOwner.test.ts、workspaceTabPolicy.test.ts、workspaceTabPolicyV3.test.ts、EditorGroup.test.tsx；TC-IDE-C4-01/TC-IDE-C4-02。选取 CodeWorkspaceTab.test.tsx 中对应挂载流程并补缺失断言。 先运行对应 `pnpm exec vitest run <上述测试>`；QA/native/IDEA 执行方式见共享对比契约。逐项将 A1 主流程、A2 负路径与恢复、A3 交付门禁映射到 evidence checks；有实际变更时保留 baseline failing regression。
+
+必需证据：`code-audit`、`unit`、`typecheck`、`browser`、`native`、`idea-comparison`。当前平台 native 与 IDEA 缺失不能关闭 done；代码已齐但证据缺失为 implemented。
+
+<a id="ed-audit-010"></a>
+## ED-AUDIT-010 系统剪贴板多光标粘贴对齐
+
+### 用户目标与代码现状
+
+多光标复制/粘贴使用真实系统剪贴板，内部多片段元数据不会覆盖外部应用新内容。
+
+代码事实：workspaceClipboardSession.ts 的 acquireClipboardStore/planPaste 与 GuardedSystemReadResult/WriteResult 已区分 permission、generation、performed/unknown；CodeMirrorHost 的剪贴板入口有 composing/revision guards。
+
+### 实施范围与状态
+
+Owner：src/components/editor/workspace/workspaceClipboardSession.ts、ClipboardHistoryPopup.tsx、CodeMirrorHost.tsx 剪贴板 handlers、src/lib/clipboard.ts；必要 IPC 变更追加真实 Rust owner 和 rust 证据。
+
+system text 是 OS 事实；只有 session text identity 与读回内容一致才可使用 per-selection metadata。数量相同逐片段分配、数量不同的分配规则以 IDEA 同配置实测为准并固化回归。write/read await 后重验 lease+document+view；OS effect 已发生不能记 zero effect。permission unknown 不当 denied，真正 denied 的内部 fallback 需可见且说明来源。history privacy/清理沿用现有 policy。
+
+仅修改上述职责；出现别的功能差距单独记录。依赖：ED-AUDIT-001。每个操作都遵守共享 failure/cancel/stale/effect 契约，不用其他 owner 的成功测试代替本卡行为。
+
+### IDEA 同场景步骤
+
+同 fixture 两处选择进行复制，切换 split 粘贴并 Undo；外部应用改写 OS clipboard 后再次粘贴；目标 caret 数为 1、2、3 分别记录。两端做空选择 copy/cut；Taomni 单测模拟系统读取拒绝及 await 后关闭 workspace。native finally 恢复原 host clipboard。
+
+### 验收与验证
+
+- **ED-AUDIT-010-A1：** 真实 OS 内容及 selection 数分配规则与 IDEA 对比明确，生产 paste 一次 transaction、一次 undo 恢复；外部修改后不使用旧 metadata。
+- **ED-AUDIT-010-A2：** 拒绝/unknown/取消/stale 各有准确系统副作用事实；迟到读取不修改失去 owner 的 editor，history 不跨 workspace 泄漏，fallback 明确可见。
+- **ED-AUDIT-010-A3：** focused unit、挂载入口、当前端 native 文件/clipboard 后置断言、typecheck 与 IDEA comparison 通过，未测 OS 不借 browser stub 通过。
+
+验证 V-010：workspaceClipboardSession.test.ts、workspaceClipboardHistory.test.ts、ClipboardHistoryPopup.test.tsx；TC-IDE-C3-01/02/03。测试前先读现有 case covers 和 native clipboard fixture。 先运行对应 `pnpm exec vitest run <上述测试>`；QA/native/IDEA 执行方式见共享对比契约。逐项将 A1 主流程、A2 负路径与恢复、A3 交付门禁映射到 evidence checks；有实际变更时保留 baseline failing regression。
+
+必需证据：`code-audit`、`unit`、`typecheck`、`browser`、`native`、`idea-comparison`。当前平台 native 与 IDEA 缺失不能关闭 done；代码已齐但证据缺失为 implemented。
+
+<a id="ed-audit-011"></a>
+## ED-AUDIT-011 IME 输入期间的命令与焦点隔离
+
+### 用户目标与代码现状
+
+输入法候选确认/取消不误触全局编辑命令，composition 结束后正常恢复快捷键和焦点。
+
+代码事实：CodeMirrorHost.tsx 2599 附近 compositionNavigationGuard 在 capture keydown 阶段检查 composing/isComposing，其他剪贴板/导航路径亦有 guard；需要验证 action host 和真实输入法组合。
+
+### 实施范围与状态
+
+Owner：src/components/editor/workspace/CodeMirrorHost.tsx composition guard、workspaceActionHost.ts、workspaceKeymapScheme.ts、对应测试；不改全局 OS keymap。
+
+使用真实 DOM composition lifecycle 与 CodeMirror composing 状态，workspace global action 不抢 IME Enter/Escape/方向键及候选快捷键。compositionend 后释放临时拦截；失焦、卸载、重挂载清除残留状态。复用 existing action registry，不把所有快捷键永久禁用。菜单显式命令是否可用按 readonly/owner policy 判定。
+
+仅修改上述职责；出现别的功能差距单独记录。依赖：ED-AUDIT-001。每个操作都遵守共享 failure/cancel/stale/effect 契约，不用其他 owner 的成功测试代替本卡行为。
+
+### IDEA 同场景步骤
+
+IDEA 与 QA app 打开同一含中文注释的文件。Linux IBus/Fcitx、Windows 微软拼音、macOS 拼音分别记录实际版本；输入候选、Enter 确认、Escape 取消、方向选词，期间切 focus；完成后导航/Undo。对同一次操作记录 text、selection、focus、候选窗口与误触命令。
+
+### 验收与验证
+
+- **ED-AUDIT-011-A1：** 实际输入法候选阶段没有 workspace 误导航、重复插入或错误 clipboard 操作；确认/取消与 IDEA 同系统输入法行为有实测记录。
+- **ED-AUDIT-011-A2：** compositionend、blur、unmount 后正常快捷键恢复；一次 undo 的边界与 IDEA 对比确定；合成 KeyboardEvent 单测只作 guard 回归，不能当 IME 证据。
+- **ED-AUDIT-011-A3：** 当前平台真实输入法、键盘焦点、name/role/state 与 200% zoom 的受影响 UI 检查通过；unit/typecheck 通过；Windows/Linux/macOS 分列输入法版本和未验证项。
+
+验证 V-011：CodeMirrorHost 的现有键盘测试与 workspaceActionHost 对应单测；拟新增 CodeMirrorHost.ime.test.tsx。复用 TC-IDE-C3-03 可覆盖部分焦点，IME 需新增专题手工记录或真正支持的 native verb；不伪造 YAML pass。 先运行对应 `pnpm exec vitest run <上述测试>`；QA/native/IDEA 执行方式见共享对比契约。逐项将 A1 主流程、A2 负路径与恢复、A3 交付门禁映射到 evidence checks；有实际变更时保留 baseline failing regression。
+
+必需证据：`code-audit`、`unit`、`typecheck`、`native`、`accessibility`、`idea-comparison`。当前平台 native 与 IDEA 缺失不能关闭 done；代码已齐但证据缺失为 implemented。

--- a/claudedocs/code-workspace-idea-specs/idea-2026-performance.md
+++ b/claudedocs/code-workspace-idea-specs/idea-2026-performance.md
@@ -1,0 +1,90 @@
+# 编辑器性能与发布门禁详细设计
+
+必读 [共享对比契约](./idea-2026-comparison.md)。本设计安排生产测量和必要优化，不从微基准推导用户输入延迟，也不声称本轮已经完成 IDEA 性能实测。三端实测分别记账，本轮原生交付平台为实际运行端。
+
+## 统一测量与决策
+
+每组记录设备/OS/WebView/JDK/IDEA build、Taomni source 与 build profile、fixture hash、warmup、N、全部 raw samples 和 nearest-rank p50/p95/p99。输入基线先采集再修改 hot path；restore 基线先采集再调整队列。对照组执行顺序交替，记录热/冷缓存和背景进程。进程、资源和 fixture 在 finally 清理，失败样本保留。
+
+同产品 baseline/candidate 使用同 build profile、同计时边界与环境。IDEA 跨产品比较只能用双方都能观察的端点，例如用户 action 到可见内容/交互，不拿 Taomni keydown-to-DOM 与 IDEA 的屏幕显示直接计算倍数。采样无法提供共同端点时只报告各自事实，比较为 incomparable。
+
+禁止把 runner step duration 当产品延迟。已有明确预算沿用且注明来源；没有专用预算时先记录 baseline/noise 与目标，不把通用 local-action 100ms 当冷启动预算。相同输入的 baseline/candidate 无回归采用重复基线测得的噪声范围，噪声估计在 candidate 前冻结并保留原始数据。绝对预算待正式确定时仍可测量和优化，但不得写“预算达标”或通过需要预算的验收。
+
+<a id="ed-audit-005"></a>
+## ED-AUDIT-005 输入延迟实测与热路径优化
+
+### 目标、代码与 owner
+
+连续输入 1 MiB 文本时 UI 及时响应，语义/历史不受优化破坏。5 MiB 如触发现有大文件降级，单独报告该模式，不与完整编辑模式混比。
+
+Owner：`src/components/editor/workspace/CodeMirrorHost.tsx` 的 update/reconfigure，`CodeWorkspaceTab.tsx` 的 onChange 到 document owner 热路径，`editorPerformance.test.tsx`、`src/lib/performanceInstrumentation.ts` 及现有性能 collector。先沿当前 caller 确定 store owner，禁止仅运行 `scripts/buffer_authority_benchmark.ts` 的字符串/rope 模拟宣布产品提升。依赖 ED-AUDIT-001。
+
+### 方案与异常
+
+使用实际 mounted/native editor 输入，先测定位全量 toString、重复 setState/reconfigure 和无关 Git/LSP 后台活动；只修本卡 trace 证明的耗时。复用 stable props/compartment guards，不在本卡直接完成 buffer authority 大迁移。必要 extraction 明确 owner，不改变 shared-document、save、LSP、undo、crash recovery 的 authority。
+
+应用一次编辑，观察文本与 UI readiness；采样保留 busy/failed 结果和文档 post hash，不能过滤最慢帧。probe observer 只观察，不注入状态或驱动动作，测量结束解除 instrumentation。若确认性能问题来自 scope 外引擎且无法在本卡改动，不用合成数字关闭。
+
+### 对比与验收
+
+生成固定文件：1 MiB Java-like 多行文本，5 MiB 同结构 stress fixture，另一个小文档验证普通编辑不回归。真实输入 N>=200、warmup>=20，重复至少两组并记录环境噪声。两端使用可比 editor intelligence 状态；IDEA indexing 等待完成。保存用户动作、caret、最后文档 hash 和 Undo。
+
+- **ED-AUDIT-005-A1：** 真实输入链的 baseline 与 candidate raw samples、共同端点 IDEA 测量记录可重算 percentile；缺失/不可比数据不能产生 matched 或 no-regression 结论。
+- **ED-AUDIT-005-A2：** 对 baseline trace 定位的本卡热路径完成代码优化并证明改善超出预先记录噪声；若当前实现已满足原目标，允许无重复实现，但须保留当前 source 的生产路径与无回归证据。小文档/1 MiB 文本、selection、undo、save 同步断言不变。
+- **ED-AUDIT-005-A3：** 性能 collector 与 owner focused/typecheck、当前平台 native、performance/IDEA evidence 通过；预算尚未定义的项只能报告测量/no-regression，不报告绝对预算达标。
+
+V-005：`pnpm exec vitest run src/components/editor/workspace/editorPerformance.test.tsx src/stores/appStore.test.ts` 为已有回归入口，必要时增加实际变化 owner 测试；按 native-testing.md 的 native_editor_performance 收集真实 keydown-to-DOM samples，明确它不是全 OS-to-screen。现有 `scripts/perf_baseline.py` 只作 Chromium 诊断。IDEA 屏幕计时采用相同采集器/分辨率并记录工具；当前不可实现共同计时端点则保留未验证，不编造新命令已可用。
+必需证据：code-audit、unit、typecheck、performance、native、idea-comparison。
+
+<a id="ed-audit-013"></a>
+## ED-AUDIT-013 多标签恢复的可交互时机优化
+
+### 代码事实与职责
+
+`workspaceRestoreModel.ts` 的 planWorkspaceRestore 将 leaf active target 与 background target 分离；executeBoundedAsyncQueue 将 worker concurrency 限制在 2..4。CodeWorkspaceTab.tsx 3421 附近消费 plan。是否在 active-ready 前仍等待背景文件/active-file diff，需要真实 trace 验证。
+
+Owner：`src/components/editor/workspace/workspaceRestoreModel.ts`、`useDeferredGitLineChanges.ts`、CodeWorkspaceTab.tsx restore effect，及相关性能 observation；依赖 ED-AUDIT-001、009。本卡不改变 tab close/reopen policy。
+
+### 设计
+
+定义三个时间点：打开 workspace 请求发出、focused active leaf 接受一次真实编辑且显示正确文本、全部 background restore 完成。先活跃 leaf，其他 leaf active 同样优先，但不得为了所有 active 完成而阻止已准备好 focused editor 输入。复用有界队列，后台 read 失败只影响对应 tab；取消 owner 后不发布结果，晚到 read 不覆盖用户已输入文本。
+
+将 Git diff/诊断昂贵工作延迟到当前 file ready，cache identity 保持 path+HEAD+revision；用户切换 tab 后新 active 任务优先且不重复读取同一 document。优化不能把需要的工作永久跳过伪装低 TTI。
+
+### 场景与验收
+
+固定 24 tabs、2 leaf（明确 active 文件），同一干净 fixture 与一个读取失败文件变体；分别冷启动与已运行重开 workspace，记录哪个文件何时 read/ready，active-ready 后输入 X。IDEA 用相同 tabs/layout 的工程打开动作；插件/JDK/indexing 与缓存前提完整记录。每种不少于 20 次 measured run、3 次 warmup（冷启动 warmup 单列，不改变测量 cache 定义），同时保留 all-ready 和失败数量。
+
+- **ED-AUDIT-013-A1：** active-ready 和 all-ready 两组 raw timing 可重算，未把全恢复时长误用为编辑器输入就绪；IDEA 同动作可比端点与 delta 明确。
+- **ED-AUDIT-013-A2：** 生产 trace 证明有界并发、active 优先、每文件失败隔离和取消不发布；若存在 active 被阻塞则完成 owner 优化；ready 后输入不被迟到 restore/Git diff 覆盖。
+- **ED-AUDIT-013-A3：** 同条件 candidate 相对 baseline 无超出已测噪声的回归，24 tabs 状态/编辑/关闭重开均正确；unit/typecheck、当前 native、performance 与 IDEA evidence 通过，不套用无来源的 100ms restore 预算。
+
+V-013：`pnpm exec vitest run src/components/editor/workspace/workspaceRestoreModel.test.ts src/components/editor/workspace/useDeferredGitLineChanges.test.tsx src/lib/performanceInstrumentation.test.ts`；TC-IDE-C4-02 只作功能回归，另建本卡 restore measurement fixture（拟新增）。记录 read postconditions、并发数、丢失 tab 数和原始计时。
+必需证据：code-audit、unit、typecheck、performance、native、idea-comparison。
+
+<a id="ed-audit-006"></a>
+## ED-AUDIT-006 当前源码门禁与能力发布矩阵
+
+### 交付物与范围
+
+Owner：本任务板、各卡 evidence 引用、本板拟新增 `claudedocs/code-workspace-idea-2026-capability-matrix.md`；复用 `qa-ui-auto-tests/release-evidence-plan.json` 和现有 status/rollup，必要范围调整按现有 release-plan schema。依赖本板所有行为卡 done，不自己实现其他卡的产品功能或再次扩张整个 editor backlog。
+
+本板独家持有全仓 build evidence。旧板数据仍保留原状态；不因历史 failed/check 或不必需 unrun 直接批量降级。
+
+### 验证和失败处理
+
+运行当前源 `pnpm build` 并收集完整 exit code/output。命令超过工具一次 yield 不是 build 失败，应继续等待 session；真实 timeout/cancel 记录未完成，不能自动推断 TS 错误。失败需定位实际文件和所属卡，把新发现 bug 放对应 owner 待修任务，不能排除编译文件或 skip 测试。
+
+矩阵每行是 capability + fixture + IDEA build + provider + 平台 + mode + source identity，分别记录 baseline/result/negative/undo、unit、native、performance、accessibility、idea-comparison 和未运行原因。只计算同分母可比样本，不用若干单卡 done 推导整个编辑器百分比对齐。
+
+静态 catalog 与实际执行分开，保留最新 current failure/skip；手工 macOS/IDEA 证据单列，不能造 summary/receipt。行为卡 evidence 随 source drift 失效时安排重新执行相关 scope，不能仅更新时间戳。此卡不要求每个能力强行补未规定的 a11y/performance，缺失项在矩阵标 unverified。
+
+### 验收与验证
+
+- **ED-AUDIT-006-A1：** 当前 source 的 pnpm build exit 0；QA audit --gate 通过并保留 counts；真实失败不被历史 pass 或局部 scope 隐藏。
+- **ED-AUDIT-006-A2：** 本板每个 A ID 回链到具体实现/当前可获取 evidence；矩阵有 Windows/Linux/macOS 独立格，状态符合 summary/receipt/source/case/runner identity；手工与自动化执行无混淆。
+- **ED-AUDIT-006-A3：** 在选定且非空的本板 case/feature 范围运行 status --gate，审阅通过/失败/跳过及未覆盖范围；需要 release manifest 的条目通过 audit --release-evidence，不合格项不能宣称 release-ready。
+
+V-006：`pnpm build`；设置 PYTHONPATH 后 `python -m qa_ui_auto audit --gate` 与 `python -m qa_ui_auto status --json`，根据实际 feature/case 选择明确 gate 范围（参照 comparison.md）。`task_board.py --doc claudedocs/code-workspace-idea-parity-backlog-2026-09-audit.md validate` 必须通过。既有单元/集成结果如因源变化失效，由卡 owner 范围复跑；无关功能不在此扩大验证。
+必需证据：code-audit、build、qa-lint、document。只要某行为所需的当前证据失败，矩阵保持未通过而不是生成绿 summary。
+

--- a/claudedocs/code-workspace-idea-specs/idea-2026-semantic.md
+++ b/claudedocs/code-workspace-idea-specs/idea-2026-semantic.md
@@ -1,0 +1,189 @@
+# 语义操作详细设计
+
+必读 [共享对比契约](./idea-2026-comparison.md) 与 [共享合同](./shared-contracts.md)。保持当前 UI 布局和 action registry；已确认断点与待实测差异明确分列。测试文件默认相对 `src/components/editor/workspace/`。本设计不要求实现 IDEA 私有索引/PSI 或全语言补全引擎。
+
+<a id="ed-audit-003"></a>
+## ED-AUDIT-003 文件替换范围与冲突对齐
+
+### 目标与代码事实
+
+Replace in Files 只修改预览确认的文件和匹配项，并在外部改动时阻止覆盖。
+
+findInFilesScopeModel.ts 的 planFindInFilesScope 处理 project/module/directory/recent/custom 与 fileMask；replaceInFilesModel.ts、buildReplaceEdits.ts 和 ReplacePreviewDialog.tsx 已存在。需要核验匹配集合是否沿 UI 到 workspace writer 保持一致；不是假定这些模块尚未接入。
+
+### Owner 与实现契约
+
+src/components/editor/workspace/findInFilesScopeModel.ts、replaceInFilesModel.ts、buildReplaceEdits.ts、panels/FindInFilesPanel.tsx、panels/ReplacePreviewDialog.tsx；CodeWorkspaceTab.tsx 中 replace handlers；必要时 src/lib/editor/workspaceSearch.ts / src-tauri/src/workspace_search.rs（变更则追加 rust 证据）。
+
+预览冻结 scope roots、fileMask、query/options、project-facts generation 与每文件 preimage；apply 必须使用这份匹配集并即时检查文件变化，不能扩大为当前全项目搜索。checked 项只作用于原 plan；regex 错误必须在预览前显示。readonly/dirty/excluded/超限文件逐项说明。reuse workspace edit/history；取消不创建 history，部分写入必须显式已改集合和恢复，禁止 UI 显示全部完成。
+
+依赖：ED-AUDIT-001。变化严格限制本卡职责；变更 transport/Rust 时补原生 ABI 和 focused Rust 验证，不用 stub 替代 provider。
+
+### IDEA 实测与 fixture
+
+临时工程含 src/A.java、src/B.java、test/ATest.java、excluded/Skip.java，文本含 foo、Foo、foobar 与多行。两端选 directory + *.java、case/whole-word/regex 分别搜索替换；取消预览、排除一个结果、确认剩余项、Undo。预览后外部改 B.java 再 apply，记录结果集合、冲突提示及磁盘 hash。
+
+### 验收与验证
+
+- **ED-AUDIT-003-A1：** 同一 fixture 的范围、匹配位置、选中替换集合在 IDEA 与 Taomni 可对比；修复确认 delta，结果集合不得因 UI 刷新扩大。
+- **ED-AUDIT-003-A2：** 预览后外部改变、dirty/readonly、非法 regex、取消/stale 均有回归；无 effect 分支零 history，已发生部分 effect 有真实 ledger 与恢复结果。
+- **ED-AUDIT-003-A3：** focused/mounted、当前 native 文件后置断言、typecheck 与 IDEA comparison 通过；搜索实现改动影响性能时补同 fixture 耗时证据。
+
+验证 V-003：findInFilesScopeModel.test.ts、replaceInFilesModel.test.ts、buildReplaceEdits.test.ts、panels/FindInFilesPanel.test.tsx、panels/ReplacePreviewDialog.test.tsx；拟新增 TC-IDE-AUDIT-003（实施前查重登记 covers）。 执行 `pnpm exec vitest run <本卡文件>` 与完整 owner scope 的 typecheck；每个 A ID 对应同场景主流程、负路径与交付检查。新 case/runner 命令需实现并校验后才可记录实际执行。
+
+必需证据：`code-audit`、`unit`、`typecheck`、`browser`、`native`、`idea-comparison`。所有计划当前待执行。mock-only 证明模型边界；无真实 IDEA/provider/native 时保持未运行或 implemented，不标 done。
+
+<a id="ed-audit-007"></a>
+## ED-AUDIT-007 Completion 接受与单次撤销对齐
+
+### 目标与代码事实
+
+接受 completion 后主 edit、额外 import 和 snippet 成为一个可撤销动作，延迟 resolve 不覆盖新输入。
+
+CodeWorkspaceTab.tsx 13743 附近调用真实 lspCompletion/resolve；lspCompletion.ts 的 createLspCompletionSource、commitLspCompletion 是接受 owner。已有 choice/snippet 测试，仅凭这些测试不能推断 IDEA 排序或 Smart Completion 对齐。
+
+### Owner 与实现契约
+
+src/components/editor/workspace/lspCompletion.ts、completionScopeAdapter.ts、CodeMirrorHost.tsx completion wiring、CodeWorkspaceTab.tsx completion callbacks；src/lib/editor/lsp.ts 如需 transport 变更单独记录。
+
+snapshot 固定 document revision、provider generation、caret 范围与 invocation；resolve 后复核。Insert/Replace、additionalTextEdits、snippet anchors 使用当前模块的 planCompletionChanges，不额外逐条 dispatch。已输入新字符或 provider restart 时丢弃旧接受计划并维持新文本。候选选择顺序、Enter/Tab 与 commit character 单独记录；不要求复刻 IDEA 私有 rank 或把 basic 改名 smart。
+
+依赖：ED-AUDIT-001。变化严格限制本卡职责；变更 transport/Rust 时补原生 ABI 和 focused Rust 验证，不用 stub 替代 provider。
+
+### IDEA 实测与 fixture
+
+复用 __fixtures__/jdtls 下 maven-single，使用同 JDK/dependencies，在未导入类型和带参数方法位置请求 basic completion；用 Enter/Tab 接受，snippet Tab/Shift-Tab/Escape，Undo/Redo；另做 resolve 延迟时继续输入。记录主 edit、imports、caret、snippet stops、一次 undo 文本。IDEA 对不可直接控制的 LSP 延迟不作伪对比。
+
+### 验收与验证
+
+- **ED-AUDIT-007-A1：** 真实 provider 主 edit+import+snippet 由同一接受动作完成，并与 IDEA 同输入的用户结果对比；不支持的 completion 模式显式 unavailable。
+- **ED-AUDIT-007-A2：** 延迟 resolve/取消/过期 document/provider 返回不能修改新文本；一次 undo 撤销该次所有 edits，history 与 selection 没有重复提交。
+- **ED-AUDIT-007-A3：** 现有 completion focused/mounted 回归、真实 provider、当前端 native 与 IDEA comparison/typecheck 通过；ranking 差异不能被 label normalize 吞掉。
+
+验证 V-007：lspCompletion.test.ts、lspCompletionChoice.test.ts、lspCompletionChoiceSession.test.ts、lspCompletionResolveGate.test.ts、CodeMirrorHost.completion.test.tsx；TC-IDE-C2-01/03/05。 执行 `pnpm exec vitest run <本卡文件>` 与完整 owner scope 的 typecheck；每个 A ID 对应同场景主流程、负路径与交付检查。新 case/runner 命令需实现并校验后才可记录实际执行。
+
+必需证据：`code-audit`、`unit`、`typecheck`、`browser`、`native`、`provider`、`idea-comparison`。所有计划当前待执行。mock-only 证明模型边界；无真实 IDEA/provider/native 时保持未运行或 implemented，不标 done。
+
+<a id="ed-audit-008"></a>
+## ED-AUDIT-008 Intention 预览提交与失败对齐
+
+### 目标与代码事实
+
+Alt+Enter 与同一 action 的其他入口使用同一 preview/commit owner，并显示真实失败与恢复结果。
+
+CodeWorkspaceTab.tsx runCodeAction 已消费 canonicalCodeActionService.applyPlan；codeActionProviderAdapter.ts、intentionSession.ts 与 workspaceEditApply/history 组成可复用事务链。
+
+### Owner 与实现契约
+
+src/components/editor/workspace/codeActionProviderAdapter.ts、intentionSession.ts、codeActionExecution.ts；CodeWorkspaceTab.tsx 的 requestCodeActions/runCodeAction 及其具体调用入口。
+
+request->resolve->immutable plan->preview->validate->apply->verify->history，保留 plan-only 的零副作用边界。provider command 是可能产生额外 effect 的独立轴，不能在 command 失败后把已写文本说成零效果。preview cancel/失焦/文件换代后关闭旧 session，不让结果夺焦点。菜单及 Alt+Enter 均进入同 owner，禁止重新添加 legacy executor。
+
+依赖：ED-AUDIT-001。变化严格限制本卡职责；变更 transport/Rust 时补原生 ABI 和 focused Rust 验证，不用 stub 替代 provider。
+
+### IDEA 实测与 fixture
+
+maven-single 未导入 StringUtils，通过 IDEA intention 与 Taomni Alt+Enter 选择 import quick fix；捕获可选项、预览/直接 apply 实际行为、文本和 Undo。另用两文件真实 provider edit 验证 preview 取消；command exception、request cancel/stale 在回归层模拟并记录哪些不能在 IDEA 精确复现。
+
+### 验收与验证
+
+- **ED-AUDIT-008-A1：** Alt+Enter 及另一实际 UI 入口的同 action 产生同一个实际 commit 与一次 history；import quick fix 在真实两端有可比后置文本。
+- **ED-AUDIT-008-A2：** resolve null/malformed/failure、preview cancel、stale 与 command failure 分别显示准确结果；已改文件的 recovery 不被零效果文案掩盖。
+- **ED-AUDIT-008-A3：** focused/mounted、provider、当前 native、IDEA comparison 与 typecheck 完成；apply 前后和 undo 的文本/hash 有可获取的真实产物。
+
+验证 V-008：codeActionProviderAdapter.test.ts、intentionSession.test.ts、codeActionExecution.test.ts、workspaceEditApply.test.ts、CodeWorkspaceTab.test.tsx 的 code-action 用例；复用 __fixtures__/jdtls/runner/run-jdtls-fixture.mjs 的实际支持参数，新增本卡 UI case 前核对已有覆盖。 执行 `pnpm exec vitest run <本卡文件>` 与完整 owner scope 的 typecheck；每个 A ID 对应同场景主流程、负路径与交付检查。新 case/runner 命令需实现并校验后才可记录实际执行。
+
+必需证据：`code-audit`、`unit`、`typecheck`、`browser`、`native`、`provider`、`idea-comparison`。所有计划当前待执行。mock-only 证明模型边界；无真实 IDEA/provider/native 时保持未运行或 implemented，不标 done。
+
+<a id="ed-audit-012"></a>
+## ED-AUDIT-012 语义结果跳转与返回历史对齐
+
+### 目标与代码事实
+
+从语义定义/用法结果跳转后能回到发起位置，旧查询不污染当前页或导航历史。
+
+useWorkspaceNavigation.ts、navigationHistoryModel.ts 和 UsagesScopeDialog.tsx 已存在；现有 TC-IDE-C6-01/02/05 可作真实 provider 入口。此卡不实现新的搜索引擎或全套层次面板。
+
+### Owner 与实现契约
+
+src/components/editor/workspace/useWorkspaceNavigation.ts、navigationHistoryModel.ts、UsagesScopeDialog.tsx；CodeWorkspaceTab.tsx query definition/references callbacks 与 reveal/history owner。
+
+在 request 时记录发起 document/view/position、provider 与 project identity；成功 reveal 后才写一次导航历史。结果未就绪、目标不存在、cancel/stale 不移焦点或加 history。library URI 与 workspace 路径显式区分，无法读取目标时有可见解释。pin 的结果保留原 query identity，rerun 明确产生新快照。
+
+依赖：ED-AUDIT-001。变化严格限制本卡职责；变更 transport/Rust 时补原生 ABI 和 focused Rust 验证，不用 stub 替代 provider。
+
+### IDEA 实测与 fixture
+
+maven-single 的 App/AppTest 与一个 library symbol；IDEA/Taomni Go to Declaration、Find Usages、打开第二条结果、Back/Forward；pin 后修改源文本 rerun。记录路径/范围、去重、结果顺序、reveal caret 和返回位置；库依赖差异单列。
+
+### 验收与验证
+
+- **ED-AUDIT-012-A1：** 同 fixture 的定义/用法目标和 reveal/back 位置可比较，修复确认的漏跳/错跳/重复 history；不把 lexical scan 伪称语义全集。
+- **ED-AUDIT-012-A2：** missing/library target、取消、切换 workspace、旧查询迟到都不夺焦点或污染 history；pin/rerun 的 scope 和 generation 可追溯。
+- **ED-AUDIT-012-A3：** navigation focused/mounted、实际 provider、当前端 native、IDEA comparison 和 typecheck 通过，未支持的库能力明确作为未达到而非匹配。
+
+验证 V-012：useWorkspaceNavigation.test.tsx、navigationHistoryModel.test.ts、navigationHistoryV2.test.ts、UsagesScopeDialog.test.tsx、__fixtures__/jdtls/jdtlsUsagesContract.test.ts；TC-IDE-C6-01/02/05。 执行 `pnpm exec vitest run <本卡文件>` 与完整 owner scope 的 typecheck；每个 A ID 对应同场景主流程、负路径与交付检查。新 case/runner 命令需实现并校验后才可记录实际执行。
+
+必需证据：`code-audit`、`unit`、`typecheck`、`browser`、`native`、`provider`、`idea-comparison`。所有计划当前待执行。mock-only 证明模型边界；无真实 IDEA/provider/native 时保持未运行或 implemented，不标 done。
+
+<a id="ed-audit-015"></a>
+## ED-AUDIT-015 Rearrange 支持分支接入实际事务
+
+### 目标与代码事实
+
+Rearrange Code 在有实际能力时执行成员重排，而不是仅出现执行文案。
+
+CodeWorkspaceTab.tsx 11789 起 workspace.rearrangeCode 的 execute 分支只 setStatusMessage 后 return true；buildRearrangePlan 仅在 rearrangeCleanupWorkflow.ts 定义，无生产调用。属于已确认的生产链断点。
+
+### Owner 与实现契约
+
+src/components/editor/workspace/rearrangeCleanupWorkflow.ts 仅 rearrange 部分；CodeWorkspaceTab.tsx workspace.rearrangeCode handler；codeActionProviderAdapter.ts 的确有必要的复用入口；相邻测试。与 ED-AUDIT-016 顺序修改共享文件。
+
+明确能力必须解析到可调用的 provider action，不仅是 summary boolean 或字符串猜测。执行 handler 冻结 file/view/provider/revision，向具备 source.rearrange 类能力的真实 provider 请求专用 edit，buildRearrangePlan 生成 workspace preview，再交 canonical transaction apply/verify/history。无该 provider 保持具体 unavailable，不得用 formatting 或 optimizeImports 替代。providerAdvertised 但返回空 action/unsupported 必须结束 loading 并解释，无假 success。未发现可运行 provider 时本卡不能凭单测关闭。
+
+依赖：ED-AUDIT-001、ED-AUDIT-008。变化严格限制本卡职责；变更 transport/Rust 时补原生 ABI 和 focused Rust 验证，不用 stub 替代 provider。
+
+### IDEA 实测与 fixture
+
+Java 类含 field、constructor、methods，记录 IDEA arrangement rules/profile（不得假定默认规则）。两端按相同规则执行 file Rearrange，预览、取消、apply、Undo；再在 preview 后改成员。IDEA 的排列结果是该 rules fixture 的 oracle，差异必须有源文本 diff。
+
+### 验收与验证
+
+- **ED-AUDIT-015-A1：** 真实支持 provider 从 production Rearrange 入口产生专用重排结果，post text 与 IDEA 指定 rules 可对比；无 provider 时明确未达到该能力，不再出现执行成功假象。
+- **ED-AUDIT-015-A2：** preview/cancel/stale/conflict 各有零提交回归；只读拒绝；apply 读取真实 post hash，单次 undo 恢复 preimage。
+- **ED-AUDIT-015-A3：** unit/typecheck/mounted、当前 native、真实 capable provider 与 IDEA comparison 通过；仅 JDT LS unadvertised 探针不满足本卡 provider 成功验收。
+
+验证 V-015：rearrangeCleanupWorkflow.test.ts 中新增支持分支 mounted 回归，CodeWorkspaceTab.test.tsx 从 action 入口断言文本变化；TC-IDE-C8-04 仅证明 unavailable，需新增 capable provider 的 UI case。 执行 `pnpm exec vitest run <本卡文件>` 与完整 owner scope 的 typecheck；每个 A ID 对应同场景主流程、负路径与交付检查。新 case/runner 命令需实现并校验后才可记录实际执行。
+
+必需证据：`code-audit`、`unit`、`typecheck`、`browser`、`native`、`provider`、`idea-comparison`。所有计划当前待执行。mock-only 证明模型边界；无真实 IDEA/provider/native 时保持未运行或 implemented，不标 done。
+
+<a id="ed-audit-016"></a>
+## ED-AUDIT-016 Cleanup 支持分支接入实际事务
+
+### 目标与代码事实
+
+Code Cleanup 使用真实 cleanup profile 和 provider 事务产生修改，不将普通格式化假装为 cleanup。
+
+CodeWorkspaceTab.tsx workspace.codeCleanup 的 execute 分支同样只写 Executing 文案；buildCleanupPlan 无生产调用。resolveCleanupCapabilities 还把 source.fixAll 等标记作为支持信号，需证明具体 profile 语义。
+
+### Owner 与实现契约
+
+src/components/editor/workspace/rearrangeCleanupWorkflow.ts 仅 cleanup 部分；CodeWorkspaceTab.tsx workspace.codeCleanup handler；复用 ED-AUDIT-008/015 的 canonical transaction 接口，不改 provider engine。
+
+本卡范围固定当前文件和 default profile；其他 project/module/directory profile 明确 unavailable，不扩大到全项目 cleanup。将 capabilities 中 provider id/version/profile 解析到真正可执行 action 与规则集合。source.fixAll 不能自动证明等价 IDEA inspection profile。request/plan/preview/apply/postverify/undo 与 canonical owner 同链；空 edit 是 no-change 事实，不显示执行了修复；无法执行返回准确原因。
+
+依赖：ED-AUDIT-001、ED-AUDIT-008、ED-AUDIT-015。变化严格限制本卡职责；变更 transport/Rust 时补原生 ABI 和 focused Rust 验证，不用 stub 替代 provider。
+
+### IDEA 实测与 fixture
+
+同 Java fixture 含 provider 支持且与 IDEA 选定 cleanup profile 等效的至少一个问题；记录规则启用列表。IDEA Code Cleanup 与 Taomni file cleanup 执行前后 diff，取消后 hash、只读拒绝、Undo；不以 unsupported trace 当 capable-run。
+
+### 验收与验证
+
+- **ED-AUDIT-016-A1：** 生产 Cleanup 入口运行真实 cleanup action，profile/规则可追溯，至少一个真实修复与 IDEA 对比；当前文件外文本不变。
+- **ED-AUDIT-016-A2：** profile 不支持、provider failure、no-change、取消/stale/conflict 均有准确可见状态；preview 后不静默改范围，单次 undo/恢复经过 postcondition 断言。
+- **ED-AUDIT-016-A3：** unit/typecheck/mounted、当前 native、capable provider 和 IDEA comparison 全通过；无法获得等效 provider profile 时保留明确缺口，不能改成格式化后关闭。
+
+验证 V-016：rearrangeCleanupWorkflow.test.ts 的 cleanup 子集、CodeWorkspaceTab.test.tsx 支持分支；TC-IDE-C8-04 保留 unavailable 回归，新增 file-cleanup capable case 并关联真实 provider fixture。 执行 `pnpm exec vitest run <本卡文件>` 与完整 owner scope 的 typecheck；每个 A ID 对应同场景主流程、负路径与交付检查。新 case/runner 命令需实现并校验后才可记录实际执行。
+
+必需证据：`code-audit`、`unit`、`typecheck`、`browser`、`native`、`provider`、`idea-comparison`。所有计划当前待执行。mock-only 证明模型边界；无真实 IDEA/provider/native 时保持未运行或 implemented，不标 done。

--- a/claudedocs/code-workspace-idea-specs/idea-2026-transactions.md
+++ b/claudedocs/code-workspace-idea-specs/idea-2026-transactions.md
@@ -1,0 +1,79 @@
+# 保存与重构恢复详细设计
+
+必读 [IDEA 对比契约](./idea-2026-comparison.md)、[共享合同](./shared-contracts.md)。
+产品数据模型沿用现有 typed effects；IDEA 不暴露的 IPC 状态仅作为 Taomni 安全契约，不宣称 IDEA 采用相同内部实现。所有性能、native、provider 和 IDEA 检查在本设计中均待执行。
+
+<a id="ed-audit-004"></a>
+## ED-AUDIT-004 保存中的输入竞争与最终字节对齐
+
+### 用户结果与当前代码
+
+保存后磁盘是该次冻结快照的最终编码字节；保存期间新输入继续保留为 dirty，关闭的编辑器不因回包重新出现。
+
+`src/components/editor/workspace/saveCommit.ts` 已定义 PreparedSave、FinalBytesReceipt、SaveCommitResult。其 diskEffect 为 none/committed/unknown，memoryEffect 分离 saved-current/kept-dirty/writeback-discarded。CodeWorkspaceTab.tsx 的 open/closed save catch 走 saveCommitResultFromError。这是已有机制，本卡核验并修复实际 caller 的差距，不重建另一 save pipeline。
+
+### Owner 与方案
+
+Owner：`src/components/editor/workspace/saveCommit.ts`、`saveNormalizationPipeline.ts`、`saveOrganizeImportsAdapter.ts`；`CodeWorkspaceTab.tsx` 的 prepare/write/writeback；IPC 入口 `src/lib/editor/workspace.ts` 和 `src-tauri/src/workspace_fs.rs` 若变更则必须追加 rust evidence。依赖 ED-AUDIT-001。
+
+1. 保存开始冻结 document revision、style/project/provider generation、encoding/EOL/BOM 与 expectedDiskHash。六阶段 normalization 只形成 immutable plan，organize-imports 保持 plan-only。
+2. writer 对精确快照编码且 BOM/EOL 仅写一次，receipt 的 bytes hash 必须来自真实写入确认；错误不得构造成功 receipt。
+3. 新输入出现在 await 期间：旧快照 landed 就返回 saved-stale-snapshot，保留新输入 dirty，LSP 同步当前内容。owner 已关闭时 committed-writeback-discarded 不重开 tab。
+4. expectedDiskHash 冲突为 conflict，不写盘；取消只有 pre-write 才可声称零 diskEffect。传输不确定为 unknown，提供 recoveryId，先读取实际文件核对再允许重试，避免重复执行有副作用的 provider command。
+5. 沿用现有保存错误反馈/编码入口，不增加默认自动保存策略；明确 Undo 是否只改 buffer，磁盘需再次 Save。不得擅自让 editor Undo 自动回写文件以迎合测试。
+
+### 相同 fixture 与 IDEA 动作
+
+在两端关闭会干扰测试的自动保存并记录设置，准备带中文、非 BMP 字符和尾随空格的 UTF-8/UTF-8-BOM/UTF-16LE 文件，分别 LF/CRLF。由两端现有编码/EOL 设置执行 Save，独立读取最终字节。改变文本再 Undo/Save，记录 buffer dirty 与磁盘变化。
+
+正常保存、外部改文件后保存、只读失败可作真实 IDEA 对比。IPC 延迟/new typing/owner close/unknown acknowledgement 在 Taomni 回归中受控复现；IDEA 若无法重现同等时序，记录安全扩展，不伪造其内部状态。当前端 native 用独立 fixture 模拟失败；Windows 用文件锁或 ACL，Linux/macOS 用本测试有权限恢复的只读状态。
+
+### 验收与验证
+
+- **ED-AUDIT-004-A1：** UI Save 的编码/EOL/BOM 最终字节和 Undo/再保存行为有两端实测；BOM 不重叠、CR 不重复、receipt 与独立磁盘 hash 一致。
+- **ED-AUDIT-004-A2：** 写入时输入、关闭、external conflict、known failure、unknown acknowledgement 分别返回准确效果轴；新输入不丢失，零效果路径无 history，unknown 未核对前不盲重试。
+- **ED-AUDIT-004-A3：** focused/mounted、当前平台 native 文件断言、IDEA comparison、全部 owned path typecheck 通过；若改 Rust 追加真实测试；另两端有设置和未验证项。
+
+验证 V-004：`pnpm exec vitest run src/components/editor/workspace/saveCommit.test.ts src/components/editor/workspace/saveNormalizationPipeline.test.ts src/components/editor/workspace/saveOrganizeImportsAdapter.test.ts`；补 CodeWorkspaceTab.test.tsx 的 owner 竞争回归；扩展 TC-IDE-C0-01/02，不用 observation 注入 receipt 作为通过。保存原始字节/hash、dirty 可见状态和 Undo 后内容；恢复只读 fixture 属性。
+必需证据：code-audit、unit、typecheck、browser、native、idea-comparison。
+
+<a id="ed-audit-014"></a>
+## ED-AUDIT-014 Refactor postcondition 失败阻断与恢复入口
+
+### 已确认代码差距
+
+`src/components/editor/CodeWorkspaceTab.tsx` 8941 附近在 verifyRefactorPostHashes 失败时仅 console.warn；接着可将 recoveryEntry.status 写为 committed 并登记正常 history。journal 在 mutation 之后才生成，崩溃发生于首次写入与 journal 之间无法据此恢复。
+
+`src/components/editor/workspace/refactorPlan.ts` 的 recordRefactorRecoveryJournal 吞掉 storage 错误；replayRefactorRecoveryJournal 逐项 applyText 后直接返回 preHashesRestored: true，没有读取核验；该 replay 没有 production caller。这些代码事实要求实际实现修复，不能只补一份对比报告。
+
+### Owner、范围与持久化
+
+Owner：`refactorPlan.ts` 的 journal/verify/replay，`CodeWorkspaceTab.tsx` 的 workspace-edit/refactor prepare/commit/recovery handlers，复用 `workspaceEditApply.ts`、`workspaceEditHistory.ts`；必要 UI 使用现有确认/preview 弹窗。新增 `refactorRecoveryController.ts`（拟新增）负责当前 workspace 恢复生命周期，避免把所有逻辑堆入 Tab。依赖 ED-AUDIT-001；只覆盖 text-only 多文件 rename/refactor，create/rename/delete 资源操作需保留明确不支持恢复边界，不伪称覆盖。
+
+保持 v1 journal 可读，但视为 unverified；新条目采用独立 v2 schema，含 workspace identity、transactionId、每资源 pre/post hash、encoding/EOL/BOM、状态及 applied operation index。使用独立 key 前缀，读取时验证 JSON/schema/路径属于当前 fixture/workspace，不自动重放未知旧数据。实现前先核对现有 storage/recovery adapter 并复用；不能把吞错 localStorage 写入声明为耐断电的磁盘事务。
+
+### 事务与失败设计
+
+1. 在 mutation 前构建完整 preimage/expected postimage，保存 prepared journal 并获得明确成功；持久化失败在变更前终止，显示可重试原因。journal write 接口返回 typed success/failure，不吞 quota/error。
+2. 记录 applied index；实际 postimage 对不上或读取失败时进入 recovery-required，禁止 committed 成功提示和正常成功 history；已经发生的 effect 必须列明，不能改叫 cancelled。
+3. 恢复控制器在 workspace 就绪时发现本 workspace 的 pending 条目，通过现有确认/preview 工作流显示涉及资源、恢复/暂不处理操作；不自动覆盖磁盘。关闭 workspace 释放 pending async owner。
+4. 用户选择恢复前，逐文件读取当前 hash；只在当前内容等于已知 pre/postimage 时允许恢复，第三方修改标 conflict，零覆盖。dirty open buffer 同样校验 document revision。
+5. 恢复使用现有编码 writer 和事务路径，逐文件回读；只有全部 preHashes 确认恢复才能标 rolled-back。失败保留 pending 条目和已恢复集合；重复恢复幂等，不伪造 preHashesRestored。
+6. 正常成功只有 postcondition 全通过后标 committed，并注册一次真实 Undo/Redo；撤销也需检查当前 preconditions，不能覆盖用户后续编辑。
+
+不承诺跨多文件 OS 写入天然原子性；以 journal + effect ledger + verified recovery 保证可追溯。回滚代码保留 v1/v2 未处理条目，不删除用户恢复数据。敏感源文本 journal 只写当前应用隔离存储，不进入 release 日志或 Git。
+
+### IDEA 行为对比
+
+同 maven-single 两文件 rename，通过 IDEA Rename Preview 与 Taomni rename 入口比较 preview 文件集合、取消、apply、单次 undo、外部修改冲突。记录 IDEA 2026.2 的实际 Undo 行为，不推断它的恢复存储实现。
+Taomni 特有 post-hash mismatch、storage quota、first-write 后中断、restart replay 由真实 QA fixture/单测验证，明确属于恢复安全扩展。此卡不能把 IDEA 正常 rename 的通过当作 Taomni crash recovery 通过。
+
+### 验收与验证
+
+- **ED-AUDIT-014-A1：** 从 production rename 入口注入实际 postcondition mismatch 时不登记成功 committed/history；返回 recovery-required 和准确 affected files；正常真实 provider rename 的 preview/apply/undo 与 IDEA 比较通过。
+- **ED-AUDIT-014-A2：** journal prepared 在首次 mutation 前完成；持久化失败零写入；中断重开能通过真实 UI 发现 pending 条目，第三方内容 conflict 不覆盖；同一恢复重复执行幂等。
+- **ED-AUDIT-014-A3：** 恢复后独立回读所有 preimages 才报告成功，读/写失败保存 pending 状态；focused/mounted、native restart/disk、provider、IDEA 与完整 owner scope typecheck 通过，v1 数据不被自动重放。
+
+验证 V-014：扩展 `refactorPlan.test.ts`、`workspaceEditApply.test.ts`、`workspaceEditHistory.test.ts`、`CodeWorkspaceTab.test.tsx`，新增 `refactorRecoveryController.test.ts`（均对应上述真实 owner）。TC-IDE-C6-04 复用正常路径；拟新增当前端 restart-recovery case，按 qa-ui-auto 原生生命周期能力实现，不用 page reload 冒充进程崩溃恢复。收集真实 JDT LS rename、修改前后磁盘 hash、journal 状态和恢复 UI 结果。故障 fixture 保留首次失败证据再恢复。
+必需证据：code-audit、unit、typecheck、browser、native、provider、idea-comparison。
+


### PR DESCRIPTION
…lity specifications

- Establish IntelliJ IDEA 2026.2 parity audit task board with 16 cards (ED-AUDIT-001 to ED-AUDIT-016)
- Add comprehensive capability specifications for comparison contract, editing, semantic ops, transactions, and performance
- Update code-workspace-idea-task skill to support multi-board selection via --doc and document authoring mode
- Add backlog-authoring guide for linked specification authoring and evidence guidelines