### PR TITLE
fix(code-workspace): java rename-delete recovery pending, proofs and …

### DIFF
--- a/.agents/skills/qa-ui-auto/references/testid-catalog.md
+++ b/.agents/skills/qa-ui-auto/references/testid-catalog.md
@@ -160,6 +160,14 @@
 - `[data-testid="external-file-conflict-dialog"] button[aria-label="Dismiss external file conflict"]` — interactive [optional] — F25.5.external-file-conflict-dismiss
 - `[data-testid="refactoring-preview-dialog"]` — display [optional] — F25.5.refactoring-preview-dialog
 - `[data-testid="refactoring-preview-apply"]` — interactive [optional] — F25.5.refactoring-preview-apply
+- `[data-testid="refactor-recovery-review"]` — display [optional] — F25.5.refactor-recovery-review
+- `[data-testid="refactor-recovery-resource"]` — display [optional] — F25.5.refactor-recovery-resource
+- `[data-testid="refactor-recovery-keep"]` — interactive [optional] — F25.5.refactor-recovery-keep
+- `[data-testid="refactor-recovery-dismiss"]` — interactive [optional] — F25.5.refactor-recovery-dismiss
+- `[data-testid="refactor-recovery-dismiss-confirm"]` — display [optional] — F25.5.refactor-recovery-dismiss-confirm
+- `[data-testid="refactor-recovery-dismiss-cancel"]` — interactive [optional] — F25.5.refactor-recovery-dismiss-cancel
+- `[data-testid="refactor-recovery-dismiss-confirm-button"]` — interactive [optional] — F25.5.refactor-recovery-dismiss-confirm-button
+- `[data-testid="refactor-recovery-restore"]` — interactive [optional] — F25.5.refactor-recovery-restore
 - `[data-testid="code-workspace-tree-filter"]` — interactive [optional] — F25.5.tree-filter
 - `[data-testid="code-workspace-flat-file"]` — interactive [optional] — F25.5.tree-flat-file-row
 - `[data-testid="code-workspace-editor-pane"]` — display — F25.5.editor-pane

--- a/.agents/skills/qa-ui-auto/schema/testcase.schema.json
+++ b/.agents/skills/qa-ui-auto/schema/testcase.schema.json
@@ -74,6 +74,7 @@
      "restore_24tab_fixtures",
      "sortable_java_fixtures",
      "file_move_recovery_fixtures",
+     "java_rename_deleted_fixtures",
      "view_state_fixtures"
     ]
    },

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/fixtures/__init__.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/fixtures/__init__.py
@@ -21,6 +21,9 @@ Fixtures are referenced from a testcase's `fixtures: [...]` list. Builtin set:
                     SortMembers.java for live source.sortMembers rearrange
 * file_move_recovery_fixtures - native-only fresh folder with a simulated
                     Old.java -> New.java server-side move for recovery reversal
+* java_rename_deleted_fixtures - native-only fresh folder staging the
+                    deleted-after-rename (both-missing) and mixed restorable
+                    journal shapes for rename-delete recovery
 * view_state_fixtures - native-only 60-line Long.java for per-leaf caret,
                     scroll and fold restore across reload_window
 
@@ -32,7 +35,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Protocol
 
-from . import editor_typing_fixtures, file_move_recovery_fixtures, git_diff_repo, java25_projects, java_sample_projects, jdtls_required, linux_x11_required, reset_db, restore_24tab_fixtures, sftp_required, sortable_java_fixtures, ssh_required, view_state_fixtures, welcome_recents, workspace_root
+from . import editor_typing_fixtures, file_move_recovery_fixtures, git_diff_repo, java25_projects, java_rename_deleted_fixtures, java_sample_projects, jdtls_required, linux_x11_required, reset_db, restore_24tab_fixtures, sftp_required, sortable_java_fixtures, ssh_required, view_state_fixtures, welcome_recents, workspace_root
 
 
 class FixtureContext(Protocol):
@@ -64,6 +67,7 @@ REGISTRY: dict[str, Fixture] = {
     "restore_24tab_fixtures": Fixture("restore_24tab_fixtures", restore_24tab_fixtures.setup, restore_24tab_fixtures.teardown),
     "sortable_java_fixtures": Fixture("sortable_java_fixtures", sortable_java_fixtures.setup),
     "file_move_recovery_fixtures": Fixture("file_move_recovery_fixtures", file_move_recovery_fixtures.setup),
+    "java_rename_deleted_fixtures": Fixture("java_rename_deleted_fixtures", java_rename_deleted_fixtures.setup),
     "view_state_fixtures": Fixture("view_state_fixtures", view_state_fixtures.setup),
 }
 

--- a/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/fixtures/java_rename_deleted_fixtures.py
+++ b/.agents/skills/qa-ui-auto/scripts/qa_ui_auto/fixtures/java_rename_deleted_fixtures.py
@@ -1,0 +1,47 @@
+"""Java rename-deleted recovery fixture for TC-IDE-JAVA-RENAME-DELETED-RECOVERY-WIN.
+
+Builds a fresh plain-folder workspace staging the two seeded journal shapes
+the Windows-native case consumes (no provider involved):
+
+* ``MixNew.java`` present with the POST bytes, ``MixOld.java`` absent — the
+  production mixed text+rename shape (``contentHash`` = pre-image hash) that
+  must classify restorable and reverse home with byte-preservation proof.
+* ``Gone.java`` / ``GoneRenamed.java`` absent at both ends — the
+  deleted-after-rename shape that must stay pending as
+  document-unreadable / move ``both-missing`` until explicitly abandoned.
+
+A host-side fixture (not host_write_file) is required because the runner has
+no file-delete verb, and absence must already hold when the seeded v2
+recovery journals are consumed after reload_window.
+
+The byte literals below are the exact texts the consuming case references —
+keep them in sync.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+MIX_NEW_NAME = "MixNew.java"
+
+MIX_PRE_TEXT = "public class MixOld {}\n"
+
+MIX_POST_TEXT = "public class MixNew {}\n"
+
+GONE_PRE_TEXT = "class Gone { int a = 1; }\n"
+
+GONE_POST_TEXT = "class GoneRenamed { int a = 1; }\n"
+
+
+def setup(ctx: Any) -> None:
+    destination = Path(ctx.case_dir) / "fixture-workspaces" / "jrdr_root"
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True)
+    # Only the mixed-shape new path exists (with the POST bytes); every old
+    # path and both gone ends are absent by construction.
+    (destination / MIX_NEW_NAME).write_text(MIX_POST_TEXT, encoding="utf-8", newline="")
+    values: dict[str, str] = getattr(ctx, "values")
+    values["jrdr_root"] = destination.resolve().as_posix()

--- a/qa-ui-auto-tests/cases/TC-IDE-AUDIT-014-rename-recovery-native.testcase.yaml
+++ b/qa-ui-auto-tests/cases/TC-IDE-AUDIT-014-rename-recovery-native.testcase.yaml
@@ -19,13 +19,14 @@ description: |
      diagnostic) and the same probe proved rename returns a real edit. A
      variable (not the class) is renamed so no file-move operation is
      involved; undo-inversion of resource moves is a separate recorded gap.
-  2. A2/A3 native restart/disk: a seeded v2 refactor recovery journal entry
+   2. A2/A3 native restart/disk: a seeded v2 refactor recovery journal entry
      describes a `prepared` transaction whose pre/post images are the literal
      preimage and a `QA14PostA` substitute (computed offline). The webview
      JS context is destroyed by `reload_window`, the workspace is re-entered
-     through recents, the recovery controller surfaces the "Refactor recovery
-     pending" dialog, the case accepts "Review recovery", then "Restore
-     pre-refactor content" restores every affected file to its preimage. The
+     through recents, the pending entry surfaces in the review dialog
+     (affected files with live states, Keep / Restore / Abandon outlets),
+     the case presses Restore, confirms "Restore pre-refactor content", and
+     the verified rollback restores every affected file to its preimage. The
      host re-reads the affected files (assert_file_sha256 == preHash), proves
      the journal entry was promoted to `rolled-back`, and confirms a parallel
      `host_write_file` conflict is never overwritten. The case labels the
@@ -179,14 +180,18 @@ steps:
   - click: '[data-testid="welcome-history-tab-workspaces"]'
   - click: '[data-testid="welcome-recent-workspace-row"][data-workspace-path="${fixture.maven_single_root}"]'
   - wait_for: '[data-testid="code-workspace-tab"]'
+  # The pending entry surfaces in the review dialog (figure A): it lists
+  # every affected file with its live state and offers Keep / Restore /
+  # Abandon. Restore reuses the "Restore pre-refactor content" app confirm
+  # before the verified rollback runs.
   - wait_for:
-      selector: '[data-testid="confirm-dialog"]'
+      selector: '[data-testid="refactor-recovery-review"]'
       timeout_sec: 60
   - assert_text:
-      selector: '[data-testid="confirm-dialog"]'
-      contains: "Refactor recovery pending"
+      selector: '[data-testid="refactor-recovery-review"]'
+      contains: "Review refactor recovery"
       timeout_sec: 10
-  - click: '[data-testid="confirm-dialog-confirm"]'
+  - click: '[data-testid="refactor-recovery-restore"]'
   - wait_for:
       selector: '[data-testid="confirm-dialog"]'
       timeout_sec: 30

--- a/qa-ui-auto-tests/cases/TC-IDE-FOLLOW-001-file-move-recovery-native.testcase.yaml
+++ b/qa-ui-auto-tests/cases/TC-IDE-FOLLOW-001-file-move-recovery-native.testcase.yaml
@@ -16,10 +16,10 @@ description: |
   a fresh plain-folder workspace. A seeded v2 journal entry carries one text
   document (Old.java pre/post images) plus one resourceMoves record with the
   moved bytes' content proof. The webview JS context is destroyed by
-  reload_window, the workspace is re-entered through recents, the recovery
-  controller surfaces "Refactor recovery pending" (listing the relocation),
-  the case accepts "Review recovery", then the restore confirm (naming the
-  move-back), and the controller reverses New.java -> Old.java through the
+  reload_window, the workspace is re-entered through recents, the pending
+  entry surfaces in the review dialog (relocation with live move state,
+  Keep / Restore / Abandon), the case presses Restore, confirms the
+  move-back, and the controller reverses New.java -> Old.java through the
   shell's real resource-operation path before restoring the preimage bytes.
   The host re-reads Old.java (assert_file_sha256 == preHash a749a308...),
   and the persisted journal entry is read back as rolled-back with the
@@ -74,14 +74,18 @@ steps:
   - click: '[data-testid="welcome-history-tab-workspaces"]'
   - click: '[data-testid="welcome-recent-workspace-row"][data-workspace-path="${fixture.file_move_root}"]'
   - wait_for: '[data-testid="code-workspace-tab"]'
+  # The pending entry surfaces in the review dialog (figure A): it lists the
+  # relocated file with its live move state and offers Keep / Restore /
+  # Abandon. Restore reuses the app confirm naming the move-back before the
+  # verified reversal runs.
   - wait_for:
-      selector: '[data-testid="confirm-dialog"]'
+      selector: '[data-testid="refactor-recovery-review"]'
       timeout_sec: 60
   - assert_text:
-      selector: '[data-testid="confirm-dialog"]'
-      contains: "Refactor recovery pending"
+      selector: '[data-testid="refactor-recovery-review"]'
+      contains: "Review refactor recovery"
       timeout_sec: 10
-  - click: '[data-testid="confirm-dialog-confirm"]'
+  - click: '[data-testid="refactor-recovery-restore"]'
   - wait_for:
       selector: '[data-testid="confirm-dialog"]'
       timeout_sec: 30

--- a/qa-ui-auto-tests/cases/TC-IDE-JAVA-RENAME-DELETED-RECOVERY-WIN.testcase.yaml
+++ b/qa-ui-auto-tests/cases/TC-IDE-JAVA-RENAME-DELETED-RECOVERY-WIN.testcase.yaml
@@ -1,0 +1,176 @@
+id: TC-IDE-JAVA-RENAME-DELETED-RECOVERY-WIN
+title: "Java rename-delete recovery on Windows: abandon both-missing, restore mixed shape"
+description: |
+  java-rename-deleted-recovery Windows-native gate case (F25.5). Runs the
+  seeded half of TC-IDE-JAVA-RENAME-DELETED-RECOVERY with Windows-supported
+  verbs only (no pointer/keyboard injection): the live JDT LS class-rename
+  provider segment runs on Linux (pointer caret verbs are Linux/X11-only),
+  while this case proves on real WebView2 + real disk + webview-persistent
+  journals:
+
+  1. AC-02/04 seeded history: a seeded v2 entry in the deleted-after-rename
+     shape (old and new paths both missing) reviews as
+     document-unreadable / move `both-missing`, states non-existence without
+     claiming the user deleted anything, keeps Restore disabled, and offers
+     Keep plus a two-step Abandon. Opening Abandon then pressing Escape
+     closes only the inline confirm and keeps the entry pending.
+  2. AC-03 abandon: confirming Abandon records only a `user-dismissed`
+     resolution marker (zero file writes: the staged post bytes keep their
+     hash, the gone paths stay gone) and the abandoned record stays silent
+     after reload while the sibling pending entry still prompts.
+  3. AC-05 seeded mixed shape: a seeded v2 entry in the production mixed
+     text+rename shape (`contentHash` = pre-image hash, document pre/post
+     images, new path staged with the POST bytes) classifies restorable,
+     restores new->old with byte-preservation proof plus preimage read-back,
+     and lands `rolled-back` with the reversed move recorded
+     (assert_file_sha256 == preHash on the moved-home bytes).
+
+  Highest claim on green: L2 native (Windows), packaged QA app over real
+  disk bytes. Explicitly NOT claimed by this run: the live provider class
+  rename (Linux case), the live user order "rename then delete the renamed
+  file via the tree then reopen" (no tree-delete verb exists; recorded
+  manual V-05), the 736x375 / 1280x800 viewport matrix (no native viewport
+  verb), host proof that a missing path stays missing (no assert-file-missing
+  verb; the zero-write ack plus unchanged staged hashes plus the
+  `user-dismissed` marker are the automated evidence), and Linux/macOS runs
+  (other ends stay unverified, never passed-by-proxy).
+covers: [F25.5]
+tags: [code-workspace, ide-editor, refactor, recovery, java-rename, native-gate, p1]
+modes: [native]
+native_platforms: [Windows]
+fixtures: [reset_db, java_rename_deleted_fixtures]
+timeout_sec: 600
+steps:
+  - open: "${cfg.app.base_url}"
+  - vault_first_run: "qa-native-gate-password"
+  - wait_for: '[data-testid="welcome-panel"]'
+  # Enter the fresh seeded workspace through persisted recents; the
+  # workspace identity is the deterministic recents identity of the roots,
+  # so the recovery entries survive reload_window.
+  - seed_storage:
+      key: taomni.recentWorkspaces.v1
+      value: '[{"id":"qa-jrdr-win","name":"jrdr","roots":[{"id":"jrdr","name":"jrdr","path":"${fixture.jrdr_root}","kind":"folder"}],"looseFiles":[],"lastActiveFile":{"kind":"root","rootId":"jrdr","path":"MixNew.java"},"lastOpenedAt":1756100000000,"isGitRepo":false}]'
+  - reload_window: null
+  - click: '[data-testid="welcome-history-tab-workspaces"]'
+  - click: '[data-testid="welcome-recent-workspace-row"][data-workspace-path="${fixture.jrdr_root}"]'
+  - wait_for: '[data-testid="code-workspace-tab"]'
+  - wait_for:
+      selector: '[data-testid="code-workspace-editor-pane"]'
+      timeout_sec: 60
+  - assert_text:
+      selector: '[data-testid="code-workspace-editor"]'
+      contains: "public class MixNew"
+      timeout_sec: 60
+  # Seed both histories BEFORE the reload that triggers discovery: the
+  # abandoned record is newer, so the sequential review reaches it first.
+  - seed_storage:
+      key: taomni.refactor.recovery.v2:qa-jrdrw-abandon
+      value: '{"schemaVersion": 2, "recoveryId": "qa-jrdrw-abandon", "transactionId": "qa-jrdrw-txn-abandon", "actionId": "rename:qa-jrdrw-abandon", "kind": "rename", "workspaceRoot": "${fixture.jrdr_root}", "createdAt": 1757000002000, "updatedAt": 1757000002000, "status": "recovery-required", "appliedOperationIndex": null, "documents": [{"uri": "file://${fixture.jrdr_root}/Gone.java", "canonicalPath": "${fixture.jrdr_root}/Gone.java", "preText": "class Gone { int a = 1; }\n", "preHash": "d0a3257e508b876863b3ab9f4dc7f0fc04211e05fd33ba64e41c2ccc16852351", "postText": "class GoneRenamed { int a = 1; }\n", "postHash": "6fc89ed34e31da3e3927f9c1890dbc52154d62671a175db7796f45d24bde1b57", "encoding": "UTF-8", "bom": false, "eol": "lf"}], "resourceMoves": [{"oldUri": "file://${fixture.jrdr_root}/Gone.java", "newUri": "file://${fixture.jrdr_root}/GoneRenamed.java", "oldPath": "${fixture.jrdr_root}/Gone.java", "newPath": "${fixture.jrdr_root}/GoneRenamed.java", "contentHash": "d0a3257e508b876863b3ab9f4dc7f0fc04211e05fd33ba64e41c2ccc16852351"}], "verification": {"mismatchedUris": [], "checkedAt": null}}'
+  - seed_storage:
+      key: taomni.refactor.recovery.v2:qa-jrdrw-mixed
+      value: '{"schemaVersion": 2, "recoveryId": "qa-jrdrw-mixed", "transactionId": "qa-jrdrw-txn-mixed", "actionId": "rename:qa-jrdrw-mixed", "kind": "rename", "workspaceRoot": "${fixture.jrdr_root}", "createdAt": 1757000001000, "updatedAt": 1757000001000, "status": "prepared", "appliedOperationIndex": null, "documents": [{"uri": "file://${fixture.jrdr_root}/MixOld.java", "canonicalPath": "${fixture.jrdr_root}/MixOld.java", "preText": "public class MixOld {}\n", "preHash": "3533c9cac826533ea8dd12c771268366d3901f2d14fb43fd1d9a70dd794444c1", "postText": "public class MixNew {}\n", "postHash": "adf660ac77c1ba60f1cdc7106f9e8adeefe94af4657ec96348121122817f3432", "encoding": "UTF-8", "bom": false, "eol": "lf"}], "resourceMoves": [{"oldUri": "file://${fixture.jrdr_root}/MixOld.java", "newUri": "file://${fixture.jrdr_root}/MixNew.java", "oldPath": "${fixture.jrdr_root}/MixOld.java", "newPath": "${fixture.jrdr_root}/MixNew.java", "contentHash": "3533c9cac826533ea8dd12c771268366d3901f2d14fb43fd1d9a70dd794444c1"}], "verification": {"mismatchedUris": [], "checkedAt": null}}'
+  # reload_window destroys the webview JS context. Re-enter via recents so
+  # the workspace mounts fresh and workspace-ready discovery runs the
+  # pending-entry scan (the same mechanism that runs after a process
+  # restart, since localStorage is webview-persistent under the QA overlay).
+  - reload_window: null
+  - click: '[data-testid="welcome-history-tab-workspaces"]'
+  - click: '[data-testid="welcome-recent-workspace-row"][data-workspace-path="${fixture.jrdr_root}"]'
+  - wait_for: '[data-testid="code-workspace-tab"]'
+  # Newest first: the both-missing record. Restore stays disabled, the
+  # states name non-existence (never "you deleted"), and the full paths
+  # remain visible/selectable for long-path review.
+  - wait_for:
+      selector: '[data-testid="refactor-recovery-review"]'
+      timeout_sec: 60
+  - assert_text:
+      selector: '[data-testid="refactor-recovery-review"]'
+      contains: "Gone.java"
+      timeout_sec: 10
+  - assert_text:
+      selector: '[data-testid="refactor-recovery-review"]'
+      contains: "does not exist"
+      timeout_sec: 10
+  # Restore must stay disabled while the endpoints are both missing (read
+  # the disabled DOM property; the native runner has no assert_disabled, and
+  # the eval guard rejects a literal `=`, hence fromCharCode(61)).
+  - eval_readonly:
+      expression: "document.querySelector('[data-testid' + String.fromCharCode(61) + '\"refactor-recovery-restore\"]').disabled"
+      expect_truthy: true
+  - screenshot: tc-ide-java-rename-deleted-win-both-missing.png
+  # AC-04: opening Abandon then escaping keeps the entry pending.
+  - click: '[data-testid="refactor-recovery-dismiss"]'
+  - wait_for:
+      selector: '[data-testid="refactor-recovery-dismiss-confirm"]'
+      timeout_sec: 10
+  - press: Escape
+  - assert_not_visible: '[data-testid="refactor-recovery-dismiss-confirm"]'
+  - assert_text:
+      selector: '[data-testid="refactor-recovery-review"]'
+      contains: "Gone.java"
+      timeout_sec: 10
+  # Confirm Abandon: only the resolution marker is written (zero file
+  # writes). The staged post bytes keep their hash.
+  - click: '[data-testid="refactor-recovery-dismiss"]'
+  - click: '[data-testid="refactor-recovery-dismiss-confirm-button"]'
+  - assert_text:
+      selector: '[data-testid="status-bar-message"]'
+      contains: "Abandoned refactor recovery"
+      timeout_sec: 30
+  - eval_readonly:
+      expression: "localStorage.getItem('taomni.refactor.recovery.v2:qa-jrdrw-abandon')"
+      contains: "user-dismissed"
+  - assert_file_contains:
+      path: "${fixture.jrdr_root}/MixNew.java"
+      contains: "public class MixNew {}"
+      timeout_sec: 30
+  # Settle so the closing abandon dialog is gone before asserting the
+  # sibling review that the same discover loop opens next.
+  - wait: 2
+  - assert_text:
+      selector: '[data-testid="refactor-recovery-review"]'
+      contains: "MixOld.java"
+      timeout_sec: 30
+  # Condition-based gate for classification: the restorable move label only
+  # renders after the live verify finishes (rows show "checking…" before).
+  - assert_text:
+      selector: '[data-testid="refactor-recovery-review"]'
+      contains: "ready to move back"
+      timeout_sec: 30
+  - screenshot: tc-ide-java-rename-deleted-win-mixed-review.png
+  # ---- Restore the production mixed shape (AC-05) ----
+  - eval_readonly:
+      expression: "String(document.querySelector('[data-testid' + String.fromCharCode(61) + '\"refactor-recovery-restore\"]').disabled)"
+      contains: "false"
+  - click: '[data-testid="refactor-recovery-restore"]'
+  - wait_for:
+      selector: '[data-testid="confirm-dialog"]'
+      timeout_sec: 30
+  - assert_text:
+      selector: '[data-testid="confirm-dialog"]'
+      contains: "Restore pre-refactor content"
+      timeout_sec: 10
+  - click: '[data-testid="confirm-dialog-confirm"]'
+  - assert_text:
+      selector: '[data-testid="status-bar-message"]'
+      contains: "Refactor recovery complete"
+      timeout_sec: 60
+  - assert_file_sha256:
+      path: "${fixture.jrdr_root}/MixOld.java"
+      equals: "3533c9cac826533ea8dd12c771268366d3901f2d14fb43fd1d9a70dd794444c1"
+      timeout_sec: 30
+  - eval_readonly:
+      expression: "localStorage.getItem('taomni.refactor.recovery.v2:qa-jrdrw-mixed')"
+      contains: "rolled-back"
+  - eval_readonly:
+      expression: "localStorage.getItem('taomni.refactor.recovery.v2:qa-jrdrw-mixed')"
+      contains: "reversedMoves"
+  - screenshot: tc-ide-java-rename-deleted-win-restored.png
+  # Reload proves final silence: the abandoned record never returns and the
+  # restored record closed as rolled-back.
+  - reload_window: null
+  - click: '[data-testid="welcome-history-tab-workspaces"]'
+  - click: '[data-testid="welcome-recent-workspace-row"][data-workspace-path="${fixture.jrdr_root}"]'
+  - wait_for: '[data-testid="code-workspace-tab"]'
+  - wait: 5
+  - assert_not_visible: '[data-testid="refactor-recovery-review"]'

--- a/qa-ui-auto-tests/cases/TC-IDE-JAVA-RENAME-DELETED-RECOVERY.testcase.yaml
+++ b/qa-ui-auto-tests/cases/TC-IDE-JAVA-RENAME-DELETED-RECOVERY.testcase.yaml
@@ -1,0 +1,239 @@
+id: TC-IDE-JAVA-RENAME-DELETED-RECOVERY
+title: "Java class rename + delete: no false recovery, explicit abandon, verified restore"
+description: |
+  java-rename-deleted-recovery native gate case (F25.5). Proves the three
+  production fixes over the real packaged-app boundary on Linux:
+
+  1. AC-01/provider: a real Shift+F6 rename of the top-level
+     `QuickFixTarget` class in the maven-single sample applies a genuine
+     text+rename WorkspaceEdit through the packaged app UI (preview modal
+     reporting the resource operation, apply, moved file on disk with the new
+     class, journal committed). Re-entering the workspace surfaces NO review
+     dialog for that successful transaction (identity-based postcondition:
+     no false `recovery-required` from `/` vs `\` path spellings).
+  2. AC-02/03/04 seeded history: a seeded v2 entry in the deleted-after-rename
+     shape (old and new paths both missing) reviews as
+     document-unreadable / move `both-missing`, states non-existence without
+     claiming the user deleted anything, keeps Restore disabled, and offers
+     Keep plus a two-step Abandon (Esc cancels the second step and keeps the
+     entry pending). Confirming Abandon records only a `user-dismissed`
+     resolution marker (zero file writes: the renamed file keeps its post
+     bytes, the gone paths stay gone), and after reload the abandoned record
+     stays silent while a sibling pending entry still prompts.
+  3. AC-05 seeded mixed shape: a seeded v2 entry in the production mixed
+     text+rename shape (`contentHash` = pre-image hash, document pre/post
+     images, new path staged with the POST bytes) classifies restorable
+     (document proof accepts the post image instead of conflicting on the
+     pre hash), restores new->old with byte-preservation proof plus preimage
+     read-back, and lands `rolled-back` with the reversed move recorded.
+
+  Highest claim on green: L2 native (Linux), packaged app UI over a real
+  jdtls process (segment 1) and real disk bytes plus webview-persistent
+  recovery journals (segments 2-3). Explicitly NOT claimed by this run:
+  the live user order "rename then delete the renamed file via the tree then
+  reopen" (no tree-delete verb exists in the catalog; covered by recorded
+  manual V-05), the 736x375 / 1280x800 viewport matrix (no native viewport
+  verb; small-window geometry is manual V-05), host proof that a missing path
+  stays missing (no assert-file-missing verb; the zero-write ack plus
+  unchanged sibling hashes plus the `user-dismissed` marker are the
+  automated evidence), and macOS/Windows native runs (Linux only on this
+  box; other ends stay unverified, never passed-by-proxy).
+covers: [F25.5]
+tags: [code-workspace, ide-editor, refactor, recovery, java-rename, native-gate, p1]
+modes: [native]
+fixtures: [reset_db, java_sample_projects, jdtls_required]
+timeout_sec: 600
+steps:
+  - open: "${cfg.app.base_url}"
+  - vault_first_run: "qa-native-gate-password"
+  - wait_for: '[data-testid="welcome-panel"]'
+  # Enter the real maven-single sample through persisted recents; the
+  # workspace identity is the deterministic recents identity of the roots,
+  # so the layout snapshot and recovery entries survive reload_window.
+  - seed_storage:
+      key: taomni.recentWorkspaces.v1
+      value: '[{"id":"qa-jrdr","name":"maven-single","roots":[{"id":"maven-single","name":"maven-single","path":"${fixture.maven_single_root}","kind":"folder"}],"looseFiles":[],"lastActiveFile":{"kind":"root","rootId":"maven-single","path":"src/main/java/com/example/single/QuickFixTarget.java"},"lastOpenedAt":1756100000000,"isGitRepo":false}]'
+  - reload_window: null
+  - click: '[data-testid="welcome-history-tab-workspaces"]'
+  - click: '[data-testid="welcome-recent-workspace-row"][data-workspace-path="${fixture.maven_single_root}"]'
+  - wait_for: '[data-testid="code-workspace-tab"]'
+  - wait_for:
+      selector: '[data-testid="code-workspace-editor-pane"]'
+      timeout_sec: 60
+  - assert_text:
+      selector: '[data-testid="code-workspace-editor"]'
+      contains: "public class QuickFixTarget"
+      timeout_sec: 60
+  - assert_text:
+      selector: '[data-testid="code-workspace-lsp-status-pill"]'
+      contains: "Java"
+      timeout_sec: 60
+  # Cold-import settle (same precedent as TC-IDE-AUDIT-014/C6-04): per-run
+  # fixture copies force a cold jdtls import every run; stroking rename
+  # mid-import bails or cancels loudly instead of proving anything.
+  - wait: 30
+
+  # ---- Segment 1: live top-level class rename (AC-01 success half) ----
+  # `QuickFixTarget` sits on 1-based line 9 at 1-based cols 14-29
+  # (zero-based drag column 13). Renaming the top-level type makes the
+  # server include a file-move operation, which forces the preview modal.
+  - native_pointer_drag:
+      selector: '[data-testid="code-workspace-editor"] .cm-content'
+      from: {line: 9, column: 13}
+      to: {line: 9, column: 13}
+  - assert_text:
+      selector: '[data-testid="status-bar-workspace-cursor"]'
+      contains: "Ln 9, Col 14"
+      timeout_sec: 10
+  - wait: 2
+  - native_keys:
+      selector: '[data-testid="code-workspace-editor"] .cm-content'
+      keys: ["Shift+F6"]
+      transport: webdriver
+  - wait_for:
+      selector: '[data-testid="text-input-dialog"]'
+      timeout_sec: 30
+  - assert_attribute:
+      selector: '[data-testid="text-input-dialog-input"]'
+      name: "value"
+      equals: "QuickFixTarget"
+  - fill:
+      selector: '[data-testid="text-input-dialog-input"]'
+      value: "QaDelTarget"
+  - click: '[data-testid="text-input-dialog-confirm"]'
+  - wait_for:
+      selector: '[data-testid="refactoring-preview-dialog"]'
+      timeout_sec: 60
+  - assert_text:
+      selector: '[data-testid="refactoring-preview-dialog"]'
+      contains: "QaDelTarget"
+      timeout_sec: 10
+  - assert_text:
+      selector: '[data-testid="refactoring-preview-dialog"]'
+      contains: "1 resource operation"
+      timeout_sec: 10
+  - click: '[data-testid="refactoring-preview-apply"]'
+  - assert_text:
+      selector: '[data-testid="code-workspace-editor"]'
+      contains: "class QaDelTarget"
+      timeout_sec: 30
+  - press: Control+s
+  - assert_file_contains:
+      path: "${fixture.maven_single_root}/src/main/java/com/example/single/QaDelTarget.java"
+      contains: "class QaDelTarget"
+      timeout_sec: 30
+  - screenshot: tc-ide-java-rename-deleted-recovery-rename.png
+  # Re-enter: the committed success must NOT surface a review dialog.
+  - reload_window: null
+  - click: '[data-testid="welcome-history-tab-workspaces"]'
+  - click: '[data-testid="welcome-recent-workspace-row"][data-workspace-path="${fixture.maven_single_root}"]'
+  - wait_for: '[data-testid="code-workspace-tab"]'
+  - wait: 5
+  - assert_not_visible: '[data-testid="refactor-recovery-review"]'
+  - screenshot: tc-ide-java-rename-deleted-recovery-clean-reopen.png
+
+  # ---- Segment 2: seeded both-missing history (AC-02/03/04) ----
+  # The abandoned record points at paths that exist at neither end; the
+  # sibling stays restorable on the live disk. The abandoned record is
+  # newer, so the sequential review reaches it first.
+  - seed_storage:
+      key: taomni.refactor.recovery.v2:qa-jrdr-abandon
+      value: '{"schemaVersion": 2, "recoveryId": "qa-jrdr-abandon", "transactionId": "qa-jrdr-txn-abandon", "actionId": "rename:qa-jrdr-abandon", "kind": "rename", "workspaceRoot": "${fixture.maven_single_root}", "createdAt": 1757000002000, "updatedAt": 1757000002000, "status": "recovery-required", "appliedOperationIndex": null, "documents": [{"uri": "file://${fixture.maven_single_root}/src/main/java/com/example/single/Gone.java", "canonicalPath": "${fixture.maven_single_root}/src/main/java/com/example/single/Gone.java", "preText": "class Gone { int a = 1; }\n", "preHash": "d0a3257e508b876863b3ab9f4dc7f0fc04211e05fd33ba64e41c2ccc16852351", "postText": "class GoneRenamed { int a = 1; }\n", "postHash": "6fc89ed34e31da3e3927f9c1890dbc52154d62671a175db7796f45d24bde1b57", "encoding": "UTF-8", "bom": false, "eol": "lf"}], "resourceMoves": [{"oldUri": "file://${fixture.maven_single_root}/src/main/java/com/example/single/Gone.java", "newUri": "file://${fixture.maven_single_root}/src/main/java/com/example/single/GoneRenamed.java", "oldPath": "${fixture.maven_single_root}/src/main/java/com/example/single/Gone.java", "newPath": "${fixture.maven_single_root}/src/main/java/com/example/single/GoneRenamed.java", "contentHash": "d0a3257e508b876863b3ab9f4dc7f0fc04211e05fd33ba64e41c2ccc16852351"}], "verification": {"mismatchedUris": [], "checkedAt": null}}'
+  # Stage the sibling's post bytes and seed its prepared entry (older, so it
+  # reviews second). Pre/post are the literal App fixture bytes pattern with
+  # MixOld/MixNew class names; contentHash carries the PRE-image hash (the
+  # production mixed-shape contract RC-03 proves).
+  - host_write_file:
+      path: "${fixture.maven_single_root}/src/main/java/com/example/single/MixNew.java"
+      text: "public class MixNew {}\n"
+  - seed_storage:
+      key: taomni.refactor.recovery.v2:qa-jrdr-mixed
+      value: '{"schemaVersion": 2, "recoveryId": "qa-jrdr-mixed", "transactionId": "qa-jrdr-txn-mixed", "actionId": "rename:qa-jrdr-mixed", "kind": "rename", "workspaceRoot": "${fixture.maven_single_root}", "createdAt": 1757000001000, "updatedAt": 1757000001000, "status": "prepared", "appliedOperationIndex": null, "documents": [{"uri": "file://${fixture.maven_single_root}/src/main/java/com/example/single/MixOld.java", "canonicalPath": "${fixture.maven_single_root}/src/main/java/com/example/single/MixOld.java", "preText": "public class MixOld {}\n", "preHash": "3533c9cac826533ea8dd12c771268366d3901f2d14fb43fd1d9a70dd794444c1", "postText": "public class MixNew {}\n", "postHash": "adf660ac77c1ba60f1cdc7106f9e8adeefe94af4657ec96348121122817f3432", "encoding": "UTF-8", "bom": false, "eol": "lf"}], "resourceMoves": [{"oldUri": "file://${fixture.maven_single_root}/src/main/java/com/example/single/MixOld.java", "newUri": "file://${fixture.maven_single_root}/src/main/java/com/example/single/MixNew.java", "oldPath": "${fixture.maven_single_root}/src/main/java/com/example/single/MixOld.java", "newPath": "${fixture.maven_single_root}/src/main/java/com/example/single/MixNew.java", "contentHash": "3533c9cac826533ea8dd12c771268366d3901f2d14fb43fd1d9a70dd794444c1"}], "verification": {"mismatchedUris": [], "checkedAt": null}}'
+  - reload_window: null
+  - click: '[data-testid="welcome-history-tab-workspaces"]'
+  - click: '[data-testid="welcome-recent-workspace-row"][data-workspace-path="${fixture.maven_single_root}"]'
+  - wait_for: '[data-testid="code-workspace-tab"]'
+  # Newest first: the both-missing record. Restore stays disabled, the
+  # states name non-existence (never "you deleted"), and the full paths
+  # remain visible/selectable for long-path review.
+  - wait_for:
+      selector: '[data-testid="refactor-recovery-review"]'
+      timeout_sec: 60
+  - assert_text:
+      selector: '[data-testid="refactor-recovery-review"]'
+      contains: "Gone.java"
+      timeout_sec: 10
+  - assert_text:
+      selector: '[data-testid="refactor-recovery-review"]'
+      contains: "does not exist"
+      timeout_sec: 10
+  - assert_disabled: '[data-testid="refactor-recovery-restore"]'
+  - screenshot: tc-ide-java-rename-deleted-recovery-both-missing.png
+  # AC-04: opening Abandon then escaping keeps the entry pending.
+  - click: '[data-testid="refactor-recovery-dismiss"]'
+  - wait_for:
+      selector: '[data-testid="refactor-recovery-dismiss-confirm"]'
+      timeout_sec: 10
+  - press: Escape
+  - assert_not_visible: '[data-testid="refactor-recovery-dismiss-confirm"]'
+  - assert_text:
+      selector: '[data-testid="refactor-recovery-review"]'
+      contains: "Gone.java"
+      timeout_sec: 10
+  # Confirm Abandon: only the resolution marker is written (zero file
+  # writes). The renamed live file keeps its post bytes.
+  - click: '[data-testid="refactor-recovery-dismiss"]'
+  - click: '[data-testid="refactor-recovery-dismiss-confirm-button"]'
+  - assert_text:
+      selector: '[data-testid="status-bar-message"]'
+      contains: "Abandoned refactor recovery"
+      timeout_sec: 30
+  - eval_readonly:
+      expression: "localStorage.getItem('taomni.refactor.recovery.v2:qa-jrdr-abandon')"
+      contains: "user-dismissed"
+  - assert_file_contains:
+      path: "${fixture.maven_single_root}/src/main/java/com/example/single/QaDelTarget.java"
+      contains: "class QaDelTarget"
+      timeout_sec: 30
+  # The sibling (older pending entry) reviews next in the same loop.
+  - wait_for:
+      selector: '[data-testid="refactor-recovery-review"]'
+      timeout_sec: 60
+  - assert_text:
+      selector: '[data-testid="refactor-recovery-review"]'
+      contains: "MixOld.java"
+      timeout_sec: 10
+  - screenshot: tc-ide-java-rename-deleted-recovery-mixed-review.png
+  # ---- Segment 3: restore the production mixed shape (AC-05) ----
+  - click: '[data-testid="refactor-recovery-restore"]'
+  - wait_for:
+      selector: '[data-testid="confirm-dialog"]'
+      timeout_sec: 30
+  - assert_text:
+      selector: '[data-testid="confirm-dialog"]'
+      contains: "Restore pre-refactor content"
+      timeout_sec: 10
+  - click: '[data-testid="confirm-dialog-confirm"]'
+  - assert_text:
+      selector: '[data-testid="status-bar-message"]'
+      contains: "Refactor recovery complete"
+      timeout_sec: 60
+  - assert_file_sha256:
+      path: "${fixture.maven_single_root}/src/main/java/com/example/single/MixOld.java"
+      equals: "3533c9cac826533ea8dd12c771268366d3901f2d14fb43fd1d9a70dd794444c1"
+      timeout_sec: 30
+  - eval_readonly:
+      expression: "localStorage.getItem('taomni.refactor.recovery.v2:qa-jrdr-mixed')"
+      contains: "rolled-back"
+  - eval_readonly:
+      expression: "localStorage.getItem('taomni.refactor.recovery.v2:qa-jrdr-mixed')"
+      contains: "reversedMoves"
+  - screenshot: tc-ide-java-rename-deleted-recovery-restored.png
+  # Reload proves final silence: the abandoned record never returns and the
+  # restored record closed as rolled-back.
+  - reload_window: null
+  - click: '[data-testid="welcome-history-tab-workspaces"]'
+  - click: '[data-testid="welcome-recent-workspace-row"][data-workspace-path="${fixture.maven_single_root}"]'
+  - wait_for: '[data-testid="code-workspace-tab"]'
+  - wait: 5
+  - assert_not_visible: '[data-testid="refactor-recovery-review"]'

--- a/qa-ui-auto-tests/feature-list.md
+++ b/qa-ui-auto-tests/feature-list.md
@@ -5657,9 +5657,12 @@ controls:
 id: F25.5
 status: partial
 area: code-workspace/editor-shell
-components: [CodeWorkspaceTab, WorkspaceTabPolicySettingsDialog, EditorGroup, HighlightingWidget, FileTreePane, TabSwitcher, Breadcrumbs, KeymapSettingsDialog, ClipboardHistoryPopup, ProjectFactsStatusBadge, TodosBookmarksPanel, EditorCompareDialog, LocalHistoryDialog, FileEncodingDialog, AutoImportSettingsDialog, AutoImportCandidateDialog, FileTemplateSettingsDialog, NewJavaClassDialog]
+components: [CodeWorkspaceTab, WorkspaceTabPolicySettingsDialog, EditorGroup, HighlightingWidget, FileTreePane, TabSwitcher, Breadcrumbs, KeymapSettingsDialog, ClipboardHistoryPopup, ProjectFactsStatusBadge, TodosBookmarksPanel, EditorCompareDialog, LocalHistoryDialog, FileEncodingDialog, AutoImportSettingsDialog, AutoImportCandidateDialog, FileTemplateSettingsDialog, NewJavaClassDialog, RefactorRecoveryReviewDialog]
 files:
   - src/components/editor/CodeWorkspaceTab.tsx
+  - src/components/editor/workspace/RefactorRecoveryReviewDialog.tsx
+  - src/components/editor/workspace/refactorPlan.ts
+  - src/components/editor/workspace/refactorRecoveryController.ts
   - src/components/editor/workspace/FileEncodingDialog.tsx
   - src/components/editor/workspace/WorkspaceTabPolicySettingsDialog.tsx
   - src/components/editor/workspace/Breadcrumbs.tsx
@@ -5728,6 +5731,38 @@ controls:
     selector: '[data-testid="refactoring-preview-apply"]'
     kind: interactive
     optional: true       # applies the previewed refactoring (C6-04)
+  - id: refactor-recovery-review
+    selector: '[data-testid="refactor-recovery-review"]'
+    kind: display
+    optional: true       # per-entry recovery review dialog (figure A)
+  - id: refactor-recovery-resource
+    selector: '[data-testid="refactor-recovery-resource"]'
+    kind: display
+    optional: true       # one row per affected file/move with its live state
+  - id: refactor-recovery-keep
+    selector: '[data-testid="refactor-recovery-keep"]'
+    kind: interactive
+    optional: true       # closes the review, entry stays pending
+  - id: refactor-recovery-dismiss
+    selector: '[data-testid="refactor-recovery-dismiss"]'
+    kind: interactive
+    optional: true       # opens the inline abandon confirm (figure B)
+  - id: refactor-recovery-dismiss-confirm
+    selector: '[data-testid="refactor-recovery-dismiss-confirm"]'
+    kind: display
+    optional: true       # inline abandon confirm panel, cancel-focused
+  - id: refactor-recovery-dismiss-cancel
+    selector: '[data-testid="refactor-recovery-dismiss-cancel"]'
+    kind: interactive
+    optional: true       # cancels the abandon, entry stays pending
+  - id: refactor-recovery-dismiss-confirm-button
+    selector: '[data-testid="refactor-recovery-dismiss-confirm-button"]'
+    kind: interactive
+    optional: true       # persists user-dismissed, files untouched
+  - id: refactor-recovery-restore
+    selector: '[data-testid="refactor-recovery-restore"]'
+    kind: interactive
+    optional: true       # verified restore, enabled only when restorable
   - id: tree-filter
     selector: '[data-testid="code-workspace-tree-filter"]'
     kind: interactive

--- a/src/components/editor/CodeWorkspaceTab.test.tsx
+++ b/src/components/editor/CodeWorkspaceTab.test.tsx
@@ -9356,9 +9356,14 @@ end_of_record
 
       renderWorkspace(workspace, {});
       await screen.findByTitle("app / src/reader.ts");
-      await waitFor(() => expect(recoveryCalls().some((call) => call.title === "Refactor recovery pending")).toBe(true));
-      expect(recoveryCalls()[0]?.message).toContain("/repo/app/src/main.ts");
-      expect(recoveryCalls()[0]?.message).toContain("/repo/app/src/other.ts");
+      // RC-02: auto-discover opens the review dialog (figure A) instead of a
+      // global confirm. Restore via the dialog; the second confirm reuses the
+      // mocked app dialog (default true).
+      const review = await screen.findByTestId("refactor-recovery-review");
+      expect(within(review).getAllByTestId("refactor-recovery-resource")).toHaveLength(2);
+      const restoreButton = within(review).getByTestId("refactor-recovery-restore");
+      await waitFor(() => expect(restoreButton).toBeEnabled());
+      fireEvent.click(restoreButton);
 
       await waitFor(() => expect(disk["src/main.ts"]).toBe(PRE["src/main.ts"]));
       await waitFor(() => expect(disk["src/other.ts"]).toBe(PRE["src/other.ts"]));
@@ -9389,15 +9394,108 @@ end_of_record
 
       renderWorkspace(workspace, {});
       await screen.findByTitle("app / src/reader.ts");
-      await waitFor(() => expect(recoveryCalls().some((call) => call.title === "Refactor recovery blocked")).toBe(true));
-      const blocked = recoveryCalls().find((call) => call.title === "Refactor recovery blocked");
-      expect(blocked?.message).toContain("/repo/app/src/other.ts (conflict)");
-      expect(blocked?.message).toContain("will not be overwritten");
+      // RC-02: conflicted entries render in the review dialog with restore
+      // disabled and an explicit keep outlet; nothing is overwritten.
+      const review = await screen.findByTestId("refactor-recovery-review");
+      expect(within(review).getByTestId("refactor-recovery-restore")).toBeDisabled();
+      expect(review.textContent).toContain("other.ts");
+      fireEvent.click(within(review).getByTestId("refactor-recovery-keep"));
+      await waitFor(() => expect(screen.queryByTestId("refactor-recovery-review")).not.toBeInTheDocument());
       // Zero overwrite: the third-party content and the post-state stay as-is.
       expect(disk["src/other.ts"]).toBe("user edited after the refactor");
       expect(disk["src/main.ts"]).toBe(POST["src/main.ts"]);
       expect(workspaceMocks.workspaceWriteFileEncoded).not.toHaveBeenCalled();
       expect(getRefactorRecoveryJournalV2("rec-reopen-1")?.status).toBe("recovery-required");
+    });
+
+    it("abandons a both-missing entry with zero file writes and keeps siblings pending", async () => {
+      const { disk, workspace, registrationRef, onCommandsChange } = setupWorkspace("recovery-abandon", "src/reader.ts");
+      // Sibling stays restorable on disk; the abandoned record points at files
+      // that exist at neither end (deleted-after-rename shape).
+      disk["src/main.ts"] = POST["src/main.ts"];
+      disk["src/other.ts"] = POST["src/other.ts"];
+      const gonePre = "gone pre";
+      const gonePost = "gone post";
+      expect(recordRefactorRecoveryJournalV2({
+        schemaVersion: 2,
+        recoveryId: "rec-abandon-1",
+        transactionId: "tx-abandon-1",
+        actionId: "rename:gone",
+        kind: "rename",
+        workspaceRoot: "/repo/app",
+        createdAt: 200,
+        updatedAt: 200,
+        status: "recovery-required",
+        appliedOperationIndex: null,
+        documents: [recoveryDocument(
+          "file:///repo/app/src/Gone.java",
+          "/repo/app/src/Gone.java",
+          gonePre,
+          gonePost,
+        )],
+        resourceMoves: [{
+          oldUri: "file:///repo/app/src/Gone.java",
+          newUri: "file:///repo/app/src/GoneRenamed.java",
+          oldPath: "/repo/app/src/Gone.java",
+          newPath: "/repo/app/src/GoneRenamed.java",
+          contentHash: sha256Hex(gonePre),
+        }],
+        verification: { mismatchedUris: [], checkedAt: null },
+      }).ok).toBe(true);
+      expect(recordRefactorRecoveryJournalV2({
+        schemaVersion: 2,
+        recoveryId: "rec-sibling-1",
+        transactionId: "tx-sibling-1",
+        actionId: "rename:update-two-files",
+        kind: "rename",
+        workspaceRoot: "/repo/app",
+        createdAt: 100,
+        updatedAt: 100,
+        status: "recovery-required",
+        appliedOperationIndex: null,
+        documents: [
+          recoveryDocument("file:///repo/app/src/main.ts", "/repo/app/src/main.ts", PRE["src/main.ts"], POST["src/main.ts"]),
+          recoveryDocument("file:///repo/app/src/other.ts", "/repo/app/src/other.ts", PRE["src/other.ts"], POST["src/other.ts"]),
+        ],
+        resourceMoves: [],
+        verification: { mismatchedUris: [], checkedAt: null },
+      }).ok).toBe(true);
+
+      renderWorkspace(workspace, { onCommandsChange });
+      await screen.findByTitle("app / src/reader.ts");
+      // Newest first: the both-missing record reviews first with restore disabled.
+      const abandonReview = await screen.findByTestId("refactor-recovery-review");
+      expect(abandonReview.textContent).toContain("Gone.java");
+      expect(within(abandonReview).getByTestId("refactor-recovery-restore")).toBeDisabled();
+      fireEvent.click(within(abandonReview).getByTestId("refactor-recovery-dismiss"));
+      fireEvent.click(await screen.findByTestId("refactor-recovery-dismiss-confirm-button"));
+      // Dismissal writes only the resolution marker: zero file writes, files
+      // stay exactly as they are (deleted stays deleted, sibling post intact).
+      await waitFor(() => expect(getRefactorRecoveryJournalV2("rec-abandon-1")?.resolution).toEqual({
+        kind: "user-dismissed",
+        resolvedAt: expect.any(Number),
+        reason: "keep-current-state",
+      }));
+      expect(workspaceMocks.workspaceWriteFileEncoded).not.toHaveBeenCalled();
+      expect(disk["src/main.ts"]).toBe(POST["src/main.ts"]);
+      expect(disk["src/other.ts"]).toBe(POST["src/other.ts"]);
+      expect(useAppStore.getState().statusMessage).toContain("Abandoned refactor recovery");
+      // The sibling still prompts after the abandon (same discover loop).
+      const siblingReview = await screen.findByTestId("refactor-recovery-review");
+      expect(siblingReview.textContent).toContain("main.ts");
+      expect(siblingReview.textContent).not.toContain("Gone.java");
+      fireEvent.click(within(siblingReview).getByTestId("refactor-recovery-keep"));
+      await waitFor(() => expect(screen.queryByTestId("refactor-recovery-review")).not.toBeInTheDocument());
+      expect(getRefactorRecoveryJournalV2("rec-sibling-1")?.status).toBe("recovery-required");
+      expect(getRefactorRecoveryJournalV2("rec-sibling-1")?.resolution).toBeUndefined();
+
+      // Re-review surfaces only the sibling; the abandoned record never returns.
+      const rerun = registrationRef.current?.executeAction("workspace.reviewRefactorRecovery");
+      const secondLook = await screen.findByTestId("refactor-recovery-review");
+      expect(secondLook.textContent).toContain("main.ts");
+      expect(secondLook.textContent).not.toContain("Gone.java");
+      fireEvent.click(within(secondLook).getByTestId("refactor-recovery-keep"));
+      await rerun;
     });
 
     it("never replays legacy v1 recovery journals", async () => {
@@ -10929,13 +11027,6 @@ end_of_record
         .map((key) => ({ key, entry: JSON.parse(window.localStorage.getItem(key)!) }));
     }
 
-    function recoveryCalls(): Array<{ title: string; message: string }> {
-      return vi.mocked(confirmAppDialog).mock.calls.map((call) => ({
-        title: (call[0] as { title: string }).title,
-        message: (call[0] as { message: string }).message,
-      }));
-    }
-
     function undoItem(registrationRef: Fixture["registrationRef"]) {
       return registrationRef.current?.items.find((item) => item.id === "workspace.undoWorkspaceEdit");
     }
@@ -11081,13 +11172,12 @@ end_of_record
       vi.mocked(confirmAppDialog).mockClear();
       vi.mocked(confirmAppDialog).mockResolvedValue(true);
 
-      await act(async () => {
-        await registrationRef.current?.executeAction("workspace.reviewRefactorRecovery");
-      });
-
-      await waitFor(() => expect(recoveryCalls().length).toBeGreaterThan(0));
-      const pendingDialog = recoveryCalls().find((call) => call.title.includes("recovery pending"));
-      expect(pendingDialog).toBeDefined();
+      const reviewPromise = registrationRef.current?.executeAction("workspace.reviewRefactorRecovery");
+      const review = await screen.findByTestId("refactor-recovery-review");
+      const restoreButton = within(review).getByTestId("refactor-recovery-restore");
+      await waitFor(() => expect(restoreButton).toBeEnabled());
+      fireEvent.click(restoreButton);
+      await reviewPromise;
 
       // Recovery restored src/a.ts to preText and left src/b.ts untouched
       await waitFor(() => expect(disk["src/a.ts"]).toBe(PRE["src/a.ts"]));
@@ -11140,7 +11230,7 @@ end_of_record
     });
 
     it("refuses to overwrite conflicting third-party edits during plan-less recovery", async () => {
-      const { disk, workspace, registrationRef, onCommandsChange } = setupWorkspace("planless-conflict", "src/c.ts");
+      const { disk, workspace, onCommandsChange } = setupWorkspace("planless-conflict", "src/c.ts");
       const preA = PRE["src/a.ts"]!;
       const postA = "hello ALPHA";
       recordRefactorRecoveryJournalV2({
@@ -11178,14 +11268,12 @@ end_of_record
       renderWorkspace(workspace, { onCommandsChange });
       await screen.findByTitle("app / src/c.ts");
 
-      await act(async () => {
-        await registrationRef.current?.executeAction("workspace.reviewRefactorRecovery");
-      });
-
-      await waitFor(() => expect(recoveryCalls().some((call) => call.title.includes("recovery blocked"))).toBe(true));
-      const blocked = recoveryCalls().find((call) => call.title.includes("recovery blocked"));
-      expect(blocked?.message).toContain("/repo/app/src/a.ts (conflict)");
-      expect(blocked?.message).toContain("will not be overwritten");
+      // RC-02: auto-discover opens the review dialog with restore disabled.
+      const review = await screen.findByTestId("refactor-recovery-review");
+      expect(within(review).getByTestId("refactor-recovery-restore")).toBeDisabled();
+      expect(review.textContent).toContain("a.ts");
+      fireEvent.click(within(review).getByTestId("refactor-recovery-keep"));
+      await waitFor(() => expect(screen.queryByTestId("refactor-recovery-review")).not.toBeInTheDocument());
       expect(disk["src/a.ts"]).toBe("third-party content");
       expect(workspaceMocks.workspaceWriteFileEncoded).not.toHaveBeenCalled();
       expect(getRefactorRecoveryJournalV2("rec-conflict-1")?.status).toBe("recovery-required");

--- a/src/components/editor/CodeWorkspaceTab.tsx
+++ b/src/components/editor/CodeWorkspaceTab.tsx
@@ -405,17 +405,24 @@ import {
   type WorkspaceEditPreview,
 } from "./workspace/workspaceEditPreview";
 import { RefactoringPreviewDialog } from "./workspace/RefactoringPreviewDialog";
+import { RefactorRecoveryReviewDialog } from "./workspace/RefactorRecoveryReviewDialog";
 import {
   buildRefactorPlan,
   refactorApplyGate,
   evaluateDestructiveRefactorAvailability,
   verifyRefactorPostHashes,
+  buildRefactorPostTextIndex,
+  resolveRefactorPostTextForDocument,
+  verifyRefactorMovePostEndpoints,
   refactorJournalPostImageMatches,
   refactorJournalPreImageMatches,
   prepareRefactorRecoveryJournalV2,
   recordRefactorRecoveryJournalV2,
+  getRefactorRecoveryJournalV2,
   updateRefactorRecoveryJournalV2,
   listRefactorRecoveryJournalsV2,
+  isPendingRefactorRecoveryEntry,
+  dismissRefactorRecoveryEntry,
   buildTextWorkspaceEditRecoveryPlan,
   type RefactorKind,
   type RefactorPlanV3,
@@ -427,6 +434,7 @@ import {
   classifyRefactorRecoveryPreconditions,
   createRestoreEchoSuppressor,
   executeRefactorRecovery,
+  type RefactorRecoveryPreconditionSummary,
 } from "./workspace/refactorRecoveryController";
 import { sha256Hex } from "./workspace/projectAnalysisModel";
 import { KeymapCheatSheetDialog } from "./workspace/KeymapCheatSheetDialog";
@@ -9633,42 +9641,72 @@ export function CodeWorkspaceTab({
         for (const snapshot of afterSnapshots ?? []) {
           if (snapshot.text !== null) actualPostTexts[snapshot.path] = snapshot.text;
         }
-        // ED-FOLLOW-001: a journal document addressed to a pre-move path
-        // verifies against the moved-home... post-move bytes at the new
-        // path. Without this alias every rename transaction would fail its
-        // own postcondition even though the move applied exactly as planned.
-        for (const move of preparedJournal.resourceMoves ?? []) {
-          if (!move.oldPath || !move.newPath) continue;
-          const movedText = actualPostTexts[move.newPath];
-          if (movedText !== undefined && actualPostTexts[move.oldPath] === undefined) {
-            actualPostTexts[move.oldPath] = movedText;
-          }
-        }
+        // RC-01: identity-based post index (fsPathComparisonKey) plus ordered
+        // move-chain resolution. A document addressed to a pre-move path
+        // verifies against the bytes at the end of its move chain; a
+        // still-present old path or an ambiguous chain fails closed instead
+        // of aliasing a stale buffer into a false success.
+        const postIndex = buildRefactorPostTextIndex(actualPostTexts);
         const journalMismatches = preparedJournal.documents.flatMap((doc) => {
           const target = doc.canonicalPath || doc.uri;
-          const actual = actualPostTexts[target];
-          if (actual === undefined) {
+          const resolved = resolveRefactorPostTextForDocument(
+            { uri: doc.uri, canonicalPath: doc.canonicalPath },
+            preparedJournal.resourceMoves ?? [],
+            postIndex,
+          );
+          if (!resolved) {
             return [{ uri: doc.uri, path: target, unreadable: true }];
           }
-          return refactorJournalPostImageMatches(doc, actual)
+          return refactorJournalPostImageMatches(doc, resolved.text)
             ? []
             : [{ uri: doc.uri, path: target, unreadable: false }];
         });
+        // RC-01: pure moves need endpoint proof (old gone, new present).
+        const existsByKey = new Map<string, boolean | null>();
+        for (const snapshot of afterSnapshots ?? []) {
+          existsByKey.set(fsPathComparisonKey(snapshot.path), snapshot.exists);
+        }
+        // Ensure both move ends are represented even when a snapshot is
+        // missing for one end (treated as not existing, i.e. verification
+        // fails closed below).
+        for (const move of preparedJournal.resourceMoves ?? []) {
+          for (const raw of [move.oldPath ?? move.oldUri, move.newPath ?? move.newUri]) {
+            if (raw && !existsByKey.has(fsPathComparisonKey(raw))) {
+              existsByKey.set(fsPathComparisonKey(raw), false);
+            }
+          }
+        }
+        const movePostCheck = verifyRefactorMovePostEndpoints(
+          preparedJournal.resourceMoves ?? [],
+          existsByKey,
+        );
         const postHashCheck = options.plan
           ? verifyRefactorPostHashes(options.plan, actualPostTexts)
-          : { allMatched: true, mismatches: [], verifiedDocuments: 0 };
+          : { allMatched: true, mismatches: [], missing: [], verifiedDocuments: 0 };
         const failureBoundaryIndex = allOutcomes.find((outcome) => (
           outcome.operationIndex !== null
           && (outcome.status === "failed" || outcome.status === "skipped")
         ))?.operationIndex ?? null;
         const failedOutcomes = allOutcomes.filter((outcome) => outcome.status === "failed" || outcome.status === "skipped");
-        if (!afterSnapshots || journalMismatches.length > 0 || !postHashCheck.allMatched) {
+        // RC-01/AC-06: a required document without post text (`missing`), a
+        // plan mismatch, a journal mismatch, or an unverified move endpoint
+        // all fail closed. Zero verified documents never stand in for a plan
+        // that expected text.
+        const hasMissingPost = journalMismatches.some((mismatch) => mismatch.unreadable)
+          || postHashCheck.missing.length > 0
+          || !movePostCheck.allVerified;
+        if (!afterSnapshots || journalMismatches.length > 0 || !postHashCheck.allMatched || !movePostCheck.allVerified) {
           const mismatchedPaths = Array.from(new Set([
             ...journalMismatches.map((mismatch) => mismatch.path),
             ...postHashCheck.mismatches.map((mismatch) => {
               const doc = options.plan?.documents.find((candidate) => candidate.uri === mismatch.uri);
               return doc?.canonicalPath ?? mismatch.uri;
             }),
+            ...postHashCheck.missing.map((miss) => {
+              const doc = options.plan?.documents.find((candidate) => candidate.uri === miss.uri);
+              return doc?.canonicalPath ?? miss.uri;
+            }),
+            ...movePostCheck.missing,
           ]));
           const appliedEffects = allOutcomes
             .filter((outcome) => outcome.status.startsWith("applied") || bufferEffectPerformed(outcome))
@@ -9684,6 +9722,8 @@ export function CodeWorkspaceTab({
               mismatchedUris: Object.freeze([
                 ...journalMismatches.map((mismatch) => mismatch.uri),
                 ...postHashCheck.mismatches.map((mismatch) => mismatch.uri),
+                ...postHashCheck.missing.map((miss) => miss.uri),
+                ...movePostCheck.missing,
               ]),
               checkedAt: Date.now(),
               appliedEffects: Object.freeze(appliedEffects),
@@ -9700,6 +9740,9 @@ export function CodeWorkspaceTab({
           console.warn("[refactor] Post-refactor postcondition failure detected:", {
             journalMismatches,
             planMismatches: postHashCheck.mismatches,
+            planMissing: postHashCheck.missing,
+            moveMissing: movePostCheck.missing,
+            hasMissingPost,
           });
           const prefix = preparedJournal.kind === "replace" || preparedJournal.kind === "other"
             ? "Workspace edit"
@@ -9955,77 +9998,84 @@ export function CodeWorkspaceTab({
   }, [applyLspWorkspaceEditNow]);
 
   // ED-AUDIT-014: pending refactor recovery entries are surfaced through the
-  // existing confirmation workflow when the workspace becomes ready. The
-  // runner is held in a ref because it closes over callbacks defined above.
+  // review dialog when the workspace becomes ready. The runner is held in a
+  // ref because it closes over callbacks defined above.
   const refactorRecoveryPromptRef = useRef<(
     (entry: RefactorRecoveryJournalEntryV2, ownerInstanceId: string) => Promise<void>
   ) | null>(null);
   const handledRefactorRecoveryIdsRef = useRef<Set<string>>(new Set());
   const handledRefactorRecoveryOwnerRef = useRef<string | null>(null);
+  // RC-02: one-entry review dialog state (figure A). The dialog owns the
+  // A→B abandon confirm inline (cancel-focused); restore's second confirm
+  // reuses the global app dialog. Async work stays in this owner.
+  const [refactorRecoveryReview, setRefactorRecoveryReview] = useState<{
+    entry: RefactorRecoveryJournalEntryV2;
+    ownerInstanceId: string;
+    preconditions: RefactorRecoveryPreconditionSummary | null;
+    loading: boolean;
+    error: string | null;
+    busy: boolean;
+  } | null>(null);
+  const refactorRecoveryBusyRef = useRef<Set<string>>(new Set());
+  const refactorRecoveryResolveRef = useRef<Map<string, () => void>>(new Map());
+  const refactorRecoveryReviewRef = useRef<typeof refactorRecoveryReview | null>(null);
+  refactorRecoveryReviewRef.current = refactorRecoveryReview;
 
-  const promptRefactorRecoveryEntry = useCallback(async (
+  const closeRefactorRecoveryReview = useCallback((recoveryId: string) => {
+    setRefactorRecoveryReview((current) => (
+      current && current.entry.recoveryId === recoveryId ? null : current
+    ));
+    const resolve = refactorRecoveryResolveRef.current.get(recoveryId);
+    if (resolve) {
+      refactorRecoveryResolveRef.current.delete(recoveryId);
+      resolve();
+    }
+  }, []);
+
+  const classifyRecoveryEntry = useCallback(async (
     entry: RefactorRecoveryJournalEntryV2,
+  ): Promise<RefactorRecoveryPreconditionSummary> => classifyRefactorRecoveryPreconditions(entry, async (path) => {
+    const snapshot = await readWorkspaceEditPathSnapshot(path);
+    return snapshot && snapshot.text !== null ? { text: snapshot.text } : null;
+  }, {
+    pathExists: async (path) => {
+      const snapshot = await readWorkspaceEditPathSnapshot(path);
+      return snapshot === null ? null : snapshot.exists;
+    },
+  }), [readWorkspaceEditPathSnapshot]);
+
+  const runRecoveryRestore = useCallback(async (
+    targetEntry: RefactorRecoveryJournalEntryV2,
+    targetPreconditions: RefactorRecoveryPreconditionSummary,
     ownerInstanceId: string,
   ): Promise<void> => {
     const released = () => workspaceInstanceIdRef.current !== ownerInstanceId;
-    const documentList = entry.documents
-      .map((doc) => doc.canonicalPath ?? doc.uri);
-    // ED-FOLLOW-001: journalled file moves are listed alongside the text
-    // documents so the pending entry honestly describes the relocation the
-    // restore will reverse.
-    const moveList = (entry.resourceMoves ?? [])
-      .filter((move) => move.oldPath && move.newPath)
-      .map((move) => `${move.oldPath} → ${move.newPath} (moved back on restore)`);
-    const resourceList = [...documentList, ...moveList].join("\n");
-    const review = await confirmAppDialog({
-      title: "Refactor recovery pending",
-      message: `A previous ${entry.kind} transaction was interrupted or failed its postcondition check. Affected files:\n${resourceList}\n\nReview the pending recovery entry?`,
-      confirmLabel: "Review recovery",
-    });
-    if (released() || !review) return;
-    const preconditions = await classifyRefactorRecoveryPreconditions(entry, async (path) => {
-      const snapshot = await readWorkspaceEditPathSnapshot(path);
-      return snapshot && snapshot.text !== null ? { text: snapshot.text } : null;
-    }, {
-      // ED-FOLLOW-001: move endpoints need existence distinct from
-      // readability (a missing old path is the expected restorable state,
-      // not an unreadable file).
-      pathExists: async (path) => {
-        const snapshot = await readWorkspaceEditPathSnapshot(path);
-        return snapshot === null ? null : snapshot.exists;
-      },
-    });
-    if (released()) return;
-    if (preconditions.overall === "already-restored") {
-      updateRefactorRecoveryJournalV2(entry.recoveryId, (current) => ({
-        ...current,
-        status: "rolled-back",
-        verification: { mismatchedUris: Object.freeze([]), checkedAt: Date.now() },
-      }));
-      setStatusMessage("Refactor recovery: every affected file already matches its pre-refactor content; entry closed.");
-      return;
-    }
-    if (preconditions.overall === "conflict" || preconditions.overall === "unreadable") {
-      const blocked = preconditions.documents.filter((doc) => (
-        doc.state === "conflict" || doc.state === "unreadable"
-      ));
-      await confirmAppDialog({
-        title: "Refactor recovery blocked",
-        message: `These files changed since the transaction and will not be overwritten:\n${
-          blocked.map((doc) => `${doc.canonicalPath ?? doc.uri} (${doc.state})`).join("\n")
-        }\n\nThe pending entry is kept; resolve the files externally and reopen the workspace to retry.`,
-        confirmLabel: "Keep pending",
+    const recoveryId = targetEntry.recoveryId;
+    if (refactorRecoveryBusyRef.current.has(recoveryId)) return;
+    refactorRecoveryBusyRef.current.add(recoveryId);
+    setRefactorRecoveryReview((current) => (
+      current && current.entry.recoveryId === recoveryId ? { ...current, busy: true, error: null } : current
+    ));
+    try {
+      const documentList = targetEntry.documents.map((doc) => doc.canonicalPath ?? doc.uri);
+      const moveList = (targetEntry.resourceMoves ?? [])
+        .filter((move) => move.oldPath && move.newPath)
+        .map((move) => `${move.oldPath} → ${move.newPath} (moved back on restore)`);
+      const resourceList = [...documentList, ...moveList].join("\n");
+      const restore = await confirmAppDialog({
+        title: "Restore pre-refactor content",
+        message: `Restore ${targetEntry.documents.length} file(s) to their pre-refactor content`
+          + `${moveList.length > 0 ? ` and move ${moveList.length} relocated file(s) back` : ""}?\n${resourceList}`,
+        confirmLabel: "Restore files",
       });
-      return;
-    }
-    const restore = await confirmAppDialog({
-      title: "Restore pre-refactor content",
-      message: `Restore ${entry.documents.length} file(s) to their pre-refactor content`
-        + `${moveList.length > 0 ? ` and move ${moveList.length} relocated file(s) back` : ""}?\n${resourceList}`,
-      confirmLabel: "Restore files",
-    });
-    if (released() || !restore) return;
-    const execution = await executeRefactorRecovery(entry, preconditions, {
+      if (released()) return;
+      if (!restore) {
+        setRefactorRecoveryReview((current) => (
+          current && current.entry.recoveryId === recoveryId ? { ...current, busy: false } : current
+        ));
+        return;
+      }
+      const execution = await executeRefactorRecovery(targetEntry, targetPreconditions, {
       restoreText: async (doc) => {        const targetPath = doc.canonicalPath || doc.uri;
         const current = await readWorkspaceEditPathSnapshot(targetPath);
         if (!current || !current.exists || current.text === null) {
@@ -10110,9 +10160,12 @@ export function CodeWorkspaceTab({
         return snapshot && snapshot.text !== null ? { text: snapshot.text } : null;
       },
     });
-    if (released()) return;
+    if (released()) {
+      refactorRecoveryBusyRef.current.delete(recoveryId);
+      return;
+    }
     if (execution.state === "rolled-back") {
-      updateRefactorRecoveryJournalV2(entry.recoveryId, (current) => ({
+      updateRefactorRecoveryJournalV2(targetEntry.recoveryId, (current) => ({
         ...current,
         status: "rolled-back",
         verification: {
@@ -10128,6 +10181,8 @@ export function CodeWorkspaceTab({
           + `${execution.reversedMoves.length > 0 ? `, moved back ${execution.reversedMoves.length}` : ""}`
           + `${execution.contentUnverifiedMoves.length > 0 ? ` (${execution.contentUnverifiedMoves.length} move(s) without a content proof)` : ""}.`,
       );
+      refactorRecoveryBusyRef.current.delete(recoveryId);
+      closeRefactorRecoveryReview(recoveryId);
       return;
     }
     const problems = [
@@ -10137,7 +10192,7 @@ export function CodeWorkspaceTab({
       ...execution.moveFailures.map((failure) => `${failure.newUri}: ${failure.reason}`),
     ];
     // ED-REPAIR-004: partial recovery failure retains facts, accurate reasons, and progress in persistent journal
-    updateRefactorRecoveryJournalV2(entry.recoveryId, (current) => ({
+    updateRefactorRecoveryJournalV2(targetEntry.recoveryId, (current) => ({
       ...current,
       status: "recovery-required",
       verification: {
@@ -10149,19 +10204,207 @@ export function CodeWorkspaceTab({
         restoredUris: Object.freeze([...(current.verification?.restoredUris ?? []), ...execution.restoredUris]),
       },
     }));
-    handledRefactorRecoveryIdsRef.current.delete(entry.recoveryId);
-    await confirmAppDialog({
-      title: "Refactor recovery incomplete",
-      message: `Restored ${execution.restoredUris.length} of ${entry.documents.length} file(s). Pending entry kept:\n${problems.join("\n")}`,
-      confirmLabel: "Keep pending",
+    // Keep the review open with a visible error so the user can retry,
+    // keep pending, or abandon this record. Refresh preconditions so the
+    // dialog reflects the post-attempt states.
+    try {
+      const refreshed = await classifyRecoveryEntry(targetEntry);
+      if (!released()) {
+        setRefactorRecoveryReview((current) => (
+          current && current.entry.recoveryId === recoveryId
+            ? {
+              ...current,
+              preconditions: refreshed,
+              loading: false,
+              busy: false,
+              error: `Restore incomplete: restored ${execution.restoredUris.length} of ${targetEntry.documents.length} file(s). ${problems.join("; ")}`,
+            }
+            : current
+        ));
+      }
+    } catch (error) {
+      if (!released()) {
+        setRefactorRecoveryReview((current) => (
+          current && current.entry.recoveryId === recoveryId
+            ? {
+              ...current,
+              busy: false,
+              error: `Restore incomplete: restored ${execution.restoredUris.length} of ${targetEntry.documents.length} file(s). ${problems.join("; ")}`,
+            }
+            : current
+        ));
+      }
+    } finally {
+      refactorRecoveryBusyRef.current.delete(recoveryId);
+    }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setRefactorRecoveryReview((current) => (
+        current && current.entry.recoveryId === targetEntry.recoveryId
+          ? { ...current, busy: false, error: `Restore failed: ${message}` }
+          : current
+      ));
+      refactorRecoveryBusyRef.current.delete(targetEntry.recoveryId);
+    }
+  }, [applyLspResourceOperation, applyLspWorkspaceEditNow, classifyRecoveryEntry, closeRefactorRecoveryReview, readWorkspaceEditPathSnapshot, refreshTree, setStatusMessage]);
+
+  const runRecoveryDismiss = useCallback(async (
+    targetEntry: RefactorRecoveryJournalEntryV2,
+    ownerInstanceId: string,
+  ): Promise<void> => {
+    const released = () => workspaceInstanceIdRef.current !== ownerInstanceId;
+    const recoveryId = targetEntry.recoveryId;
+    if (released()) return;
+    if (refactorRecoveryBusyRef.current.has(recoveryId)) return;
+    refactorRecoveryBusyRef.current.add(recoveryId);
+    setRefactorRecoveryReview((current) => (
+      current && current.entry.recoveryId === recoveryId ? { ...current, busy: true, error: null } : current
+    ));
+    try {
+      // Re-read the latest record synchronously before comparing: no await
+      // between the freshness check and the dismiss write inside the helper.
+      const latest = getRefactorRecoveryJournalV2(recoveryId);
+      if (!latest) {
+        throw new Error("recovery entry is missing; refresh and try again");
+      }
+      if (latest.workspaceRoot !== targetEntry.workspaceRoot || latest.transactionId !== targetEntry.transactionId) {
+        throw new Error("recovery entry changed to a different transaction; refresh and confirm again");
+      }
+      if (!isPendingRefactorRecoveryEntry(latest)) {
+        // Already resolved elsewhere: close quietly without file effects.
+        setStatusMessage("Refactor recovery entry is no longer pending.");
+        refactorRecoveryBusyRef.current.delete(recoveryId);
+        closeRefactorRecoveryReview(recoveryId);
+        return;
+      }
+      const result = dismissRefactorRecoveryEntry(recoveryId, targetEntry.updatedAt);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      if (released()) return;
+      const affectedCount = targetEntry.documents.length + (targetEntry.resourceMoves ?? []).length;
+      setStatusMessage(
+        `Abandoned refactor recovery for ${affectedCount} file(s); files left exactly as they are now.`,
+      );
+      refactorRecoveryBusyRef.current.delete(recoveryId);
+      closeRefactorRecoveryReview(recoveryId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!released()) {
+        setRefactorRecoveryReview((current) => (
+          current && current.entry.recoveryId === recoveryId
+            ? { ...current, busy: false, error: `Could not abandon recovery: ${message}` }
+            : current
+        ));
+      }
+      refactorRecoveryBusyRef.current.delete(recoveryId);
+    }
+  }, [closeRefactorRecoveryReview, setStatusMessage]);
+
+  const keepRecoveryReview = useCallback((recoveryId: string) => {
+    closeRefactorRecoveryReview(recoveryId);
+  }, [closeRefactorRecoveryReview]);
+
+  const promptRefactorRecoveryEntry = useCallback(async (
+    entry: RefactorRecoveryJournalEntryV2,
+    ownerInstanceId: string,
+  ): Promise<void> => {
+    const released = () => workspaceInstanceIdRef.current !== ownerInstanceId;
+    if (released()) return;
+    // RC-02: dismissed/committed entries are never pending; skip without UI.
+    const latestAtOpen = getRefactorRecoveryJournalV2(entry.recoveryId) ?? entry;
+    if (!isPendingRefactorRecoveryEntry(latestAtOpen)) return;
+    if (refactorRecoveryBusyRef.current.has(entry.recoveryId)) return;
+    // Bridge the dialog's user action back to the sequential discover loop:
+    // resolve only when the review closes (keep/restore-success/dismiss).
+    // Restore/dismiss failures keep the dialog open and do not resolve.
+    await new Promise<void>((resolve) => {
+      refactorRecoveryResolveRef.current.set(entry.recoveryId, resolve);
+      setRefactorRecoveryReview({
+        entry: latestAtOpen,
+        ownerInstanceId,
+        preconditions: null,
+        loading: true,
+        error: null,
+        busy: false,
+      });
+      void (async () => {
+        try {
+          const preconditions = await classifyRecoveryEntry(latestAtOpen);
+          if (released()) {
+            closeRefactorRecoveryReview(entry.recoveryId);
+            return;
+          }
+          if (preconditions.overall === "already-restored") {
+            updateRefactorRecoveryJournalV2(entry.recoveryId, (currentEntry) => ({
+              ...currentEntry,
+              status: "rolled-back",
+              verification: { mismatchedUris: Object.freeze([]), checkedAt: Date.now() },
+            }));
+            setStatusMessage("Refactor recovery: every affected file already matches its pre-refactor content; entry closed.");
+            closeRefactorRecoveryReview(entry.recoveryId);
+            return;
+          }
+          // Functional update with creation fallback: the loading state set
+          // above may not have rendered yet when a fast classify resolves
+          // (state updater would see null and drop this update). Either way
+          // the dialog ends loaded with preconditions.
+          setRefactorRecoveryReview((currentState) => {
+            if (currentState && currentState.entry.recoveryId === entry.recoveryId) {
+              return { ...currentState, preconditions, loading: false };
+            }
+            if (!currentState) {
+              return {
+                entry: latestAtOpen,
+                ownerInstanceId,
+                preconditions,
+                loading: false,
+                error: null,
+                busy: false,
+              };
+            }
+            return currentState;
+          });
+        } catch (error) {
+          if (released()) {
+            closeRefactorRecoveryReview(entry.recoveryId);
+            return;
+          }
+          const message = `Could not verify the pending entry: ${error instanceof Error ? error.message : String(error)}`;
+          setRefactorRecoveryReview((currentState) => {
+            if (currentState && currentState.entry.recoveryId === entry.recoveryId) {
+              return { ...currentState, loading: false, error: message };
+            }
+            if (!currentState) {
+              return {
+                entry: latestAtOpen,
+                ownerInstanceId,
+                preconditions: null,
+                loading: false,
+                error: message,
+                busy: false,
+              };
+            }
+            return currentState;
+          });
+        }
+      })();
     });
-  }, [applyLspResourceOperation, applyLspWorkspaceEditNow, readWorkspaceEditPathSnapshot, refreshTree, setStatusMessage]);
+  }, [classifyRecoveryEntry, closeRefactorRecoveryReview, setStatusMessage]);
   refactorRecoveryPromptRef.current = promptRefactorRecoveryEntry;
 
   useEffect(() => {
     if (handledRefactorRecoveryOwnerRef.current !== workspaceInstanceId) {
       handledRefactorRecoveryOwnerRef.current = workspaceInstanceId;
       handledRefactorRecoveryIdsRef.current = new Set();
+      // RC-02: workspace switch releases pending dialogs; stale async
+      // results must never commit to the new instance.
+      for (const resolve of refactorRecoveryResolveRef.current.values()) {
+        try { resolve(); } catch { /* ignore */ }
+      }
+      refactorRecoveryResolveRef.current.clear();
+      refactorRecoveryBusyRef.current.clear();
+      setRefactorRecoveryReview(null);
     }
     let disposed = false;
     const discover = async () => {
@@ -10169,11 +10412,10 @@ export function CodeWorkspaceTab({
       const runner = refactorRecoveryPromptRef.current;
       if (!rootPath || !runner) return;
       const listing = listRefactorRecoveryJournalsV2(rootPath);
-      const pending = listing.entries.filter((entry) => (
-        entry.status === "prepared" || entry.status === "recovery-required"
-      ));
+      const pending = listing.entries.filter(isPendingRefactorRecoveryEntry);
       for (const entry of pending) {
         if (disposed) return;
+        if (workspaceInstanceIdRef.current !== workspaceInstanceId) return;
         if (handledRefactorRecoveryIdsRef.current.has(entry.recoveryId)) continue;
         handledRefactorRecoveryIdsRef.current.add(entry.recoveryId);
         await runner(entry, workspaceInstanceId);
@@ -14284,9 +14526,7 @@ export function CodeWorkspaceTab({
         const rootPath = roots[0]?.path;
         if (!rootPath) return;
         const listing = listRefactorRecoveryJournalsV2(rootPath);
-        const pending = listing.entries.filter((entry) => (
-          entry.status === "prepared" || entry.status === "recovery-required"
-        ));
+        const pending = listing.entries.filter(isPendingRefactorRecoveryEntry);
         if (pending.length === 0) {
           setStatusMessage("No pending recovery entries found");
           return;
@@ -20193,6 +20433,28 @@ export function CodeWorkspaceTab({
             refactoringPreviewModal.resolve(false);
             setRefactoringPreviewModal(null);
           }}
+        />
+      )}
+      {refactorRecoveryReview && (
+        <RefactorRecoveryReviewDialog
+          entry={refactorRecoveryReview.entry}
+          workspaceRoot={roots[0]?.path ?? refactorRecoveryReview.entry.workspaceRoot}
+          preconditions={refactorRecoveryReview.preconditions}
+          loading={refactorRecoveryReview.loading}
+          error={refactorRecoveryReview.error}
+          busy={refactorRecoveryReview.busy}
+          onKeep={() => keepRecoveryReview(refactorRecoveryReview.entry.recoveryId)}
+          onRestore={() => {
+            const current = refactorRecoveryReviewRef.current;
+            if (!current || !current.preconditions) return;
+            void runRecoveryRestore(current.entry, current.preconditions, current.ownerInstanceId);
+          }}
+          onDismiss={() => {
+            const current = refactorRecoveryReviewRef.current;
+            if (!current) return;
+            void runRecoveryDismiss(current.entry, current.ownerInstanceId);
+          }}
+          onClose={() => keepRecoveryReview(refactorRecoveryReview.entry.recoveryId)}
         />
       )}
       {activeCompareSession && (

--- a/src/components/editor/workspace/RefactorRecoveryReviewDialog.test.tsx
+++ b/src/components/editor/workspace/RefactorRecoveryReviewDialog.test.tsx
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { RefactorRecoveryReviewDialog } from "./RefactorRecoveryReviewDialog";
+import { sha256Hex } from "./projectAnalysisModel";
+import type { RefactorRecoveryJournalEntryV2 } from "./refactorPlan";
+import type { RefactorRecoveryPreconditionSummary } from "./refactorRecoveryController";
+
+afterEach(cleanup);
+
+const preText = "public class MyTest {}";
+const postText = "public class MyTesting {}";
+
+const entry: RefactorRecoveryJournalEntryV2 = {
+  schemaVersion: 2,
+  recoveryId: "rec-dialog-1",
+  transactionId: "tx-dialog-1",
+  actionId: "rename:test",
+  kind: "rename",
+  workspaceRoot: "/repo/app",
+  createdAt: 100,
+  updatedAt: 200,
+  status: "recovery-required",
+  appliedOperationIndex: null,
+  documents: [{
+    uri: "file:///repo/app/src/MyTest.java",
+    canonicalPath: "/repo/app/src/MyTest.java",
+    preText,
+    preHash: sha256Hex(preText),
+    postText,
+    postHash: sha256Hex(postText),
+    encoding: "UTF-8",
+    bom: false,
+    eol: "lf",
+  }],
+  resourceMoves: [{
+    oldUri: "file:///repo/app/src/MyTest.java",
+    newUri: "file:///repo/app/src/MyTesting.java",
+    oldPath: "/repo/app/src/MyTest.java",
+    newPath: "/repo/app/src/MyTesting.java",
+    contentHash: sha256Hex(preText),
+  }],
+  verification: { mismatchedUris: [], checkedAt: null },
+};
+
+const restorable: RefactorRecoveryPreconditionSummary = {
+  documents: [{ uri: entry.documents[0]!.uri, canonicalPath: entry.documents[0]!.canonicalPath, state: "restorable", currentHash: "x" }],
+  moves: [{
+    oldUri: entry.resourceMoves[0]!.oldUri,
+    newUri: entry.resourceMoves[0]!.newUri,
+    oldPath: entry.resourceMoves[0]!.oldPath,
+    newPath: entry.resourceMoves[0]!.newPath,
+    state: "restorable",
+    currentHash: "x",
+    contentVerified: true,
+    detail: "restorable",
+  }],
+  overall: "restorable",
+};
+
+const conflict: RefactorRecoveryPreconditionSummary = {
+  documents: [{ uri: entry.documents[0]!.uri, canonicalPath: entry.documents[0]!.canonicalPath, state: "unreadable", currentHash: null }],
+  moves: [{
+    oldUri: entry.resourceMoves[0]!.oldUri,
+    newUri: entry.resourceMoves[0]!.newUri,
+    oldPath: entry.resourceMoves[0]!.oldPath,
+    newPath: entry.resourceMoves[0]!.newPath,
+    state: "conflict",
+    currentHash: null,
+    contentVerified: true,
+    detail: "both-missing",
+  }],
+  overall: "conflict",
+};
+
+function renderDialog(summary: RefactorRecoveryPreconditionSummary | null, overrides = {}) {
+  const handlers = {
+    onKeep: vi.fn(),
+    onRestore: vi.fn(),
+    onDismiss: vi.fn(),
+    onClose: vi.fn(),
+  };
+  render(
+    <RefactorRecoveryReviewDialog
+      entry={entry}
+      workspaceRoot="/repo/app"
+      preconditions={summary}
+      loading={summary === null}
+      error={null}
+      busy={false}
+      {...handlers}
+      {...overrides}
+    />,
+  );
+  return handlers;
+}
+
+describe("RefactorRecoveryReviewDialog (RC-02/AC-02/07)", () => {
+  it("lists every affected resource with full paths and keeps restore available when restorable", () => {
+    renderDialog(restorable);
+    expect(screen.getByTestId("refactor-recovery-review")).toBeInTheDocument();
+    expect(screen.getAllByTestId("refactor-recovery-resource")).toHaveLength(2);
+    expect(screen.getByTestId("refactor-recovery-restore")).toBeEnabled();
+    expect(screen.getByTestId("refactor-recovery-dismiss")).toBeEnabled();
+    expect(screen.getByTestId("refactor-recovery-keep")).toBeEnabled();
+  });
+
+  it("disables restore on conflict, never claims the user deleted files", () => {
+    renderDialog(conflict);
+    expect(screen.getByTestId("refactor-recovery-restore")).toBeDisabled();
+    // Both ends missing is stated as non-existence, never attributed to the user.
+    const text = screen.getByTestId("refactor-recovery-review").textContent ?? "";
+    expect(text).toContain("does not exist");
+    expect(text).not.toContain("you deleted");
+    expect(text).not.toContain("user deleted");
+  });
+
+  it("requires a second cancel-focused confirm before abandoning (DEC-01)", async () => {
+    const handlers = renderDialog(restorable);
+    fireEvent.click(screen.getByTestId("refactor-recovery-dismiss"));
+    // First click only opens the inline confirm; nothing persisted yet.
+    expect(handlers.onDismiss).not.toHaveBeenCalled();
+    expect(screen.getByTestId("refactor-recovery-dismiss-confirm")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("refactor-recovery-dismiss-cancel")).toHaveFocus());
+    fireEvent.click(screen.getByTestId("refactor-recovery-dismiss-confirm-button"));
+    expect(handlers.onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancelling the second confirm keeps the review open with zero effects", () => {
+    const handlers = renderDialog(restorable);
+    fireEvent.click(screen.getByTestId("refactor-recovery-dismiss"));
+    fireEvent.click(screen.getByTestId("refactor-recovery-dismiss-cancel"));
+    expect(handlers.onDismiss).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("refactor-recovery-dismiss-confirm")).not.toBeInTheDocument();
+    expect(screen.getByTestId("refactor-recovery-review")).toBeInTheDocument();
+  });
+
+  it("breaks long paths instead of overflowing (AC-07)", () => {
+    renderDialog(restorable);
+    const resources = screen.getAllByTestId("refactor-recovery-resource");
+    for (const row of resources) {
+      expect(row.className).toContain("rounded");
+      const label = row.querySelector("div");
+      expect(label?.className).toContain("break-all");
+    }
+    const dialog = screen.getByTestId("refactor-recovery-review");
+    expect(dialog.className).toContain("w-[min(640px,92vw)]");
+    expect(dialog.className).toContain("max-h-[90vh]");
+  });
+});

--- a/src/components/editor/workspace/RefactorRecoveryReviewDialog.tsx
+++ b/src/components/editor/workspace/RefactorRecoveryReviewDialog.tsx
@@ -1,0 +1,331 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AlertTriangle, X } from "lucide-react";
+import type {
+  RefactorRecoveryJournalEntryV2,
+} from "./refactorPlan";
+import type { RefactorRecoveryPreconditionSummary } from "./refactorRecoveryController";
+
+export interface RefactorRecoveryReviewDialogProps {
+  entry: RefactorRecoveryJournalEntryV2;
+  workspaceRoot: string;
+  preconditions: RefactorRecoveryPreconditionSummary | null;
+  loading: boolean;
+  error: string | null;
+  busy: boolean;
+  onKeep: () => void;
+  onRestore: () => void;
+  onDismiss: () => void;
+  onClose: () => void;
+}
+
+function relativeOrFull(path: string, workspaceRoot: string): string {
+  const root = workspaceRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+  const normalized = path.replace(/\\/g, "/");
+  const rootKey = root.toLowerCase();
+  if (normalized.toLowerCase().startsWith(`${rootKey}/`)) {
+    return normalized.slice(root.length + 1);
+  }
+  return path;
+}
+
+function docStateLabel(state: string): string {
+  switch (state) {
+    case "restorable": return "restorable";
+    case "already-restored": return "already at pre-refactor content";
+    case "conflict": return "changed since the transaction (kept)";
+    case "unreadable": return "unreadable";
+    default: return state;
+  }
+}
+
+function moveStateLabel(state: string, detail?: string): string {
+  if (state === "restorable") return "moved; ready to move back";
+  if (state === "already-restored") return "already moved back";
+  if (state === "unreadable") return "unreadable";
+  switch (detail) {
+    case "both-missing": return "file does not exist at either end";
+    case "both-present": return "both ends exist; reversal would destroy bytes";
+    case "content-changed": return "content at the new path changed (kept)";
+    case "ambiguous-proof": return "ambiguous journal mapping (kept)";
+    default: return "conflicting state (kept)";
+  }
+}
+
+/**
+ * RC-02/DEC-01 review surface (figure A): one pending transaction at a time.
+ * Lists every text document and move endpoint with its live state, never
+ * claims an unreadable file was "deleted by the user", and offers explicit
+ * Keep / Restore / Abandon outlets. Abandon only ends this record's reminder
+ * (owner confirms again before persisting); it never rebuilds files.
+ */
+export function RefactorRecoveryReviewDialog({
+  entry,
+  workspaceRoot,
+  preconditions,
+  loading,
+  error,
+  busy,
+  onKeep,
+  onRestore,
+  onDismiss,
+  onClose,
+}: RefactorRecoveryReviewDialogProps) {
+  const keepRef = useRef<HTMLButtonElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const cancelDismissRef = useRef<HTMLButtonElement>(null);
+  // Figure B: inline second confirm for abandon. Cancel stays focused so
+  // keyboard confirmation cannot abandon by accident; no files change here —
+  // the owner persists the dismissal only after this explicit step.
+  const [confirmingDismiss, setConfirmingDismiss] = useState(false);
+
+  useEffect(() => {
+    window.setTimeout(() => keepRef.current?.focus(), 0);
+  }, []);
+
+  useEffect(() => {
+    if (confirmingDismiss) {
+      window.setTimeout(() => cancelDismissRef.current?.focus(), 0);
+    }
+  }, [confirmingDismiss]);
+
+  useEffect(() => {
+    setConfirmingDismiss(false);
+  }, [entry.recoveryId]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      if (busy) return;
+      if (confirmingDismiss) {
+        setConfirmingDismiss(false);
+        return;
+      }
+      onClose();
+    }
+  };
+
+  const rows = useMemo(() => {
+    const seen = new Set<string>();
+    const items: Array<{ key: string; label: string; full: string; state: string }> = [];
+    const keyOf = (raw: string): string => {
+      try {
+        // Keep the dialog dependency-light: case-insensitive comparison for
+        // Windows-style paths, exact otherwise. Identity grouping only.
+        const normalized = raw.replace(/\\/g, "/");
+        return /^(?:[a-zA-Z]:|\\\\|\/\/)/.test(raw) || /^[a-zA-Z]:/.test(normalized)
+          ? normalized.toLowerCase()
+          : normalized;
+      } catch {
+        return raw;
+      }
+    };
+    for (const doc of entry.documents) {
+      const full = doc.canonicalPath ?? doc.uri;
+      const key = `doc:${keyOf(full)}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const state = loading || !preconditions
+        ? "checking…"
+        : preconditions.documents.find((d) => d.uri === doc.uri)?.state ?? "unreadable";
+      items.push({
+        key,
+        label: relativeOrFull(full, workspaceRoot),
+        full,
+        state: loading ? "checking…" : docStateLabel(state),
+      });
+    }
+    for (const move of entry.resourceMoves ?? []) {
+      const oldFull = move.oldPath ?? move.oldUri;
+      const newFull = move.newPath ?? move.newUri;
+      const key = `move:${keyOf(oldFull)}->${keyOf(newFull)}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const precondition = preconditions?.moves.find((m) => m.newUri === move.newUri && m.oldUri === move.oldUri);
+      const state = loading || !precondition
+        ? "checking…"
+        : moveStateLabel(precondition.state, precondition.detail);
+      const label = `${relativeOrFull(oldFull, workspaceRoot)} → ${relativeOrFull(newFull, workspaceRoot)}`;
+      items.push({ key, label, full: `${oldFull} → ${newFull}`, state });
+    }
+    return items;
+  }, [entry, preconditions, loading, workspaceRoot]);
+
+  const overall = preconditions?.overall ?? null;
+  const canRestore = !loading && !busy && !error && !confirmingDismiss && overall === "restorable";
+  const canDismiss = !loading && !busy;
+  const affectedCount = rows.length;
+
+  return (
+      <div
+        className="fixed inset-0 z-[940] flex items-center justify-center bg-black/45 p-4"
+        onClick={() => {
+          if (busy) return;
+          if (confirmingDismiss) {
+            setConfirmingDismiss(false);
+            return;
+          }
+          onClose();
+        }}
+        onKeyDown={handleKeyDown}
+      >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Review refactor recovery"
+        data-testid="refactor-recovery-review"
+        className="flex max-h-[90vh] w-[min(640px,92vw)] flex-col overflow-hidden rounded border border-[var(--taomni-code-border)] bg-[var(--taomni-code-bg)] shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="flex min-h-11 shrink-0 items-center gap-2 border-b border-[var(--taomni-code-border)] px-3">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[12px] font-semibold text-[var(--taomni-code-text)]">
+              Review refactor recovery
+            </div>
+            <div className="truncate text-[10px] text-[var(--taomni-code-muted)]">
+              {entry.kind} · {affectedCount} affected file{affectedCount === 1 ? "" : "s"} · {new Date(entry.createdAt).toLocaleString()}
+            </div>
+          </div>
+          <button
+            ref={closeRef}
+            type="button"
+            aria-label="Close recovery review"
+            title="Keep pending and close"
+            disabled={busy}
+            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded hover:bg-[var(--taomni-code-active-line-bg)] disabled:opacity-40"
+            onClick={() => {
+              if (confirmingDismiss) {
+                setConfirmingDismiss(false);
+                return;
+              }
+              onClose();
+            }}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-auto px-3 py-2">
+          <div className="mb-1 text-[10px] text-[var(--taomni-code-muted)]">
+            Workspace: <span className="break-all font-mono">{workspaceRoot}</span>
+          </div>
+          <div className="mb-2 text-[11px] leading-5 text-[var(--taomni-code-text)]">
+            {overall === "already-restored"
+              ? "Every affected file already matches its pre-refactor content. Closing keeps no pending reminder."
+              : overall === "restorable"
+                ? "The recorded post-state is intact. Restoring moves relocated files back and writes pre-refactor content with read-back verification."
+                : "Some files cannot be restored automatically and will not be overwritten. Keeping or abandoning changes no files."}
+          </div>
+          {loading && (
+            <div className="mb-2 text-[11px] text-[var(--taomni-code-muted)]">
+              Loading and verifying the pending entry…
+            </div>
+          )}
+          {error && (
+            <div className="mb-2 rounded border border-red-500/40 bg-red-500/10 px-2 py-1.5 text-[11px] text-red-300" role="alert">
+              {error}
+            </div>
+          )}
+          <ul className="flex flex-col gap-1.5">
+            {rows.map((row) => (
+              <li
+                key={row.key}
+                data-testid="refactor-recovery-resource"
+                className="rounded border border-[var(--taomni-code-border)] px-2 py-1.5"
+              >
+                <div className="break-all font-mono text-[11px] text-[var(--taomni-code-text)]" title={row.full}>
+                  {row.label}
+                </div>
+                <div className="mt-0.5 break-all text-[10px] text-[var(--taomni-code-muted)]" title={row.full}>
+                  {row.state} · <span className="select-text">{row.full}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+          {rows.length === 0 && (
+            <div className="py-4 text-center text-[11px] text-[var(--taomni-code-muted)]">
+              This entry records no files.
+            </div>
+          )}
+          <div className="mt-2 text-[10px] leading-4 text-[var(--taomni-code-muted)]">
+            Abandon ends only this record&apos;s reminder and keeps files exactly as they are now.
+            It never rebuilds deleted files or edits references.
+          </div>
+          {confirmingDismiss && (
+            <div
+              className="mt-2 rounded border border-red-500/40 bg-red-500/10 px-2 py-1.5"
+              data-testid="refactor-recovery-dismiss-confirm"
+            >
+              <div className="text-[11px] font-semibold text-red-200">
+                Abandon recovery for {affectedCount} file{affectedCount === 1 ? "" : "s"}?
+              </div>
+              <div className="mt-0.5 break-all text-[11px] leading-4 text-red-100/90">
+                This ends only this reminder and keeps the current state (files stay missing as they are now).
+                It does not restore files, edit references, or affect other pending entries.
+              </div>
+            </div>
+          )}
+        </div>
+
+        <footer className="flex shrink-0 flex-wrap items-center justify-end gap-2 border-t border-[var(--taomni-code-border)] px-3 py-2">
+          {confirmingDismiss ? (
+            <>
+              <button
+                ref={cancelDismissRef}
+                type="button"
+                data-testid="refactor-recovery-dismiss-cancel"
+                disabled={busy}
+                className="h-8 rounded px-3 text-[11px] hover:bg-[var(--taomni-code-active-line-bg)] disabled:opacity-40"
+                onClick={() => setConfirmingDismiss(false)}
+              >
+                Keep pending
+              </button>
+              <button
+                type="button"
+                data-testid="refactor-recovery-dismiss-confirm-button"
+                disabled={!canDismiss}
+                className="h-8 rounded bg-red-700 px-3 text-[11px] font-medium text-white hover:brightness-110 disabled:opacity-40"
+                onClick={onDismiss}
+              >
+                Abandon recovery
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                ref={keepRef}
+                type="button"
+                data-testid="refactor-recovery-keep"
+                disabled={busy}
+                className="h-8 rounded px-3 text-[11px] hover:bg-[var(--taomni-code-active-line-bg)] disabled:opacity-40"
+                onClick={onKeep}
+              >
+                Keep pending
+              </button>
+              <button
+                type="button"
+                data-testid="refactor-recovery-dismiss"
+                disabled={!canDismiss}
+                title="Abandon this recovery reminder; files stay as they are"
+                className="h-8 rounded px-3 text-[11px] hover:bg-red-500/15 hover:text-red-300 disabled:opacity-40"
+                onClick={() => setConfirmingDismiss(true)}
+              >
+                Abandon recovery…
+              </button>
+              <button
+                type="button"
+                data-testid="refactor-recovery-restore"
+                disabled={!canRestore}
+                title={canRestore ? "Restore pre-refactor content" : "Restore is available only when the recorded post-state is intact"}
+                className="h-8 rounded bg-[var(--taomni-accent)] px-3 text-[11px] font-medium text-white hover:brightness-110 disabled:opacity-40"
+                onClick={onRestore}
+              >
+                Restore files
+              </button>
+            </>
+          )}
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/workspace/refactorPlan.test.ts
+++ b/src/components/editor/workspace/refactorPlan.test.ts
@@ -8,6 +8,9 @@ import {
   verifyExclusionSafety,
   evaluateDestructiveRefactorAvailability,
   verifyRefactorPostHashes,
+  buildRefactorPostTextIndex,
+  resolveRefactorPostTextForDocument,
+  verifyRefactorMovePostEndpoints,
   buildRefactorRecoveryJournalEntry,
   recordRefactorRecoveryJournal,
   getRefactorRecoveryJournal,
@@ -19,11 +22,16 @@ import {
   listRefactorRecoveryJournalsV2,
   updateRefactorRecoveryJournalV2,
   clearRefactorRecoveryJournalV2,
+  isPendingRefactorRecoveryEntry,
+  dismissRefactorRecoveryEntry,
+  resolveRecoveryMoveProof,
+  recoveryMoveProofMatches,
   refactorJournalPostImageMatches,
   resolveRecoveryDocTarget,
   type RefactorPlanV4,
   type RefactorRecoveryDocumentSnapshotV2,
 } from "./refactorPlan";
+import { normalizeFsPath, fsPathComparisonKey } from "./codeWorkspaceModel";
 import { sha256Hex } from "./projectAnalysisModel";
 
 const dummyLocation: LspLocation = {
@@ -1155,5 +1163,281 @@ describe("ED-PROJECT-005: refactor plan facts generation pinning", () => {
     const unpinned = refactorApplyGate(factsPinnedPlan(null));
     expect(unpinned.allowed).toBe(true);
     useProjectFactsStore.setState({ workspaces: {} });
+  });
+});
+
+describe("java-rename-deleted-recovery RC-01: identity-based post verification", () => {
+  // Production preparation for a top-level class rename: one text op on the
+  // old path plus one rename op old -> new. contentHash keeps the pre-image
+  // (historical meaning); post bytes live at the new path.
+  const prepareClassRename = (oldPath: string, newPath: string) => {
+    const oldUri = `file://${oldPath.replace(/\\/g, "/")}`;
+    const newUri = `file://${newPath.replace(/\\/g, "/")}`;
+    const preText = "public class MyTest {}";
+    const preparation = prepareRefactorRecoveryJournalV2({
+      plan: { actionId: "rename-class", kind: "rename", documents: [] },
+      edit: {
+        documentEdits: [],
+        operations: [
+          {
+            kind: "text",
+            document: {
+              uri: oldUri,
+              path: oldPath,
+              version: null,
+              edits: [
+                { range: { start: { line: 0, character: 13 }, end: { line: 0, character: 19 } }, newText: "MyTesting" },
+              ],
+            },
+          },
+          {
+            kind: "rename",
+            oldUri,
+            newUri,
+            oldPath,
+            newPath,
+            overwrite: false,
+            ignoreIfExists: false,
+            annotationId: null,
+          },
+        ],
+      } as unknown as LspWorkspaceEdit,
+      preImages: [{
+        uri: oldUri,
+        canonicalPath: normalizeFsPath(oldPath),
+        preText,
+        encoding: "UTF-8",
+        bom: false,
+        eol: "lf" as const,
+      }],
+      workspaceRoot: "D:/fixture/ique",
+      transactionId: "tx-class-rename",
+    });
+    if (preparation.state !== "prepared") throw new Error("expected prepared");
+    return preparation.entry;
+  };
+
+  it("resolves the post text through backslash/forward-slash spellings (RC-01)", () => {
+    const entry = prepareClassRename(
+      String.raw`D:\fixture\ique\MyTest.java`,
+      String.raw`D:\fixture\ique\MyTesting.java`,
+    );
+    const postText = "public class MyTesting {}";
+    // Shell snapshot keyed with forward slashes; move pair keeps backslashes.
+    const index = buildRefactorPostTextIndex({
+      [normalizeFsPath(String.raw`D:/fixture/ique/MyTesting.java`)]: postText,
+    });
+    const resolved = resolveRefactorPostTextForDocument(
+      { uri: entry.documents[0]!.uri, canonicalPath: entry.documents[0]!.canonicalPath },
+      entry.resourceMoves,
+      index,
+    );
+    expect(resolved?.text).toBe(postText);
+  });
+
+  it("treats drive-casing and file-URI spellings as the same resource", () => {
+    const entry = prepareClassRename("/workspace/MyTest.java", "/workspace/MyTesting.java");
+    const index = buildRefactorPostTextIndex({
+      "file:///workspace/MyTesting.java": "public class MyTesting {}",
+    });
+    const resolved = resolveRefactorPostTextForDocument(
+      { uri: entry.documents[0]!.uri, canonicalPath: entry.documents[0]!.canonicalPath },
+      entry.resourceMoves,
+      index,
+    );
+    expect(resolved?.text).toBe("public class MyTesting {}");
+    const upper = buildRefactorPostTextIndex({ "/WORKSPACE/MyTesting.java": "x" });
+    void upper;
+    // POSIX paths stay case-sensitive: different case must not merge.
+    const posixIndex = buildRefactorPostTextIndex({ "/workspace/Other.java": "x" });
+    expect(resolveRefactorPostTextForDocument(
+      { uri: "file:///workspace/other.java", canonicalPath: "/workspace/other.java" },
+      [],
+      posixIndex,
+    )).toBeNull();
+  });
+
+  it("fails closed on ambiguous chains and stale old buffers (RC-01/AC-06)", () => {
+    const entry = prepareClassRename("/workspace/A.java", "/workspace/B.java");
+    // Stale old buffer shadowing disk: old still present -> no alias success.
+    const bothPresent = buildRefactorPostTextIndex({
+      "/workspace/A.java": "stale",
+      "/workspace/B.java": "public class MyTesting {}",
+    });
+    expect(resolveRefactorPostTextForDocument(
+      { uri: entry.documents[0]!.uri, canonicalPath: entry.documents[0]!.canonicalPath },
+      entry.resourceMoves,
+      bothPresent,
+    )).toBeNull();
+    // Chained moves A->B, B->C with an ambiguous fan-out fail closed.
+    const chained = resolveRefactorPostTextForDocument(
+      { uri: "file:///workspace/A.java", canonicalPath: "/workspace/A.java" },
+      [
+        { oldUri: "file:///workspace/A.java", newUri: "file:///workspace/B.java", oldPath: "/workspace/A.java", newPath: "/workspace/B.java", contentHash: null },
+        { oldUri: "file:///workspace/A.java", newUri: "file:///workspace/C.java", oldPath: "/workspace/A.java", newPath: "/workspace/C.java", contentHash: null },
+      ],
+      buildRefactorPostTextIndex({ "/workspace/C.java": "x" }),
+    );
+    expect(chained).toBeNull();
+  });
+
+  it("reports missing required post text instead of silently skipping (RC-01)", () => {
+    const plan = buildRefactorPlan({
+      actionId: "rename-missing",
+      kind: "rename",
+      evidence: dummyEvidence,
+      edit: {
+        documentEdits: [{
+          uri: "file:///workspace/A.java",
+          path: "/workspace/A.java",
+          edits: [{ range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } }, newText: "b" }],
+        }],
+      },
+      roots: [{ path: "/workspace" }],
+      currentTexts: { "/workspace/A.java": "a" },
+    });
+    const result = verifyRefactorPostHashes(plan, {});
+    expect(result.allMatched).toBe(false);
+    expect(result.missing).toHaveLength(1);
+    expect(result.missing[0]!.uri).toBe("file:///workspace/A.java");
+  });
+
+  it("accepts EOL-only differences in plan verification (RC-01)", () => {
+    const plan = buildRefactorPlan({
+      actionId: "rename-eol",
+      kind: "rename",
+      evidence: dummyEvidence,
+      edit: {
+        documentEdits: [{
+          uri: "file:///workspace/A.java",
+          path: "/workspace/A.java",
+          edits: [{ range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } }, newText: "b" }],
+        }],
+      },
+      roots: [{ path: "/workspace" }],
+      currentTexts: { "/workspace/A.java": "a\nb\n" },
+    });
+    const doc = plan.documents[0]!;
+    expect(doc.expectedPostHash).not.toBeNull();
+    // Same content saved with CRLF must verify, foreign content must not.
+    const crlf = "b\nb\n".replace(/\n/g, "\r\n");
+    void crlf;
+    const lfPost = "b\nb\n";
+    const ok = verifyRefactorPostHashes(plan, { "/workspace/A.java": lfPost.replace(/\n/g, "\r\n") });
+    expect(ok.allMatched).toBe(true);
+    const bad = verifyRefactorPostHashes(plan, { "/workspace/A.java": "foreign" });
+    expect(bad.allMatched).toBe(false);
+    expect(bad.mismatches).toHaveLength(1);
+  });
+
+  it("proves pure-move endpoints old-gone/new-present (RC-01/AC-06)", () => {
+    const moves = [{
+      oldUri: "file:///workspace/Old.java",
+      newUri: "file:///workspace/New.java",
+      oldPath: "/workspace/Old.java",
+      newPath: "/workspace/New.java",
+      contentHash: null,
+    }];
+    const keyOf = (p: string) => p;
+    void keyOf;
+    const verified = verifyRefactorMovePostEndpoints(moves, new Map([
+      [fsPathComparisonKey("/workspace/Old.java"), false],
+      [fsPathComparisonKey("/workspace/New.java"), true],
+    ]));
+    expect(verified.allVerified).toBe(true);
+    const bothMissing = verifyRefactorMovePostEndpoints(moves, new Map([
+      [fsPathComparisonKey("/workspace/Old.java"), false],
+      [fsPathComparisonKey("/workspace/New.java"), false],
+    ]));
+    expect(bothMissing.allVerified).toBe(false);
+  });
+});
+
+describe("java-rename-deleted-recovery RC-02/RC-03: resolution and move proof", () => {
+  const mockStorage = () => {
+    const store = new Map<string, string>();
+    return {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, v); },
+      removeItem: (k: string) => { store.delete(k); },
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() { return store.size; },
+      clear: () => store.clear(),
+    } as unknown as Storage;
+  };
+
+  const storedEntry = (overrides: Partial<import("./refactorPlan").RefactorRecoveryJournalEntryV2> = {}) => ({
+    schemaVersion: 2 as const,
+    recoveryId: "rec-dismiss-1",
+    transactionId: "tx-dismiss-1",
+    actionId: "rename:test",
+    kind: "rename" as const,
+    workspaceRoot: "/workspace",
+    createdAt: 100,
+    updatedAt: 200,
+    status: "recovery-required" as const,
+    appliedOperationIndex: null,
+    documents: [],
+    resourceMoves: [],
+    verification: { mismatchedUris: [] as readonly string[], checkedAt: null },
+    ...overrides,
+  });
+
+  it("keeps historical entries pending and validates the dismissal marker", () => {
+    expect(isPendingRefactorRecoveryEntry(storedEntry())).toBe(true);
+    expect(isPendingRefactorRecoveryEntry(storedEntry({ status: "committed" }))).toBe(false);
+    expect(isPendingRefactorRecoveryEntry(storedEntry({
+      resolution: { kind: "user-dismissed", resolvedAt: 300, reason: "keep-current-state" },
+    }))).toBe(false);
+  });
+
+  it("dismisses exactly one record with a stale-version guard and zero file effects", () => {
+    const storage = mockStorage();
+    const before = storedEntry();
+    expect(recordRefactorRecoveryJournalV2(before, storage)).toEqual({ ok: true });
+    const other = storedEntry({ recoveryId: "rec-other", transactionId: "tx-other" });
+    expect(recordRefactorRecoveryJournalV2(other, storage)).toEqual({ ok: true });
+
+    const ok = dismissRefactorRecoveryEntry("rec-dismiss-1", 200, storage, 300);
+    expect(ok).toEqual({ ok: true });
+    const reread = getRefactorRecoveryJournalV2("rec-dismiss-1", storage)!;
+    expect(reread.resolution).toEqual({ kind: "user-dismissed", resolvedAt: 300, reason: "keep-current-state" });
+    expect(reread.status).toBe("recovery-required");
+    expect(isPendingRefactorRecoveryEntry(reread)).toBe(false);
+    // The sibling pending record is untouched.
+    expect(isPendingRefactorRecoveryEntry(getRefactorRecoveryJournalV2("rec-other", storage)!)).toBe(true);
+
+    // Stale confirmations never overwrite newer state.
+    const stale = dismissRefactorRecoveryEntry("rec-dismiss-1", 200, storage, 400);
+    expect(stale.ok).toBe(false);
+  });
+
+  it("derives the move proof from the matching journal document (RC-03)", () => {
+    const preText = "public class MyTest {}";
+    const postText = "public class MyTesting {}";
+    const doc: RefactorRecoveryDocumentSnapshotV2 = {
+      uri: "file:///workspace/MyTest.java",
+      canonicalPath: "/workspace/MyTest.java",
+      preText,
+      preHash: sha256Hex(preText),
+      postText,
+      postHash: sha256Hex(postText),
+      encoding: "UTF-8",
+      bom: false,
+      eol: "lf",
+    };
+    const move = {
+      oldUri: "file:///workspace/MyTest.java",
+      newUri: "file:///workspace/MyTesting.java",
+      oldPath: "/workspace/MyTest.java",
+      newPath: "/workspace/MyTesting.java",
+      contentHash: sha256Hex(preText),
+    };
+    const proof = resolveRecoveryMoveProof(move, [doc]);
+    expect(proof.kind).toBe("document");
+    // The live post image at the new path proves the bytes; foreign text does not.
+    expect(recoveryMoveProofMatches(proof, postText)).toBe(true);
+    expect(recoveryMoveProofMatches(proof, preText)).toBe(true);
+    expect(recoveryMoveProofMatches(proof, "third-party")).toBe(false);
   });
 });

--- a/src/components/editor/workspace/refactorPlan.ts
+++ b/src/components/editor/workspace/refactorPlan.ts
@@ -3,7 +3,7 @@ import type {
   LspWorkspaceEdit,
   LspWorkspaceEditOperation,
 } from "../../../lib/editor/lsp";
-import { normalizeFsPath, relativePathWithinRoot } from "./codeWorkspaceModel";
+import { fsPathComparisonKey, normalizeFsPath, relativePathWithinRoot } from "./codeWorkspaceModel";
 import type { CapabilityEvidenceV3 } from "./capabilityEvidence";
 import { workspaceEditOperations } from "./workspaceEditPreview";
 import { useProjectFactsStore } from "../../../stores/projectFactsStore";
@@ -586,38 +586,170 @@ export function verifyExclusionSafety(
 /**
  * ED-REF-001-A3: Verifies that post-refactor document contents match the
  * expected post-hashes computed during plan construction.
+ *
+ * RC-01 fix (java-rename-deleted-recovery): path lookup is identity-based
+ * (`fsPathComparisonKey`, handling `/` vs `\`, drive casing, file URIs),
+ * a required document without actual text is a `missing` failure instead of
+ * a silent skip, and EOL-only differences are accepted so CRLF saves are not
+ * mistaken for content mismatches in one checker while accepted in another.
  */
+export function buildRefactorPostTextIndex(
+  actualPostTexts: Record<string, string>,
+): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const [rawKey, text] of Object.entries(actualPostTexts)) {
+    index.set(fsPathComparisonKey(rawKey), text);
+  }
+  return index;
+}
+
+function planPostHashMatches(expectedPostHash: string, actualText: string): boolean {
+  if (sha256Hex(actualText) === expectedPostHash) return true;
+  // Accept EOL-only differences: the shared committer may normalize line
+  // endings when writing closed files. Checking the LF/CRLF/CR variants of
+  // the actual text covers both LF-expected and CRLF-expected plans without
+  // masking real content changes.
+  const unified = actualText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  if (sha256Hex(unified) === expectedPostHash) return true;
+  if (sha256Hex(unified.replace(/\n/g, "\r\n")) === expectedPostHash) return true;
+  if (sha256Hex(unified.replace(/\n/g, "\r")) === expectedPostHash) return true;
+  return false;
+}
+
 export function verifyRefactorPostHashes(
   plan: Pick<RefactorPlanV4, "documents">,
   actualPostTexts: Record<string, string>,
 ): {
   allMatched: boolean;
   mismatches: Array<{ uri: string; expectedPostHash: string; actualPostHash: string }>;
+  missing: Array<{ uri: string; expectedPostHash: string }>;
   verifiedDocuments: number;
 } {
+  const index = buildRefactorPostTextIndex(actualPostTexts);
   const mismatches: Array<{ uri: string; expectedPostHash: string; actualPostHash: string }> = [];
+  const missing: Array<{ uri: string; expectedPostHash: string }> = [];
   let verifiedDocuments = 0;
 
   for (const doc of plan.documents) {
     if (!doc.expectedPostHash) continue;
-    const actualText = actualPostTexts[doc.uri] ?? (doc.canonicalPath ? actualPostTexts[doc.canonicalPath] : undefined);
-    if (actualText === undefined) continue;
+    const candidates = [doc.uri, doc.canonicalPath].filter((v): v is string => !!v);
+    let actualText: string | undefined;
+    for (const candidate of candidates) {
+      const hit = index.get(fsPathComparisonKey(candidate));
+      if (hit !== undefined) {
+        actualText = hit;
+        break;
+      }
+    }
+    if (actualText === undefined) {
+      missing.push({ uri: doc.uri, expectedPostHash: doc.expectedPostHash });
+      continue;
+    }
     verifiedDocuments += 1;
-    const actualHash = sha256Hex(actualText);
-    if (actualHash !== doc.expectedPostHash) {
+    if (!planPostHashMatches(doc.expectedPostHash, actualText)) {
       mismatches.push({
         uri: doc.uri,
         expectedPostHash: doc.expectedPostHash,
-        actualPostHash: actualHash,
+        actualPostHash: sha256Hex(actualText),
       });
     }
   }
 
   return {
-    allMatched: mismatches.length === 0,
+    allMatched: mismatches.length === 0 && missing.length === 0,
     mismatches,
+    missing,
     verifiedDocuments,
   };
+}
+
+/**
+ * RC-01: ordered move-aware post-text resolution for journal/plan checks.
+ *
+ * A text document addressed to a pre-move path verifies against the bytes at
+ * the end of its move chain. The chain follows `resourceMoves` order; an
+ * ambiguous mapping (multiple moves from the same old path, cycles) or a
+ * still-present old path fails closed with `null` instead of guessing by
+ * basename or an unrelated same-name file. Display/IO paths are untouched;
+ * only the comparison keys are used for identity.
+ */
+export function resolveRefactorPostTextForDocument(
+  doc: { uri: string; canonicalPath: string | null },
+  moves: readonly RefactorRecoveryResourceMoveV1[],
+  index: ReadonlyMap<string, string>,
+): { text: string; resolvedPath: string } | null {
+  const startRaw = doc.canonicalPath || doc.uri;
+  const startKey = fsPathComparisonKey(startRaw);
+  // Follow the ordered move chain starting at the document identity.
+  let currentKey = startKey;
+  let currentRaw = startRaw;
+  const visited = new Set<string>([currentKey]);
+  let followed = false;
+  for (let step = 0; step < moves.length; step += 1) {
+    const candidates = moves.filter((move) => {
+      if (!move.oldPath && !move.oldUri) return false;
+      const oldKeys = [move.oldPath, move.oldUri].filter((v): v is string => !!v)
+        .map((v) => fsPathComparisonKey(v));
+      return oldKeys.includes(currentKey);
+    });
+    if (candidates.length === 0) break;
+    // Ambiguous fan-out: fail closed.
+    if (candidates.length > 1) return null;
+    const next = candidates[0]!;
+    const nextRaw = next.newPath || next.newUri;
+    if (!nextRaw) return null;
+    const nextKey = fsPathComparisonKey(nextRaw);
+    if (visited.has(nextKey)) return null;
+    visited.add(nextKey);
+    currentKey = nextKey;
+    currentRaw = nextRaw;
+    followed = true;
+  }
+  if (!followed) {
+    const direct = index.get(startKey);
+    return direct === undefined ? null : { text: direct, resolvedPath: startRaw };
+  }
+  // A completed rename removes the old path: a still-present old identity
+  // means the move did not complete (or a stale buffer is shadowing disk).
+  // Never prefer the stale old bytes; fail closed so the journal stays
+  // recovery-required instead of recording a false success.
+  if (index.has(startKey)) return null;
+  // Every intermediate except the final target must also be gone; otherwise
+  // the chain did not fully apply.
+  for (const seen of visited) {
+    if (seen !== startKey && seen !== currentKey && index.has(seen)) return null;
+  }
+  const finalText = index.get(currentKey);
+  return finalText === undefined ? null : { text: finalText, resolvedPath: currentRaw };
+}
+
+/**
+ * RC-01: pure-move endpoint proof for post verification. Every journalled
+ * move must show old-gone and new-present; anything else (both present,
+ * both missing, unreadable) is a postcondition failure, never a success.
+ */
+export function verifyRefactorMovePostEndpoints(
+  moves: readonly RefactorRecoveryResourceMoveV1[],
+  existsByKey: ReadonlyMap<string, boolean | null>,
+): { allVerified: boolean; missing: string[]; verifiedMoves: number } {
+  const missing: string[] = [];
+  let verifiedMoves = 0;
+  for (const move of moves) {
+    const oldRaw = move.oldPath || move.oldUri;
+    const newRaw = move.newPath || move.newUri;
+    if (!oldRaw || !newRaw) {
+      missing.push(`${move.oldUri} -> ${move.newUri}`);
+      continue;
+    }
+    const oldExists = existsByKey.get(fsPathComparisonKey(oldRaw));
+    const newExists = existsByKey.get(fsPathComparisonKey(newRaw));
+    if (oldExists === false && newExists === true) {
+      verifiedMoves += 1;
+      continue;
+    }
+    missing.push(`${oldRaw} -> ${newRaw}`);
+  }
+  return { allVerified: missing.length === 0, missing, verifiedMoves };
 }
 
 /**
@@ -796,6 +928,18 @@ export interface RefactorRecoveryJournalEntryV2 {
    * were journalled.
    */
   resourceMoves: readonly RefactorRecoveryResourceMoveV1[];
+  /**
+   * java-rename-deleted-recovery (RC-02, DEC-01/02): explicit user handling
+   * for a pending entry. `user-dismissed` ends only the recovery reminder
+   * for this record and keeps the current on-disk deletion state; it never
+   * rebuilds files, edits references, or rewrites status/pre/post history.
+   * Absent on historical entries, which stay pending until handled.
+   */
+  resolution?: {
+    kind: "user-dismissed";
+    resolvedAt: number;
+    reason: "keep-current-state";
+  };
   verification: {
     mismatchedUris: readonly string[];
     checkedAt: number | null;
@@ -884,6 +1028,16 @@ export function isRefactorRecoveryJournalEntryV2(
         || candidate.contentHash !== null && typeof candidate.contentHash !== "string"
       ) return false;
     }
+  }
+  // RC-02: optional user resolution; absent on historical entries. When
+  // present it must be a well-formed user-dismissed record; anything else
+  // keeps the entry readable but invalid so it is never silently dropped.
+  if (entry.resolution !== undefined) {
+    if (!entry.resolution || typeof entry.resolution !== "object") return false;
+    const resolution = entry.resolution as NonNullable<RefactorRecoveryJournalEntryV2["resolution"]>;
+    if (resolution.kind !== "user-dismissed") return false;
+    if (resolution.reason !== "keep-current-state") return false;
+    if (typeof resolution.resolvedAt !== "number") return false;
   }
   if (!entry.verification || typeof entry.verification !== "object") return false;
   if (!Array.isArray(entry.verification.mismatchedUris)) return false;
@@ -997,6 +1151,63 @@ export function clearRefactorRecoveryJournalV2(
   }
 }
 
+/**
+ * RC-02: single pending predicate for v2 recovery entries. `prepared` and
+ * `recovery-required` with no valid `user-dismissed` resolution are pending;
+ * committed/rolled-back or dismissed entries are not. All auto-discover,
+ * command-palette, and status surfaces must use this predicate instead of
+ * copying the status filter expression.
+ */
+export function isPendingRefactorRecoveryEntry(entry: RefactorRecoveryJournalEntryV2): boolean {
+  if (entry.status !== "prepared" && entry.status !== "recovery-required") return false;
+  const resolution = entry.resolution;
+  if (!resolution) return true;
+  return !(
+    resolution.kind === "user-dismissed"
+    && resolution.reason === "keep-current-state"
+    && typeof resolution.resolvedAt === "number"
+  );
+}
+
+/**
+ * RC-02: synchronously dismiss one pending entry (abandon this recovery
+ * reminder, keep the current on-disk state). The read-compare-write happens
+ * with no `await` in between so a single JS instance cannot interleave a
+ * second dismiss/recover of the same record mid-flight; callers must still
+ * serialize recover-vs-dismiss ownership per entry at the UI layer and
+ * re-fetch the latest entry before calling (stale `expectedUpdatedAt`
+ * fails instead of overwriting a newer transaction/recovery state).
+ * The journal facts (status/pre/post/moves/verification) are preserved;
+ * only the `resolution` marker and `updatedAt` change. Zero file writes.
+ */
+export function dismissRefactorRecoveryEntry(
+  recoveryId: string,
+  expectedUpdatedAt: number,
+  storage: Storage = defaultRecoveryStorage(),
+  now: number = Date.now(),
+): RefactorJournalWriteResult {
+  const current = getRefactorRecoveryJournalV2(recoveryId, storage);
+  if (!current) return { ok: false, reason: `recovery journal ${recoveryId} is missing or invalid` };
+  if (current.updatedAt !== expectedUpdatedAt) {
+    return { ok: false, reason: "recovery entry changed since it was reviewed; refresh and confirm again" };
+  }
+  if (!isPendingRefactorRecoveryEntry(current)) {
+    return { ok: false, reason: "recovery entry is no longer pending" };
+  }
+  return recordRefactorRecoveryJournalV2(
+    {
+      ...current,
+      updatedAt: now,
+      resolution: {
+        kind: "user-dismissed",
+        resolvedAt: now,
+        reason: "keep-current-state",
+      },
+    },
+    storage,
+  );
+}
+
 export interface RefactorRecoveryPreImageV2 {
   uri: string;
   canonicalPath: string | null;
@@ -1080,23 +1291,85 @@ export function resolveRecoveryDocTarget(
   oldExists: (oldPath: string) => boolean,
 ): string {
   const recorded = doc.canonicalPath || doc.uri;
+  const recordedKey = fsPathComparisonKey(recorded);
   for (const move of moves) {
     if (!move.oldPath || !move.newPath) continue;
-    const recordedNorm = normalizeFsPath(recorded);
     if (
-      normalizeFsPath(move.oldPath) === recordedNorm
-      || normalizeFsPath(move.oldUri) === recordedNorm
+      (move.oldPath && fsPathComparisonKey(move.oldPath) === recordedKey)
+      || (move.oldUri && fsPathComparisonKey(move.oldUri) === recordedKey)
     ) {
       return oldExists(move.oldPath) ? recorded : move.newPath;
     }
     if (
-      normalizeFsPath(move.newPath) === recordedNorm
-      || normalizeFsPath(move.newUri) === recordedNorm
+      (move.newPath && fsPathComparisonKey(move.newPath) === recordedKey)
+      || (move.newUri && fsPathComparisonKey(move.newUri) === recordedKey)
     ) {
       return recorded;
     }
   }
   return recorded;
+}
+
+/**
+ * RC-03: content proof for one journalled file move.
+ *
+ * The v2 `resourceMoves.contentHash` keeps its historical meaning (the moved
+ * bytes at prepare time, i.e. the matching text-op preimage). For a mixed
+ * text+rename transaction the live bytes at the new path are the POST image,
+ * so comparing only against `contentHash` falsely conflicts a healthy
+ * rename. When a unique journal document matches the move, that document's
+ * recorded pre/post images are authoritative: either image (under the
+ * shared encode/EOL rules) proves the bytes. A pure move without a document
+ * keeps the legacy `contentHash` proof; a move with neither stays
+ * content-unverified and never upgrades to verified. Multiple matching
+ * documents or an indeterminate chain stage refuses to guess.
+ */
+export type RefactorRecoveryMoveProof =
+  | { kind: "document"; doc: RefactorRecoveryDocumentSnapshotV2 }
+  | { kind: "legacy-hash"; hash: string }
+  | { kind: "unverified" }
+  | { kind: "ambiguous"; reason: string };
+
+export function resolveRecoveryMoveProof(
+  move: RefactorRecoveryResourceMoveV1,
+  documents: readonly RefactorRecoveryDocumentSnapshotV2[],
+): RefactorRecoveryMoveProof {
+  const keys = new Set<string>();
+  for (const raw of [move.oldPath, move.oldUri, move.newPath, move.newUri]) {
+    if (raw) keys.add(fsPathComparisonKey(raw));
+  }
+  const matched = documents.filter((doc) => {
+    const docKeys = [doc.canonicalPath, doc.uri].filter((v): v is string => !!v)
+      .map((v) => fsPathComparisonKey(v));
+    return docKeys.some((key) => keys.has(key));
+  });
+  if (matched.length > 1) {
+    return { kind: "ambiguous", reason: "multiple journal documents match the same file move" };
+  }
+  if (matched.length === 1) {
+    return { kind: "document", doc: matched[0]! };
+  }
+  if (move.contentHash !== null) return { kind: "legacy-hash", hash: move.contentHash };
+  return { kind: "unverified" };
+}
+
+/**
+ * RC-03: checks live bytes against a move proof. Document proofs accept the
+ * recorded preimage (move not yet applied / partially restored) or postimage
+ * (text edits applied, now sitting at the new path), under the shared
+ * EOL rules. Legacy proofs compare the single hash. Unverified always
+ * passes the content gate (endpoints still gate the move); ambiguous never
+ * does.
+ */
+export function recoveryMoveProofMatches(
+  proof: RefactorRecoveryMoveProof,
+  liveText: string,
+): boolean {
+  if (proof.kind === "unverified") return true;
+  if (proof.kind === "ambiguous") return false;
+  if (proof.kind === "legacy-hash") return sha256Hex(liveText) === proof.hash;
+  return refactorJournalPreImageMatches(proof.doc, liveText)
+    || refactorJournalPostImageMatches(proof.doc, liveText);
 }
 
 export function prepareRefactorRecoveryJournalV2(input: {
@@ -1128,21 +1401,35 @@ export function prepareRefactorRecoveryJournalV2(input: {
   const resourceMoves: RefactorRecoveryResourceMoveV1[] = [];
   for (const operation of renameOperations) {
     if (operation.kind !== "rename") continue;
-    const oldPath = recoveryMovePath(operation.oldUri, operation.oldPath);
-    const newPath = recoveryMovePath(operation.newUri, operation.newPath);
-    if (!oldPath || !newPath) {
+    const rawOldPath = recoveryMovePath(operation.oldUri, operation.oldPath);
+    const rawNewPath = recoveryMovePath(operation.newUri, operation.newPath);
+    if (!rawOldPath || !rawNewPath) {
       return {
         state: "incomplete",
         reason: `File move has no resolvable path pair (${operation.oldUri} -> ${operation.newUri}); refusing to mutate without a recovery journal`,
       };
     }
+    // RC-01: normalize display paths; historical unnormalized entries keep
+    // working because every reader compares by `fsPathComparisonKey`.
+    const oldPath = normalizeFsPath(rawOldPath);
+    const newPath = normalizeFsPath(rawNewPath);
     // The moved bytes' content proof comes from the matching text-op
     // preimage when the moved file also carries text edits; null otherwise
     // (reversal then moves bytes without a content proof).
-    const matchingPreImage = preImages.find((candidate) => (
-      (candidate.canonicalPath !== null && normalizeFsPath(candidate.canonicalPath) === normalizeFsPath(oldPath))
-      || candidate.uri === operation.oldUri
-    ));
+    const matchingPreImage = preImages.find((candidate) => {
+      if (candidate.canonicalPath !== null) {
+        try {
+          if (fsPathComparisonKey(candidate.canonicalPath) === fsPathComparisonKey(oldPath)) return true;
+        } catch {
+          // Fall through to URI comparison.
+        }
+      }
+      try {
+        return fsPathComparisonKey(candidate.uri) === fsPathComparisonKey(operation.oldUri);
+      } catch {
+        return candidate.uri === operation.oldUri;
+      }
+    });
     resourceMoves.push({
       oldUri: operation.oldUri,
       newUri: operation.newUri,
@@ -1154,11 +1441,21 @@ export function prepareRefactorRecoveryJournalV2(input: {
   const documents: RefactorRecoveryDocumentSnapshotV2[] = [];
   for (const operation of textOperations) {
     const document = operation.document;
-    const preImage = preImages.find((candidate) => (
-      candidate.uri === document.uri
-      || (document.path !== null && candidate.canonicalPath !== null
-        && normalizeFsPath(candidate.canonicalPath) === normalizeFsPath(document.path))
-    ));
+    const preImage = preImages.find((candidate) => {
+      try {
+        if (fsPathComparisonKey(candidate.uri) === fsPathComparisonKey(document.uri)) return true;
+      } catch {
+        if (candidate.uri === document.uri) return true;
+      }
+      if (document.path !== null && candidate.canonicalPath !== null) {
+        try {
+          return fsPathComparisonKey(candidate.canonicalPath) === fsPathComparisonKey(document.path);
+        } catch {
+          return false;
+        }
+      }
+      return false;
+    });
     if (!preImage) {
       return {
         state: "incomplete",
@@ -1170,7 +1467,7 @@ export function prepareRefactorRecoveryJournalV2(input: {
       : preImage.preText;
     documents.push({
       uri: document.uri,
-      canonicalPath: preImage.canonicalPath,
+      canonicalPath: preImage.canonicalPath ? normalizeFsPath(preImage.canonicalPath) : null,
       preText: preImage.preText,
       preHash: sha256Hex(preImage.preText),
       postText,

--- a/src/components/editor/workspace/refactorRecoveryController.test.ts
+++ b/src/components/editor/workspace/refactorRecoveryController.test.ts
@@ -5,6 +5,8 @@ import {
   executeRefactorRecovery,
   RESTORE_ECHO_SUPPRESS_WINDOW_MS,
 } from "./refactorRecoveryController";
+import { prepareRefactorRecoveryJournalV2 } from "./refactorPlan";
+import { normalizeFsPath } from "./codeWorkspaceModel";
 import { sha256Hex } from "./projectAnalysisModel";
 import type { RefactorRecoveryJournalEntryV2 } from "./refactorPlan";
 
@@ -399,6 +401,168 @@ describe("ED-AUDIT-014: refactor recovery controller", () => {
       suppressor.markRestored("/workspace/C.java", 2000);
       expect(suppressor.shouldSuppress("/workspace/C.java", 1999)).toBe(false);
       expect(suppressor.shouldSuppress("/workspace/C.java", 2000)).toBe(false);
+    });
+  });
+
+  describe("java-rename-deleted-recovery: production preparation for class rename", () => {
+    const oldPath = "/workspace/MyTest.java";
+    const newPath = "/workspace/MyTesting.java";
+    const oldUri = "file:///workspace/MyTest.java";
+    const newUri = "file:///workspace/MyTesting.java";
+    const preText = "public class MyTest {}";
+    const postText = "public class MyTesting {}";
+
+    const preparedEntry = (): RefactorRecoveryJournalEntryV2 => {
+      const preparation = prepareRefactorRecoveryJournalV2({
+        plan: { actionId: "rename-class", kind: "rename", documents: [] },
+        edit: {
+          documentEdits: [],
+          operations: [
+            {
+              kind: "text",
+              document: {
+                uri: oldUri,
+                path: oldPath,
+                version: null,
+                edits: [
+                  { range: { start: { line: 0, character: 13 }, end: { line: 0, character: 19 } }, newText: "MyTesting" },
+                ],
+              },
+            },
+            {
+              kind: "rename",
+              oldUri,
+              newUri,
+              oldPath,
+              newPath,
+              overwrite: false,
+              ignoreIfExists: false,
+              annotationId: null,
+            },
+          ],
+        } as unknown as import("../../../lib/editor/lsp").LspWorkspaceEdit,
+        preImages: [{
+          uri: oldUri,
+          canonicalPath: normalizeFsPath(oldPath),
+          preText,
+          encoding: "UTF-8",
+          bom: false,
+          eol: "lf" as const,
+        }],
+        workspaceRoot: "/workspace",
+        transactionId: "tx-class",
+      });
+      if (preparation.state !== "prepared") throw new Error("expected prepared");
+      return preparation.entry;
+    };
+
+    it("classifies the completed rename as restorable via the post image (RC-03)", async () => {
+      const journal = preparedEntry();
+      // contentHash keeps the historical pre-image meaning.
+      expect(journal.resourceMoves[0]!.contentHash).toBe(sha256Hex(preText));
+      // Post-move disk: old gone, new present with the POST bytes.
+      const disk = new Map([[normalizeFsPath(newPath), postText]]);
+      const summary = await classifyRefactorRecoveryPreconditions(
+        journal,
+        async (path) => {
+          for (const [k, v] of disk) {
+            if (normalizeFsPath(k) === normalizeFsPath(path)) return { text: v };
+          }
+          return null;
+        },
+        { pathExists: async (path) => [...disk.keys()].some((k) => normalizeFsPath(k) === normalizeFsPath(path)) },
+      );
+      expect(summary.moves[0]!.state).toBe("restorable");
+      expect(summary.documents[0]!.state).toBe("restorable");
+      expect(summary.overall).toBe("restorable");
+    });
+
+    it("reports both-missing as conflict/unreadable and never auto-resolves deletion (RC-02)", async () => {
+      const journal = preparedEntry();
+      const summary = await classifyRefactorRecoveryPreconditions(
+        journal,
+        async () => null,
+        { pathExists: async () => false },
+      );
+      expect(summary.moves[0]!.state).toBe("conflict");
+      expect(summary.moves[0]!.detail).toBe("both-missing");
+      expect(summary.documents[0]!.state).toBe("unreadable");
+      expect(summary.overall).toBe("conflict");
+    });
+
+    it("restores path and content with byte-preservation proof, idempotently (RC-03/AC-05)", async () => {
+      const journal = preparedEntry();
+      const disk = new Map([[newPath, postText]]);
+      const preconditions = await classifyRefactorRecoveryPreconditions(
+        journal,
+        async (path) => (disk.get(path) === undefined ? null : { text: disk.get(path)! }),
+        { pathExists: async (path) => disk.has(path) },
+      );
+      expect(preconditions.overall).toBe("restorable");
+      const execution = await executeRefactorRecovery(journal, preconditions, {
+        restoreText: async (doc) => {
+          disk.set(doc.canonicalPath ?? doc.uri, doc.preText);
+        },
+        readBack: async (doc) => {
+          const text = disk.get(doc.canonicalPath ?? doc.uri);
+          return text === undefined ? null : { text };
+        },
+        reverseResourceMove: async (move) => {
+          const text = disk.get(move.newPath!);
+          if (text === undefined) throw new Error("new path missing");
+          disk.delete(move.newPath!);
+          disk.set(move.oldPath!, text);
+        },
+        pathExists: async (path) => disk.has(path),
+        readMoveText: async (path) => {
+          const text = disk.get(path);
+          return text === undefined ? null : { text };
+        },
+      });
+      expect(execution.state).toBe("rolled-back");
+      expect(execution.reversedMoves).toEqual([newPath]);
+      expect(disk.get(oldPath)).toBe(preText);
+      expect(disk.has(newPath)).toBe(false);
+      // Re-running over restored content skips writes (idempotent).
+      const again = await classifyRefactorRecoveryPreconditions(
+        journal,
+        async (path) => (disk.get(path) === undefined ? null : { text: disk.get(path)! }),
+        { pathExists: async (path) => disk.has(path) },
+      );
+      expect(again.overall).toBe("already-restored");
+    });
+
+    it("skips linked text writes when the move reversal fails (RC-03/AC-06)", async () => {
+      const journal = preparedEntry();
+      const disk = new Map([[newPath, postText]]);
+      const preconditions = await classifyRefactorRecoveryPreconditions(
+        journal,
+        async (path) => (disk.get(path) === undefined ? null : { text: disk.get(path)! }),
+        { pathExists: async (path) => disk.has(path) },
+      );
+      const writes: string[] = [];
+      const execution = await executeRefactorRecovery(journal, preconditions, {
+        restoreText: async (doc) => {
+          writes.push(doc.canonicalPath ?? doc.uri);
+        },
+        readBack: async (doc) => {
+          const text = disk.get(doc.canonicalPath ?? doc.uri);
+          return text === undefined ? null : { text };
+        },
+        // Broken reversal: leaves the new path behind.
+        reverseResourceMove: async (move) => {
+          disk.set(move.oldPath!, postText);
+        },
+        pathExists: async (path) => disk.has(path),
+        readMoveText: async (path) => {
+          const text = disk.get(path);
+          return text === undefined ? null : { text };
+        },
+      });
+      expect(execution.state).toBe("pending");
+      expect(execution.moveFailures).toHaveLength(1);
+      expect(writes).toHaveLength(0);
+      expect(execution.failures[0]!.reason).toContain("associated file move failed");
     });
   });
 });

--- a/src/components/editor/workspace/refactorRecoveryController.ts
+++ b/src/components/editor/workspace/refactorRecoveryController.ts
@@ -3,7 +3,12 @@ import type {
   RefactorRecoveryJournalEntryV2,
   RefactorRecoveryResourceMoveV1,
 } from "./refactorPlan";
-import { resolveRecoveryDocTarget } from "./refactorPlan";
+import {
+  recoveryMoveProofMatches,
+  resolveRecoveryDocTarget,
+  resolveRecoveryMoveProof,
+} from "./refactorPlan";
+import { fsPathComparisonKey } from "./codeWorkspaceModel";
 import { sha256Hex } from "./projectAnalysisModel";
 import { normalizeLineEndings } from "./saveNormalizationPipeline";
 
@@ -56,6 +61,12 @@ export interface RefactorRecoveryMovePrecondition {
    * without a content guarantee and reports it as content-unverified.
    */
   contentVerified: boolean;
+  /**
+   * RC-02/RC-03: fine-grained reason for UI display (`both-missing`,
+   * `both-present`, `content-changed`, `read-failed`, `ambiguous-proof`,
+   * `missing-pair`). The coarse `state` union stays the executor guard.
+   */
+  detail?: string;
 }
 
 export interface RefactorRecoveryPreconditionSummary {
@@ -79,14 +90,23 @@ export async function classifyRefactorRecoveryPreconditions(
   hooks: RefactorRecoveryClassifyHooks = {},
 ): Promise<RefactorRecoveryPreconditionSummary> {
   const moves = entry.resourceMoves ?? [];
+  const journalDocuments = entry.documents ?? [];
   const existence = new Map<string, boolean>();
+  const keyOf = (path: string): string => {
+    try {
+      return fsPathComparisonKey(path);
+    } catch {
+      return path;
+    }
+  };
   const checkExists = async (path: string): Promise<boolean | null> => {
-    const cached = existence.get(path);
+    const key = keyOf(path);
+    const cached = existence.get(key);
     if (cached !== undefined) return cached;
     if (hooks.pathExists) {
       try {
         const result = await hooks.pathExists(path);
-        if (result !== null) existence.set(path, result);
+        if (result !== null) existence.set(key, result);
         return result;
       } catch {
         return null;
@@ -99,14 +119,14 @@ export async function classifyRefactorRecoveryPreconditions(
       return null;
     }
   };
-  const oldExists = (oldPath: string): boolean => existence.get(oldPath) === true;
-  const documents: RefactorRecoveryPrecondition[] = [];
+  const oldExists = (oldPath: string): boolean => existence.get(keyOf(oldPath)) === true;
+  const docPreconditions: RefactorRecoveryPrecondition[] = [];
   let sawConflict = false;
   let sawUnreadable = false;
   let sawRestorable = false;
   const movePreconditions: RefactorRecoveryMovePrecondition[] = [];
   for (const move of moves) {
-    movePreconditions.push(await classifyRecoveryMove(move, readText, checkExists));
+    movePreconditions.push(await classifyRecoveryMove(move, readText, checkExists, journalDocuments));
   }
   for (const doc of entry.documents) {
     const target = resolveRecoveryDocTarget(doc, moves, oldExists);
@@ -137,7 +157,7 @@ export async function classifyRefactorRecoveryPreconditions(
       state = "unreadable";
       sawUnreadable = true;
     }
-    documents.push({ uri: doc.uri, canonicalPath: doc.canonicalPath, state, currentHash });
+    docPreconditions.push({ uri: doc.uri, canonicalPath: doc.canonicalPath, state, currentHash });
   }
   for (const move of movePreconditions) {
     if (move.state === "conflict") sawConflict = true;
@@ -151,14 +171,16 @@ export async function classifyRefactorRecoveryPreconditions(
       : sawRestorable
         ? "restorable"
         : "already-restored";
-  return { documents, moves: movePreconditions, overall };
+  return { documents: docPreconditions, moves: movePreconditions, overall };
 }
 
 async function classifyRecoveryMove(
   move: RefactorRecoveryResourceMoveV1,
   readText: (canonicalPath: string) => Promise<{ text: string } | null>,
   checkExists: (path: string) => Promise<boolean | null>,
+  documents: readonly RefactorRecoveryDocumentSnapshotV2[] = [],
 ): Promise<RefactorRecoveryMovePrecondition> {
+  const proof = resolveRecoveryMoveProof(move, documents);
   const base: RefactorRecoveryMovePrecondition = {
     oldUri: move.oldUri,
     newUri: move.newUri,
@@ -166,31 +188,42 @@ async function classifyRecoveryMove(
     newPath: move.newPath,
     state: "unreadable",
     currentHash: null,
-    contentVerified: move.contentHash !== null,
+    contentVerified: proof.kind !== "unverified",
+    detail: "read-failed",
   };
-  if (!move.oldPath || !move.newPath) return base;
+  if (!move.oldPath || !move.newPath) return { ...base, detail: "missing-pair" };
+  if (proof.kind === "ambiguous") {
+    return { ...base, state: "conflict", detail: "ambiguous-proof" };
+  }
   const [oldKnown, newKnown] = await Promise.all([
     checkExists(move.oldPath),
     checkExists(move.newPath),
   ]);
   if (oldKnown === null || newKnown === null) return base;
-  if (oldKnown && !newKnown) return { ...base, state: "already-restored" };
+  if (oldKnown && !newKnown) return { ...base, state: "already-restored", detail: "already-restored" };
   if (!oldKnown && newKnown) {
-    if (move.contentHash === null) return { ...base, state: "restorable" };
+    // RC-03: the live bytes at the new path are the POST image for mixed
+    // text+rename transactions. A document proof accepts preimage (move not
+    // yet applied / partially restored) or postimage (edits applied); the
+    // legacy single-hash proof is kept for pure moves without documents.
+    if (proof.kind === "unverified") return { ...base, state: "restorable", detail: "restorable" };
     try {
       const current = await readText(move.newPath);
       if (current === null) return base;
       const currentHash = sha256Hex(current.text);
-      if (currentHash !== move.contentHash) {
-        return { ...base, state: "conflict", currentHash };
+      if (!recoveryMoveProofMatches(proof, current.text)) {
+        return { ...base, state: "conflict", currentHash, detail: "content-changed" };
       }
-      return { ...base, state: "restorable", currentHash };
+      return { ...base, state: "restorable", currentHash, detail: "restorable" };
     } catch {
       return base;
     }
   }
   // Both present, or both missing: reversing would destroy or invent bytes.
-  return { ...base, state: "conflict" };
+  // Both-missing is the deleted-after-rename shape: it stays pending with an
+  // explicit abandon outlet instead of auto-resolving.
+  if (!oldKnown && !newKnown) return { ...base, state: "conflict", detail: "both-missing" };
+  return { ...base, state: "conflict", detail: "both-present" };
 }
 
 export interface RefactorRecoveryExecution {
@@ -267,13 +300,21 @@ export async function executeRefactorRecovery(
     moveFailures: [],
   };
   const oldExistsLive = new Map<string, boolean>();
+  const keyOfLive = (path: string): string => {
+    try {
+      return fsPathComparisonKey(path);
+    } catch {
+      return path;
+    }
+  };
   const checkOldExists = async (oldPath: string): Promise<boolean> => {
-    const cached = oldExistsLive.get(oldPath);
+    const key = keyOfLive(oldPath);
+    const cached = oldExistsLive.get(key);
     if (cached !== undefined) return cached;
     if (!hooks.pathExists) return false;
     try {
       const result = await hooks.pathExists(oldPath);
-      oldExistsLive.set(oldPath, result);
+      oldExistsLive.set(key, result);
       return result;
     } catch {
       return false;
@@ -283,14 +324,22 @@ export async function executeRefactorRecovery(
     const precondition = move.newUri ? moveByNewUri.get(move.newUri) : undefined;
     const state = precondition?.state ?? "unreadable";
     if (state === "already-restored") {
-      if (move.oldPath) oldExistsLive.set(move.oldPath, true);
+      if (move.oldPath) oldExistsLive.set(keyOfLive(move.oldPath), true);
       continue;
     }
     if (state === "conflict") {
       execution.moveConflicts.push({
         oldUri: move.oldUri,
         newUri: move.newUri,
-        reason: "move endpoints changed since the transaction; reversal would destroy or invent bytes",
+        reason: precondition?.detail === "both-missing"
+          ? "both move endpoints are missing; reversal would invent bytes"
+          : precondition?.detail === "both-present"
+            ? "both move endpoints are present; reversal would destroy bytes"
+            : precondition?.detail === "content-changed"
+              ? "bytes at the new path changed since the transaction; reversal would destroy third-party content"
+              : precondition?.detail === "ambiguous-proof"
+                ? "multiple journal documents match the same file move; reversal refused to guess"
+                : "move endpoints changed since the transaction; reversal would destroy or invent bytes",
       });
       continue;
     }
@@ -312,6 +361,49 @@ export async function executeRefactorRecovery(
       });
       continue;
     }
+    // RC-03: prove the move preserves bytes. Re-read the source endpoint now,
+    // record the hash that actually matched, reverse, then prove the bytes at
+    // home equal the pre-reverse hash (plus the journal proof). A move that
+    // fails here must block its associated text documents below.
+    const proof = resolveRecoveryMoveProof(move, entry.documents ?? []);
+    if (proof.kind === "ambiguous") {
+      execution.moveFailures.push({
+        oldUri: move.oldUri,
+        newUri: move.newUri,
+        reason: "multiple journal documents match the same file move; reversal refused to guess",
+      });
+      continue;
+    }
+    let preReverseHash: string | null = null;
+    if (proof.kind !== "unverified") {
+      try {
+        const preReverse = hooks.readMoveText ? await hooks.readMoveText(move.newPath) : null;
+        if (preReverse === null) {
+          execution.moveFailures.push({
+            oldUri: move.oldUri,
+            newUri: move.newUri,
+            reason: "bytes at the new path unreadable before reversal; content proof failed",
+          });
+          continue;
+        }
+        if (!recoveryMoveProofMatches(proof, preReverse.text)) {
+          execution.moveFailures.push({
+            oldUri: move.oldUri,
+            newUri: move.newUri,
+            reason: "bytes at the new path changed since the transaction; reversal would destroy third-party content",
+          });
+          continue;
+        }
+        preReverseHash = sha256Hex(preReverse.text);
+      } catch {
+        execution.moveFailures.push({
+          oldUri: move.oldUri,
+          newUri: move.newUri,
+          reason: "bytes at the new path unreadable before reversal; content proof failed",
+        });
+        continue;
+      }
+    }
     try {
       await hooks.reverseResourceMove(move);
       const oldPresent = await checkOldExists(move.oldPath);
@@ -331,29 +423,47 @@ export async function executeRefactorRecovery(
         });
         continue;
       }
-      if (move.contentHash !== null) {
-        let currentHash: string | null = null;
+      if (proof.kind === "unverified") {
+        execution.contentUnverifiedMoves.push(move.newPath);
+      } else {
+        let postHash: string | null = null;
+        let postText: string | null = null;
         try {
           const current = hooks.readMoveText ? await hooks.readMoveText(move.oldPath) : null;
-          currentHash = current === null ? null : sha256Hex(current.text);
+          postText = current === null ? null : current.text;
+          postHash = current === null ? null : sha256Hex(current.text);
         } catch {
-          currentHash = null;
+          postHash = null;
         }
-        if (currentHash !== move.contentHash) {
+        if (postHash === null || postText === null) {
           execution.moveFailures.push({
             oldUri: move.oldUri,
             newUri: move.newUri,
-            reason: currentHash === null
-              ? "moved-home bytes unreadable; content proof failed"
-              : "moved-home bytes do not match the journalled content proof",
+            reason: "moved-home bytes unreadable; content proof failed",
           });
           continue;
         }
-      } else {
-        execution.contentUnverifiedMoves.push(move.newPath);
+        // The reversal must preserve the exact bytes observed before the
+        // move; afterwards those bytes must still satisfy the journal proof.
+        if (preReverseHash !== null && postHash !== preReverseHash) {
+          execution.moveFailures.push({
+            oldUri: move.oldUri,
+            newUri: move.newUri,
+            reason: "moved-home bytes differ from the pre-reversal bytes; move altered content",
+          });
+          continue;
+        }
+        if (!recoveryMoveProofMatches(proof, postText)) {
+          execution.moveFailures.push({
+            oldUri: move.oldUri,
+            newUri: move.newUri,
+            reason: "moved-home bytes do not match the journalled content proof",
+          });
+          continue;
+        }
       }
       execution.reversedMoves.push(move.newPath);
-      oldExistsLive.set(move.oldPath, true);
+      oldExistsLive.set(keyOfLive(move.oldPath), true);
     } catch (error) {
       execution.moveFailures.push({
         oldUri: move.oldUri,
@@ -362,9 +472,47 @@ export async function executeRefactorRecovery(
       });
     }
   }
+  // RC-03: a text document linked to a failed/conflicted move must not be
+  // written to the wrong path after the reversal failed.
+  const blockedDocKeys = new Set<string>();
+  const failedMoves = [
+    ...execution.moveConflicts.map((m) => ({ oldUri: m.oldUri, newUri: m.newUri })),
+    ...execution.moveFailures.map((m) => ({ oldUri: m.oldUri, newUri: m.newUri })),
+  ];
+  for (const failed of failedMoves) {
+    const failedMove = moves.find((m) => m.oldUri === failed.oldUri && m.newUri === failed.newUri);
+    if (!failedMove) continue;
+    for (const raw of [failedMove.oldPath, failedMove.oldUri, failedMove.newPath, failedMove.newUri]) {
+      if (!raw) continue;
+      try {
+        blockedDocKeys.add(fsPathComparisonKey(raw));
+      } catch {
+        blockedDocKeys.add(raw);
+      }
+    }
+  }
+  const docBlockedByMove = (doc: RefactorRecoveryDocumentSnapshotV2): boolean => {
+    for (const raw of [doc.canonicalPath, doc.uri]) {
+      if (!raw) continue;
+      try {
+        if (blockedDocKeys.has(fsPathComparisonKey(raw))) return true;
+      } catch {
+        if (blockedDocKeys.has(raw)) return true;
+      }
+    }
+    return false;
+  };
   for (const doc of entry.documents) {
     const precondition = byUri.get(doc.uri);
     const state = precondition?.state ?? "unreadable";
+    if (docBlockedByMove(doc)) {
+      execution.failures.push({
+        uri: doc.uri,
+        canonicalPath: doc.canonicalPath,
+        reason: "associated file move failed; text restore skipped to avoid writing to the wrong path",
+      });
+      continue;
+    }
     if (state === "already-restored") {
       execution.skippedUris.push(doc.uri);
       continue;


### PR DESCRIPTION
…abandon outlet

Implements docs-issue/code-workspace-java-rename-deleted-recovery-design.md (RC-01/RC-02/RC-03, DEC-01 v1: per-record confirm abandon, keep deleted state).

RC-01 postcondition path identity (refactorPlan.ts, CodeWorkspaceTab.tsx):
- Add buildRefactorPostTextIndex / resolveRefactorPostTextForDocument / verifyRefactorMovePostEndpoints: all lookups by fsPathComparisonKey, ordered move-chain resolution for pre-move addressed documents, fail closed on stale old buffers, ambiguous fan-out/cycles and unverified pure-move endpoints (old-gone/new-present proof required).
- verifyRefactorPostHashes: missing required post text is now a `missing` failure instead of a silent skip; EOL-only differences accepted so CRLF saves are not mismatches in one checker and matches in another.
- Shell post-verify uses the index + chain resolver + endpoint proof and records missing/move-missing in mismatchedUris; writer paths normalized, historical unnormalized entries still resolve by comparison key.

RC-03 recovery content proof (refactorPlan.ts, refactorRecoveryController.ts):
- Keep resourceMoves.contentHash as the prepare-time (pre-image) hash; add resolveRecoveryMoveProof / recoveryMoveProofMatches: a unique matching journal document is authoritative (pre- OR post-image under shared EOL rules), pure moves keep the legacy hash, proof-less stays content-unverified, multi-match is ambiguous and never guessed.
- classifyRecoveryMove accepts the post image at the new path (fixes the healthy mixed text+rename classifying as conflict); both-missing / both-present / content-changed / ambiguous-proof reported as fine detail while conflict/unreadable stay the executor guard.
- executeRefactorRecovery re-reads the new path before reversal, reverses, then proves moved-home bytes equal the pre-reversal hash and satisfy the proof; documents linked to failed moves are never written.

RC-02 explicit abandon + review UI (DEC-01/02):
- Journal v2 gains optional resolution {kind:user-dismissed, reason:keep-current-state}; status/pre/post/moves/verification facts untouched; validator accepts it, old readers ignore it.
- isPendingRefactorRecoveryEntry is the single pending predicate used by auto-discover and workspace.reviewRefactorRecovery.
- dismissRefactorRecoveryEntry: synchronous read-compare-write with expected-updatedAt staleness guard; zero file writes.
- New RefactorRecoveryReviewDialog (figure A/B): per-entry resource list with live states ("file does not exist at either end", never "you deleted"), restore enabled only when restorable, inline cancel-focused abandon confirm, break-all long paths, min(640px,92vw)/90vh scroll layout, focus trap/Esc/focus restore; z-index below global confirms so the restore second-confirm stays clickable (found by native testing).
- Shell review flow is dialog-driven with per-entry recover/dismiss ownership, workspace-switch/unmount release, and error-preserving retry.

Tests & QA:
- Unit: path spellings (backslash/slash, drive case, file URI, UNC), missing/EOL/chain/endpoint, resolution + stale dismiss, production- preparation mixed rename classify/restore/idempotency/failure-skip (refactorPlan 45, controller 22, dialog 5).
- Mounted CodeWorkspaceTab 179/179 incl. new both-missing abandon (zero writes, sibling still prompts, no re-prompt) and dialog-driven restore/conflict flows.
- QA: new TC-IDE-JAVA-RENAME-DELETED-RECOVERY (Linux/provider) and -WIN (Windows seeded AC-02/03/04/05) + java_rename_deleted_fixtures (+ schema enum); 014/FOLLOW-001 recovery steps moved to the review dialog; F25.5 controls/files extended; audit --gate clean.
- Native Windows/WebView2: FOLLOW-001 green x2, WIN green x3 (1 transient classify-latency fail kept, case hardened with a poll-for-restorable gate); IMPROVE-002 fails identically on baseline (pre-existing cold-import timing, unrelated).
- Unverified: Linux/macOS native, live tree-delete->reopen order, 736x375 viewport matrix (no supporting verbs; manual V-05 outstanding).