### PR TITLE
fix(code-workspace): fix candidate menu hover conflicts and disabled …

### DIFF
--- a/src/components/ContextMenu.test.tsx
+++ b/src/components/ContextMenu.test.tsx
@@ -154,5 +154,87 @@ describe("ContextMenu", () => {
     fireEvent.keyDown(window, { key: "Escape" });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  describe("code-candidates appearance", () => {
+    it("renders code candidate styling without default hover background classes", () => {
+      const items: MenuItem[] = [
+        { label: "Quick Fixes", disabled: true },
+        { label: "Add type annotation", onClick: vi.fn() },
+        { label: "Import class", onClick: vi.fn() },
+      ];
+
+      render(<ContextMenu appearance="code-candidates" items={items} x={10} y={10} onClose={vi.fn()} />);
+
+      const menu = screen.getByTestId("context-menu");
+      expect(menu).toHaveAttribute("data-appearance", "code-candidates");
+      expect(menu.style.background).toBe("var(--taomni-code-tooltip-bg)");
+
+      const header = screen.getByTestId("context-menu-item-quick-fixes");
+      const fix1 = screen.getByTestId("context-menu-item-add-type-annotation");
+      const fix2 = screen.getByTestId("context-menu-item-import-class");
+
+      // Initial active index skips disabled header and selects first candidate
+      expect(fix1).toHaveAttribute("data-active", "true");
+      expect(fix2).not.toHaveAttribute("data-active");
+      expect(header).not.toHaveAttribute("data-active");
+
+      // Buttons under code-candidates do not have hover:bg-[var(--taomni-hover)] class
+      expect(fix1.className).not.toContain("hover:bg-[var(--taomni-hover)]");
+      expect(fix2.className).not.toContain("hover:bg-[var(--taomni-hover)]");
+    });
+
+    it("moves focus on arrow navigation and does not leave hover selection on previous item", () => {
+      const items: MenuItem[] = [
+        { label: "Fix 1", onClick: vi.fn() },
+        { label: "Fix 2", onClick: vi.fn() },
+      ];
+
+      render(<ContextMenu appearance="code-candidates" items={items} x={10} y={10} onClose={vi.fn()} />);
+
+      const fix1 = screen.getByTestId("context-menu-item-fix-1");
+      const fix2 = screen.getByTestId("context-menu-item-fix-2");
+
+      expect(fix1).toHaveAttribute("data-active", "true");
+      expect(fix2).not.toHaveAttribute("data-active");
+
+      // ArrowDown moves active to Fix 2
+      fireEvent.keyDown(window, { key: "ArrowDown" });
+      expect(fix2).toHaveAttribute("data-active", "true");
+      expect(fix1).not.toHaveAttribute("data-active");
+
+      // Hovering or moving mouse without physical displacement does not steal focus back
+      fireEvent.mouseMove(fix1, { movementX: 0, movementY: 0 });
+      expect(fix2).toHaveAttribute("data-active", "true");
+      expect(fix1).not.toHaveAttribute("data-active");
+
+      // Physical mouse move on Fix 1 reactivates it
+      fireEvent.mouseMove(fix1, { movementX: 2, movementY: 1 });
+      expect(fix1).toHaveAttribute("data-active", "true");
+      expect(fix2).not.toHaveAttribute("data-active");
+    });
+
+    it("does not activate disabled headers on mouse hover or move", () => {
+      const items: MenuItem[] = [
+        { label: "Header", disabled: true },
+        { label: "Fix", onClick: vi.fn() },
+      ];
+
+      render(<ContextMenu appearance="code-candidates" items={items} x={10} y={10} onClose={vi.fn()} />);
+
+      const header = screen.getByTestId("context-menu-item-header");
+      const fix = screen.getByTestId("context-menu-item-fix");
+
+      expect(fix).toHaveAttribute("data-active", "true");
+      expect(header).not.toHaveAttribute("data-active");
+
+      fireEvent.mouseEnter(header);
+      expect(header).not.toHaveAttribute("data-active");
+      expect(fix).toHaveAttribute("data-active", "true");
+
+      fireEvent.mouseMove(header, { movementX: 5, movementY: 5 });
+      expect(header).not.toHaveAttribute("data-active");
+      expect(fix).toHaveAttribute("data-active", "true");
+    });
+  });
 });
 

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -185,11 +185,11 @@ export const MenuSurface = forwardRef<HTMLDivElement, ContextMenuAppearance & {
       data-testid="context-menu"
       data-taomni-context-menu=""
       data-appearance={appearance}
-      className="min-w-[220px] py-1 rounded shadow-lg border text-[12px] outline-none"
+      className={`min-w-[220px] ${appearance === "code-candidates" ? "py-0" : "py-1"} rounded shadow-lg border text-[12px] outline-none`}
       style={{
-        background: "var(--taomni-panel-bg)",
-        borderColor: "var(--taomni-divider)",
-        color: "var(--taomni-text)",
+        background: appearance === "code-candidates" ? "var(--taomni-code-tooltip-bg)" : "var(--taomni-panel-bg)",
+        borderColor: appearance === "code-candidates" ? "var(--taomni-code-border)" : "var(--taomni-divider)",
+        color: appearance === "code-candidates" ? "var(--taomni-code-text)" : "var(--taomni-text)",
         ...style,
         maxHeight: "calc(100vh - 12px)",
         overflowY: "auto",
@@ -198,6 +198,7 @@ export const MenuSurface = forwardRef<HTMLDivElement, ContextMenuAppearance & {
       {items.map((item, i) => (
         <MenuRow
           key={i}
+          appearance={appearance}
           item={item}
           active={activeIndex === i}
           isSubmenuOpen={openSubmenuIndex === i}
@@ -272,6 +273,7 @@ function PortalFlyout({
 }
 
 function MenuRow({
+  appearance,
   item,
   active,
   isSubmenuOpen,
@@ -280,6 +282,7 @@ function MenuRow({
   onCloseSubmenu,
   onClose,
 }: {
+  appearance?: "default" | "code-candidates";
   item: MenuItem;
   active: boolean;
   isSubmenuOpen: boolean;
@@ -293,6 +296,26 @@ function MenuRow({
   const closeTimer = useRef<number | null>(null);
 
   const open = isSubmenuOpen || openByHover;
+  const isCodeCandidates = appearance === "code-candidates";
+
+  const handleHover = () => {
+    if (item.disabled) return;
+    onHover();
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (item.disabled) return;
+    if (e.movementX !== undefined && e.movementY !== undefined && e.movementX === 0 && e.movementY === 0) {
+      return;
+    }
+    if (!active) {
+      onHover();
+    }
+  };
+
+  const rowClassName = isCodeCandidates
+    ? "w-full px-2 py-0.5 text-left flex items-center gap-2 disabled:opacity-40 outline-none"
+    : "w-full px-3 py-1 text-left flex items-center gap-2 hover:bg-[var(--taomni-hover)] data-[active=true]:bg-[var(--taomni-hover)] disabled:opacity-40 outline-none";
 
   useEffect(
     () => () => {
@@ -340,21 +363,22 @@ function MenuRow({
     const openNow = () => {
       cancelClose();
       setOpenByHover(true);
-      onHover();
+      handleHover();
       onOpenSubmenu();
     };
 
     return (
       <div
         className="relative group/menu-row"
-        onMouseEnter={item.openOnClick ? () => { cancelClose(); onHover(); } : openNow}
+        onMouseEnter={item.openOnClick ? () => { cancelClose(); handleHover(); } : (item.disabled ? undefined : openNow)}
+        onMouseMove={handleMouseMove}
         onMouseLeave={scheduleClose}
       >
         <button
           ref={triggerRef}
           data-testid={item.testId ?? `context-menu-item-${slugForTestId(item.label)}`}
           data-active={active ? "true" : undefined}
-          className="w-full px-3 py-1 text-left flex items-center gap-2 hover:bg-[var(--taomni-hover)] data-[active=true]:bg-[var(--taomni-hover)] disabled:opacity-40 outline-none"
+          className={rowClassName}
           style={item.danger ? { color: "#b22222" } : undefined}
           disabled={item.disabled}
           onClick={item.openOnClick ? () => {
@@ -375,6 +399,7 @@ function MenuRow({
             {item.customPanel ? item.customPanel : (
               <MenuSurface
                 isSubmenu
+                appearance={appearance}
                 items={item.children ?? []}
                 onClose={onClose}
                 onBack={() => {
@@ -394,9 +419,10 @@ function MenuRow({
       ref={triggerRef}
       data-testid={item.testId ?? `context-menu-item-${slugForTestId(item.label)}`}
       data-active={active ? "true" : undefined}
-      className="w-full px-3 py-1 text-left flex items-center gap-2 hover:bg-[var(--taomni-hover)] data-[active=true]:bg-[var(--taomni-hover)] disabled:opacity-40 outline-none"
+      className={rowClassName}
       style={item.danger ? { color: "#b22222" } : undefined}
-      onMouseEnter={onHover}
+      onMouseEnter={handleHover}
+      onMouseMove={handleMouseMove}
       onClick={() => {
         item.onClick?.();
         onClose();

--- a/src/index.css
+++ b/src/index.css
@@ -1265,7 +1265,7 @@ select.taomni-input:not(.appearance-none):not([multiple]) {
   border: 1px solid var(--taomni-code-border) !important;
   border-radius: 4px;
   box-shadow: var(--taomni-shadow-lg);
-  padding: 0;
+  padding: 0 !important;
   font-family: var(--taomni-code-font-family);
   font-size: var(--taomni-code-font-size);
   line-height: 1.5;
@@ -1278,21 +1278,33 @@ select.taomni-input:not(.appearance-none):not([multiple]) {
   overflow-y: auto;
 }
 .cm-tooltip-autocomplete > ul > li[role="option"],
-[data-taomni-context-menu][data-appearance="code-candidates"] > button {
-  padding: 2px 8px;
+[data-taomni-context-menu][data-appearance="code-candidates"] button {
+  padding: 2px 8px !important;
   cursor: pointer;
+  background: transparent !important;
+}
+.cm-tooltip-autocomplete > ul > li[role="option"]:not([aria-selected="true"]):hover,
+[data-taomni-context-menu][data-appearance="code-candidates"] button:not([data-active="true"]):hover {
+  background: transparent !important;
+  color: inherit !important;
 }
 .cm-tooltip-autocomplete > ul > li[aria-selected="true"][role="option"],
-[data-taomni-context-menu][data-appearance="code-candidates"] > button[data-active="true"]:enabled {
-  background: #1d4ed8;
-  color: #ffffff;
-  box-shadow: inset 3px 0 #93c5fd;
+[data-taomni-context-menu][data-appearance="code-candidates"] button[data-active="true"]:enabled,
+[data-taomni-context-menu][data-appearance="code-candidates"] button[data-active="true"]:enabled:hover {
+  background: #1d4ed8 !important;
+  color: #ffffff !important;
+  box-shadow: inset 3px 0 #93c5fd !important;
 }
 .cm-tooltip-autocomplete > ul > li[aria-selected="true"] .cm-completionIcon,
 .cm-tooltip-autocomplete > ul > li[aria-selected="true"] .cm-completionMatchedText,
-[data-taomni-context-menu][data-appearance="code-candidates"] > button[data-active="true"]:enabled span {
-  color: inherit;
-  opacity: 1;
+[data-taomni-context-menu][data-appearance="code-candidates"] button[data-active="true"]:enabled span {
+  color: inherit !important;
+  opacity: 1 !important;
+}
+[data-taomni-context-menu][data-appearance="code-candidates"] button:disabled {
+  cursor: default !important;
+  opacity: 0.55;
+  background: transparent !important;
 }
 
 .taomni-proto-btn {


### PR DESCRIPTION
…header focus

Resolve keyboard and mouse focus fighting, default Tailwind hover class pollution, and disabled header activation in code candidate menus (appearance="code-candidates", used by Alt+Enter Code Actions).

1. Focus fighting & synthetic mouse events:
   - Ignore zero-displacement mousemove events (movementX === 0 && movementY === 0) in MenuRow to prevent synthetic mouse events from stealing focus back when navigating candidates via arrow keys.
   - Guard handleHover and handleMouseMove with disabled check to prevent disabled group headers (e.g. "Quick Fixes") from capturing active index.

2. Hover styling isolation & dual-highlight prevention:
   - Isolate candidate row class names from default Tailwind hover classes (hover:bg-[var(--taomni-hover)] and data-[active=true]:bg-[var(--taomni-hover)]).
   - In src/index.css, ensure non-active candidate buttons keep transparent background on hover, preventing confusing dual-highlight artifacts when keyboard selection and mouse hover point to different items.
   - Expand CSS selector from direct child '> button' to descendant 'button' so nested items and flyout triggers receive proper candidate styling.
   - Add button:disabled rules in src/index.css with default cursor, 0.55 opacity, and transparent background.

3. Padding & submenus:
   - Match CodeMirror autocomplete surface padding by setting py-0 on MenuSurface and px-2 py-0.5 on rows under appearance="code-candidates".
   - Propagate appearance attribute recursively down to portaled submenus.

4. Unit tests:
   - Add unit tests in src/components/ContextMenu.test.tsx covering code-candidates style class isolation, arrow navigation resistance to stationary mouse events, and disabled header hover immunity.